### PR TITLE
fix(dashboard): dashboard links pin/unpin update in-place on the client (no reload)

### DIFF
--- a/src/app/api/dashboard-links/pin/route.ts
+++ b/src/app/api/dashboard-links/pin/route.ts
@@ -8,6 +8,11 @@ export const dynamic = "force-dynamic";
 
 const MAX_PINNED_LINKS = 5;
 
+type PinApiResponse = {
+  pinnedSlugs: string[];
+  maxPinnedLinks: number;
+};
+
 function sanitizeReturnTo(value: string | undefined): string {
   if (!value || !value.startsWith("/")) return "/";
   if (value.startsWith("//")) return "/";
@@ -21,6 +26,8 @@ function sanitizeReturnTo(value: string | undefined): string {
  * @response 303
  */
 export async function POST(request: Request) {
+  const wantsJson =
+    request.headers.get("accept")?.includes("application/json") ?? false;
   const formData = await request.formData();
   const parsedBody = dashboardLinkPinRequestSchema.safeParse({
     slug: formData.get("slug"),
@@ -29,6 +36,12 @@ export async function POST(request: Request) {
   });
 
   if (!parsedBody.success) {
+    if (wantsJson) {
+      return NextResponse.json<PinApiResponse>(
+        { pinnedSlugs: [], maxPinnedLinks: MAX_PINNED_LINKS },
+        { status: 400 },
+      );
+    }
     return NextResponse.redirect(new URL("/", request.url), 303);
   }
 
@@ -38,6 +51,12 @@ export async function POST(request: Request) {
   const link = USTC_DASHBOARD_LINKS.find((item) => item.slug === slug);
 
   if (!link) {
+    if (wantsJson) {
+      return NextResponse.json<PinApiResponse>({
+        pinnedSlugs: [],
+        maxPinnedLinks: MAX_PINNED_LINKS,
+      });
+    }
     return NextResponse.redirect(new URL(returnTo, request.url), 303);
   }
 
@@ -45,12 +64,20 @@ export async function POST(request: Request) {
   const userId = session?.user?.id;
 
   if (!userId) {
+    if (wantsJson) {
+      return NextResponse.json<PinApiResponse>(
+        { pinnedSlugs: [], maxPinnedLinks: MAX_PINNED_LINKS },
+        { status: 401 },
+      );
+    }
     return NextResponse.redirect(new URL(returnTo, request.url), 303);
   }
 
+  let pinnedSlugs: string[] = [];
+
   try {
     if (action === "pin") {
-      await prisma.$transaction(async (tx) => {
+      pinnedSlugs = await prisma.$transaction(async (tx) => {
         await tx.dashboardLinkPin.upsert({
           where: { userId_slug: { userId, slug } },
           create: { userId, slug },
@@ -72,11 +99,23 @@ export async function POST(request: Request) {
             },
           });
         }
+
+        const finalRows = await tx.dashboardLinkPin.findMany({
+          where: { userId },
+          select: { slug: true },
+        });
+        return finalRows.map((row) => row.slug);
       });
     } else {
       await prisma.dashboardLinkPin.deleteMany({
         where: { userId, slug },
       });
+
+      const finalRows = await prisma.dashboardLinkPin.findMany({
+        where: { userId },
+        select: { slug: true },
+      });
+      pinnedSlugs = finalRows.map((row) => row.slug);
     }
   } catch (error) {
     console.error("Failed to update dashboard link pin state", {
@@ -84,6 +123,19 @@ export async function POST(request: Request) {
       slug,
       action,
       error,
+    });
+
+    const fallbackRows = await prisma.dashboardLinkPin.findMany({
+      where: { userId },
+      select: { slug: true },
+    });
+    pinnedSlugs = fallbackRows.map((row) => row.slug);
+  }
+
+  if (wantsJson) {
+    return NextResponse.json<PinApiResponse>({
+      pinnedSlugs,
+      maxPinnedLinks: MAX_PINNED_LINKS,
     });
   }
 

--- a/src/components/home-view/dashboard-links-with-search.tsx
+++ b/src/components/home-view/dashboard-links-with-search.tsx
@@ -95,9 +95,54 @@ export function DashboardLinksWithSearch({
 }) {
   const t = useTranslations("meDashboard");
   const [searchQuery, setSearchQuery] = useState("");
+  const [linksState, setLinksState] = useState(groupedLinks);
+  const [updatingSlug, setUpdatingSlug] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const filteredGroups = filterGroupedBySearch(groupedLinks, searchQuery);
+  useEffect(() => {
+    setLinksState(groupedLinks);
+  }, [groupedLinks]);
+
+  const filteredGroups = filterGroupedBySearch(linksState, searchQuery);
+
+  const handlePinSubmit = useCallback(
+    async (slug: string, nextAction: "pin" | "unpin") => {
+      setUpdatingSlug(slug);
+      try {
+        const formData = new FormData();
+        formData.set("slug", slug);
+        formData.set("action", nextAction);
+        formData.set("returnTo", returnTo);
+
+        const response = await fetch("/api/dashboard-links/pin", {
+          method: "POST",
+          body: formData,
+          headers: {
+            accept: "application/json",
+          },
+        });
+
+        if (!response.ok) return;
+        const data = (await response.json()) as {
+          pinnedSlugs?: string[];
+        };
+        const pinnedSlugs = new Set(data.pinnedSlugs ?? []);
+
+        setLinksState((previous) =>
+          previous.map((entry) => ({
+            ...entry,
+            links: entry.links.map((link) => ({
+              ...link,
+              isPinned: pinnedSlugs.has(link.slug),
+            })),
+          })),
+        );
+      } finally {
+        setUpdatingSlug(null);
+      }
+    },
+    [returnTo],
+  );
 
   const focusSearch = useCallback(() => {
     inputRef.current?.focus();
@@ -182,7 +227,14 @@ export function DashboardLinksWithSearch({
                   <form
                     action="/api/dashboard-links/pin"
                     method="post"
-                    className="pointer-events-auto absolute top-2 right-2 opacity-100 transition-opacity md:pointer-events-none md:opacity-0 md:group-hover:pointer-events-auto md:group-hover:opacity-100 md:group-focus-within:pointer-events-auto md:group-focus-within:opacity-100"
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      void handlePinSubmit(
+                        link.slug,
+                        link.isPinned ? "unpin" : "pin",
+                      );
+                    }}
+                    className={`pointer-events-auto absolute top-2 right-2 opacity-100 transition-opacity ${link.isPinned ? "" : "md:pointer-events-none md:opacity-0 md:group-hover:pointer-events-auto md:group-hover:opacity-100 md:group-focus-within:pointer-events-auto md:group-focus-within:opacity-100"}`}
                   >
                     <input type="hidden" name="slug" value={link.slug} />
                     <input type="hidden" name="returnTo" value={returnTo} />
@@ -193,9 +245,10 @@ export function DashboardLinksWithSearch({
                     />
                     <button
                       type="submit"
+                      disabled={updatingSlug === link.slug}
                       aria-label={pinLabel}
                       title={pinLabel}
-                      className="inline-flex h-8 w-8 items-center justify-center rounded-md border bg-card/95 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                      className="inline-flex h-8 w-8 items-center justify-center rounded-md border bg-card/95 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       <Pin
                         className={`h-4 w-4 ${link.isPinned ? "fill-current text-primary" : ""}`}


### PR DESCRIPTION
### Motivation
- Avoid a full page reload when pinning/unpinning links on the `/?tab=links` view by performing the update client-side for immediate UI feedback.  
- Ensure the client reflects the authoritative pinned set after the server enforces `MAX_PINNED_LINKS` (overflow unpins).  
- Keep the pinned indicator visible for already-pinned links at all times while preserving hover-reveal for unpinned links on larger viewports.

### Description
- Added JSON support to the pin API at `src/app/api/dashboard-links/pin/route.ts`, returning an authoritative `{ pinnedSlugs, maxPinnedLinks }` payload when the request `Accept` header includes `application/json`, while preserving existing 303 redirect behavior for normal form submissions.  
- The API now computes and returns the final pinned slugs after mutations, and returns appropriate error JSON responses for malformed requests and unauthenticated users.  
- Updated the UI component `DashboardLinksWithSearch` (`src/components/home-view/dashboard-links-with-search.tsx`) to hold `linksState`, intercept pin form submit, `fetch` the API with `accept:

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6828abbe08328812f6c41ab6861f6)