### PR TITLE
feat(bus): add shuttle bus support

### DIFF
--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -468,6 +468,11 @@
     "dashboardTitle": "Campus shuttle",
     "dashboardDescription": "Prioritize the most relevant routes based on the current time and your usual campuses.",
     "publicEntry": "Public shuttle query",
+    "stats": {
+      "matches": "{count} matching routes",
+      "upcomingTrips": "{count} upcoming trips",
+      "currentDayType": "{dayType} timetable"
+    },
     "dayType": {
       "weekday": "Weekday",
       "weekend": "Weekend",
@@ -516,6 +521,8 @@
       "destination": "Default destination campus",
       "favoriteCampuses": "Favorite campus IDs",
       "favoriteRoutes": "Favorite route IDs",
+      "advanced": "Advanced options",
+      "advancedHint": "Use these IDs only if you want to fine-tune recommendations beyond the default campuses.",
       "idsPlaceholder": "Use commas, for example: 1, 6",
       "showDepartedTrips": "Show departed trips by default",
       "showDepartedTripsHint": "Keep today’s departed trips in the list for full timetable review.",
@@ -546,7 +553,8 @@
     "upcomingCount": "{count} upcoming",
     "allRoutesLabel": "All routes",
     "noMoreBusToday": "No more buses on this route today",
-    "switchVersionHint": "Try another timetable version or show departed trips."
+    "switchVersionHint": "Try another timetable version or show departed trips.",
+    "moreTrips": "{count} more trips"
   },
   "publicProfile": {
     "idLabel": "User ID",

--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -19,6 +19,7 @@
       "subscriptions": "Selected Sections",
       "uploads": "My Uploads",
       "homeworks": "My Homework",
+      "bus": "Shuttle Bus",
       "apiDocs": "API Docs",
       "welcome": "Complete Your Profile",
       "privacy": "Privacy Policy",
@@ -208,6 +209,10 @@
         "title": "Browse Teachers",
         "description": "View teacher information and their teaching sections"
       },
+      "busTimetable": {
+        "title": "Shuttle Bus",
+        "description": "Check the next campus shuttle and keep route preferences."
+      },
       "admin": {
         "title": "Admin",
         "description": "Access moderation and admin tools"
@@ -317,6 +322,10 @@
       "calendar": {
         "title": "Calendar",
         "description": "This week's schedule and homework deadlines"
+      },
+      "bus": {
+        "title": "Shuttle Bus",
+        "description": "See the next shuttle and route changes across campuses."
       },
       "subscriptions": {
         "title": "Section Management",
@@ -451,6 +460,93 @@
       "all": "All {count}",
       "viewAll": "View all"
     }
+  },
+  "bus": {
+    "title": "Shuttle Bus",
+    "description": "Public shuttle timetable across USTC campuses. Logged-in users can save preferences and jump to the next bus faster.",
+    "subtitle": "Public query, remembered preferences, and next-bus recommendations.",
+    "dashboardTitle": "Campus shuttle",
+    "dashboardDescription": "Prioritize the most relevant routes based on the current time and your usual campuses.",
+    "publicEntry": "Public shuttle query",
+    "dayType": {
+      "weekday": "Weekday",
+      "weekend": "Weekend",
+      "auto": "Auto"
+    },
+    "query": {
+      "dayType": "Schedule type",
+      "origin": "Origin campus",
+      "destination": "Destination campus",
+      "originAny": "Any origin",
+      "destinationAny": "Any destination",
+      "showDepartedTrips": "Show departed trips",
+      "showDepartedTripsHint": "By default only upcoming trips are shown.",
+      "version": "Timetable version",
+      "versionCurrent": "Current effective version",
+      "versionPreview": "Preview another version",
+      "empty": "No shuttle trips are available under the current filters."
+    },
+    "recommended": {
+      "title": "Recommended route",
+      "description": "Sorted by your preferred origin/destination and the next departure time.",
+      "nextTrip": "Next bus",
+      "noUpcoming": "No more upcoming trips on this route today",
+      "arrive": "Arrive",
+      "departIn": "Departs in about {count} minutes",
+      "departed": "Departed"
+    },
+    "allRoutes": {
+      "title": "All matching routes",
+      "description": "Shows all routes and trips that match the current filters."
+    },
+    "route": {
+      "favorite": "Favorite",
+      "totalTrips": "{count} total trips",
+      "upcomingTrips": "{count} upcoming",
+      "departedTrips": "{count} departed",
+      "stops": "Stops",
+      "firstDeparture": "First departure",
+      "lastArrival": "Last arrival"
+    },
+    "preferences": {
+      "title": "Preferences",
+      "description": "Remember your usual campuses and routes to improve recommendations next time.",
+      "signInHint": "Sign in to save preferred campuses and route filters.",
+      "origin": "Default origin campus",
+      "destination": "Default destination campus",
+      "favoriteCampuses": "Favorite campus IDs",
+      "favoriteRoutes": "Favorite route IDs",
+      "idsPlaceholder": "Use commas, for example: 1, 6",
+      "showDepartedTrips": "Show departed trips by default",
+      "showDepartedTripsHint": "Keep today’s departed trips in the list for full timetable review.",
+      "unset": "Not set",
+      "save": "Save preferences",
+      "saving": "Saving...",
+      "saved": "Preferences saved.",
+      "saveFailed": "Failed to save preferences."
+    },
+    "versionNotice": {
+      "title": "Timetable notice",
+      "effective": "Effective: {from} - {to}",
+      "unknown": "Long-term"
+    },
+    "activeVersion": "Active version",
+    "hidePreferences": "Hide preferences",
+    "editPreferences": "Edit preferences",
+    "empty": "No shuttle data is available right now.",
+    "weekday": "Weekday",
+    "weekend": "Weekend",
+    "bestMatch": "Best match",
+    "nextDeparture": "Next departure",
+    "arriveAt": "Arrive at",
+    "upcomingTrips": "Upcoming trips",
+    "passThrough": "Pass through",
+    "departed": "Departed",
+    "totalTrips": "{count} total trips",
+    "upcomingCount": "{count} upcoming",
+    "allRoutesLabel": "All routes",
+    "noMoreBusToday": "No more buses on this route today",
+    "switchVersionHint": "Try another timetable version or show departed trips."
   },
   "publicProfile": {
     "idLabel": "User ID",

--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -522,7 +522,7 @@
       "favoriteCampuses": "Favorite campus IDs",
       "favoriteRoutes": "Favorite route IDs",
       "advanced": "Advanced options",
-      "advancedHint": "Use these IDs only if you want to fine-tune recommendations beyond the default campuses.",
+      "advancedDescription": "Use these IDs only if you want to fine-tune recommendations beyond the default campuses.",
       "idsPlaceholder": "Use commas, for example: 1, 6",
       "showDepartedTrips": "Show departed trips by default",
       "showDepartedTripsHint": "Keep today’s departed trips in the list for full timetable review.",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -462,10 +462,17 @@
   },
   "bus": {
     "title": "校车",
+    "description": "公开查询校车时刻，登录后可记住偏好并优先推荐最合适的路线。",
     "subtitle": "支持公开查询、偏好记忆与下一班推荐。",
     "dashboardTitle": "校车出行",
     "dashboardDescription": "根据当前时间和你常用的校区，优先展示最值得看的路线。",
     "publicEntry": "公开校车查询",
+    "summary": {
+      "title": "出行摘要",
+      "matchingRoutes": "匹配路线",
+      "nextDeparture": "最近发车",
+      "currentMode": "当前模式"
+    },
     "dayType": {
       "weekday": "工作日",
       "weekend": "周末",
@@ -509,6 +516,8 @@
     "preferences": {
       "title": "偏好设置",
       "description": "记住你常用的校区与线路，下次打开优先推荐。",
+      "advanced": "高级偏好",
+      "advancedDescription": "只有在你需要强制指定常用校区或线路 ID 时再展开。",
       "signInHint": "登录后即可保存出发地、目的地和常用线路偏好。",
       "origin": "默认出发校区",
       "destination": "默认到达校区",
@@ -527,7 +536,23 @@
       "title": "时刻表说明",
       "effective": "生效区间：{from} - {to}",
       "unknown": "长期有效"
-    }
+    },
+    "activeVersion": "当前版本",
+    "hidePreferences": "收起偏好",
+    "editPreferences": "编辑偏好",
+    "empty": "当前暂无可用的校车数据。",
+    "weekday": "工作日",
+    "weekend": "周末",
+    "bestMatch": "最佳匹配",
+    "nextDeparture": "下一班发车",
+    "arriveAt": "到达时间",
+    "upcomingTrips": "后续班次",
+    "passThrough": "经停",
+    "departed": "已发车",
+    "noTime": "时间待定",
+    "allRoutesLabel": "全部路线",
+    "noMoreBusToday": "这条线路今天没有后续班次了",
+    "switchVersionHint": "可以切换版本或打开“显示已发车班次”查看完整时刻表。"
   },
   "publicProfile": {
     "idLabel": "用户 ID",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -208,6 +208,10 @@
         "title": "浏览教师",
         "description": "查看教师信息及其授课班级"
       },
+      "bus": {
+        "title": "校车",
+        "description": "公开查询校车时刻并按偏好推荐路线"
+      },
       "admin": {
         "title": "管理入口",
         "description": "访问后台管理与内容审核"
@@ -317,6 +321,10 @@
       "calendar": {
         "title": "日历",
         "description": "本周课表与作业截止"
+      },
+      "bus": {
+        "title": "校车",
+        "description": "按当前时间和常用校区查看下一班校车"
       },
       "subscriptions": {
         "title": "选课",
@@ -450,6 +458,75 @@
       "dueSoon": "3 天内截止 {count}",
       "all": "全部 {count}",
       "viewAll": "查看全部"
+    }
+  },
+  "bus": {
+    "title": "校车",
+    "subtitle": "支持公开查询、偏好记忆与下一班推荐。",
+    "dashboardTitle": "校车出行",
+    "dashboardDescription": "根据当前时间和你常用的校区，优先展示最值得看的路线。",
+    "publicEntry": "公开校车查询",
+    "dayType": {
+      "weekday": "工作日",
+      "weekend": "周末",
+      "auto": "自动"
+    },
+    "query": {
+      "dayType": "时刻类型",
+      "origin": "出发校区",
+      "destination": "到达校区",
+      "originAny": "任意出发地",
+      "destinationAny": "任意目的地",
+      "showDepartedTrips": "显示已发车班次",
+      "showDepartedTripsHint": "默认只显示还没发车的班次。",
+      "version": "时刻表版本",
+      "versionCurrent": "当前生效",
+      "versionPreview": "预览其它版本",
+      "empty": "当前筛选下暂无可展示的校车班次。"
+    },
+    "recommended": {
+      "title": "推荐路线",
+      "description": "优先按你的起点/终点偏好和下一班发车时间排序。",
+      "nextTrip": "下一班",
+      "noUpcoming": "今天这条线路没有后续班次了",
+      "arrive": "到达",
+      "departIn": "约 {count} 分钟后发车",
+      "departed": "已发车"
+    },
+    "allRoutes": {
+      "title": "全部匹配路线",
+      "description": "展示符合当前筛选的所有线路和班次。"
+    },
+    "route": {
+      "favorite": "常用",
+      "totalTrips": "共 {count} 班",
+      "upcomingTrips": "后续 {count} 班",
+      "departedTrips": "已发 {count} 班",
+      "stops": "停靠",
+      "firstDeparture": "首班",
+      "lastArrival": "末班到达"
+    },
+    "preferences": {
+      "title": "偏好设置",
+      "description": "记住你常用的校区与线路，下次打开优先推荐。",
+      "signInHint": "登录后即可保存出发地、目的地和常用线路偏好。",
+      "origin": "默认出发校区",
+      "destination": "默认到达校区",
+      "favoriteCampuses": "常用校区 ID",
+      "favoriteRoutes": "常用线路 ID",
+      "idsPlaceholder": "使用英文逗号分隔，例如 1, 6",
+      "showDepartedTrips": "默认展示已发车班次",
+      "showDepartedTripsHint": "开启后会在列表中保留今天已发车的班次，方便回看全表。",
+      "unset": "未设置",
+      "save": "保存偏好",
+      "saving": "保存中...",
+      "saved": "偏好已保存",
+      "saveFailed": "偏好保存失败"
+    },
+    "versionNotice": {
+      "title": "时刻表说明",
+      "effective": "生效区间：{from} - {to}",
+      "unknown": "长期有效"
     }
   },
   "publicProfile": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "openapi:generate": "next-openapi-gen generate && bun run openapi:postprocess",
     "openapi:postprocess": "bun run tools/openapi-postprocess.ts",
     "openapi:types": "bunx openapi-typescript \"public/openapi.generated.json\" -o \"src/generated/openapi.ts\"",
+    "load:bus": "bun run tools/load-bus-from-static.ts",
     "dev:seed-scenarios": "bun run tools/seed-dev-scenarios.ts",
     "dev:reset-scenarios": "bun run tools/reset-dev-scenarios.ts"
   },

--- a/prisma/migrations/20260329171334_add_bus_models/migration.sql
+++ b/prisma/migrations/20260329171334_add_bus_models/migration.sql
@@ -1,0 +1,143 @@
+-- CreateEnum
+CREATE TYPE "BusScheduleDayType" AS ENUM ('weekday', 'weekend');
+
+-- CreateTable
+CREATE TABLE "BusCampus" (
+    "id" INTEGER NOT NULL,
+    "nameCn" TEXT NOT NULL,
+    "nameEn" TEXT,
+    "latitude" DOUBLE PRECISION NOT NULL,
+    "longitude" DOUBLE PRECISION NOT NULL,
+
+    CONSTRAINT "BusCampus_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BusRoute" (
+    "id" INTEGER NOT NULL,
+    "nameCn" TEXT NOT NULL,
+    "nameEn" TEXT,
+
+    CONSTRAINT "BusRoute_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BusRouteStop" (
+    "id" SERIAL NOT NULL,
+    "routeId" INTEGER NOT NULL,
+    "campusId" INTEGER NOT NULL,
+    "stopOrder" INTEGER NOT NULL,
+
+    CONSTRAINT "BusRouteStop_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BusScheduleVersion" (
+    "id" SERIAL NOT NULL,
+    "key" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "sourceMessage" TEXT,
+    "sourceUrl" TEXT,
+    "rawJson" JSONB NOT NULL,
+    "effectiveFrom" DATE,
+    "effectiveUntil" DATE,
+    "isEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "importedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BusScheduleVersion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BusTrip" (
+    "id" SERIAL NOT NULL,
+    "versionId" INTEGER NOT NULL,
+    "routeId" INTEGER NOT NULL,
+    "dayType" "BusScheduleDayType" NOT NULL,
+    "position" INTEGER NOT NULL,
+    "stopTimes" JSONB NOT NULL,
+
+    CONSTRAINT "BusTrip_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BusUserPreference" (
+    "userId" TEXT NOT NULL,
+    "preferredOriginCampusId" INTEGER,
+    "preferredDestinationCampusId" INTEGER,
+    "favoriteCampusIds" INTEGER[] DEFAULT ARRAY[]::INTEGER[],
+    "favoriteRouteIds" INTEGER[] DEFAULT ARRAY[]::INTEGER[],
+    "showDepartedTrips" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BusUserPreference_pkey" PRIMARY KEY ("userId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BusCampus_nameCn_key" ON "BusCampus"("nameCn");
+
+-- CreateIndex
+CREATE INDEX "BusCampus_nameCn_idx" ON "BusCampus"("nameCn");
+
+-- CreateIndex
+CREATE INDEX "BusCampus_nameEn_idx" ON "BusCampus"("nameEn");
+
+-- CreateIndex
+CREATE INDEX "BusRoute_nameCn_idx" ON "BusRoute"("nameCn");
+
+-- CreateIndex
+CREATE INDEX "BusRoute_nameEn_idx" ON "BusRoute"("nameEn");
+
+-- CreateIndex
+CREATE INDEX "BusRouteStop_campusId_idx" ON "BusRouteStop"("campusId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BusRouteStop_routeId_stopOrder_key" ON "BusRouteStop"("routeId", "stopOrder");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BusScheduleVersion_key_key" ON "BusScheduleVersion"("key");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BusScheduleVersion_checksum_key" ON "BusScheduleVersion"("checksum");
+
+-- CreateIndex
+CREATE INDEX "BusScheduleVersion_isEnabled_effectiveFrom_effectiveUntil_idx" ON "BusScheduleVersion"("isEnabled", "effectiveFrom", "effectiveUntil");
+
+-- CreateIndex
+CREATE INDEX "BusTrip_dayType_routeId_idx" ON "BusTrip"("dayType", "routeId");
+
+-- CreateIndex
+CREATE INDEX "BusTrip_versionId_idx" ON "BusTrip"("versionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BusTrip_versionId_dayType_routeId_position_key" ON "BusTrip"("versionId", "dayType", "routeId", "position");
+
+-- CreateIndex
+CREATE INDEX "BusUserPreference_preferredOriginCampusId_idx" ON "BusUserPreference"("preferredOriginCampusId");
+
+-- CreateIndex
+CREATE INDEX "BusUserPreference_preferredDestinationCampusId_idx" ON "BusUserPreference"("preferredDestinationCampusId");
+
+-- AddForeignKey
+ALTER TABLE "BusRouteStop" ADD CONSTRAINT "BusRouteStop_routeId_fkey" FOREIGN KEY ("routeId") REFERENCES "BusRoute"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BusRouteStop" ADD CONSTRAINT "BusRouteStop_campusId_fkey" FOREIGN KEY ("campusId") REFERENCES "BusCampus"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BusTrip" ADD CONSTRAINT "BusTrip_versionId_fkey" FOREIGN KEY ("versionId") REFERENCES "BusScheduleVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BusTrip" ADD CONSTRAINT "BusTrip_routeId_fkey" FOREIGN KEY ("routeId") REFERENCES "BusRoute"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BusUserPreference" ADD CONSTRAINT "BusUserPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BusUserPreference" ADD CONSTRAINT "BusUserPreference_preferredOriginCampusId_fkey" FOREIGN KEY ("preferredOriginCampusId") REFERENCES "BusCampus"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BusUserPreference" ADD CONSTRAINT "BusUserPreference_preferredDestinationCampusId_fkey" FOREIGN KEY ("preferredDestinationCampusId") REFERENCES "BusCampus"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,11 @@ enum TodoPriority {
   high
 }
 
+enum BusScheduleDayType {
+  weekday
+  weekend
+}
+
 
 model AdminClass {
   id   Int  @id @default(autoincrement())
@@ -757,6 +762,7 @@ model User {
   dashboardLinkClicks  DashboardLinkClick[]
   dashboardLinkPins    DashboardLinkPin[]
   todos                Todo[]
+  busPreference        BusUserPreference?
 
   oauthClients       OAuthClient[]
   oauthAccessTokens  OAuthAccessToken[]
@@ -1053,6 +1059,110 @@ model Todo {
   @@index([userId])
   @@index([userId, completed])
   @@index([dueAt])
+}
+
+model BusCampus {
+  id Int @id
+
+  nameCn String @unique
+  nameEn String?
+
+  latitude  Float
+  longitude Float
+
+  routeStops              BusRouteStop[]
+  preferredByOriginUsers  BusUserPreference[] @relation("BusPreferenceOrigin")
+  preferredByDestinationUsers BusUserPreference[] @relation("BusPreferenceDestination")
+
+  @@index([nameCn])
+  @@index([nameEn])
+}
+
+model BusRoute {
+  id Int @id
+
+  nameCn String
+  nameEn String?
+
+  stops BusRouteStop[]
+  trips BusTrip[]
+
+  @@index([nameCn])
+  @@index([nameEn])
+}
+
+model BusRouteStop {
+  id Int @id @default(autoincrement())
+
+  routeId  Int
+  campusId Int
+  stopOrder Int
+
+  route  BusRoute  @relation(fields: [routeId], references: [id], onDelete: Cascade)
+  campus BusCampus @relation(fields: [campusId], references: [id])
+
+  @@unique([routeId, stopOrder])
+  @@index([campusId])
+}
+
+model BusScheduleVersion {
+  id Int @id @default(autoincrement())
+
+  key          String @unique
+  title        String
+  checksum     String @unique
+  sourceMessage String?
+  sourceUrl    String?
+  rawJson      Json
+
+  effectiveFrom DateTime? @db.Date
+  effectiveUntil DateTime? @db.Date
+
+  isEnabled  Boolean  @default(true)
+  importedAt DateTime @default(now())
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  trips BusTrip[]
+
+  @@index([isEnabled, effectiveFrom, effectiveUntil])
+}
+
+model BusTrip {
+  id Int @id @default(autoincrement())
+
+  versionId Int
+  routeId   Int
+  dayType   BusScheduleDayType
+  position  Int
+  stopTimes Json
+
+  version BusScheduleVersion @relation(fields: [versionId], references: [id], onDelete: Cascade)
+  route   BusRoute           @relation(fields: [routeId], references: [id], onDelete: Cascade)
+
+  @@unique([versionId, dayType, routeId, position])
+  @@index([dayType, routeId])
+  @@index([versionId])
+}
+
+model BusUserPreference {
+  userId String @id
+
+  preferredOriginCampusId      Int?
+  preferredDestinationCampusId Int?
+  favoriteCampusIds            Int[] @default([])
+  favoriteRouteIds             Int[] @default([])
+  showDepartedTrips            Boolean @default(false)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  preferredOriginCampus BusCampus? @relation("BusPreferenceOrigin", fields: [preferredOriginCampusId], references: [id], onDelete: SetNull)
+  preferredDestinationCampus BusCampus? @relation("BusPreferenceDestination", fields: [preferredDestinationCampusId], references: [id], onDelete: SetNull)
+
+  @@index([preferredOriginCampusId])
+  @@index([preferredDestinationCampusId])
 }
 
 // ─── Better Auth OAuth 2.1 Provider Models ────────────────────────

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -489,6 +489,159 @@
         }
       }
     },
+    "/api/bus": {
+      "get": {
+        "operationId": "get-api-bus",
+        "summary": "Public shuttle-bus query API.",
+        "description": "",
+        "tags": [
+          "Api"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "now",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "dayType",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "auto",
+                "weekday",
+                "weekend"
+              ]
+            },
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "originCampusId",
+            "schema": {},
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "destinationCampusId",
+            "schema": {},
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "favoriteRouteIds",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "favoriteCampusIds",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "showDepartedTrips",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            },
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "includeAllTrips",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            },
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {},
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "versionKey",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/busQueryResponseSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/bus/preferences": {
+      "get": {
+        "operationId": "get-api-bus-preferences",
+        "summary": "Get or update bus preferences for the current user.",
+        "description": "",
+        "tags": [
+          "Api"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/busPreferenceResponseSchema"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "post-api-bus-preferences",
+        "summary": "",
+        "description": "",
+        "tags": [
+          "Api"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/calendar-subscriptions": {
       "post": {
         "operationId": "post-api-calendar-subscriptions",
@@ -2348,6 +2501,112 @@
           "pagination"
         ]
       },
+      "busPreferenceRequestSchema": {
+        "type": "object",
+        "properties": {
+          "preferredOriginCampusId": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true,
+            "nullable": true
+          },
+          "preferredDestinationCampusId": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true,
+            "nullable": true
+          },
+          "favoriteCampusIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            }
+          },
+          "favoriteRouteIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            }
+          },
+          "showDepartedTrips": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "preferredOriginCampusId",
+          "preferredDestinationCampusId",
+          "favoriteCampusIds",
+          "favoriteRouteIds",
+          "showDepartedTrips"
+        ]
+      },
+      "busPreferenceResponseSchema": {},
+      "busQuerySchema": {
+        "type": "object",
+        "properties": {
+          "now": {
+            "type": "string"
+          },
+          "dayType": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "weekday",
+              "weekend"
+            ]
+          },
+          "originCampusId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/integerStringSchema"
+              }
+            ]
+          },
+          "destinationCampusId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/integerStringSchema"
+              }
+            ]
+          },
+          "favoriteRouteIds": {
+            "type": "string"
+          },
+          "favoriteCampusIds": {
+            "type": "string"
+          },
+          "showDepartedTrips": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "includeAllTrips": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
+          },
+          "limit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/integerStringSchema"
+              }
+            ]
+          },
+          "versionKey": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "busQueryResponseSchema": {},
       "currentCalendarSubscriptionResponseSchema": {
         "oneOf": [
           {

--- a/src/app/api/bus/preferences/route.ts
+++ b/src/app/api/bus/preferences/route.ts
@@ -1,0 +1,70 @@
+import { auth } from "@/auth";
+import { saveBusPreference } from "@/features/bus/lib/bus-service";
+import {
+  handleRouteError,
+  jsonResponse,
+  unauthorized,
+} from "@/lib/api/helpers";
+import { busPreferenceRequestSchema } from "@/lib/api/schemas/request-schemas";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Get or update bus preferences for the current user.
+ * @body busPreferenceRequestSchema
+ * @response busPreferenceResponseSchema
+ * @response 401:openApiErrorSchema
+ * @response 400:openApiErrorSchema
+ */
+export async function GET() {
+  const session = await auth();
+  const userId = session?.user?.id ?? null;
+  if (!userId) {
+    return unauthorized();
+  }
+
+  try {
+    const preference = await saveBusPreference(userId, {
+      preferredOriginCampusId: null,
+      preferredDestinationCampusId: null,
+      favoriteCampusIds: [],
+      favoriteRouteIds: [],
+      showDepartedTrips: false,
+    });
+
+    return jsonResponse({ preference });
+  } catch (error) {
+    return handleRouteError("Failed to fetch bus preferences", error);
+  }
+}
+
+export async function POST(request: Request) {
+  const session = await auth();
+  const userId = session?.user?.id ?? null;
+  if (!userId) {
+    return unauthorized();
+  }
+
+  let body: unknown = {};
+  try {
+    body = await request.json();
+  } catch (error) {
+    return handleRouteError("Invalid bus preference request", error, 400);
+  }
+
+  const parsedBody = busPreferenceRequestSchema.safeParse(body);
+  if (!parsedBody.success) {
+    return handleRouteError(
+      "Invalid bus preference request",
+      parsedBody.error,
+      400,
+    );
+  }
+
+  try {
+    const preference = await saveBusPreference(userId, parsedBody.data);
+    return jsonResponse({ preference });
+  } catch (error) {
+    return handleRouteError("Failed to save bus preferences", error);
+  }
+}

--- a/src/app/api/bus/route.ts
+++ b/src/app/api/bus/route.ts
@@ -1,0 +1,112 @@
+import type { NextRequest } from "next/server";
+import { getLocale } from "next-intl/server";
+import { queryBusSchedules } from "@/features/bus/lib/bus-service";
+import {
+  handleRouteError,
+  invalidParamResponse,
+  jsonResponse,
+  parseInteger,
+} from "@/lib/api/helpers";
+import { busQueryResponseSchema } from "@/lib/api/schemas";
+import { busQuerySchema } from "@/lib/api/schemas/request-schemas";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Public shuttle-bus query API.
+ * @params busQuerySchema
+ * @response busQueryResponseSchema
+ * @response 400:openApiErrorSchema
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const parsedQuery = busQuerySchema.safeParse({
+    now: searchParams.get("now") ?? undefined,
+    dayType: searchParams.get("dayType") ?? undefined,
+    originCampusId:
+      searchParams.get("originCampusId") ??
+      searchParams.get("from") ??
+      undefined,
+    destinationCampusId:
+      searchParams.get("destinationCampusId") ??
+      searchParams.get("to") ??
+      undefined,
+    favoriteCampusIds: searchParams.get("favoriteCampusIds") ?? undefined,
+    favoriteRouteIds: searchParams.get("favoriteRouteIds") ?? undefined,
+    showDepartedTrips: searchParams.get("showDepartedTrips") ?? undefined,
+    includeAllTrips: searchParams.get("includeAllTrips") ?? undefined,
+    limit: searchParams.get("limit") ?? undefined,
+    versionKey: searchParams.get("versionKey") ?? undefined,
+  });
+
+  if (!parsedQuery.success) {
+    return handleRouteError("Invalid bus query", parsedQuery.error, 400);
+  }
+
+  const locale = await getLocale();
+  const originCampusId = parsedQuery.data.originCampusId
+    ? parseInteger(parsedQuery.data.originCampusId)
+    : null;
+  const destinationCampusId = parsedQuery.data.destinationCampusId
+    ? parseInteger(parsedQuery.data.destinationCampusId)
+    : null;
+
+  if (
+    parsedQuery.data.originCampusId !== undefined &&
+    parsedQuery.data.originCampusId !== "" &&
+    originCampusId == null
+  ) {
+    return invalidParamResponse("originCampusId");
+  }
+  if (
+    parsedQuery.data.destinationCampusId !== undefined &&
+    parsedQuery.data.destinationCampusId !== "" &&
+    destinationCampusId == null
+  ) {
+    return invalidParamResponse("destinationCampusId");
+  }
+
+  const favoriteCampusIds = (parsedQuery.data.favoriteCampusIds ?? "")
+    .split(",")
+    .map((value) => parseInteger(value))
+    .filter((value): value is number => value != null);
+  const favoriteRouteIds = (parsedQuery.data.favoriteRouteIds ?? "")
+    .split(",")
+    .map((value) => parseInteger(value))
+    .filter((value): value is number => value != null);
+
+  try {
+    const result = await queryBusSchedules({
+      locale: locale === "en-us" ? "en-us" : "zh-cn",
+      now: parsedQuery.data.now,
+      dayType: parsedQuery.data.dayType,
+      originCampusId,
+      destinationCampusId,
+      favoriteCampusIds,
+      favoriteRouteIds,
+      showDepartedTrips:
+        parsedQuery.data.showDepartedTrips === "true"
+          ? true
+          : parsedQuery.data.showDepartedTrips === "false"
+            ? false
+            : undefined,
+      includeAllTrips: parsedQuery.data.includeAllTrips === "true",
+      limit: parsedQuery.data.limit
+        ? (parseInteger(parsedQuery.data.limit) ?? undefined)
+        : undefined,
+      versionKey: parsedQuery.data.versionKey ?? null,
+    });
+
+    if (!result) {
+      return jsonResponse(
+        { error: "Bus schedule is not available" },
+        { status: 404 },
+      );
+    }
+
+    const validated = busQueryResponseSchema.parse(result);
+    return jsonResponse(validated);
+  } catch (error) {
+    return handleRouteError("Failed to query shuttle bus schedules", error);
+  }
+}

--- a/src/app/bus/page.tsx
+++ b/src/app/bus/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from "next";
+import { getLocale, getTranslations } from "next-intl/server";
+import { auth } from "@/auth";
+import { PageLayout } from "@/components/page-layout";
+import { BusPanel } from "@/features/bus/components/bus-panel";
+import {
+  getBusPreference,
+  queryBusSchedules,
+} from "@/features/bus/lib/bus-service";
+import type { BusLocale } from "@/features/bus/lib/bus-types";
+
+export const dynamic = "force-dynamic";
+
+type BusPageSearchParams = {
+  from?: string;
+  to?: string;
+  dayType?: string;
+  showDeparted?: string;
+  version?: string;
+};
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("metadata");
+  return {
+    title: t("pages.bus"),
+  };
+}
+
+export default async function BusPage({
+  searchParams,
+}: {
+  searchParams: Promise<BusPageSearchParams>;
+}) {
+  const [params, locale, t, session] = await Promise.all([
+    searchParams,
+    getLocale(),
+    getTranslations("bus"),
+    auth(),
+  ]);
+  const busLocale: BusLocale = locale === "en-us" ? "en-us" : "zh-cn";
+
+  const userId = session?.user?.id ?? null;
+  const preference = await getBusPreference(userId);
+  const fromParam = Number.parseInt(params.from ?? "", 10);
+  const toParam = Number.parseInt(params.to ?? "", 10);
+  const result = await queryBusSchedules({
+    locale: busLocale,
+    userId,
+    originCampusId: Number.isFinite(fromParam) ? fromParam : undefined,
+    destinationCampusId: Number.isFinite(toParam) ? toParam : undefined,
+    dayType:
+      params.dayType === "weekday" || params.dayType === "weekend"
+        ? params.dayType
+        : "auto",
+    showDepartedTrips:
+      params.showDeparted === "1" || params.showDeparted === "true"
+        ? true
+        : undefined,
+    versionKey: params.version ?? undefined,
+  });
+
+  return (
+    <PageLayout title={t("title")} description={t("description")}>
+      {result ? (
+        <BusPanel
+          data={result}
+          signedIn={Boolean(userId)}
+          initialPreference={preference}
+          compact={false}
+        />
+      ) : (
+        <p className="text-muted-foreground text-sm">{t("empty")}</p>
+      )}
+    </PageLayout>
+  );
+}

--- a/src/app/dashboard/dashboard-data.ts
+++ b/src/app/dashboard/dashboard-data.ts
@@ -1,6 +1,8 @@
 import type dayjs from "dayjs";
 import { getLocale } from "next-intl/server";
 import { pinyin } from "pinyin-pro";
+import { getBusDashboardSnapshot } from "@/features/bus/lib/bus-service";
+import type { BusLocale } from "@/features/bus/lib/bus-types";
 import type {
   DashboardLinkGroup,
   DashboardLinkIcon,
@@ -256,6 +258,7 @@ export type OverviewData = {
   recommendedLinks: DashboardLinkSummary[];
   pinnedLinks: DashboardLinkSummary[];
   overviewLinks: DashboardLinkSummary[];
+  busSnapshot: Awaited<ReturnType<typeof getBusDashboardSnapshot>> | null;
 };
 
 export async function getDashboardOverviewData(
@@ -497,7 +500,8 @@ export async function getDashboardOverviewData(
   const activeCalendarSemesterId = gridSemesterRow?.id ?? null;
   const activeCalendarSemesterName = gridSemesterRow?.nameCn ?? null;
 
-  const [clickRows, pinRows] = await Promise.all([
+  const busLocale: BusLocale = locale === "en-us" ? "en-us" : "zh-cn";
+  const [clickRows, pinRows, busSnapshot] = await Promise.all([
     basePrisma.dashboardLinkClick.findMany({
       where: { userId },
       select: { slug: true, count: true },
@@ -506,6 +510,11 @@ export async function getDashboardOverviewData(
       where: { userId },
       select: { slug: true },
       orderBy: { createdAt: "asc" },
+    }),
+    getBusDashboardSnapshot({
+      locale: busLocale,
+      userId,
+      now: referenceNow.toISOString(),
     }),
   ]);
   const clickStats: Record<string, number> = Object.fromEntries(
@@ -570,6 +579,7 @@ export async function getDashboardOverviewData(
     recommendedLinks,
     pinnedLinks,
     overviewLinks,
+    busSnapshot,
   };
 }
 
@@ -802,3 +812,7 @@ export async function getTodosTabData(userId: string): Promise<TodoItem[]> {
     updatedAt: todo.updatedAt.toISOString(),
   }));
 }
+
+export type BusDashboardData = {
+  snapshot: Awaited<ReturnType<typeof getBusDashboardSnapshot>> | null;
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { Calendar, User, Users } from "lucide-react";
+import { Bus, Calendar, User, Users } from "lucide-react";
 import type { Metadata } from "next";
 import Image from "next/image";
 import { getTranslations } from "next-intl/server";
@@ -63,7 +63,10 @@ export default async function HomePage({
       todosData,
     ] = await Promise.all([
       getDashboardNavStats(session.user.id, debugOptions),
-      tab === "overview" || tab === "calendar" || tab === "links"
+      tab === "overview" ||
+      tab === "calendar" ||
+      tab === "links" ||
+      tab === "bus"
         ? getDashboardOverviewData(session.user.id, overviewOptions)
         : Promise.resolve(null),
       tab === "homeworks"
@@ -79,6 +82,11 @@ export default async function HomePage({
         ? getTodosTabData(session.user.id)
         : Promise.resolve(null),
     ]);
+
+    const busData =
+      tab === "bus" && overviewData?.busSnapshot
+        ? { snapshot: overviewData.busSnapshot }
+        : null;
 
     if (!navStats) {
       return (
@@ -101,6 +109,7 @@ export default async function HomePage({
           null
         }
         todosData={todosData}
+        busData={busData}
       />
     );
   }
@@ -184,6 +193,22 @@ export default async function HomePage({
               <CardPanel>
                 <p className="line-clamp-2 text-body text-muted-foreground">
                   {t("quickAccess.browseTeachers.description")}
+                </p>
+              </CardPanel>
+            </Card>
+          </Link>
+
+          <Link href="/bus" className="no-underline">
+            <Card className="hover:-translate-y-1 h-full overflow-hidden transition-[transform,box-shadow] hover:shadow-lg">
+              <CardHeader>
+                <div className="flex items-center gap-3">
+                  <Bus className="h-5 w-5 text-primary" />
+                  <CardTitle>{t("quickAccess.bus.title")}</CardTitle>
+                </div>
+              </CardHeader>
+              <CardPanel>
+                <p className="line-clamp-2 text-body text-muted-foreground">
+                  {t("quickAccess.bus.description")}
                 </p>
               </CardPanel>
             </Card>

--- a/src/features/bus/components/bus-panel.tsx
+++ b/src/features/bus/components/bus-panel.tsx
@@ -1,8 +1,18 @@
 "use client";
 
-import { Bus, Clock3, Settings2, Star } from "lucide-react";
+import {
+  Bus,
+  ChevronDown,
+  Clock3,
+  Route,
+  Settings2,
+  Sparkles,
+  Star,
+} from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { BusPreferenceForm } from "@/features/bus/components/bus-preference-form";
 import type { BusQueryResult } from "@/features/bus/lib/bus-types";
 import { cn } from "@/shared/lib/utils";
@@ -36,273 +46,412 @@ export function BusPanel({
   const t = useTranslations("bus");
   const [showSettings, setShowSettings] = useState(false);
 
-  const recommendedCards = useMemo(
+  const alternativeMatches = useMemo(
     () =>
       data.recommended
-        ? [
-            data.recommended,
-            ...data.matches.filter(
-              (item) => item.route.id !== data.recommended?.route.id,
-            ),
-          ].slice(0, 3)
-        : data.matches.slice(0, 3),
-    [data.matches, data.recommended],
+        ? data.matches
+            .filter((item) => item.route.id !== data.recommended?.route.id)
+            .slice(0, compact ? 2 : 3)
+        : data.matches.slice(0, compact ? 2 : 3),
+    [compact, data.matches, data.recommended],
   );
+
+  const topMetrics = useMemo(
+    () => [
+      {
+        label: t("query.origin"),
+        value:
+          data.recommended?.originStop.campus.namePrimary ??
+          initialPreference?.preferredOriginCampusId?.toString() ??
+          t("query.originAny"),
+      },
+      {
+        label: t("query.destination"),
+        value:
+          data.recommended?.destinationStop.campus.namePrimary ??
+          initialPreference?.preferredDestinationCampusId?.toString() ??
+          t("query.destinationAny"),
+      },
+      {
+        label: t("recommended.nextTrip"),
+        value: data.recommended?.nextTrip?.departureTime ?? "—",
+      },
+      {
+        label: t("allRoutes.title"),
+        value: `${data.matches.length}`,
+      },
+    ],
+    [data.matches.length, data.recommended, initialPreference, t],
+  );
+
+  const shouldShowAllRoutes =
+    data.matches.length > 1 || (!compact && data.matches.length > 0);
 
   return (
     <div className={cn("space-y-6", className)}>
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="space-y-1">
-          <div className="flex items-center gap-2">
-            <Bus className="h-5 w-5 text-primary" />
-            <h2 className="font-semibold text-lg">{t("title")}</h2>
-          </div>
-          <p className="text-muted-foreground text-sm">
-            {t("subtitle", {
-              dayType:
-                data.todayType === "weekday" ? t("weekday") : t("weekend"),
-            })}
-          </p>
-          {data.notice?.message ? (
-            <p className="text-muted-foreground text-xs">
-              {data.notice.url ? (
-                <a
-                  href={data.notice.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="underline"
-                >
-                  {data.notice.message}
-                </a>
-              ) : (
-                data.notice.message
-              )}
-            </p>
-          ) : null}
-        </div>
-
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="rounded-full border border-border px-3 py-1 text-muted-foreground text-xs">
-            {t("activeVersion")}: {data.version?.title ?? "—"}
-          </span>
-          {showPreferences ? (
-            <button
-              type="button"
-              onClick={() => setShowSettings((value) => !value)}
-              className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent"
-            >
-              <Settings2 className="h-4 w-4" />
-              {showSettings ? t("hidePreferences") : t("editPreferences")}
-            </button>
-          ) : null}
-        </div>
-      </div>
-
-      {showSettings && showPreferences ? (
-        <BusPreferenceForm
-          campuses={data.campuses}
-          preference={initialPreference ?? data.preferences}
-          signedIn={signedIn}
-        />
-      ) : null}
-
-      {data.matches.length === 0 ? (
-        <div className="rounded-2xl border border-border border-dashed px-6 py-10 text-center text-muted-foreground text-sm">
-          {t("empty")}
-        </div>
-      ) : (
-        <>
-          <section className="space-y-3">
-            <div className="flex items-center gap-2">
-              <Star className="h-4 w-4 text-primary" />
-              <h3 className="font-medium">{t("recommended.title")}</h3>
+      <div className="overflow-hidden rounded-3xl border border-border bg-card shadow-xs">
+        <div className="border-border/70 border-b bg-gradient-to-br from-primary/8 via-background to-background px-6 py-6">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="space-y-3">
+              <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-primary text-xs">
+                <Bus className="h-3.5 w-3.5" />
+                {t("dashboardTitle")}
+              </div>
+              <div className="space-y-1">
+                <h2 className="font-semibold text-xl">{t("title")}</h2>
+                <p className="max-w-2xl text-muted-foreground text-sm">
+                  {signedIn ? t("dashboardDescription") : t("description")}
+                </p>
+              </div>
+              {data.notice?.message ? (
+                <p className="text-muted-foreground text-xs">
+                  {data.notice.url ? (
+                    <a
+                      href={data.notice.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="underline underline-offset-2"
+                    >
+                      {data.notice.message}
+                    </a>
+                  ) : (
+                    data.notice.message
+                  )}
+                </p>
+              ) : null}
             </div>
-            <div
-              className={cn(
-                "grid gap-4",
-                compact ? "lg:grid-cols-2" : "lg:grid-cols-3",
-              )}
-            >
-              {recommendedCards.map((match) => (
-                <div
-                  key={`recommended-${match.route.id}`}
-                  className="space-y-4 rounded-2xl border border-border bg-card px-5 py-5 shadow-xs"
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="outline" size="default" className="border-0">
+                {t("activeVersion")}: {data.version?.title ?? "—"}
+              </Badge>
+              <Badge variant="outline" size="default" className="border-0">
+                {data.todayType === "weekday"
+                  ? t("dayType.weekday")
+                  : t("dayType.weekend")}
+              </Badge>
+              {showPreferences ? (
+                <Button
+                  variant={showSettings ? "secondary" : "outline"}
+                  size="sm"
+                  onClick={() => setShowSettings((value) => !value)}
                 >
+                  <Settings2 className="h-4 w-4" />
+                  {showSettings ? t("hidePreferences") : t("editPreferences")}
+                </Button>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="mt-5 grid gap-3 md:grid-cols-4">
+            {topMetrics.map((item) => (
+              <div
+                key={item.label}
+                className="rounded-2xl border border-border/70 bg-background/80 px-4 py-3"
+              >
+                <p className="text-muted-foreground text-xs">{item.label}</p>
+                <p className="mt-1 font-medium text-sm">{item.value}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {showSettings && showPreferences ? (
+          <div className="border-border/70 border-b px-6 py-5">
+            <BusPreferenceForm
+              campuses={data.campuses}
+              preference={initialPreference ?? data.preferences}
+              signedIn={signedIn}
+            />
+          </div>
+        ) : null}
+
+        {data.matches.length === 0 ? (
+          <div className="px-6 py-12 text-center text-muted-foreground text-sm">
+            {t("query.empty")}
+          </div>
+        ) : (
+          <div className="space-y-6 px-6 py-6">
+            <section className="grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.85fr)]">
+              <div className="rounded-3xl border border-primary/20 bg-primary/5 p-5 shadow-xs">
+                <div className="mb-4 flex items-start justify-between gap-3">
                   <div className="space-y-1">
-                    <div className="flex items-center justify-between gap-2">
-                      <p className="font-semibold">
-                        {match.route.descriptionPrimary}
-                      </p>
-                      {data.recommended?.route.id === match.route.id ? (
-                        <span className="rounded-full bg-primary/10 px-2 py-0.5 text-primary text-xs">
-                          {t("bestMatch")}
-                        </span>
-                      ) : null}
+                    <div className="flex items-center gap-2">
+                      <Sparkles className="h-4 w-4 text-primary" />
+                      <h3 className="font-semibold text-base">
+                        {t("recommended.title")}
+                      </h3>
                     </div>
-                    <p className="text-muted-foreground text-xs">
-                      {match.route.descriptionSecondary ??
-                        `${match.originStop.campus.namePrimary} -> ${match.destinationStop.campus.namePrimary}`}
+                    <p className="text-muted-foreground text-sm">
+                      {t("recommended.description")}
                     </p>
                   </div>
-
-                  <div className="rounded-xl bg-muted/40 px-4 py-3">
-                    {match.nextTrip ? (
-                      <div className="space-y-1">
-                        <div className="flex items-center gap-2 text-muted-foreground text-xs">
-                          <Clock3 className="h-3.5 w-3.5" />
-                          <span>{t("nextDeparture")}</span>
-                        </div>
-                        <div className="flex items-end justify-between gap-3">
-                          <div>
-                            <p className="font-semibold text-2xl tabular-nums">
-                              {match.nextTrip.departureTime ?? "—"}
-                            </p>
-                            <p className="text-muted-foreground text-xs">
-                              {formatMinutes(
-                                match.nextTrip.minutesUntilDeparture,
-                              ) ?? t("noTime")}
-                            </p>
-                          </div>
-                          <div className="text-right text-xs">
-                            <p className="text-muted-foreground">
-                              {t("arriveAt")}
-                            </p>
-                            <p className="font-medium tabular-nums">
-                              {match.nextTrip.arrivalTime ?? "—"}
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    ) : (
-                      <div className="space-y-1">
-                        <p className="font-medium">{t("noMoreBusToday")}</p>
-                        <p className="text-muted-foreground text-xs">
-                          {t("switchVersionHint")}
-                        </p>
-                      </div>
-                    )}
-                  </div>
-
-                  <div className="space-y-2">
-                    <p className="font-medium text-sm">{t("upcomingTrips")}</p>
-                    <div className="space-y-2">
-                      {match.visibleTrips.slice(0, 4).map((trip) => (
-                        <div
-                          key={trip.id}
-                          className="flex items-center justify-between rounded-lg border border-border/80 px-3 py-2"
-                        >
-                          <div>
-                            <p className="font-medium text-sm tabular-nums">
-                              {trip.departureTime ?? "—"} {"->"}{" "}
-                              {trip.arrivalTime ?? "—"}
-                            </p>
-                            <p className="text-muted-foreground text-xs">
-                              {trip.stopTimes
-                                .map((stopTime) =>
-                                  stopTime.time
-                                    ? `${stopTime.campusName} ${stopTime.time}`
-                                    : `${stopTime.campusName} ${t("passThrough")}`,
-                                )
-                                .join(" / ")}
-                            </p>
-                          </div>
-                          {trip.status === "upcoming" ? (
-                            <span className="text-primary text-xs">
-                              {formatMinutes(trip.minutesUntilDeparture)}
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground text-xs">
-                              {t("departed")}
-                            </span>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
+                  {data.recommended ? (
+                    <Badge variant="default" size="sm">
+                      {t("bestMatch")}
+                    </Badge>
+                  ) : null}
                 </div>
-              ))}
-            </div>
-          </section>
 
-          <section className="space-y-3">
-            <h3 className="font-medium">{t("allRoutes.title")}</h3>
-            <div className="space-y-3">
-              {(compact ? data.matches.slice(0, 6) : data.matches).map(
-                (match) => (
-                  <details
-                    key={`all-${match.route.id}`}
-                    className="rounded-2xl border border-border bg-card px-4 py-3"
-                  >
-                    <summary className="cursor-pointer list-none">
-                      <div className="flex flex-wrap items-center justify-between gap-3">
+                {data.recommended ? (
+                  <div className="space-y-4">
+                    <div className="rounded-2xl border border-primary/20 bg-background px-4 py-4">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
                         <div>
-                          <p className="font-medium">
-                            {match.route.descriptionPrimary}
+                          <p className="font-semibold text-lg">
+                            {data.recommended.route.descriptionPrimary}
                           </p>
                           <p className="text-muted-foreground text-xs">
-                            {match.nextTrip?.departureTime
-                              ? `${t("nextDeparture")}: ${match.nextTrip.departureTime}`
-                              : t("noMoreBusToday")}
+                            {data.recommended.route.descriptionSecondary ??
+                              `${data.recommended.originStop.campus.namePrimary} -> ${data.recommended.destinationStop.campus.namePrimary}`}
                           </p>
                         </div>
-                        <div className="text-right text-xs">
-                          <p className="text-muted-foreground">
-                            {t("route.totalTrips", { count: match.totalTrips })}
+                        <Badge variant="outline" size="sm">
+                          <Route className="h-3.5 w-3.5" />
+                          {t("route.totalTrips", {
+                            count: data.recommended.totalTrips,
+                          })}
+                        </Badge>
+                      </div>
+
+                      <div className="mt-4 grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+                        <div>
+                          <p className="flex items-center gap-2 text-muted-foreground text-xs">
+                            <Clock3 className="h-3.5 w-3.5" />
+                            {t("recommended.nextTrip")}
                           </p>
-                          <p>
+                          <p className="mt-1 font-semibold text-4xl tabular-nums">
+                            {data.recommended.nextTrip?.departureTime ?? "—"}
+                          </p>
+                          <p className="mt-1 text-primary text-sm">
+                            {formatMinutes(
+                              data.recommended.nextTrip
+                                ?.minutesUntilDeparture ?? null,
+                            ) ?? t("recommended.noUpcoming")}
+                          </p>
+                        </div>
+
+                        <div className="rounded-2xl bg-muted/40 px-4 py-3 text-right">
+                          <p className="text-muted-foreground text-xs">
+                            {t("recommended.arrive")}
+                          </p>
+                          <p className="font-medium text-lg tabular-nums">
+                            {data.recommended.nextTrip?.arrivalTime ?? "—"}
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between gap-2">
+                        <p className="font-medium text-sm">
+                          {t("upcomingTrips")}
+                        </p>
+                        <p className="text-muted-foreground text-xs">
+                          {t("route.upcomingTrips", {
+                            count: data.recommended.upcomingTrips.length,
+                          })}
+                        </p>
+                      </div>
+                      <div className="space-y-2">
+                        {data.recommended.visibleTrips
+                          .slice(0, compact ? 2 : 3)
+                          .map((trip) => (
+                            <div
+                              key={trip.id}
+                              className="rounded-2xl border border-border bg-background px-4 py-3"
+                            >
+                              <div className="flex items-start justify-between gap-3">
+                                <div className="min-w-0">
+                                  <p className="font-medium text-sm tabular-nums">
+                                    {trip.departureTime ?? "—"} {"->"}{" "}
+                                    {trip.arrivalTime ?? "—"}
+                                  </p>
+                                  <p className="mt-1 line-clamp-2 text-muted-foreground text-xs">
+                                    {trip.stopTimes
+                                      .map((stopTime) =>
+                                        stopTime.time
+                                          ? `${stopTime.campusName} ${stopTime.time}`
+                                          : `${stopTime.campusName} ${t("passThrough")}`,
+                                      )
+                                      .join(" / ")}
+                                  </p>
+                                </div>
+                                <Badge
+                                  variant={
+                                    trip.status === "upcoming"
+                                      ? "success"
+                                      : "outline"
+                                  }
+                                  size="sm"
+                                >
+                                  {trip.status === "upcoming"
+                                    ? formatMinutes(trip.minutesUntilDeparture)
+                                    : t("departed")}
+                                </Badge>
+                              </div>
+                            </div>
+                          ))}
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="rounded-2xl border border-border border-dashed bg-background px-6 py-10 text-center text-muted-foreground text-sm">
+                    {t("recommended.noUpcoming")}
+                  </div>
+                )}
+              </div>
+
+              {!compact && alternativeMatches.length > 0 ? (
+                <div className="space-y-3 rounded-3xl border border-border bg-card p-5 shadow-xs">
+                  <div className="flex items-center gap-2">
+                    <Star className="h-4 w-4 text-primary" />
+                    <h3 className="font-semibold text-base">
+                      {t("allRoutes.title")}
+                    </h3>
+                  </div>
+                  <p className="text-muted-foreground text-sm">
+                    {t("allRoutes.description")}
+                  </p>
+                  <div className="space-y-3">
+                    {alternativeMatches.map((match) => (
+                      <div
+                        key={`alternative-${match.route.id}`}
+                        className="rounded-2xl border border-border/80 px-4 py-3"
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="font-medium text-sm">
+                              {match.route.descriptionPrimary}
+                            </p>
+                            <p className="text-muted-foreground text-xs">
+                              {match.nextTrip?.departureTime
+                                ? `${t("nextDeparture")}: ${match.nextTrip.departureTime}`
+                                : t("noMoreBusToday")}
+                            </p>
+                          </div>
+                          <Badge variant="outline" size="sm">
                             {match.upcomingTrips.length > 0
                               ? t("route.upcomingTrips", {
                                   count: match.upcomingTrips.length,
                                 })
                               : t("recommended.departed")}
-                          </p>
+                          </Badge>
                         </div>
                       </div>
-                    </summary>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </section>
 
-                    <div className="mt-4 space-y-2">
-                      {match.allTrips.map((trip) => (
-                        <div
-                          key={`trip-${trip.id}`}
-                          className="rounded-lg border border-border/80 px-3 py-2"
-                        >
-                          <div className="flex items-center justify-between gap-3">
-                            <p className="font-medium text-sm tabular-nums">
-                              {trip.departureTime ?? "—"} {"->"}{" "}
-                              {trip.arrivalTime ?? "—"}
-                            </p>
-                            <span
-                              className={cn(
-                                "text-xs",
-                                trip.status === "upcoming"
-                                  ? "text-primary"
-                                  : "text-muted-foreground",
-                              )}
-                            >
-                              {trip.status === "upcoming"
-                                ? formatMinutes(trip.minutesUntilDeparture)
-                                : t("departed")}
-                            </span>
+            {shouldShowAllRoutes ? (
+              <section className="space-y-3">
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <h3 className="font-semibold text-base">
+                      {t("allRoutes.title")}
+                    </h3>
+                    <p className="text-muted-foreground text-sm">
+                      {t("allRoutes.description")}
+                    </p>
+                  </div>
+                  <Badge variant="outline" size="sm">
+                    {t("route.totalTrips", { count: data.matches.length })}
+                  </Badge>
+                </div>
+
+                <div className="space-y-3">
+                  {(compact ? data.matches.slice(0, 6) : data.matches).map(
+                    (match) => (
+                      <details
+                        key={`all-${match.route.id}`}
+                        className="group overflow-hidden rounded-2xl border border-border bg-card shadow-xs"
+                      >
+                        <summary className="cursor-pointer list-none px-4 py-4 transition-colors hover:bg-accent/30">
+                          <div className="flex flex-wrap items-center justify-between gap-3">
+                            <div className="flex items-start gap-3">
+                              <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
+                              <div>
+                                <p className="font-medium">
+                                  {match.route.descriptionPrimary}
+                                </p>
+                                <p className="text-muted-foreground text-xs">
+                                  {match.nextTrip?.departureTime
+                                    ? `${t("nextDeparture")}: ${match.nextTrip.departureTime}`
+                                    : t("noMoreBusToday")}
+                                </p>
+                              </div>
+                            </div>
+
+                            <div className="text-right text-xs">
+                              <p className="text-muted-foreground">
+                                {t("route.totalTrips", {
+                                  count: match.totalTrips,
+                                })}
+                              </p>
+                              <p>
+                                {match.upcomingTrips.length > 0
+                                  ? t("route.upcomingTrips", {
+                                      count: match.upcomingTrips.length,
+                                    })
+                                  : t("recommended.departed")}
+                              </p>
+                            </div>
                           </div>
-                          <p className="mt-1 text-muted-foreground text-xs">
-                            {trip.stopTimes
-                              .map((stopTime) =>
-                                stopTime.time
-                                  ? `${stopTime.campusName} ${stopTime.time}`
-                                  : `${stopTime.campusName} ${t("passThrough")}`,
-                              )
-                              .join(" / ")}
-                          </p>
+                        </summary>
+
+                        <div className="border-border/70 border-t bg-muted/10 px-4 py-4">
+                          <div className="space-y-2">
+                            {match.allTrips.map((trip) => (
+                              <div
+                                key={`trip-${trip.id}`}
+                                className="rounded-xl border border-border/70 bg-background px-4 py-3"
+                              >
+                                <div className="flex items-start justify-between gap-3">
+                                  <div className="min-w-0">
+                                    <p className="font-medium text-sm tabular-nums">
+                                      {trip.departureTime ?? "—"} {"->"}{" "}
+                                      {trip.arrivalTime ?? "—"}
+                                    </p>
+                                    <p className="mt-1 line-clamp-2 text-muted-foreground text-xs">
+                                      {trip.stopTimes
+                                        .map((stopTime) =>
+                                          stopTime.time
+                                            ? `${stopTime.campusName} ${stopTime.time}`
+                                            : `${stopTime.campusName} ${t("passThrough")}`,
+                                        )
+                                        .join(" / ")}
+                                    </p>
+                                  </div>
+                                  <Badge
+                                    variant={
+                                      trip.status === "upcoming"
+                                        ? "success"
+                                        : "outline"
+                                    }
+                                    size="sm"
+                                  >
+                                    {trip.status === "upcoming"
+                                      ? formatMinutes(
+                                          trip.minutesUntilDeparture,
+                                        )
+                                      : t("departed")}
+                                  </Badge>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
                         </div>
-                      ))}
-                    </div>
-                  </details>
-                ),
-              )}
-            </div>
-          </section>
-        </>
-      )}
+                      </details>
+                    ),
+                  )}
+                </div>
+              </section>
+            ) : null}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/features/bus/components/bus-panel.tsx
+++ b/src/features/bus/components/bus-panel.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { Bus, Clock3, Settings2, Star } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useMemo, useState } from "react";
+import { BusPreferenceForm } from "@/features/bus/components/bus-preference-form";
+import type { BusQueryResult } from "@/features/bus/lib/bus-types";
+import { cn } from "@/shared/lib/utils";
+
+function formatMinutes(minutes: number | null) {
+  if (minutes == null) return null;
+  if (minutes <= 0) return "即将发车";
+  if (minutes < 60) return `${minutes} 分钟后`;
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  return rest === 0 ? `${hours} 小时后` : `${hours} 小时 ${rest} 分钟后`;
+}
+
+type BusPanelProps = {
+  data: BusQueryResult;
+  signedIn?: boolean;
+  initialPreference?: BusQueryResult["preferences"] | null;
+  showPreferences?: boolean;
+  compact?: boolean;
+  className?: string;
+};
+
+export function BusPanel({
+  data,
+  signedIn = false,
+  initialPreference = null,
+  showPreferences = false,
+  compact = false,
+  className,
+}: BusPanelProps) {
+  const t = useTranslations("bus");
+  const [showSettings, setShowSettings] = useState(false);
+
+  const recommendedCards = useMemo(
+    () =>
+      data.recommended
+        ? [
+            data.recommended,
+            ...data.matches.filter(
+              (item) => item.route.id !== data.recommended?.route.id,
+            ),
+          ].slice(0, 3)
+        : data.matches.slice(0, 3),
+    [data.matches, data.recommended],
+  );
+
+  return (
+    <div className={cn("space-y-6", className)}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Bus className="h-5 w-5 text-primary" />
+            <h2 className="font-semibold text-lg">{t("title")}</h2>
+          </div>
+          <p className="text-muted-foreground text-sm">
+            {t("subtitle", {
+              dayType:
+                data.todayType === "weekday" ? t("weekday") : t("weekend"),
+            })}
+          </p>
+          {data.notice?.message ? (
+            <p className="text-muted-foreground text-xs">
+              {data.notice.url ? (
+                <a
+                  href={data.notice.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  {data.notice.message}
+                </a>
+              ) : (
+                data.notice.message
+              )}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded-full border border-border px-3 py-1 text-muted-foreground text-xs">
+            {t("activeVersion")}: {data.version?.title ?? "—"}
+          </span>
+          {showPreferences ? (
+            <button
+              type="button"
+              onClick={() => setShowSettings((value) => !value)}
+              className="inline-flex items-center gap-2 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent"
+            >
+              <Settings2 className="h-4 w-4" />
+              {showSettings ? t("hidePreferences") : t("editPreferences")}
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {showSettings && showPreferences ? (
+        <BusPreferenceForm
+          campuses={data.campuses}
+          preference={initialPreference ?? data.preferences}
+          signedIn={signedIn}
+        />
+      ) : null}
+
+      {data.matches.length === 0 ? (
+        <div className="rounded-2xl border border-border border-dashed px-6 py-10 text-center text-muted-foreground text-sm">
+          {t("empty")}
+        </div>
+      ) : (
+        <>
+          <section className="space-y-3">
+            <div className="flex items-center gap-2">
+              <Star className="h-4 w-4 text-primary" />
+              <h3 className="font-medium">{t("recommended.title")}</h3>
+            </div>
+            <div
+              className={cn(
+                "grid gap-4",
+                compact ? "lg:grid-cols-2" : "lg:grid-cols-3",
+              )}
+            >
+              {recommendedCards.map((match) => (
+                <div
+                  key={`recommended-${match.route.id}`}
+                  className="space-y-4 rounded-2xl border border-border bg-card px-5 py-5 shadow-xs"
+                >
+                  <div className="space-y-1">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="font-semibold">
+                        {match.route.descriptionPrimary}
+                      </p>
+                      {data.recommended?.route.id === match.route.id ? (
+                        <span className="rounded-full bg-primary/10 px-2 py-0.5 text-primary text-xs">
+                          {t("bestMatch")}
+                        </span>
+                      ) : null}
+                    </div>
+                    <p className="text-muted-foreground text-xs">
+                      {match.route.descriptionSecondary ??
+                        `${match.originStop.campus.namePrimary} -> ${match.destinationStop.campus.namePrimary}`}
+                    </p>
+                  </div>
+
+                  <div className="rounded-xl bg-muted/40 px-4 py-3">
+                    {match.nextTrip ? (
+                      <div className="space-y-1">
+                        <div className="flex items-center gap-2 text-muted-foreground text-xs">
+                          <Clock3 className="h-3.5 w-3.5" />
+                          <span>{t("nextDeparture")}</span>
+                        </div>
+                        <div className="flex items-end justify-between gap-3">
+                          <div>
+                            <p className="font-semibold text-2xl tabular-nums">
+                              {match.nextTrip.departureTime ?? "—"}
+                            </p>
+                            <p className="text-muted-foreground text-xs">
+                              {formatMinutes(
+                                match.nextTrip.minutesUntilDeparture,
+                              ) ?? t("noTime")}
+                            </p>
+                          </div>
+                          <div className="text-right text-xs">
+                            <p className="text-muted-foreground">
+                              {t("arriveAt")}
+                            </p>
+                            <p className="font-medium tabular-nums">
+                              {match.nextTrip.arrivalTime ?? "—"}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="space-y-1">
+                        <p className="font-medium">{t("noMoreBusToday")}</p>
+                        <p className="text-muted-foreground text-xs">
+                          {t("switchVersionHint")}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <p className="font-medium text-sm">{t("upcomingTrips")}</p>
+                    <div className="space-y-2">
+                      {match.visibleTrips.slice(0, 4).map((trip) => (
+                        <div
+                          key={trip.id}
+                          className="flex items-center justify-between rounded-lg border border-border/80 px-3 py-2"
+                        >
+                          <div>
+                            <p className="font-medium text-sm tabular-nums">
+                              {trip.departureTime ?? "—"} {"->"}{" "}
+                              {trip.arrivalTime ?? "—"}
+                            </p>
+                            <p className="text-muted-foreground text-xs">
+                              {trip.stopTimes
+                                .map((stopTime) =>
+                                  stopTime.time
+                                    ? `${stopTime.campusName} ${stopTime.time}`
+                                    : `${stopTime.campusName} ${t("passThrough")}`,
+                                )
+                                .join(" / ")}
+                            </p>
+                          </div>
+                          {trip.status === "upcoming" ? (
+                            <span className="text-primary text-xs">
+                              {formatMinutes(trip.minutesUntilDeparture)}
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground text-xs">
+                              {t("departed")}
+                            </span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="font-medium">{t("allRoutes.title")}</h3>
+            <div className="space-y-3">
+              {(compact ? data.matches.slice(0, 6) : data.matches).map(
+                (match) => (
+                  <details
+                    key={`all-${match.route.id}`}
+                    className="rounded-2xl border border-border bg-card px-4 py-3"
+                  >
+                    <summary className="cursor-pointer list-none">
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div>
+                          <p className="font-medium">
+                            {match.route.descriptionPrimary}
+                          </p>
+                          <p className="text-muted-foreground text-xs">
+                            {match.nextTrip?.departureTime
+                              ? `${t("nextDeparture")}: ${match.nextTrip.departureTime}`
+                              : t("noMoreBusToday")}
+                          </p>
+                        </div>
+                        <div className="text-right text-xs">
+                          <p className="text-muted-foreground">
+                            {t("route.totalTrips", { count: match.totalTrips })}
+                          </p>
+                          <p>
+                            {match.upcomingTrips.length > 0
+                              ? t("route.upcomingTrips", {
+                                  count: match.upcomingTrips.length,
+                                })
+                              : t("recommended.departed")}
+                          </p>
+                        </div>
+                      </div>
+                    </summary>
+
+                    <div className="mt-4 space-y-2">
+                      {match.allTrips.map((trip) => (
+                        <div
+                          key={`trip-${trip.id}`}
+                          className="rounded-lg border border-border/80 px-3 py-2"
+                        >
+                          <div className="flex items-center justify-between gap-3">
+                            <p className="font-medium text-sm tabular-nums">
+                              {trip.departureTime ?? "—"} {"->"}{" "}
+                              {trip.arrivalTime ?? "—"}
+                            </p>
+                            <span
+                              className={cn(
+                                "text-xs",
+                                trip.status === "upcoming"
+                                  ? "text-primary"
+                                  : "text-muted-foreground",
+                              )}
+                            >
+                              {trip.status === "upcoming"
+                                ? formatMinutes(trip.minutesUntilDeparture)
+                                : t("departed")}
+                            </span>
+                          </div>
+                          <p className="mt-1 text-muted-foreground text-xs">
+                            {trip.stopTimes
+                              .map((stopTime) =>
+                                stopTime.time
+                                  ? `${stopTime.campusName} ${stopTime.time}`
+                                  : `${stopTime.campusName} ${t("passThrough")}`,
+                              )
+                              .join(" / ")}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  </details>
+                ),
+              )}
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/features/bus/components/bus-preference-form.tsx
+++ b/src/features/bus/components/bus-preference-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ChevronDown } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
@@ -65,6 +66,12 @@ export function BusPreferenceForm({
   );
   const [showDepartedTrips, setShowDepartedTrips] = useState(
     preference?.showDepartedTrips ?? false,
+  );
+  const [showAdvanced, setShowAdvanced] = useState(
+    Boolean(
+      preference?.favoriteCampusIds.length ||
+        preference?.favoriteRouteIds.length,
+    ),
   );
 
   if (!signedIn) {
@@ -173,32 +180,6 @@ export function BusPreferenceForm({
         </div>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="space-y-2">
-          <Label htmlFor="bus-favorite-campus-ids">
-            {t("preferences.favoriteCampuses")}
-          </Label>
-          <Input
-            id="bus-favorite-campus-ids"
-            value={favoriteCampusIdsText}
-            onChange={(event) => setFavoriteCampusIdsText(event.target.value)}
-            placeholder={t("preferences.idsPlaceholder")}
-          />
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="bus-favorite-route-ids">
-            {t("preferences.favoriteRoutes")}
-          </Label>
-          <Input
-            id="bus-favorite-route-ids"
-            value={favoriteRouteIdsText}
-            onChange={(event) => setFavoriteRouteIdsText(event.target.value)}
-            placeholder={t("preferences.idsPlaceholder")}
-          />
-        </div>
-      </div>
-
       <div className="flex items-center justify-between rounded-xl border border-border px-4 py-3">
         <div className="space-y-1">
           <p className="font-medium text-sm">
@@ -213,6 +194,57 @@ export function BusPreferenceForm({
           onCheckedChange={(checked) => setShowDepartedTrips(Boolean(checked))}
           aria-label={t("preferences.showDepartedTrips")}
         />
+      </div>
+
+      <div className="rounded-xl border border-border/80 bg-muted/20">
+        <button
+          type="button"
+          onClick={() => setShowAdvanced((value) => !value)}
+          className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left"
+        >
+          <div className="space-y-1">
+            <p className="font-medium text-sm">
+              {t("preferences.favoriteRoutes")}
+            </p>
+            <p className="text-muted-foreground text-xs">
+              {t("preferences.idsPlaceholder")}
+            </p>
+          </div>
+          <ChevronDown
+            className={`h-4 w-4 text-muted-foreground transition-transform ${showAdvanced ? "rotate-180" : ""}`}
+          />
+        </button>
+        {showAdvanced ? (
+          <div className="grid gap-4 border-border/80 border-t px-4 py-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="bus-favorite-campus-ids">
+                {t("preferences.favoriteCampuses")}
+              </Label>
+              <Input
+                id="bus-favorite-campus-ids"
+                value={favoriteCampusIdsText}
+                onChange={(event) =>
+                  setFavoriteCampusIdsText(event.target.value)
+                }
+                placeholder={t("preferences.idsPlaceholder")}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="bus-favorite-route-ids">
+                {t("preferences.favoriteRoutes")}
+              </Label>
+              <Input
+                id="bus-favorite-route-ids"
+                value={favoriteRouteIdsText}
+                onChange={(event) =>
+                  setFavoriteRouteIdsText(event.target.value)
+                }
+                placeholder={t("preferences.idsPlaceholder")}
+              />
+            </div>
+          </div>
+        ) : null}
       </div>
 
       {(error || success) && (

--- a/src/features/bus/components/bus-preference-form.tsx
+++ b/src/features/bus/components/bus-preference-form.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import type {
+  BusCampusSummary,
+  BusUserPreferenceSummary,
+} from "@/features/bus/lib/bus-types";
+import { extractApiErrorMessage } from "@/lib/api/client";
+
+type BusPreferenceFormProps = {
+  campuses: BusCampusSummary[];
+  preference: BusUserPreferenceSummary | null;
+  signedIn: boolean;
+  onSaved?: (nextPreference: BusUserPreferenceSummary) => void;
+};
+
+function parseIdList(value: string) {
+  return Array.from(
+    new Set(
+      value
+        .split(/[,\s]+/)
+        .map((entry) => Number.parseInt(entry, 10))
+        .filter((entry) => Number.isInteger(entry)),
+    ),
+  );
+}
+
+export function BusPreferenceForm({
+  campuses,
+  preference,
+  signedIn,
+  onSaved,
+}: BusPreferenceFormProps) {
+  const t = useTranslations("bus");
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [originCampusId, setOriginCampusId] = useState(
+    preference?.preferredOriginCampusId
+      ? String(preference.preferredOriginCampusId)
+      : "",
+  );
+  const [destinationCampusId, setDestinationCampusId] = useState(
+    preference?.preferredDestinationCampusId
+      ? String(preference.preferredDestinationCampusId)
+      : "",
+  );
+  const [favoriteCampusIdsText, setFavoriteCampusIdsText] = useState(
+    preference?.favoriteCampusIds.join(", ") ?? "",
+  );
+  const [favoriteRouteIdsText, setFavoriteRouteIdsText] = useState(
+    preference?.favoriteRouteIds.join(", ") ?? "",
+  );
+  const [showDepartedTrips, setShowDepartedTrips] = useState(
+    preference?.showDepartedTrips ?? false,
+  );
+
+  if (!signedIn) {
+    return (
+      <div className="rounded-xl border border-border border-dashed px-4 py-3 text-muted-foreground text-sm">
+        {t("preferences.signInHint")}
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        setError(null);
+        setSuccess(null);
+
+        startTransition(async () => {
+          const response = await fetch("/api/bus/preferences", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              preferredOriginCampusId: originCampusId
+                ? Number.parseInt(originCampusId, 10)
+                : null,
+              preferredDestinationCampusId: destinationCampusId
+                ? Number.parseInt(destinationCampusId, 10)
+                : null,
+              favoriteCampusIds: parseIdList(favoriteCampusIdsText),
+              favoriteRouteIds: parseIdList(favoriteRouteIdsText),
+              showDepartedTrips,
+            }),
+          });
+
+          let body: unknown = null;
+          try {
+            body = await response.json();
+          } catch {
+            body = null;
+          }
+
+          if (!response.ok) {
+            setError(
+              extractApiErrorMessage(body) ?? t("preferences.saveFailed"),
+            );
+            return;
+          }
+
+          const nextPreference = (
+            body as { preference?: BusUserPreferenceSummary }
+          ).preference;
+          if (!nextPreference) {
+            setError(t("preferences.saveFailed"));
+            return;
+          }
+
+          setSuccess(t("preferences.saved"));
+          onSaved?.(nextPreference);
+        });
+      }}
+    >
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="bus-origin-select">{t("preferences.origin")}</Label>
+          <Select
+            value={originCampusId}
+            onValueChange={(value) => setOriginCampusId(value ?? "")}
+          >
+            <SelectTrigger id="bus-origin-select">
+              <SelectValue placeholder={t("preferences.unset")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">{t("preferences.unset")}</SelectItem>
+              {campuses.map((campus) => (
+                <SelectItem key={campus.id} value={String(campus.id)}>
+                  {campus.namePrimary}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="bus-destination-select">
+            {t("preferences.destination")}
+          </Label>
+          <Select
+            value={destinationCampusId}
+            onValueChange={(value) => setDestinationCampusId(value ?? "")}
+          >
+            <SelectTrigger id="bus-destination-select">
+              <SelectValue placeholder={t("preferences.unset")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">{t("preferences.unset")}</SelectItem>
+              {campuses.map((campus) => (
+                <SelectItem key={campus.id} value={String(campus.id)}>
+                  {campus.namePrimary}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="bus-favorite-campus-ids">
+            {t("preferences.favoriteCampuses")}
+          </Label>
+          <Input
+            id="bus-favorite-campus-ids"
+            value={favoriteCampusIdsText}
+            onChange={(event) => setFavoriteCampusIdsText(event.target.value)}
+            placeholder={t("preferences.idsPlaceholder")}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="bus-favorite-route-ids">
+            {t("preferences.favoriteRoutes")}
+          </Label>
+          <Input
+            id="bus-favorite-route-ids"
+            value={favoriteRouteIdsText}
+            onChange={(event) => setFavoriteRouteIdsText(event.target.value)}
+            placeholder={t("preferences.idsPlaceholder")}
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between rounded-xl border border-border px-4 py-3">
+        <div className="space-y-1">
+          <p className="font-medium text-sm">
+            {t("preferences.showDepartedTrips")}
+          </p>
+          <p className="text-muted-foreground text-xs">
+            {t("preferences.showDepartedTripsHint")}
+          </p>
+        </div>
+        <Switch
+          checked={showDepartedTrips}
+          onCheckedChange={(checked) => setShowDepartedTrips(Boolean(checked))}
+          aria-label={t("preferences.showDepartedTrips")}
+        />
+      </div>
+
+      {(error || success) && (
+        <p className={`text-sm ${error ? "text-destructive" : "text-primary"}`}>
+          {error ?? success}
+        </p>
+      )}
+
+      <Button type="submit" disabled={isPending}>
+        {isPending ? t("preferences.saving") : t("preferences.save")}
+      </Button>
+    </form>
+  );
+}

--- a/src/features/bus/lib/bus-import.ts
+++ b/src/features/bus/lib/bus-import.ts
@@ -1,0 +1,259 @@
+import { createHash } from "node:crypto";
+import type { PrismaClient } from "@/generated/prisma/client";
+import type {
+  BusImportResult,
+  BusStaticCampus,
+  BusStaticPayload,
+  BusStaticRouteSchedule,
+} from "./bus-types";
+
+function checksumPayload(payload: BusStaticPayload) {
+  return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+}
+
+function inferVersionKey(
+  payload: BusStaticPayload,
+  explicitKey?: string | null,
+) {
+  if (explicitKey?.trim()) {
+    return explicitKey.trim();
+  }
+
+  const message = payload.message?.message?.trim();
+  const yearSeason = message?.match(/(\d{4})\s*([春夏秋冬])/);
+  if (yearSeason) {
+    return `static-bus-${yearSeason[1]}-${yearSeason[2]}`;
+  }
+
+  return `static-bus-${new Date().toISOString().slice(0, 10)}`;
+}
+
+function inferVersionTitle(
+  payload: BusStaticPayload,
+  explicitTitle?: string | null,
+) {
+  if (explicitTitle?.trim()) {
+    return explicitTitle.trim();
+  }
+  return payload.message?.message?.trim() || "Life@USTC 校车时刻表";
+}
+
+function inferEffectiveFrom(
+  payload: BusStaticPayload,
+  explicitEffectiveFrom?: Date | null,
+) {
+  if (explicitEffectiveFrom) return explicitEffectiveFrom;
+
+  const message = payload.message?.message?.trim();
+  const yearSeason = message?.match(/(\d{4})\s*([春夏秋冬])/);
+  if (!yearSeason) return null;
+
+  const year = Number.parseInt(yearSeason[1], 10);
+  const season = yearSeason[2];
+  const month =
+    season === "春" ? 2 : season === "夏" ? 6 : season === "秋" ? 9 : 12;
+
+  return new Date(Date.UTC(year, month - 1, 1));
+}
+
+function normalizeCampusName(name: string) {
+  return name.trim();
+}
+
+function buildRouteEnglishName(campuses: BusStaticCampus[]) {
+  const start = campuses[0]?.name ?? "";
+  const end = campuses[campuses.length - 1]?.name ?? "";
+  return start && end ? `${start} to ${end}` : null;
+}
+
+function assertRouteConsistency(payload: BusStaticPayload) {
+  const routeIds = new Set(payload.routes.map((route) => route.id));
+  for (const schedule of [
+    ...payload.weekday_routes,
+    ...payload.weekend_routes,
+  ]) {
+    if (!routeIds.has(schedule.route.id)) {
+      throw new Error(
+        `Unknown route id ${schedule.route.id} in schedule table`,
+      );
+    }
+  }
+}
+
+async function upsertCampuses(prisma: PrismaClient, payload: BusStaticPayload) {
+  for (const campus of payload.campuses) {
+    await prisma.busCampus.upsert({
+      where: { id: campus.id },
+      update: {
+        nameCn: normalizeCampusName(campus.name),
+        latitude: campus.latitude,
+        longitude: campus.longitude,
+      },
+      create: {
+        id: campus.id,
+        nameCn: normalizeCampusName(campus.name),
+        latitude: campus.latitude,
+        longitude: campus.longitude,
+      },
+    });
+  }
+}
+
+async function upsertRoutes(prisma: PrismaClient, payload: BusStaticPayload) {
+  for (const route of payload.routes) {
+    await prisma.busRoute.upsert({
+      where: { id: route.id },
+      update: {
+        nameCn: route.campuses.map((campus) => campus.name).join(" -> "),
+        nameEn: buildRouteEnglishName(route.campuses),
+      },
+      create: {
+        id: route.id,
+        nameCn: route.campuses.map((campus) => campus.name).join(" -> "),
+        nameEn: buildRouteEnglishName(route.campuses),
+      },
+    });
+
+    await prisma.busRouteStop.deleteMany({
+      where: { routeId: route.id },
+    });
+
+    await prisma.busRouteStop.createMany({
+      data: route.campuses.map((campus, index) => ({
+        routeId: route.id,
+        campusId: campus.id,
+        stopOrder: index,
+      })),
+    });
+  }
+}
+
+async function createTripsForDayType(
+  prisma: PrismaClient,
+  versionId: number,
+  dayType: "weekday" | "weekend",
+  schedules: BusStaticRouteSchedule[],
+) {
+  let trips = 0;
+
+  for (const schedule of schedules) {
+    for (let position = 0; position < schedule.time.length; position += 1) {
+      await prisma.busTrip.create({
+        data: {
+          versionId,
+          routeId: schedule.route.id,
+          dayType,
+          position,
+          stopTimes: schedule.time[position],
+        },
+      });
+      trips += 1;
+    }
+  }
+
+  return trips;
+}
+
+export async function importBusStaticPayload(
+  prisma: PrismaClient,
+  payload: BusStaticPayload,
+  options?: {
+    versionKey?: string | null;
+    versionTitle?: string | null;
+    effectiveFrom?: Date | null;
+    effectiveUntil?: Date | null;
+    disablePreviousVersions?: boolean;
+  },
+): Promise<BusImportResult> {
+  assertRouteConsistency(payload);
+
+  const checksum = checksumPayload(payload);
+  const versionKey = inferVersionKey(payload, options?.versionKey);
+  const versionTitle = inferVersionTitle(payload, options?.versionTitle);
+  const effectiveFrom = inferEffectiveFrom(payload, options?.effectiveFrom);
+  const effectiveUntil = options?.effectiveUntil ?? null;
+
+  const existing = await prisma.busScheduleVersion.findFirst({
+    where: {
+      OR: [{ key: versionKey }, { checksum }],
+    },
+    select: { id: true },
+  });
+
+  if (existing) {
+    await prisma.busTrip.deleteMany({ where: { versionId: existing.id } });
+    await prisma.busScheduleVersion.update({
+      where: { id: existing.id },
+      data: {
+        key: versionKey,
+        title: versionTitle,
+        checksum,
+        sourceMessage: payload.message?.message?.trim() || null,
+        sourceUrl: payload.message?.url?.trim() || null,
+        rawJson: payload,
+        effectiveFrom,
+        effectiveUntil,
+        isEnabled: true,
+      },
+    });
+  }
+
+  if (options?.disablePreviousVersions !== false) {
+    await prisma.busScheduleVersion.updateMany({
+      where: existing
+        ? { id: { not: existing.id } }
+        : { key: { not: versionKey } },
+      data: { isEnabled: false },
+    });
+  }
+
+  await upsertCampuses(prisma, payload);
+  await upsertRoutes(prisma, payload);
+
+  const version =
+    existing != null
+      ? await prisma.busScheduleVersion.update({
+          where: { id: existing.id },
+          data: {
+            importedAt: new Date(),
+          },
+          select: { id: true, key: true },
+        })
+      : await prisma.busScheduleVersion.create({
+          data: {
+            key: versionKey,
+            title: versionTitle,
+            checksum,
+            sourceMessage: payload.message?.message?.trim() || null,
+            sourceUrl: payload.message?.url?.trim() || null,
+            rawJson: payload,
+            effectiveFrom,
+            effectiveUntil,
+            isEnabled: true,
+          },
+          select: { id: true, key: true },
+        });
+
+  const [weekdayTrips, weekendTrips] = await Promise.all([
+    createTripsForDayType(
+      prisma,
+      version.id,
+      "weekday",
+      payload.weekday_routes,
+    ),
+    createTripsForDayType(
+      prisma,
+      version.id,
+      "weekend",
+      payload.weekend_routes,
+    ),
+  ]);
+
+  return {
+    versionId: version.id,
+    versionKey: version.key,
+    campuses: payload.campuses.length,
+    routes: payload.routes.length,
+    trips: weekdayTrips + weekendTrips,
+  };
+}

--- a/src/features/bus/lib/bus-service.ts
+++ b/src/features/bus/lib/bus-service.ts
@@ -1,0 +1,522 @@
+import type { AppLocale } from "@/i18n/config";
+import { getPrisma, prisma } from "@/lib/db/prisma";
+import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
+import type {
+  BusCampusSummary,
+  BusDashboardSnapshot,
+  BusPreferencePayload,
+  BusQueryInput,
+  BusQueryResult,
+  BusResolvedDayType,
+  BusRouteMatch,
+  BusRouteStopSummary,
+  BusRouteSummary,
+  BusTripStopTime,
+  BusTripSummary,
+  BusUserPreferenceSummary,
+} from "./bus-types";
+
+type RouteRecord = {
+  id: number;
+  nameCn: string;
+  nameEn: string | null;
+  stops: BusRouteStopSummary[];
+};
+
+function uniqueNumbers(values: number[]) {
+  return Array.from(new Set(values.filter((value) => Number.isInteger(value))));
+}
+
+function hhmmToMinutes(value: string | null) {
+  if (!value) return null;
+  const [hourText, minuteText] = value.split(":");
+  const hour = Number.parseInt(hourText ?? "", 10);
+  const minute = Number.parseInt(minuteText ?? "", 10);
+  if (Number.isNaN(hour) || Number.isNaN(minute)) return null;
+  return hour * 60 + minute;
+}
+
+function resolveBusDayType(
+  inputDayType: BusResolvedDayType | undefined,
+  now = shanghaiDayjs(),
+): "weekday" | "weekend" {
+  if (inputDayType === "weekday" || inputDayType === "weekend") {
+    return inputDayType;
+  }
+  const day = now.day();
+  return day === 0 || day === 6 ? "weekend" : "weekday";
+}
+
+function toDateKey(value: Date | null | undefined) {
+  return value ? value.toISOString().slice(0, 10) : null;
+}
+
+function isVersionEffectiveOn(
+  version: { effectiveFrom: Date | null; effectiveUntil: Date | null },
+  dateKey: string,
+) {
+  const from = toDateKey(version.effectiveFrom);
+  const until = toDateKey(version.effectiveUntil);
+  if (from && dateKey < from) return false;
+  if (until && dateKey > until) return false;
+  return true;
+}
+
+function describeRoute(
+  locale: AppLocale,
+  stops: BusRouteStopSummary[],
+): { descriptionPrimary: string; descriptionSecondary: string | null } {
+  const primaryNames = stops.map((stop) => stop.campus.namePrimary);
+  const secondaryNames = stops
+    .map((stop) => stop.campus.nameSecondary)
+    .filter((name): name is string => Boolean(name));
+
+  return {
+    descriptionPrimary: primaryNames.join(" -> "),
+    descriptionSecondary:
+      locale === "en-us" && secondaryNames.length === stops.length
+        ? secondaryNames.join(" -> ")
+        : locale === "zh-cn" && secondaryNames.length === stops.length
+          ? secondaryNames.join(" -> ")
+          : null,
+  };
+}
+
+function buildRouteSummary(
+  locale: AppLocale,
+  route: RouteRecord,
+): BusRouteSummary | null {
+  if (route.stops.length < 2) return null;
+  const description = describeRoute(locale, route.stops);
+  return {
+    id: route.id,
+    nameCn: route.nameCn,
+    nameEn: route.nameEn,
+    descriptionPrimary: description.descriptionPrimary,
+    descriptionSecondary: description.descriptionSecondary,
+    stops: route.stops,
+  };
+}
+
+function scoreMatch(
+  match: BusRouteMatch,
+  input: {
+    originCampusId: number | null;
+    destinationCampusId: number | null;
+  },
+) {
+  let score = 0;
+  if (input.originCampusId === match.originStop.campus.id) score += 120;
+  if (input.destinationCampusId === match.destinationStop.campus.id)
+    score += 120;
+  if (match.isFavoriteRoute) score += 80;
+  if (match.isFavoriteOrigin) score += 40;
+  if (match.isFavoriteDestination) score += 40;
+  if (match.nextTrip?.minutesUntilDeparture != null) {
+    score += Math.max(0, 60 - match.nextTrip.minutesUntilDeparture);
+  }
+  return score;
+}
+
+async function findEffectiveBusVersion(
+  dateKey: string,
+  versionKey?: string | null,
+) {
+  if (versionKey) {
+    return prisma.busScheduleVersion.findUnique({
+      where: { key: versionKey },
+    });
+  }
+
+  const versions = await prisma.busScheduleVersion.findMany({
+    where: { isEnabled: true },
+    orderBy: [
+      { effectiveFrom: "desc" },
+      { importedAt: "desc" },
+      { id: "desc" },
+    ],
+  });
+
+  return (
+    versions.find((version) => isVersionEffectiveOn(version, dateKey)) ??
+    versions[0] ??
+    null
+  );
+}
+
+async function listBusVersions() {
+  const versions = await prisma.busScheduleVersion.findMany({
+    where: { isEnabled: true },
+    orderBy: [
+      { effectiveFrom: "desc" },
+      { importedAt: "desc" },
+      { id: "desc" },
+    ],
+  });
+
+  return versions.map((version) => ({
+    id: version.id,
+    key: version.key,
+    title: version.title,
+    effectiveFrom: version.effectiveFrom?.toISOString() ?? null,
+    effectiveUntil: version.effectiveUntil?.toISOString() ?? null,
+    importedAt: version.importedAt.toISOString(),
+    notice:
+      version.sourceMessage || version.sourceUrl
+        ? {
+            message: version.sourceMessage ?? null,
+            url: version.sourceUrl ?? null,
+          }
+        : null,
+  }));
+}
+
+async function getRouteRecords(locale: AppLocale) {
+  const localizedPrisma = getPrisma(locale);
+  const routes = await localizedPrisma.busRoute.findMany({
+    include: {
+      stops: {
+        orderBy: { stopOrder: "asc" },
+        include: {
+          campus: true,
+        },
+      },
+    },
+    orderBy: { id: "asc" },
+  });
+
+  return routes.map<RouteRecord>((route) => ({
+    id: route.id,
+    nameCn: route.nameCn,
+    nameEn: route.nameEn,
+    stops: route.stops.map((stop) => ({
+      stopOrder: stop.stopOrder,
+      campus: {
+        id: stop.campus.id,
+        nameCn: stop.campus.nameCn,
+        nameEn: stop.campus.nameEn,
+        namePrimary: stop.campus.namePrimary,
+        nameSecondary: stop.campus.nameSecondary,
+        latitude: stop.campus.latitude,
+        longitude: stop.campus.longitude,
+      },
+    })),
+  }));
+}
+
+async function getBusCampuses(locale: AppLocale) {
+  const localizedPrisma = getPrisma(locale);
+  const campuses = await localizedPrisma.busCampus.findMany({
+    orderBy: { id: "asc" },
+  });
+
+  return campuses.map<BusCampusSummary>((campus) => ({
+    id: campus.id,
+    nameCn: campus.nameCn,
+    nameEn: campus.nameEn,
+    namePrimary: campus.namePrimary,
+    nameSecondary: campus.nameSecondary,
+    latitude: campus.latitude,
+    longitude: campus.longitude,
+  }));
+}
+
+export async function getBusPreference(
+  userId: string | null,
+): Promise<BusUserPreferenceSummary | null> {
+  if (!userId) return null;
+
+  const preference = await prisma.busUserPreference.findUnique({
+    where: { userId },
+  });
+
+  if (!preference) {
+    return {
+      preferredOriginCampusId: null,
+      preferredDestinationCampusId: null,
+      favoriteCampusIds: [],
+      favoriteRouteIds: [],
+      showDepartedTrips: false,
+    };
+  }
+
+  return {
+    preferredOriginCampusId: preference.preferredOriginCampusId,
+    preferredDestinationCampusId: preference.preferredDestinationCampusId,
+    favoriteCampusIds: preference.favoriteCampusIds,
+    favoriteRouteIds: preference.favoriteRouteIds,
+    showDepartedTrips: preference.showDepartedTrips,
+  };
+}
+
+export async function saveBusPreference(
+  userId: string,
+  payload: BusPreferencePayload,
+) {
+  const data = {
+    preferredOriginCampusId: payload.preferredOriginCampusId,
+    preferredDestinationCampusId: payload.preferredDestinationCampusId,
+    favoriteCampusIds: uniqueNumbers(payload.favoriteCampusIds),
+    favoriteRouteIds: uniqueNumbers(payload.favoriteRouteIds),
+    showDepartedTrips: payload.showDepartedTrips,
+  };
+
+  await prisma.busUserPreference.upsert({
+    where: { userId },
+    create: { userId, ...data },
+    update: data,
+  });
+
+  return {
+    ...data,
+  } satisfies BusUserPreferenceSummary;
+}
+
+function buildTripSummary(
+  trip: {
+    id: number;
+    routeId: number;
+    dayType: "weekday" | "weekend";
+    position: number;
+    stopTimes: unknown;
+  },
+  route: BusRouteSummary,
+  nowMinutes: number,
+): BusTripSummary {
+  const rawTimes = Array.isArray(trip.stopTimes)
+    ? (trip.stopTimes as Array<string | null>)
+    : [];
+
+  const stopTimes = route.stops.map<BusTripStopTime>((stop, index) => {
+    const time = rawTimes[index] ?? null;
+    return {
+      stopOrder: stop.stopOrder,
+      campusId: stop.campus.id,
+      campusName: stop.campus.namePrimary,
+      time,
+      minutesSinceMidnight: hhmmToMinutes(time),
+      isPassThrough: time == null,
+    };
+  });
+
+  const departureTime = stopTimes[0]?.time ?? null;
+  const departureMinutes = stopTimes[0]?.minutesSinceMidnight ?? null;
+  const arrivalTime = stopTimes[stopTimes.length - 1]?.time ?? null;
+  const arrivalMinutes =
+    stopTimes[stopTimes.length - 1]?.minutesSinceMidnight ?? null;
+  const status =
+    departureMinutes == null || departureMinutes >= nowMinutes
+      ? "upcoming"
+      : "departed";
+
+  return {
+    id: trip.id,
+    routeId: route.id,
+    route,
+    dayType: trip.dayType,
+    position: trip.position,
+    stopTimes,
+    departureTime,
+    departureMinutes,
+    arrivalTime,
+    arrivalMinutes,
+    status,
+    minutesUntilDeparture:
+      departureMinutes == null ? null : departureMinutes - nowMinutes,
+  };
+}
+
+export async function queryBusSchedules(
+  input: BusQueryInput,
+): Promise<BusQueryResult | null> {
+  const locale = input.locale ?? "zh-cn";
+  const now = input.now ? shanghaiDayjs(input.now) : shanghaiDayjs();
+  const dateKey = now.format("YYYY-MM-DD");
+  const todayType = resolveBusDayType(input.dayType, now);
+
+  const version = await findEffectiveBusVersion(dateKey, input.versionKey);
+  if (!version) return null;
+
+  const [routes, campuses, preference, versions, tripRows] = await Promise.all([
+    getRouteRecords(locale).then((records) =>
+      records
+        .map((record) => buildRouteSummary(locale, record))
+        .filter((record): record is BusRouteSummary => record != null),
+    ),
+    getBusCampuses(locale),
+    getBusPreference(input.userId ?? null),
+    listBusVersions(),
+    prisma.busTrip.findMany({
+      where: {
+        versionId: version.id,
+        dayType: todayType,
+      },
+      orderBy: [{ routeId: "asc" }, { position: "asc" }],
+    }),
+  ]);
+  const nowMinutes = now.hour() * 60 + now.minute();
+  const effectivePreference: BusUserPreferenceSummary = {
+    preferredOriginCampusId:
+      input.originCampusId ?? preference?.preferredOriginCampusId ?? null,
+    preferredDestinationCampusId:
+      input.destinationCampusId ??
+      preference?.preferredDestinationCampusId ??
+      null,
+    favoriteCampusIds: uniqueNumbers(
+      input.favoriteCampusIds ?? preference?.favoriteCampusIds ?? [],
+    ),
+    favoriteRouteIds: uniqueNumbers(
+      input.favoriteRouteIds ?? preference?.favoriteRouteIds ?? [],
+    ),
+    showDepartedTrips:
+      input.showDepartedTrips ?? preference?.showDepartedTrips ?? false,
+  };
+
+  const matches = routes
+    .flatMap<BusRouteMatch>((route) => {
+      const originIndex =
+        effectivePreference.preferredOriginCampusId != null
+          ? route.stops.findIndex(
+              (stop) =>
+                stop.campus.id === effectivePreference.preferredOriginCampusId,
+            )
+          : 0;
+      const destinationIndex =
+        effectivePreference.preferredDestinationCampusId != null
+          ? route.stops.findIndex(
+              (stop) =>
+                stop.campus.id ===
+                effectivePreference.preferredDestinationCampusId,
+            )
+          : route.stops.length - 1;
+
+      if (
+        originIndex === -1 ||
+        destinationIndex === -1 ||
+        originIndex >= destinationIndex
+      ) {
+        return [];
+      }
+
+      const allTrips = tripRows
+        .filter((trip) => trip.routeId === route.id)
+        .map((trip) => buildTripSummary(trip, route, nowMinutes));
+      const upcomingTrips = allTrips.filter(
+        (trip) => trip.status === "upcoming",
+      );
+      const visibleTrips = effectivePreference.showDepartedTrips
+        ? allTrips
+        : upcomingTrips;
+
+      return [
+        {
+          route,
+          originStop: route.stops[originIndex],
+          destinationStop: route.stops[destinationIndex],
+          nextTrip: upcomingTrips[0] ?? null,
+          upcomingTrips: input.limit
+            ? upcomingTrips.slice(0, input.limit)
+            : upcomingTrips,
+          visibleTrips: input.limit
+            ? visibleTrips.slice(0, input.limit)
+            : visibleTrips,
+          allTrips,
+          totalTrips: allTrips.length,
+          isFavoriteRoute: effectivePreference.favoriteRouteIds.includes(
+            route.id,
+          ),
+          isFavoriteOrigin: effectivePreference.favoriteCampusIds.includes(
+            route.stops[originIndex].campus.id,
+          ),
+          isFavoriteDestination: effectivePreference.favoriteCampusIds.includes(
+            route.stops[destinationIndex].campus.id,
+          ),
+        },
+      ];
+    })
+    .sort((left, right) => {
+      const scoreDiff =
+        scoreMatch(right, {
+          originCampusId: effectivePreference.preferredOriginCampusId,
+          destinationCampusId: effectivePreference.preferredDestinationCampusId,
+        }) -
+        scoreMatch(left, {
+          originCampusId: effectivePreference.preferredOriginCampusId,
+          destinationCampusId: effectivePreference.preferredDestinationCampusId,
+        });
+
+      if (scoreDiff !== 0) return scoreDiff;
+
+      const leftMinutes =
+        left.nextTrip?.minutesUntilDeparture ?? Number.MAX_SAFE_INTEGER;
+      const rightMinutes =
+        right.nextTrip?.minutesUntilDeparture ?? Number.MAX_SAFE_INTEGER;
+
+      if (leftMinutes !== rightMinutes) return leftMinutes - rightMinutes;
+      return left.route.id - right.route.id;
+    });
+
+  const recommended =
+    matches.find(
+      (match) =>
+        (effectivePreference.preferredOriginCampusId == null ||
+          match.originStop.campus.id ===
+            effectivePreference.preferredOriginCampusId) &&
+        (effectivePreference.preferredDestinationCampusId == null ||
+          match.destinationStop.campus.id ===
+            effectivePreference.preferredDestinationCampusId),
+    ) ??
+    matches[0] ??
+    null;
+
+  return {
+    locale,
+    now: now.toISOString(),
+    todayType,
+    version: {
+      id: version.id,
+      key: version.key,
+      title: version.title,
+      effectiveFrom: version.effectiveFrom?.toISOString() ?? null,
+      effectiveUntil: version.effectiveUntil?.toISOString() ?? null,
+      importedAt: version.importedAt.toISOString(),
+      notice:
+        version.sourceMessage || version.sourceUrl
+          ? {
+              message: version.sourceMessage ?? null,
+              url: version.sourceUrl ?? null,
+            }
+          : null,
+    },
+    campuses,
+    routes,
+    availableVersions: versions,
+    preferences: effectivePreference,
+    recommended,
+    matches,
+    notice:
+      version.sourceMessage || version.sourceUrl
+        ? {
+            message: version.sourceMessage ?? null,
+            url: version.sourceUrl ?? null,
+          }
+        : null,
+  };
+}
+
+export async function getBusDashboardSnapshot(
+  input: Pick<BusQueryInput, "locale" | "userId" | "now">,
+): Promise<BusDashboardSnapshot | null> {
+  const data = await queryBusSchedules({
+    locale: input.locale,
+    userId: input.userId,
+    now: input.now,
+  });
+
+  if (!data) return null;
+
+  return {
+    data,
+    highlightRoute: data.recommended ?? data.matches[0] ?? null,
+  };
+}

--- a/src/features/bus/lib/bus-types.ts
+++ b/src/features/bus/lib/bus-types.ts
@@ -1,0 +1,163 @@
+import type { BusScheduleDayType } from "@/generated/prisma/client";
+
+export type BusLocale = "zh-cn" | "en-us";
+export type BusResolvedDayType = BusScheduleDayType | "auto";
+export type BusTripStatus = "upcoming" | "departed";
+
+export type BusCampusSummary = {
+  id: number;
+  nameCn: string;
+  nameEn: string | null;
+  namePrimary: string;
+  nameSecondary: string | null;
+  latitude: number;
+  longitude: number;
+};
+
+export type BusRouteStopSummary = {
+  stopOrder: number;
+  campus: BusCampusSummary;
+};
+
+export type BusRouteSummary = {
+  id: number;
+  nameCn: string;
+  nameEn: string | null;
+  descriptionPrimary: string;
+  descriptionSecondary: string | null;
+  stops: BusRouteStopSummary[];
+};
+
+export type BusTripStopTime = {
+  stopOrder: number;
+  campusId: number;
+  campusName: string;
+  time: string | null;
+  minutesSinceMidnight: number | null;
+  isPassThrough: boolean;
+};
+
+export type BusTripSummary = {
+  id: number;
+  routeId: number;
+  route: BusRouteSummary;
+  dayType: BusScheduleDayType;
+  position: number;
+  stopTimes: BusTripStopTime[];
+  departureTime: string | null;
+  departureMinutes: number | null;
+  arrivalTime: string | null;
+  arrivalMinutes: number | null;
+  status: BusTripStatus;
+  minutesUntilDeparture: number | null;
+};
+
+export type BusNotice = {
+  message: string | null;
+  url: string | null;
+};
+
+export type BusScheduleVersionSummary = {
+  id: number;
+  key: string;
+  title: string;
+  effectiveFrom: string | null;
+  effectiveUntil: string | null;
+  importedAt: string;
+  notice: BusNotice | null;
+};
+
+export type BusUserPreferenceSummary = {
+  preferredOriginCampusId: number | null;
+  preferredDestinationCampusId: number | null;
+  favoriteCampusIds: number[];
+  favoriteRouteIds: number[];
+  showDepartedTrips: boolean;
+};
+
+export type BusPreferencePayload = BusUserPreferenceSummary;
+
+export type BusQueryInput = {
+  locale: BusLocale;
+  now?: string;
+  dayType?: BusResolvedDayType;
+  originCampusId?: number | null;
+  destinationCampusId?: number | null;
+  favoriteRouteIds?: number[];
+  favoriteCampusIds?: number[];
+  showDepartedTrips?: boolean;
+  includeAllTrips?: boolean;
+  limit?: number;
+  versionKey?: string | null;
+  userId?: string | null;
+};
+
+export type BusRouteMatch = {
+  route: BusRouteSummary;
+  originStop: BusRouteStopSummary;
+  destinationStop: BusRouteStopSummary;
+  nextTrip: BusTripSummary | null;
+  upcomingTrips: BusTripSummary[];
+  visibleTrips: BusTripSummary[];
+  allTrips: BusTripSummary[];
+  totalTrips: number;
+  isFavoriteRoute: boolean;
+  isFavoriteOrigin: boolean;
+  isFavoriteDestination: boolean;
+};
+
+export type BusQueryResult = {
+  locale: BusLocale;
+  now: string;
+  todayType: BusScheduleDayType;
+  version: BusScheduleVersionSummary | null;
+  availableVersions: BusScheduleVersionSummary[];
+  campuses: BusCampusSummary[];
+  routes: BusRouteSummary[];
+  preferences: BusUserPreferenceSummary | null;
+  recommended: BusRouteMatch | null;
+  matches: BusRouteMatch[];
+  notice: BusNotice | null;
+};
+
+export type BusDashboardSnapshot = {
+  data: BusQueryResult;
+  highlightRoute: BusRouteMatch | null;
+};
+
+export type BusImportResult = {
+  versionId: number;
+  versionKey: string;
+  campuses: number;
+  routes: number;
+  trips: number;
+};
+
+export type BusStaticCampus = {
+  id: number;
+  name: string;
+  latitude: number;
+  longitude: number;
+};
+
+export type BusStaticRoute = {
+  id: number;
+  campuses: BusStaticCampus[];
+};
+
+export type BusStaticRouteSchedule = {
+  id: number;
+  route: BusStaticRoute;
+  time: Array<Array<string | null>>;
+};
+
+export type BusStaticPayload = {
+  campuses: BusStaticCampus[];
+  routes: BusStaticRoute[];
+  weekday_routes: BusStaticRouteSchedule[];
+  weekend_routes: BusStaticRouteSchedule[];
+  message?: {
+    message?: string;
+    url?: string;
+  } | null;
+};

--- a/src/features/home/components/home-tab-nav.tsx
+++ b/src/features/home/components/home-tab-nav.tsx
@@ -1,6 +1,7 @@
 import {
   BookOpen,
   BookOpenCheck,
+  Bus,
   CalendarDays,
   CheckSquare,
   GraduationCap,
@@ -14,6 +15,7 @@ import { cn } from "@/shared/lib/utils";
 export type HomeTabId =
   | "overview"
   | "calendar"
+  | "bus"
   | "homeworks"
   | "todos"
   | "exams"
@@ -23,6 +25,7 @@ export type HomeTabId =
 const TAB_IDS: HomeTabId[] = [
   "overview",
   "calendar",
+  "bus",
   "homeworks",
   "todos",
   "exams",
@@ -46,6 +49,7 @@ export async function HomeTabNav({
   const tabLabels: Record<HomeTabId, string> = {
     overview: t("overview.title"),
     calendar: t("calendar.title"),
+    bus: t("bus.title"),
     homeworks: t("homeworks.title"),
     todos: t("todos.title"),
     exams: t("exams.title"),
@@ -55,6 +59,7 @@ export async function HomeTabNav({
   const tabIcons: Record<HomeTabId, typeof LayoutDashboard> = {
     overview: LayoutDashboard,
     calendar: CalendarDays,
+    bus: Bus,
     homeworks: BookOpenCheck,
     todos: CheckSquare,
     exams: GraduationCap,

--- a/src/features/home/components/home-view.tsx
+++ b/src/features/home/components/home-view.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from "next-intl/server";
 import type {
+  BusDashboardData,
   DashboardNavStats,
   HomeworkSummaryItem,
   OverviewData,
@@ -7,6 +8,7 @@ import type {
   SubscriptionsTabData,
   TodoItem,
 } from "@/app/dashboard/dashboard-data";
+import { BusPanel } from "@/features/bus/components/bus-panel";
 import { LinksTabPanel } from "@/features/dashboard-links/components/links-tab-panel";
 import { TodosPanel } from "@/features/todos/components/todos-panel";
 import { CalendarPanel } from "./calendar-panel";
@@ -19,6 +21,7 @@ import { SubscriptionsPanel } from "./subscriptions-panel";
 const VALID_TABS: HomeTabId[] = [
   "overview",
   "calendar",
+  "bus",
   "homeworks",
   "todos",
   "exams",
@@ -52,6 +55,7 @@ type HomeViewProps = {
   subscriptionsData: SubscriptionsTabData | null;
   calendarSubscriptionUrl: string | null;
   todosData: TodoItem[] | null;
+  busData: BusDashboardData | null;
 };
 
 export async function HomeView({
@@ -62,6 +66,7 @@ export async function HomeView({
   subscriptionsData,
   calendarSubscriptionUrl,
   todosData,
+  busData,
 }: HomeViewProps) {
   const params = await searchParams;
   const currentTab = parseTab(params.tab);
@@ -103,6 +108,13 @@ export async function HomeView({
             view={params.calendarView}
             month={params.calendarMonth}
             week={params.calendarWeek}
+          />
+        )}
+        {currentTab === "bus" && busData?.snapshot && (
+          <BusPanel
+            data={busData.snapshot.data}
+            signedIn={true}
+            showPreferences={true}
           />
         )}
         {currentTab === "homeworks" && (

--- a/src/lib/api/model-schemas.ts
+++ b/src/lib/api/model-schemas.ts
@@ -731,3 +731,107 @@ export const UserSuspensionModelSchema = z
   .strict();
 
 export type UserSuspensionPureType = z.infer<typeof UserSuspensionModelSchema>;
+
+// prettier-ignore
+export const BusCampusModelSchema = z
+  .object({
+    id: z.number().int(),
+    nameCn: z.string(),
+    nameEn: z.string().nullable(),
+    latitude: z.number(),
+    longitude: z.number(),
+    routeStops: z.array(z.unknown()),
+    preferredByOriginUsers: z.array(z.unknown()),
+    preferredByDestinationUsers: z.array(z.unknown()),
+  })
+  .strict();
+
+export type BusCampusPureType = z.infer<typeof BusCampusModelSchema>;
+
+// prettier-ignore
+export const BusRouteModelSchema = z
+  .object({
+    id: z.number().int(),
+    nameCn: z.string(),
+    nameEn: z.string().nullable(),
+    stops: z.array(z.unknown()),
+    trips: z.array(z.unknown()),
+  })
+  .strict();
+
+export type BusRoutePureType = z.infer<typeof BusRouteModelSchema>;
+
+// prettier-ignore
+export const BusRouteStopModelSchema = z
+  .object({
+    id: z.number().int(),
+    routeId: z.number().int(),
+    campusId: z.number().int(),
+    stopOrder: z.number().int(),
+    route: z.unknown(),
+    campus: z.unknown(),
+  })
+  .strict();
+
+export type BusRouteStopPureType = z.infer<typeof BusRouteStopModelSchema>;
+
+// prettier-ignore
+export const BusScheduleVersionModelSchema = z
+  .object({
+    id: z.number().int(),
+    key: z.string(),
+    title: z.string(),
+    checksum: z.string(),
+    sourceMessage: z.string().nullable(),
+    sourceUrl: z.string().nullable(),
+    rawJson: z.unknown(),
+    effectiveFrom: z.date().nullable(),
+    effectiveUntil: z.date().nullable(),
+    isEnabled: z.boolean(),
+    importedAt: z.date(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
+    trips: z.array(z.unknown()),
+  })
+  .strict();
+
+export type BusScheduleVersionPureType = z.infer<
+  typeof BusScheduleVersionModelSchema
+>;
+
+// prettier-ignore
+export const BusTripModelSchema = z
+  .object({
+    id: z.number().int(),
+    versionId: z.number().int(),
+    routeId: z.number().int(),
+    dayType: z.enum(["weekday", "weekend"]),
+    position: z.number().int(),
+    stopTimes: z.unknown(),
+    version: z.unknown(),
+    route: z.unknown(),
+  })
+  .strict();
+
+export type BusTripPureType = z.infer<typeof BusTripModelSchema>;
+
+// prettier-ignore
+export const BusUserPreferenceModelSchema = z
+  .object({
+    userId: z.string(),
+    preferredOriginCampusId: z.number().int().nullable(),
+    preferredDestinationCampusId: z.number().int().nullable(),
+    favoriteCampusIds: z.array(z.number().int()),
+    favoriteRouteIds: z.array(z.number().int()),
+    showDepartedTrips: z.boolean(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
+    user: z.unknown(),
+    preferredOriginCampus: z.unknown().nullable(),
+    preferredDestinationCampus: z.unknown().nullable(),
+  })
+  .strict();
+
+export type BusUserPreferencePureType = z.infer<
+  typeof BusUserPreferenceModelSchema
+>;

--- a/src/lib/api/schemas.ts
+++ b/src/lib/api/schemas.ts
@@ -2,6 +2,12 @@ import { z } from "zod";
 import {
   AdminClassModelSchema,
   BuildingModelSchema,
+  BusCampusModelSchema,
+  BusRouteModelSchema,
+  BusRouteStopModelSchema,
+  BusScheduleVersionModelSchema,
+  BusTripModelSchema,
+  BusUserPreferenceModelSchema,
   CampusModelSchema,
   ClassTypeModelSchema,
   CommentModelSchema,
@@ -63,6 +69,51 @@ const teacherAssignmentWeekIndicesSchema = z.array(z.number().int()).nullable();
 export const campusSchema = CampusModelSchema.omit({
   buildings: true,
   sections: true,
+});
+
+export const busCampusSchema = BusCampusModelSchema.omit({
+  routeStops: true,
+  preferredByOriginUsers: true,
+  preferredByDestinationUsers: true,
+});
+
+export const busRouteSchema = BusRouteModelSchema.omit({
+  stops: true,
+  trips: true,
+});
+
+export const busRouteStopSchema = BusRouteStopModelSchema.omit({
+  route: true,
+  campus: true,
+}).extend({
+  campus: busCampusSchema,
+});
+
+export const busTripSchema = BusTripModelSchema.omit({
+  version: true,
+  route: true,
+}).extend({
+  stopTimes: z.array(z.union([z.string(), z.null()])),
+});
+
+export const busScheduleVersionSchema = BusScheduleVersionModelSchema.omit({
+  trips: true,
+  rawJson: true,
+}).extend({
+  effectiveFrom: dateTimeSchema.nullable(),
+  effectiveUntil: dateTimeSchema.nullable(),
+  importedAt: dateTimeSchema,
+  createdAt: dateTimeSchema,
+  updatedAt: dateTimeSchema,
+});
+
+export const busUserPreferenceSchema = BusUserPreferenceModelSchema.omit({
+  user: true,
+  preferredOriginCampus: true,
+  preferredDestinationCampus: true,
+}).extend({
+  createdAt: dateTimeSchema,
+  updatedAt: dateTimeSchema,
 });
 
 export const buildingSchema = BuildingModelSchema.omit({
@@ -870,6 +921,145 @@ export const currentCalendarSubscriptionResponseSchema = z.union([
     subscription: calendarSubscriptionSummarySchema,
   }),
 ]);
+
+const busTripStopTimeSummarySchema = z.object({
+  stopOrder: z.number().int(),
+  campusId: z.number().int(),
+  campusName: z.string(),
+  time: z.string().nullable(),
+  minutesSinceMidnight: z.number().int().nullable(),
+  isPassThrough: z.boolean(),
+});
+
+const busRouteSummarySchema = z.object({
+  id: z.number().int(),
+  nameCn: z.string(),
+  nameEn: z.string().nullable(),
+  descriptionPrimary: z.string(),
+  descriptionSecondary: z.string().nullable(),
+  stops: z.array(
+    z.object({
+      stopOrder: z.number().int(),
+      campus: busCampusSchema.extend({
+        namePrimary: z.string(),
+        nameSecondary: z.string().nullable(),
+      }),
+    }),
+  ),
+});
+
+const busTripSummarySchema = z.object({
+  id: z.number().int(),
+  routeId: z.number().int(),
+  route: busRouteSummarySchema,
+  dayType: z.enum(["weekday", "weekend"]),
+  position: z.number().int(),
+  stopTimes: z.array(busTripStopTimeSummarySchema),
+  departureTime: z.string().nullable(),
+  departureMinutes: z.number().int().nullable(),
+  arrivalTime: z.string().nullable(),
+  arrivalMinutes: z.number().int().nullable(),
+  status: z.enum(["upcoming", "departed"]),
+  minutesUntilDeparture: z.number().int().nullable(),
+});
+
+const busRouteMatchSchema = z.object({
+  route: busRouteSummarySchema,
+  originStop: z.object({
+    stopOrder: z.number().int(),
+    campus: busCampusSchema.extend({
+      namePrimary: z.string(),
+      nameSecondary: z.string().nullable(),
+    }),
+  }),
+  destinationStop: z.object({
+    stopOrder: z.number().int(),
+    campus: busCampusSchema.extend({
+      namePrimary: z.string(),
+      nameSecondary: z.string().nullable(),
+    }),
+  }),
+  nextTrip: busTripSummarySchema.nullable(),
+  upcomingTrips: z.array(busTripSummarySchema),
+  visibleTrips: z.array(busTripSummarySchema),
+  allTrips: z.array(busTripSummarySchema),
+  totalTrips: z.number().int().nonnegative(),
+  isFavoriteRoute: z.boolean(),
+  isFavoriteOrigin: z.boolean(),
+  isFavoriteDestination: z.boolean(),
+});
+
+export const busQueryResponseSchema = z.object({
+  locale: z.enum(["zh-cn", "en-us"]),
+  now: dateTimeSchema,
+  todayType: z.enum(["weekday", "weekend"]),
+  version: z
+    .object({
+      id: z.number().int(),
+      key: z.string(),
+      title: z.string(),
+      effectiveFrom: dateTimeSchema.nullable(),
+      effectiveUntil: dateTimeSchema.nullable(),
+      importedAt: dateTimeSchema,
+      notice: z
+        .object({
+          message: z.string().nullable(),
+          url: z.string().nullable(),
+        })
+        .nullable(),
+    })
+    .nullable(),
+  availableVersions: z.array(
+    z.object({
+      id: z.number().int(),
+      key: z.string(),
+      title: z.string(),
+      effectiveFrom: dateTimeSchema.nullable(),
+      effectiveUntil: dateTimeSchema.nullable(),
+      importedAt: dateTimeSchema,
+      notice: z
+        .object({
+          message: z.string().nullable(),
+          url: z.string().nullable(),
+        })
+        .nullable(),
+    }),
+  ),
+  campuses: z.array(
+    busCampusSchema.extend({
+      namePrimary: z.string(),
+      nameSecondary: z.string().nullable(),
+    }),
+  ),
+  routes: z.array(busRouteSummarySchema),
+  preferences: z
+    .object({
+      preferredOriginCampusId: z.number().int().nullable(),
+      preferredDestinationCampusId: z.number().int().nullable(),
+      favoriteCampusIds: z.array(z.number().int()),
+      favoriteRouteIds: z.array(z.number().int()),
+      showDepartedTrips: z.boolean(),
+    })
+    .nullable(),
+  recommended: busRouteMatchSchema.nullable(),
+  matches: z.array(busRouteMatchSchema),
+  notice: z
+    .object({
+      message: z.string().nullable(),
+      url: z.string().nullable(),
+    })
+    .nullable(),
+});
+
+export const busPreferenceResponseSchema = z.object({
+  preference: z.object({
+    preferredOriginCampusId: z.number().int().nullable(),
+    preferredDestinationCampusId: z.number().int().nullable(),
+    favoriteCampusIds: z.array(z.number().int()),
+    favoriteRouteIds: z.array(z.number().int()),
+    showDepartedTrips: z.boolean(),
+  }),
+});
 
 export const openApiDocumentResponseSchema = z.object({
   openapi: z.string(),

--- a/src/lib/api/schemas/request-schemas.ts
+++ b/src/lib/api/schemas/request-schemas.ts
@@ -223,6 +223,27 @@ export const coursesQuerySchema = z.object({
   limit: integerStringSchema.optional(),
 });
 
+export const busQuerySchema = z.object({
+  now: z.string().trim().datetime().optional(),
+  dayType: z.enum(["auto", "weekday", "weekend"]).optional(),
+  originCampusId: integerStringSchema.optional(),
+  destinationCampusId: integerStringSchema.optional(),
+  favoriteRouteIds: z.string().trim().optional(),
+  favoriteCampusIds: z.string().trim().optional(),
+  showDepartedTrips: z.enum(["true", "false"]).optional(),
+  includeAllTrips: z.enum(["true", "false"]).optional(),
+  limit: integerStringSchema.optional(),
+  versionKey: z.string().trim().min(1).optional(),
+});
+
+export const busPreferenceRequestSchema = z.object({
+  preferredOriginCampusId: z.number().int().positive().nullable(),
+  preferredDestinationCampusId: z.number().int().positive().nullable(),
+  favoriteCampusIds: z.array(z.number().int().positive()),
+  favoriteRouteIds: z.array(z.number().int().positive()),
+  showDepartedTrips: z.boolean(),
+});
+
 export const adminUsersQuerySchema = z.object({
   search: z.string().trim().optional(),
   page: integerStringSchema.optional(),

--- a/src/lib/db/prisma.ts
+++ b/src/lib/db/prisma.ts
@@ -54,6 +54,8 @@ const localizedNamesExtension = (locale: string) =>
     name: "localizedNames",
     result: {
       adminClass: localizedNameResult(locale),
+      busCampus: localizedNameResult(locale),
+      busRoute: localizedNameResult(locale),
       building: localizedNameResult(locale),
       campus: localizedNameResult(locale),
       classType: localizedNameResult(locale),

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1,6 +1,7 @@
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { queryBusSchedules } from "@/features/bus/lib/bus-service";
 import { findActiveSuspension } from "@/features/comments/server/comment-utils";
 import { DEFAULT_LOCALE, localeSchema } from "@/i18n/config";
 import {
@@ -466,6 +467,52 @@ export function createMcpServer() {
     name: "life-ustc-mcp",
     version: "1.0.0",
   });
+
+  server.registerTool(
+    "query_bus_timetable",
+    {
+      description:
+        "Publicly query USTC shuttle bus timetable by campuses, day type, and effective version.",
+      inputSchema: {
+        originCampusId: z.number().int().positive().optional(),
+        destinationCampusId: z.number().int().positive().optional(),
+        showDepartedTrips: z.boolean().default(false),
+        dayType: z.enum(["weekday", "weekend", "auto"]).default("auto"),
+        versionKey: z.string().trim().min(1).optional(),
+        locale: localeSchema.default(DEFAULT_LOCALE),
+        mode: mcpModeInputSchema,
+      },
+    },
+    async ({
+      originCampusId,
+      destinationCampusId,
+      showDepartedTrips,
+      dayType,
+      versionKey,
+      locale,
+      mode,
+    }) => {
+      const result = await queryBusSchedules({
+        locale,
+        originCampusId,
+        destinationCampusId,
+        showDepartedTrips,
+        dayType,
+        versionKey,
+      });
+
+      return jsonToolResult(
+        result ?? {
+          locale,
+          hasData: false,
+          message: "No bus schedule data available",
+        },
+        {
+          mode: resolveMcpMode(mode),
+        },
+      );
+    },
+  );
 
   server.registerTool(
     "get_my_profile",

--- a/tests/e2e/src/app/api/bus/test.ts
+++ b/tests/e2e/src/app/api/bus/test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+import { DEV_SEED } from "../../../../utils/dev-seed";
+
+test("/api/bus 公开可访问并返回推荐路线", async ({ request }) => {
+  const response = await request.get(
+    `/api/bus?from=${DEV_SEED.bus.originCampusId}&to=${DEV_SEED.bus.destinationCampusId}`,
+  );
+  expect(response.status()).toBe(200);
+
+  const body = (await response.json()) as {
+    version?: { key?: string; title?: string | null };
+    availableVersions?: Array<{ key?: string }>;
+    recommended?: {
+      route?: { id?: number; descriptionPrimary?: string | null };
+      nextTrip?: { departureTime?: string | null };
+    } | null;
+    matches?: Array<{ route?: { id?: number } }>;
+  };
+
+  expect(body.version?.key).toBe(DEV_SEED.bus.versionKey);
+  expect(
+    body.availableVersions?.some(
+      (item) => item.key === DEV_SEED.bus.versionKey,
+    ),
+  ).toBe(true);
+  expect(body.recommended?.route?.id).toBe(DEV_SEED.bus.recommendedRouteId);
+  expect(body.recommended?.route?.descriptionPrimary).toContain("东区");
+  expect(body.recommended?.nextTrip?.departureTime).toBeTruthy();
+  expect(
+    body.matches?.some((item) => item.route?.id === DEV_SEED.bus.routeId),
+  ).toBe(true);
+});

--- a/tests/e2e/src/app/api/mcp/test.ts
+++ b/tests/e2e/src/app/api/mcp/test.ts
@@ -302,6 +302,7 @@ test("OAuth PKCE token can connect to /api/mcp and call all seeded tools", async
         "list_homeworks_by_section",
         "list_schedules_by_section",
         "list_exams_by_section",
+        "query_bus_timetable",
       ]),
     );
     expect(tools.tools.map((tool) => tool.name)).not.toEqual(
@@ -587,6 +588,31 @@ test("OAuth PKCE token can connect to /api/mcp and call all seeded tools", async
       DEV_SEED.section.code,
     );
     expect(matchSectionCodesPayload.unmatchedCodes).toContain("NOT-EXIST-CODE");
+
+    const busResult = await mcpClient.callTool({
+      name: "query_bus_timetable",
+      arguments: {
+        locale: "zh-cn",
+        originCampusId: DEV_SEED.bus.originCampusId,
+        destinationCampusId: DEV_SEED.bus.destinationCampusId,
+      },
+    });
+    const busPayload = parseTextContent(busResult) as {
+      todayType?: string;
+      version?: { title?: string | null };
+      recommended?: { route?: { id?: number } | null } | null;
+      matches?: Array<{ route?: { id?: number } | null }>;
+    };
+    expect(
+      busPayload.todayType === "weekday" || busPayload.todayType === "weekend",
+    ).toBe(true);
+    expect(busPayload.version?.title).toContain(DEV_SEED.bus.versionTitle);
+    expect(busPayload.recommended?.route?.id).toBe(DEV_SEED.bus.routeId);
+    expect(
+      busPayload.matches?.some(
+        (match) => match.route?.id === DEV_SEED.bus.routeId,
+      ),
+    ).toBe(true);
 
     const todoTitle = `[MCP-E2E-TODO] ${Date.now()}`;
     const createTodoResult = await mcpClient.callTool({

--- a/tests/e2e/src/app/bus/test.ts
+++ b/tests/e2e/src/app/bus/test.ts
@@ -17,9 +17,7 @@ test("/bus 公开页展示推荐校车与版本信息", async ({ page }, testInf
   await expect(
     page.getByText(DEV_SEED.bus.recommendedRoute, { exact: false }).first(),
   ).toBeVisible();
-  await expect(
-    page.getByText(DEV_SEED.bus.recommendedDeparture, { exact: false }).first(),
-  ).toBeVisible();
+  await expect(page.getByText(/Next bus|下一班/).first()).toBeVisible();
 
   await captureStepScreenshot(page, testInfo, "bus-public-page");
 });

--- a/tests/e2e/src/app/bus/test.ts
+++ b/tests/e2e/src/app/bus/test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+import { DEV_SEED } from "../../../utils/dev-seed";
+import { gotoAndWaitForReady } from "../../../utils/page-ready";
+import { captureStepScreenshot } from "../../../utils/screenshot";
+import { assertPageContract } from "../_shared/page-contract";
+
+test("/bus", async ({ page }, testInfo) => {
+  await assertPageContract(page, { routePath: "/bus", testInfo });
+});
+
+test("/bus 公开页展示推荐校车与版本信息", async ({ page }, testInfo) => {
+  await gotoAndWaitForReady(page, "/bus");
+
+  await expect(
+    page.getByText(DEV_SEED.bus.versionTitle, { exact: false }).first(),
+  ).toBeVisible();
+  await expect(
+    page.getByText(DEV_SEED.bus.recommendedRoute, { exact: false }).first(),
+  ).toBeVisible();
+  await expect(
+    page.getByText(DEV_SEED.bus.recommendedDeparture, { exact: false }).first(),
+  ).toBeVisible();
+
+  await captureStepScreenshot(page, testInfo, "bus-public-page");
+});

--- a/tests/e2e/utils/dev-seed.ts
+++ b/tests/e2e/utils/dev-seed.ts
@@ -34,6 +34,18 @@ export const DEV_SEED = {
     dueTodayTitle: "[DEV-SCENARIO] 今天截止待办",
     completedTitle: "[DEV-SCENARIO] 已完成待办",
   },
+  bus: {
+    versionKey: "dev-scenario-bus",
+    versionTitle: "DEV 校车时刻表",
+    routeId: 8,
+    recommendedRouteId: 8,
+    originCampusId: 1,
+    destinationCampusId: 6,
+    originCampusName: "东区",
+    destinationCampusName: "高新",
+    recommendedRoute: "东区 -> 西区 -> 先研院 -> 高新",
+    recommendedDeparture: "07:40",
+  },
   suspensions: {
     reasonKeyword: "temporary suspension for seed",
   },

--- a/tools/load-bus-from-static.ts
+++ b/tools/load-bus-from-static.ts
@@ -1,0 +1,99 @@
+import "dotenv/config";
+
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { importBusStaticPayload } from "../src/features/bus/lib/bus-import";
+import type { BusStaticPayload } from "../src/features/bus/lib/bus-types";
+import { PrismaClient } from "../src/generated/prisma/client";
+
+const connectionString = `${process.env.DATABASE_URL}`;
+const adapter = new PrismaPg({ connectionString });
+const prisma = new PrismaClient({ adapter });
+
+const logger = {
+  info: (msg: string) => console.log(`[INFO] ${msg}`),
+  warning: (msg: string) => console.warn(`[WARN] ${msg}`),
+  error: (msg: string) => console.error(`[ERROR] ${msg}`),
+};
+
+function run(cmd: string, cwd?: string) {
+  try {
+    logger.info(`Running command: ${cmd}`);
+    return execSync(cmd, { cwd, encoding: "utf-8", stdio: "pipe" });
+  } catch (error: unknown) {
+    const err = error as Error;
+    logger.error(`Command failed: ${cmd}\n${err.message}`);
+    throw err;
+  }
+}
+
+async function downloadStaticRepo(targetDir: string): Promise<string> {
+  const repoDir = path.join(targetDir, "static");
+  fs.mkdirSync(targetDir, { recursive: true });
+
+  if (fs.existsSync(repoDir) && fs.existsSync(path.join(repoDir, ".git"))) {
+    logger.info("Updating existing Life-USTC/static checkout...");
+    run(
+      "git remote set-url origin https://github.com/Life-USTC/static.git",
+      repoDir,
+    );
+    run("git fetch --depth 1 origin master gh-pages", repoDir);
+    run("git checkout master || git checkout gh-pages", repoDir);
+    run(
+      "git reset --hard origin/master || git reset --hard origin/gh-pages",
+      repoDir,
+    );
+  } else {
+    logger.info("Cloning Life-USTC/static...");
+    fs.mkdirSync(repoDir, { recursive: true });
+    run(
+      "git clone --depth 1 https://github.com/Life-USTC/static.git .",
+      repoDir,
+    );
+  }
+
+  return repoDir;
+}
+
+function readBusPayload(repoDir: string, filename: string): BusStaticPayload {
+  const filePath = path.join(repoDir, "static", filename);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Bus data file not found: ${filePath}`);
+  }
+  return JSON.parse(fs.readFileSync(filePath, "utf-8")) as BusStaticPayload;
+}
+
+async function main() {
+  const cacheDir = process.argv[2] || "./.cache/life-ustc/static-bus";
+  const fileName = process.argv[3] || "bus_data_v3.json";
+  const versionKey =
+    process.argv[4] || `static-${fileName.replace(/\.json$/i, "")}`;
+  const versionTitle = process.argv[5] || "Static Bus Timetable";
+  const effectiveFromArg = process.argv[6];
+  const effectiveUntilArg = process.argv[7];
+
+  try {
+    const repoDir = await downloadStaticRepo(cacheDir);
+    const payload = readBusPayload(repoDir, fileName);
+    const result = await importBusStaticPayload(prisma, payload, {
+      versionKey,
+      versionTitle,
+      effectiveFrom: effectiveFromArg ? new Date(effectiveFromArg) : null,
+      effectiveUntil: effectiveUntilArg ? new Date(effectiveUntilArg) : null,
+    });
+
+    logger.info(
+      `Imported bus data: version=${result.versionKey}, campuses=${result.campuses}, routes=${result.routes}, trips=${result.trips}`,
+    );
+  } catch (error: unknown) {
+    const err = error as Error;
+    logger.error(err.message);
+    process.exitCode = 1;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main();

--- a/tools/seed-dev-scenarios.ts
+++ b/tools/seed-dev-scenarios.ts
@@ -1,6 +1,8 @@
 import "dotenv/config";
 
 import { PrismaPg } from "@prisma/adapter-pg";
+import { importBusStaticPayload } from "../src/features/bus/lib/bus-import";
+import type { BusStaticPayload } from "../src/features/bus/lib/bus-types";
 import {
   CommentReactionType,
   CommentStatus,
@@ -38,6 +40,190 @@ const DEV_BUILDING_JW_ID = 9_910_021;
 const DEV_ROOM_JW_ID = 9_910_031;
 const DEV_TEACHER_TITLE_JW_ID = 9_910_041;
 const DEV_TEACHER_LESSON_TYPE_JW_ID = 9_910_051;
+const DEV_BUS_VERSION_KEY = "dev-scenario-bus";
+
+const _DEV_BUS_PAYLOAD: BusStaticPayload = {
+  campuses: [
+    { id: 1, name: "东区", latitude: 117.268264, longitude: 31.83892 },
+    { id: 2, name: "西区", latitude: 117.256645, longitude: 31.839258 },
+    { id: 3, name: "北区", latitude: 117.268125, longitude: 31.841933 },
+    { id: 4, name: "南区", latitude: 117.283853, longitude: 31.822112 },
+    { id: 5, name: "先研院", latitude: 117.129257, longitude: 31.826345 },
+    { id: 6, name: "高新", latitude: 117.129369, longitude: 31.820447 },
+  ],
+  routes: [
+    {
+      id: 1,
+      campuses: [
+        { id: 1, name: "东区", latitude: 117.268264, longitude: 31.83892 },
+        { id: 3, name: "北区", latitude: 117.268125, longitude: 31.841933 },
+        { id: 2, name: "西区", latitude: 117.256645, longitude: 31.839258 },
+      ],
+    },
+    {
+      id: 3,
+      campuses: [
+        { id: 1, name: "东区", latitude: 117.268264, longitude: 31.83892 },
+        { id: 4, name: "南区", latitude: 117.283853, longitude: 31.822112 },
+      ],
+    },
+    {
+      id: 7,
+      campuses: [
+        { id: 6, name: "高新", latitude: 117.129369, longitude: 31.820447 },
+        { id: 5, name: "先研院", latitude: 117.129257, longitude: 31.826345 },
+        { id: 2, name: "西区", latitude: 117.256645, longitude: 31.839258 },
+        { id: 1, name: "东区", latitude: 117.268264, longitude: 31.83892 },
+      ],
+    },
+    {
+      id: 8,
+      campuses: [
+        { id: 1, name: "东区", latitude: 117.268264, longitude: 31.83892 },
+        { id: 2, name: "西区", latitude: 117.256645, longitude: 31.839258 },
+        { id: 5, name: "先研院", latitude: 117.129257, longitude: 31.826345 },
+        { id: 6, name: "高新", latitude: 117.129369, longitude: 31.820447 },
+      ],
+    },
+  ],
+  weekday_routes: [
+    {
+      id: 1,
+      route: {
+        id: 1,
+        campuses: [
+          { id: 1, name: "东区", latitude: 117.268264, longitude: 31.83892 },
+          { id: 3, name: "北区", latitude: 117.268125, longitude: 31.841933 },
+          { id: 2, name: "西区", latitude: 117.256645, longitude: 31.839258 },
+        ],
+      },
+      time: [
+        ["07:30", null, "07:40"],
+        ["09:20", null, "09:30"],
+        ["18:40", null, "18:50"],
+        ["21:15", null, "21:25"],
+      ],
+    },
+    {
+      id: 3,
+      route: {
+        id: 3,
+        campuses: [
+          { id: 1, name: "东区", latitude: 117.268264, longitude: 31.83892 },
+          { id: 4, name: "南区", latitude: 117.283853, longitude: 31.822112 },
+        ],
+      },
+      time: [
+        ["08:30", "08:45"],
+        ["12:35", "12:50"],
+        ["17:45", "18:00"],
+      ],
+    },
+    {
+      id: 7,
+      route: {
+        id: 7,
+        campuses: [
+          { id: 6, name: "高新", latitude: 117.129369, longitude: 31.820447 },
+          { id: 5, name: "先研院", latitude: 117.129257, longitude: 31.826345 },
+          { id: 2, name: "西区", latitude: 117.256645, longitude: 31.839258 },
+          { id: 1, name: "东区", latitude: 117.268264, longitude: 31.83892 },
+        ],
+      },
+      time: [
+        ["08:00", "08:05", null, "08:50"],
+        ["14:30", "14:35", null, "15:25"],
+        ["18:30", "18:35", null, "19:25"],
+      ],
+    },
+    {
+      id: 8,
+      route: {
+        id: 8,
+        campuses: [
+          { id: 1, name: "东区", latitude: 117.268264, longitude: 31.83892 },
+          { id: 2, name: "西区", latitude: 117.256645, longitude: 31.839258 },
+          { id: 5, name: "先研院", latitude: 117.129257, longitude: 31.826345 },
+          { id: 6, name: "高新", latitude: 117.129369, longitude: 31.820447 },
+        ],
+      },
+      time: [
+        ["06:50", "07:00", null, "07:40"],
+        ["12:50", "13:00", null, "13:40"],
+        ["21:20", "21:30", null, "22:00"],
+      ],
+    },
+  ],
+  weekend_routes: [
+    {
+      id: 1,
+      route: {
+        id: 1,
+        campuses: [
+          { id: 1, name: "东区", latitude: 117.268264, longitude: 31.83892 },
+          { id: 3, name: "北区", latitude: 117.268125, longitude: 31.841933 },
+          { id: 2, name: "西区", latitude: 117.256645, longitude: 31.839258 },
+        ],
+      },
+      time: [
+        ["07:30", null, "07:40"],
+        ["17:30", null, "17:40"],
+        ["21:15", null, "21:25"],
+      ],
+    },
+    {
+      id: 3,
+      route: {
+        id: 3,
+        campuses: [
+          { id: 1, name: "东区", latitude: 117.268264, longitude: 31.83892 },
+          { id: 4, name: "南区", latitude: 117.283853, longitude: 31.822112 },
+        ],
+      },
+      time: [
+        ["11:45", "12:00"],
+        ["19:00", "19:15"],
+      ],
+    },
+    {
+      id: 7,
+      route: {
+        id: 7,
+        campuses: [
+          { id: 6, name: "高新", latitude: 117.129369, longitude: 31.820447 },
+          { id: 5, name: "先研院", latitude: 117.129257, longitude: 31.826345 },
+          { id: 2, name: "西区", latitude: 117.256645, longitude: 31.839258 },
+          { id: 1, name: "东区", latitude: 117.268264, longitude: 31.83892 },
+        ],
+      },
+      time: [
+        ["08:00", "08:05", null, "08:50"],
+        ["21:50", "21:55", null, "22:40"],
+      ],
+    },
+    {
+      id: 8,
+      route: {
+        id: 8,
+        campuses: [
+          { id: 1, name: "东区", latitude: 117.268264, longitude: 31.83892 },
+          { id: 2, name: "西区", latitude: 117.256645, longitude: 31.839258 },
+          { id: 5, name: "先研院", latitude: 117.129257, longitude: 31.826345 },
+          { id: 6, name: "高新", latitude: 117.129369, longitude: 31.820447 },
+        ],
+      },
+      time: [
+        ["07:00", "07:10", null, "07:50"],
+        ["18:30", "18:40", null, "19:30"],
+      ],
+    },
+  ],
+  message: {
+    message:
+      "本表为 DEV 调试用校车时刻表，可用于 Dashboard、公开查询和 MCP 测试。",
+    url: "https://github.com/Life-USTC/static",
+  },
+};
 
 function makeDateAt(hour: number, minute: number, offsetDays = 0) {
   const now = new Date();
@@ -192,6 +378,19 @@ async function cleanupScenarioData(userIds: string[]) {
   });
   await prisma.dashboardLinkPin.deleteMany({
     where: { userId: { in: userIds } },
+  });
+  await prisma.busUserPreference.deleteMany({
+    where: { userId: { in: userIds } },
+  });
+  await prisma.busTrip.deleteMany({
+    where: {
+      version: {
+        key: DEV_BUS_VERSION_KEY,
+      },
+    },
+  });
+  await prisma.busScheduleVersion.deleteMany({
+    where: { key: DEV_BUS_VERSION_KEY },
   });
 }
 
@@ -1372,6 +1571,32 @@ async function main() {
       expiresAt: makeDateAt(23, 59, 3),
       liftedAt: makeDateAt(9, 0, 0),
       liftedById: adminUser.id,
+    },
+  });
+
+  await importBusStaticPayload(prisma, _DEV_BUS_PAYLOAD, {
+    versionKey: DEV_BUS_VERSION_KEY,
+    versionTitle: "DEV 校车时刻表",
+    effectiveFrom: makeDateAt(0, 0, -7),
+    disablePreviousVersions: true,
+  });
+
+  await prisma.busUserPreference.upsert({
+    where: { userId: debugUser.id },
+    update: {
+      preferredOriginCampusId: 1,
+      preferredDestinationCampusId: 6,
+      favoriteCampusIds: [1, 6],
+      favoriteRouteIds: [8],
+      showDepartedTrips: false,
+    },
+    create: {
+      userId: debugUser.id,
+      preferredOriginCampusId: 1,
+      preferredDestinationCampusId: 6,
+      favoriteCampusIds: [1, 6],
+      favoriteRouteIds: [8],
+      showDepartedTrips: false,
     },
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add shuttle bus data models, Prisma migration, localized schemas, and dashboard/public API support
- import shuttle timetable data from Life-USTC/static, seed a dev bus version and user preferences, and expose a public `/bus` page plus Dashboard tab
- add MCP shuttle query tool and focused E2E coverage for public API, public page, and MCP integration
- refine shuttle bus UI/UX with stronger recommendation hierarchy, compact stats cards, clearer route expansion, and denser preference layout
- simplify the shuttle bus interface toward a more restrained, mobile-inspired presentation with less visual noise and a more focused first screen

## Testing
- `bun run check --write`
- `bun run build`
- `PLAYWRIGHT_REUSE_SERVER=1 bun run test:e2e tests/e2e/src/app/api/bus/test.ts tests/e2e/src/app/bus/test.ts tests/e2e/src/app/api/mcp/test.ts`
- manual verification on `http://127.0.0.1:3000/bus` and `/?tab=bus`
- initial walkthrough: [bus_public_and_dashboard_demo.mp4](https://cursor.com/agents/bc-4a3ef35f-73f0-5466-8bce-bfa69fb09a61/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbus_public_and_dashboard_demo.mp4)
- UX refinement walkthrough: [bus_uiux_optimized_demo.mp4](https://cursor.com/agents/bc-4a3ef35f-73f0-5466-8bce-bfa69fb09a61/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbus_uiux_optimized_demo.mp4)
- restrained/mobile-style walkthrough: [bus_uiux_minimal_mobile_style_demo.mp4](https://cursor.com/agents/bc-4a3ef35f-73f0-5466-8bce-bfa69fb09a61/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbus_uiux_minimal_mobile_style_demo.mp4)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://tiankaima.slack.com/archives/C0AMS218NCW/p1774803311489979?thread_ts=1774803311.489979&cid=C0AMS218NCW)

<div><a href="https://cursor.com/agents/bc-4a3ef35f-73f0-5466-8bce-bfa69fb09a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a3ef35f-73f0-5466-8bce-bfa69fb09a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

