### PR TITLE
fix(e2e): anchor dashboard snapshots

### DIFF
--- a/docs/features/overview.json
+++ b/docs/features/overview.json
@@ -81,7 +81,7 @@
             "returns": "{ user, currentSemester, subscriptions, nextClass, upcomingDeadlines, upcomingEvents, todos, bus }",
             "notes": [
               "Preferred single-call snapshot for assistant workflows.",
-              "Overlaps get_my_overview but adds currentSemester, currentSemesterSections, nextClass, merged deadlines, and preferred-bus departures.",
+              "Overlaps get_my_overview but adds currentSemester, currentSemesterSections, nextClass, merged deadlines, and preferred-bus departures; accepts optional atTime to anchor those time windows instead of using the server clock.",
               "Default mode should stay assistant-compact; request full mode when the caller explicitly needs full nested schedule, room, teacher, or homework payloads.",
               "Summary mode should be materially smaller than default, focusing on counts and the next few actionable items instead of mirroring the full compact snapshot."
             ]
@@ -89,7 +89,10 @@
           {
             "name": "get_next_class",
             "returns": "{ found: Boolean, nextClass, currentSemester }",
-            "notes": ["Focused extract for 'what is my next class?' prompts."]
+            "notes": [
+              "Focused extract for 'what is my next class?' prompts.",
+              "Accepts optional atTime to anchor the lookup instead of using the server clock."
+            ]
           },
           {
             "name": "get_upcoming_deadlines",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,8 @@ import {
   getSubscriptionsTabData,
   getTodosTabData,
 } from "@/features/home/server/dashboard-tab-data";
+import { parseDateInput } from "@/lib/time/parse-date-input";
+import { toShanghaiIsoString } from "@/lib/time/serialize-date-output";
 
 export const dynamic = "force-dynamic";
 
@@ -27,7 +29,14 @@ type HomeSearchParams = {
   tab?: string;
   dayType?: string;
   calendarSemester?: string;
+  snapshotAt?: string;
 };
+
+function parseSnapshotReferenceTime(value: string | undefined) {
+  if (process.env.E2E_DEBUG_AUTH !== "1" || !value) return undefined;
+  const parsed = parseDateInput(value);
+  return parsed instanceof Date ? parsed : undefined;
+}
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("metadata");
@@ -47,6 +56,7 @@ export default async function HomePage({
   if (session?.user?.id) {
     const params = await searchParams;
     const tab = params.tab ?? "overview";
+    const referenceNow = parseSnapshotReferenceTime(params.snapshotAt);
     const parsedCalendarSemester = parseInt(params.calendarSemester ?? "", 10);
     const overviewOptions =
       tab === "calendar" &&
@@ -55,10 +65,11 @@ export default async function HomePage({
         ? {
             calendarSemesterId: parsedCalendarSemester,
             skipLinks: true,
+            referenceNow,
           }
         : tab === "calendar"
-          ? { skipLinks: true }
-          : {};
+          ? { skipLinks: true, referenceNow }
+          : { referenceNow };
 
     const [
       navStats,
@@ -70,7 +81,7 @@ export default async function HomePage({
       todosData,
       busData,
     ] = await Promise.all([
-      getDashboardNavStats(session.user.id),
+      getDashboardNavStats(session.user.id, referenceNow),
       tab === "overview" || tab === "calendar"
         ? getDashboardOverviewData(session.user.id, overviewOptions)
         : Promise.resolve(null),
@@ -104,6 +115,7 @@ export default async function HomePage({
       <HomeView
         searchParams={searchParams}
         navStats={navStats}
+        referenceNow={referenceNow ? toShanghaiIsoString(referenceNow) : null}
         overviewData={overviewData}
         linksData={linksData?.dashboardLinks ?? null}
         homeworksData={homeworksData}

--- a/src/features/home/components/exams-list.tsx
+++ b/src/features/home/components/exams-list.tsx
@@ -58,13 +58,20 @@ function isExamCompleted(exam: ExamRow, now: dayjs.Dayjs) {
   return examEnd.isBefore(now);
 }
 
-export function ExamsList({ exams }: { exams: ExamRow[] }) {
+export function ExamsList({
+  exams,
+  referenceNow,
+}: {
+  exams: ExamRow[];
+  referenceNow?: string | null;
+}) {
   const t = useTranslations("meDashboard.nav.exams");
   const tSection = useTranslations("sectionDetail");
   const [filter, setFilter] = useState<ExamFilter>("incomplete");
 
   const filteredExams = useMemo(() => {
-    const now = dayjs();
+    const anchoredNow = referenceNow ? dayjs(referenceNow) : null;
+    const now = anchoredNow?.isValid() ? anchoredNow : dayjs();
     if (filter === "completed") {
       return exams.filter((exam) => isExamCompleted(exam, now));
     }
@@ -72,7 +79,7 @@ export function ExamsList({ exams }: { exams: ExamRow[] }) {
       return exams.filter((exam) => !isExamCompleted(exam, now));
     }
     return exams;
-  }, [exams, filter]);
+  }, [exams, filter, referenceNow]);
 
   return (
     <div className="space-y-4">

--- a/src/features/home/components/exams-panel.tsx
+++ b/src/features/home/components/exams-panel.tsx
@@ -25,7 +25,13 @@ type ExamRow = {
   rooms: string;
 };
 
-export async function ExamsPanel({ data }: { data: SubscriptionsTabData }) {
+export async function ExamsPanel({
+  data,
+  referenceNow,
+}: {
+  data: SubscriptionsTabData;
+  referenceNow?: string | null;
+}) {
   const tNav = await getTranslations("meDashboard.nav");
   const tCommon = await getTranslations("common");
 
@@ -95,5 +101,5 @@ export async function ExamsPanel({ data }: { data: SubscriptionsTabData }) {
     );
   }
 
-  return <ExamsList exams={exams} />;
+  return <ExamsList exams={exams} referenceNow={referenceNow} />;
 }

--- a/src/features/home/components/home-view.tsx
+++ b/src/features/home/components/home-view.tsx
@@ -122,9 +122,12 @@ export async function HomeView({
           <HomeworksPanel
             homeworkSummaries={homeworksData?.homeworkSummaries ?? []}
             sections={homeworksData?.sections ?? []}
+            referenceNow={referenceNow}
           />
         )}
-        {currentTab === "todos" && <TodosPanel todos={todosData ?? []} />}
+        {currentTab === "todos" && (
+          <TodosPanel todos={todosData ?? []} referenceNow={referenceNow} />
+        )}
         {currentTab === "exams" && subscriptionsData && (
           <ExamsPanel data={subscriptionsData} referenceNow={referenceNow} />
         )}

--- a/src/features/home/components/home-view.tsx
+++ b/src/features/home/components/home-view.tsx
@@ -48,6 +48,7 @@ type HomeViewProps = {
     overviewWeek?: string;
   }>;
   navStats: DashboardNavStats;
+  referenceNow: string | null;
   overviewData: OverviewData | null;
   linksData: DashboardLinkSummary[] | null;
   homeworksData: {
@@ -63,6 +64,7 @@ type HomeViewProps = {
 export async function HomeView({
   searchParams,
   navStats,
+  referenceNow,
   overviewData,
   linksData,
   homeworksData,
@@ -124,7 +126,7 @@ export async function HomeView({
         )}
         {currentTab === "todos" && <TodosPanel todos={todosData ?? []} />}
         {currentTab === "exams" && subscriptionsData && (
-          <ExamsPanel data={subscriptionsData} />
+          <ExamsPanel data={subscriptionsData} referenceNow={referenceNow} />
         )}
         {currentTab === "subscriptions" && subscriptionsData && (
           <SubscriptionsPanel data={subscriptionsData} />

--- a/src/features/home/components/homeworks-panel.tsx
+++ b/src/features/home/components/homeworks-panel.tsx
@@ -17,11 +17,13 @@ import { Link } from "@/i18n/routing";
 type HomeworksPanelProps = {
   homeworkSummaries: HomeworkSummaryItem[];
   sections: SectionOption[];
+  referenceNow?: string | null;
 };
 
 export async function HomeworksPanel({
   homeworkSummaries,
   sections,
+  referenceNow,
 }: HomeworksPanelProps) {
   const t = await getTranslations("myHomeworks");
   const tCommon = await getTranslations("common");
@@ -43,6 +45,10 @@ export async function HomeworksPanel({
   }
 
   return (
-    <HomeworkSummaryList homeworks={homeworkSummaries} sections={sections} />
+    <HomeworkSummaryList
+      homeworks={homeworkSummaries}
+      sections={sections}
+      referenceNow={referenceNow}
+    />
   );
 }

--- a/src/features/home/server/assistant-dashboard-snapshot.ts
+++ b/src/features/home/server/assistant-dashboard-snapshot.ts
@@ -19,8 +19,9 @@ export async function getAssistantDashboardSnapshot(input: {
   userId: string;
   locale: AppLocale;
   dayLimit?: number;
+  atTime?: Date;
 }) {
-  const now = new Date();
+  const now = input.atTime ?? new Date();
   const dayLimit = input.dayLimit ?? 7;
   const dateTo = new Date(now.getTime() + dayLimit * 24 * 60 * 60 * 1000);
   const currentSemester = await findCurrentSemester(prisma.semester, now);

--- a/src/features/home/server/assistant-dashboard-snapshot.ts
+++ b/src/features/home/server/assistant-dashboard-snapshot.ts
@@ -100,6 +100,7 @@ export async function getAssistantDashboardSnapshot(input: {
       locale: input.locale,
       dateFrom: now,
       dateTo,
+      eventWindowMode: "start",
     }),
     prisma.todo.findMany({
       where: {

--- a/src/features/home/server/calendar-events.ts
+++ b/src/features/home/server/calendar-events.ts
@@ -14,6 +14,10 @@ function startOfShanghaiDay(date: Date) {
   return new Date(`${formatShanghaiDate(date)}T00:00:00+08:00`);
 }
 
+function addDays(date: Date, days: number) {
+  return new Date(date.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
 function toDateTimeFromHHmm(baseDate: Date | null, hhmm: number | null) {
   if (!baseDate) return null;
 
@@ -24,28 +28,81 @@ function toDateTimeFromHHmm(baseDate: Date | null, hhmm: number | null) {
   );
 }
 
+function isWithinExactWindow(
+  {
+    start,
+    end,
+  }: {
+    start: Date | null;
+    end?: Date | null;
+  },
+  windowStart: Date,
+  windowEnd: Date,
+  includeWindowEnd: boolean,
+) {
+  if (!start) return false;
+
+  const startTime = start.getTime();
+  if (Number.isNaN(startTime)) return false;
+
+  if (end) {
+    const endTime = end.getTime();
+    if (Number.isNaN(endTime)) return false;
+    return (
+      endTime > windowStart.getTime() &&
+      (includeWindowEnd
+        ? startTime <= windowEnd.getTime()
+        : startTime < windowEnd.getTime())
+    );
+  }
+
+  return (
+    startTime >= windowStart.getTime() &&
+    (includeWindowEnd
+      ? startTime <= windowEnd.getTime()
+      : startTime < windowEnd.getTime())
+  );
+}
+
 export async function listUserCalendarEvents(
   userId: string,
   {
     locale = DEFAULT_LOCALE,
     dateFrom,
     dateTo,
+    dateFromIsDateOnly = false,
+    dateToIsDateOnly = false,
+    dateToInclusive = false,
   }: {
     locale?: string;
     dateFrom?: Date | null;
     dateTo?: Date | null;
+    dateFromIsDateOnly?: boolean;
+    dateToIsDateOnly?: boolean;
+    dateToInclusive?: boolean;
   } = {},
 ) {
-  const windowStart = dateFrom ?? startOfShanghaiDay(new Date());
+  const windowStart = dateFrom
+    ? dateFromIsDateOnly
+      ? startOfShanghaiDay(dateFrom)
+      : dateFrom
+    : startOfShanghaiDay(new Date());
   const windowEnd =
-    dateTo ?? new Date(windowStart.getTime() + 7 * 24 * 60 * 60 * 1000);
+    dateTo && dateToIsDateOnly
+      ? addDays(startOfShanghaiDay(dateTo), 1)
+      : (dateTo ?? addDays(windowStart, 7));
+  const includeWindowEnd = Boolean(
+    dateTo && dateToInclusive && !dateToIsDateOnly,
+  );
+  const calendarDateStart = startOfShanghaiDay(windowStart);
+  const calendarDateEnd = dateTo ?? windowEnd;
   const sectionIds = await getSubscribedSectionIds(userId);
 
   const [schedules, homeworks, exams] = await Promise.all([
     listSubscribedSchedules(userId, {
       locale,
-      dateFrom: windowStart,
-      dateTo: windowEnd,
+      dateFrom: calendarDateStart,
+      dateTo: calendarDateEnd,
       sectionIds,
     }),
     listSubscribedHomeworks(userId, {
@@ -57,8 +114,8 @@ export async function listUserCalendarEvents(
     }),
     listSubscribedExams(userId, {
       locale,
-      dateFrom: windowStart,
-      dateTo: windowEnd,
+      dateFrom: calendarDateStart,
+      dateTo: calendarDateEnd,
       includeDateUnknown: false,
       sectionIds,
     }),
@@ -84,12 +141,14 @@ export async function listUserCalendarEvents(
     orderBy: [{ dueAt: "asc" }, { createdAt: "desc" }],
   });
 
-  return [
+  const events = [
     ...schedules.map((schedule) => {
       const at = toDateTimeFromHHmm(schedule.date, schedule.startTime);
       return {
         type: "schedule" as const,
         at: at ? toShanghaiIsoString(at) : null,
+        filterStart: at,
+        filterEnd: null,
         sortKey: at?.getTime() ?? Number.MAX_SAFE_INTEGER,
         payload: schedule,
       };
@@ -99,14 +158,22 @@ export async function listUserCalendarEvents(
       at: homework.submissionDueAt
         ? toShanghaiIsoString(homework.submissionDueAt)
         : null,
+      filterStart: homework.submissionDueAt,
+      filterEnd: null,
       sortKey: homework.submissionDueAt?.getTime() ?? Number.MAX_SAFE_INTEGER,
       payload: homework,
     })),
     ...exams.map((exam) => {
       const at = toDateTimeFromHHmm(exam.examDate, exam.startTime);
+      const filterEnd =
+        exam.examDate && exam.startTime === null
+          ? addDays(startOfShanghaiDay(exam.examDate), 1)
+          : null;
       return {
         type: "exam" as const,
         at: at ? toShanghaiIsoString(at) : null,
+        filterStart: at,
+        filterEnd,
         sortKey: at?.getTime() ?? Number.MAX_SAFE_INTEGER,
         payload: exam,
       };
@@ -114,10 +181,29 @@ export async function listUserCalendarEvents(
     ...todos.map((todo) => ({
       type: "todo_due" as const,
       at: todo.dueAt ? toShanghaiIsoString(todo.dueAt) : null,
+      filterStart: todo.dueAt,
+      filterEnd: null,
       sortKey: todo.dueAt?.getTime() ?? Number.MAX_SAFE_INTEGER,
       payload: todo,
     })),
-  ]
+  ];
+
+  return events
+    .filter((event) =>
+      isWithinExactWindow(
+        { start: event.filterStart, end: event.filterEnd },
+        windowStart,
+        windowEnd,
+        includeWindowEnd,
+      ),
+    )
     .sort((a, b) => a.sortKey - b.sortKey)
-    .map(({ sortKey: _sortKey, ...event }) => event);
+    .map(
+      ({
+        filterStart: _filterStart,
+        filterEnd: _filterEnd,
+        sortKey: _sortKey,
+        ...event
+      }) => event,
+    );
 }

--- a/src/features/home/server/calendar-events.ts
+++ b/src/features/home/server/calendar-events.ts
@@ -28,6 +28,10 @@ function toDateTimeFromHHmm(baseDate: Date | null, hhmm: number | null) {
   );
 }
 
+function endOfCalendarDateWindow(windowEnd: Date) {
+  return addDays(startOfShanghaiDay(windowEnd), 1);
+}
+
 function isWithinExactWindow(
   {
     start,
@@ -95,7 +99,7 @@ export async function listUserCalendarEvents(
     dateTo && dateToInclusive && !dateToIsDateOnly,
   );
   const calendarDateStart = startOfShanghaiDay(windowStart);
-  const calendarDateEnd = dateTo ?? windowEnd;
+  const calendarDateEnd = endOfCalendarDateWindow(windowEnd);
   const sectionIds = await getSubscribedSectionIds(userId);
 
   const [schedules, homeworks, exams] = await Promise.all([
@@ -126,7 +130,10 @@ export async function listUserCalendarEvents(
     where: {
       userId,
       completed: false,
-      dueAt: { gte: windowStart, lt: windowEnd },
+      dueAt: {
+        gte: windowStart,
+        ...(includeWindowEnd ? { lte: windowEnd } : { lt: windowEnd }),
+      },
     },
     select: {
       id: true,
@@ -144,11 +151,12 @@ export async function listUserCalendarEvents(
   const events = [
     ...schedules.map((schedule) => {
       const at = toDateTimeFromHHmm(schedule.date, schedule.startTime);
+      const endsAt = toDateTimeFromHHmm(schedule.date, schedule.endTime);
       return {
         type: "schedule" as const,
         at: at ? toShanghaiIsoString(at) : null,
         filterStart: at,
-        filterEnd: null,
+        filterEnd: endsAt,
         sortKey: at?.getTime() ?? Number.MAX_SAFE_INTEGER,
         payload: schedule,
       };
@@ -165,10 +173,15 @@ export async function listUserCalendarEvents(
     })),
     ...exams.map((exam) => {
       const at = toDateTimeFromHHmm(exam.examDate, exam.startTime);
+      const endsAt =
+        exam.endTime === null
+          ? null
+          : toDateTimeFromHHmm(exam.examDate, exam.endTime);
       const filterEnd =
-        exam.examDate && exam.startTime === null
+        endsAt ??
+        (exam.examDate && exam.startTime === null
           ? addDays(startOfShanghaiDay(exam.examDate), 1)
-          : null;
+          : null);
       return {
         type: "exam" as const,
         at: at ? toShanghaiIsoString(at) : null,

--- a/src/features/home/server/calendar-events.ts
+++ b/src/features/home/server/calendar-events.ts
@@ -43,13 +43,14 @@ function isWithinExactWindow(
   windowStart: Date,
   windowEnd: Date,
   includeWindowEnd: boolean,
+  mode: "overlap" | "start",
 ) {
   if (!start) return false;
 
   const startTime = start.getTime();
   if (Number.isNaN(startTime)) return false;
 
-  if (end) {
+  if (mode === "overlap" && end) {
     const endTime = end.getTime();
     if (Number.isNaN(endTime)) return false;
     return (
@@ -77,6 +78,7 @@ export async function listUserCalendarEvents(
     dateFromIsDateOnly = false,
     dateToIsDateOnly = false,
     dateToInclusive = false,
+    eventWindowMode = "overlap",
   }: {
     locale?: string;
     dateFrom?: Date | null;
@@ -84,6 +86,7 @@ export async function listUserCalendarEvents(
     dateFromIsDateOnly?: boolean;
     dateToIsDateOnly?: boolean;
     dateToInclusive?: boolean;
+    eventWindowMode?: "overlap" | "start";
   } = {},
 ) {
   const windowStart = dateFrom
@@ -208,6 +211,7 @@ export async function listUserCalendarEvents(
         windowStart,
         windowEnd,
         includeWindowEnd,
+        eventWindowMode,
       ),
     )
     .sort((a, b) => a.sortKey - b.sortKey)

--- a/src/features/home/server/dashboard-overview-data.ts
+++ b/src/features/home/server/dashboard-overview-data.ts
@@ -41,6 +41,8 @@ export type OverviewDataOptions = {
   calendarSemesterId?: number;
   /** Skip dashboard-links queries when the caller doesn't need them (e.g. calendar tab). */
   skipLinks?: boolean;
+  /** Override the current time for deterministic snapshot and test views. */
+  referenceNow?: Date;
 };
 
 export type DashboardNavStats = {
@@ -53,8 +55,11 @@ export type DashboardNavStats = {
 
 export async function getDashboardNavStats(
   userId: string,
+  referenceDate?: Date,
 ): Promise<DashboardNavStats | null> {
-  const referenceNow = shanghaiDayjs();
+  const referenceNow = referenceDate
+    ? shanghaiDayjs(referenceDate)
+    : shanghaiDayjs();
   const todayStart = referenceNow.startOf("day");
   const tomorrowStart = todayStart.add(1, "day");
   const nowHHmm = referenceNow.hour() * 100 + referenceNow.minute();
@@ -193,7 +198,9 @@ export async function getDashboardOverviewData(
 ): Promise<OverviewData | null> {
   const locale = await getLocale();
   const localizedPrisma = getPrisma(locale);
-  const referenceNow = shanghaiDayjs();
+  const referenceNow = options.referenceNow
+    ? shanghaiDayjs(options.referenceNow)
+    : shanghaiDayjs();
   const referenceDate = referenceNow.toDate();
 
   const [semesters, user] = await Promise.all([

--- a/src/features/homeworks/components/homework-summary-list.tsx
+++ b/src/features/homeworks/components/homework-summary-list.tsx
@@ -64,6 +64,7 @@ type HomeworkSummaryListProps = {
     semesterStart: string | null;
     semesterEnd: string | null;
   }>;
+  referenceNow?: string | null;
 };
 
 type HomeworkFilter = "all" | "incomplete" | "completed";
@@ -71,6 +72,7 @@ type HomeworkFilter = "all" | "incomplete" | "completed";
 export function HomeworkSummaryList({
   homeworks,
   sections,
+  referenceNow,
 }: HomeworkSummaryListProps) {
   const t = useTranslations("homeworks");
   const tComments = useTranslations("comments");
@@ -86,6 +88,12 @@ export function HomeworkSummaryList({
     setItems(homeworks);
   }, [homeworks]);
 
+  const referenceDate = useMemo(() => {
+    if (!referenceNow) return new Date();
+    const parsed = new Date(referenceNow);
+    return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+  }, [referenceNow]);
+
   const filteredItems = useMemo(() => {
     if (filter === "completed") {
       return items.filter((homework) => Boolean(homework.completion));
@@ -98,7 +106,7 @@ export function HomeworkSummaryList({
 
   const formatDate = (value: string | null) => {
     if (!value) return t("dateTBD");
-    return formatSmartDateTime(value, new Date(), locale);
+    return formatSmartDateTime(value, referenceDate, locale);
   };
 
   const renderTags = (homework: HomeworkSummary) => (

--- a/src/features/todos/components/todo-list.tsx
+++ b/src/features/todos/components/todo-list.tsx
@@ -45,6 +45,7 @@ export type TodoItem = {
 
 type TodoListProps = {
   todos: TodoItem[];
+  referenceNow?: string | null;
 };
 
 type TodoFilter = "all" | "incomplete" | "completed";
@@ -63,7 +64,7 @@ async function deleteTodoApi(id: string) {
   if (!res.ok) throw new Error("Failed to delete todo");
 }
 
-export function TodoList({ todos }: TodoListProps) {
+export function TodoList({ todos, referenceNow }: TodoListProps) {
   const t = useTranslations("todos");
   const locale = useLocale();
   const router = useRouter();
@@ -104,7 +105,11 @@ export function TodoList({ todos }: TodoListProps) {
       return optimisticTodos.filter((t) => !t.completed);
     return optimisticTodos;
   }, [filter, optimisticTodos]);
-  const referenceNow = new Date();
+  const referenceDate = useMemo(() => {
+    if (!referenceNow) return new Date();
+    const parsed = new Date(referenceNow);
+    return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+  }, [referenceNow]);
 
   const handleToggle = (todo: TodoItem, nextCompleted?: boolean) => {
     startTransition(async () => {
@@ -201,7 +206,7 @@ export function TodoList({ todos }: TodoListProps) {
         {filteredTodos.map((todo) => {
           const Icon = PriorityIcon[todo.priority];
           const dueLabel = todo.dueAt
-            ? formatSmartDateTime(todo.dueAt, referenceNow, locale)
+            ? formatSmartDateTime(todo.dueAt, referenceDate, locale)
             : null;
           return (
             <Card

--- a/src/features/todos/components/todos-panel.tsx
+++ b/src/features/todos/components/todos-panel.tsx
@@ -3,8 +3,9 @@ import { TodoList } from "@/features/todos/components/todo-list";
 
 type TodosPanelProps = {
   todos: TodoItem[];
+  referenceNow?: string | null;
 };
 
-export function TodosPanel({ todos }: TodosPanelProps) {
-  return <TodoList todos={todos} />;
+export function TodosPanel({ todos, referenceNow }: TodosPanelProps) {
+  return <TodoList todos={todos} referenceNow={referenceNow} />;
 }

--- a/src/lib/mcp/tools/calendar-tools.ts
+++ b/src/lib/mcp/tools/calendar-tools.ts
@@ -33,6 +33,14 @@ import { summarizeCalendarEventCollection } from "@/lib/mcp/tools/event-summary"
 import { getPublicOrigin } from "@/lib/site-url";
 import { parseDateInput } from "@/lib/time/parse-date-input";
 
+const DATE_ONLY_INPUT_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function isDateOnlyInput(value: unknown) {
+  return (
+    typeof value === "string" && DATE_ONLY_INPUT_PATTERN.test(value.trim())
+  );
+}
+
 function getCalendarSubscriptionReadPayload(
   subscription: NonNullable<
     Awaited<ReturnType<typeof getUserCalendarSubscription>>
@@ -337,6 +345,9 @@ export function registerCalendarTools(server: McpServer) {
         locale,
         dateFrom: parsedDateFrom instanceof Date ? parsedDateFrom : undefined,
         dateTo: parsedDateTo instanceof Date ? parsedDateTo : undefined,
+        dateFromIsDateOnly: isDateOnlyInput(dateFrom),
+        dateToIsDateOnly: isDateOnlyInput(dateTo),
+        dateToInclusive: true,
       });
       const resolvedMode = resolveMcpMode(mode);
 

--- a/src/lib/mcp/tools/dashboard-tools.ts
+++ b/src/lib/mcp/tools/dashboard-tools.ts
@@ -15,6 +15,9 @@ import {
   summarizeDashboardSnapshot,
 } from "@/lib/mcp/tools/dashboard-summary";
 import { parseDateInput } from "@/lib/time/parse-date-input";
+import { startOfShanghaiDay } from "@/lib/time/shanghai-format";
+
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 function parseOptionalAtTime(atTime: string | undefined) {
   if (!atTime) return { ok: true as const, value: undefined };
@@ -28,7 +31,12 @@ function parseOptionalAtTime(atTime: string | undefined) {
       }),
     };
   }
-  return { ok: true as const, value: parsed };
+  return {
+    ok: true as const,
+    value: DATE_ONLY_PATTERN.test(atTime.trim())
+      ? startOfShanghaiDay(parsed)
+      : parsed,
+  };
 }
 
 export function registerDashboardTools(server: McpServer) {
@@ -124,19 +132,9 @@ export function registerDashboardTools(server: McpServer) {
     },
     async ({ dayLimit, atTime, locale, mode }, extra) => {
       const userId = getUserId(extra.authInfo);
-      let now: Date;
-      if (atTime) {
-        const parsed = parseDateInput(atTime);
-        if (!(parsed instanceof Date)) {
-          return jsonToolResult({
-            success: false,
-            message: `Invalid atTime: "${atTime}". Use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS+08:00.`,
-          });
-        }
-        now = parsed;
-      } else {
-        now = new Date();
-      }
+      const parsedAtTime = parseOptionalAtTime(atTime);
+      if (!parsedAtTime.ok) return parsedAtTime.result;
+      const now = parsedAtTime.value ?? new Date();
       const dateTo = new Date(now.getTime() + dayLimit * 24 * 60 * 60 * 1000);
       const events = await listUserCalendarEvents(userId, {
         locale,

--- a/src/lib/mcp/tools/dashboard-tools.ts
+++ b/src/lib/mcp/tools/dashboard-tools.ts
@@ -140,6 +140,7 @@ export function registerDashboardTools(server: McpServer) {
         locale,
         dateFrom: now,
         dateTo,
+        eventWindowMode: "start",
       });
       const deadlines = events.filter(
         (event) =>

--- a/src/lib/mcp/tools/dashboard-tools.ts
+++ b/src/lib/mcp/tools/dashboard-tools.ts
@@ -16,6 +16,21 @@ import {
 } from "@/lib/mcp/tools/dashboard-summary";
 import { parseDateInput } from "@/lib/time/parse-date-input";
 
+function parseOptionalAtTime(atTime: string | undefined) {
+  if (!atTime) return { ok: true as const, value: undefined };
+  const parsed = parseDateInput(atTime);
+  if (!(parsed instanceof Date)) {
+    return {
+      ok: false as const,
+      result: jsonToolResult({
+        success: false,
+        message: `Invalid atTime: "${atTime}". Use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS+08:00.`,
+      }),
+    };
+  }
+  return { ok: true as const, value: parsed };
+}
+
 export function registerDashboardTools(server: McpServer) {
   server.registerTool(
     "get_my_dashboard",
@@ -26,13 +41,21 @@ export function registerDashboardTools(server: McpServer) {
       inputSchema: {
         locale: mcpLocaleInputSchema,
         mode: mcpModeInputSchema,
+        atTime: flexDateInputSchema
+          .optional()
+          .describe(
+            "Override the reference time for next class, deadlines, events, current semester, and preferred shuttle. Defaults to now.",
+          ),
       },
     },
-    async ({ locale, mode }, extra) => {
+    async ({ locale, mode, atTime }, extra) => {
       const resolvedMode = resolveMcpMode(mode);
+      const parsedAtTime = parseOptionalAtTime(atTime);
+      if (!parsedAtTime.ok) return parsedAtTime.result;
       const snapshot = await getAssistantDashboardSnapshot({
         userId: getUserId(extra.authInfo),
         locale,
+        atTime: parsedAtTime.value,
       });
       if (resolvedMode === "full") {
         return jsonToolResult(snapshot, { mode: "full" });
@@ -56,12 +79,20 @@ export function registerDashboardTools(server: McpServer) {
       inputSchema: {
         locale: mcpLocaleInputSchema,
         mode: mcpModeInputSchema,
+        atTime: flexDateInputSchema
+          .optional()
+          .describe(
+            "Override the reference time for the next-class lookup. Defaults to now.",
+          ),
       },
     },
-    async ({ locale, mode }, extra) => {
+    async ({ locale, mode, atTime }, extra) => {
+      const parsedAtTime = parseOptionalAtTime(atTime);
+      if (!parsedAtTime.ok) return parsedAtTime.result;
       const snapshot = await getAssistantDashboardSnapshot({
         userId: getUserId(extra.authInfo),
         locale,
+        atTime: parsedAtTime.value,
       });
       return jsonToolResult(
         {

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -511,6 +511,51 @@ describe("atTime override — time-sensitive tools are anchored to SEED_DATE", (
     }
   });
 
+  it("get_upcoming_deadlines excludes already-started exams", async () => {
+    const section = await prisma.section.findUnique({
+      where: { jwId: DEV_SEED.section.jwId },
+      select: { id: true },
+    });
+    if (!section) {
+      throw new Error(`Seed section ${DEV_SEED.section.jwId} not found`);
+    }
+
+    const jwId = 926042903;
+    await prisma.exam.deleteMany({ where: { jwId } });
+
+    try {
+      await prisma.exam.create({
+        data: {
+          jwId,
+          sectionId: section.id,
+          examDate: new Date(`${SEED_DATE}T00:00:00.000Z`),
+          startTime: 900,
+          endTime: 1100,
+        },
+      });
+
+      const result = await mcp.call<{
+        deadlines?: Array<{
+          type?: string;
+          payload?: { jwId?: number | null };
+        }>;
+      }>("get_upcoming_deadlines", {
+        locale: "zh-cn",
+        dayLimit: 1,
+        atTime: shanghaiIsoOnSeedDate(1000),
+      });
+
+      expect(
+        (result.deadlines ?? []).some(
+          (deadline) =>
+            deadline.type === "exam" && deadline.payload?.jwId === jwId,
+        ),
+      ).toBe(false);
+    } finally {
+      await prisma.exam.deleteMany({ where: { jwId } });
+    }
+  });
+
   it("get_upcoming_deadlines treats date-only atTime as Shanghai day start", async () => {
     const dueAt = `${SEED_DATE}T06:30:00+08:00`;
     const todo = await prisma.todo.create({

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -23,8 +23,12 @@ let mcp: McpHarness;
 function shanghaiIsoOnSeedDate(hhmm: number, addMinutes = 0) {
   const hours = Math.trunc(hhmm / 100);
   const minutes = hhmm % 100;
-  const date = new Date(`${SEED_DATE}T00:00:00+08:00`);
-  date.setHours(hours, minutes + addMinutes, 0, 0);
+  const date = new Date(
+    Date.parse(
+      `${SEED_DATE}T${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:00+08:00`,
+    ) +
+      addMinutes * 60_000,
+  );
   return date
     .toLocaleString("sv-SE", {
       timeZone: "Asia/Shanghai",

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -174,6 +174,82 @@ describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools"
     ).toBe(true);
   });
 
+  it("list_my_calendar_events treats same-day bare date ranges as full Shanghai days", async () => {
+    const result = await mcp.call<{
+      events?: Array<{ type?: string; at?: string }>;
+    }>("list_my_calendar_events", {
+      dateFrom: SEED_DATE,
+      dateTo: SEED_DATE,
+      locale: "zh-cn",
+    });
+
+    expect(Array.isArray(result.events)).toBe(true);
+    expect(
+      (result.events ?? []).some(
+        (event) => event.type === "schedule" && event.at?.startsWith(SEED_DATE),
+      ),
+    ).toBe(true);
+  });
+
+  it("list_my_calendar_events honors an exact inclusive dateTo bound", async () => {
+    const dueAt = "2026-05-02T21:00:00+08:00";
+    const result = await mcp.call<{
+      events?: Array<{ type?: string; at?: string }>;
+    }>("list_my_calendar_events", {
+      dateFrom: dueAt,
+      dateTo: dueAt,
+      locale: "zh-cn",
+    });
+
+    expect(
+      (result.events ?? []).some(
+        (event) => event.type === "homework_due" && event.at === dueAt,
+      ),
+    ).toBe(true);
+  });
+
+  it("list_my_calendar_events keeps no-time exams visible through their day", async () => {
+    const section = await prisma.section.findUnique({
+      where: { jwId: DEV_SEED.section.jwId },
+      select: { id: true },
+    });
+    if (!section) {
+      throw new Error(`Seed section ${DEV_SEED.section.jwId} not found`);
+    }
+
+    const jwId = 926042900;
+    await prisma.exam.deleteMany({ where: { jwId } });
+
+    try {
+      await prisma.exam.create({
+        data: {
+          jwId,
+          sectionId: section.id,
+          examDate: new Date(`${SEED_DATE}T00:00:00.000Z`),
+          startTime: null,
+          endTime: null,
+        },
+      });
+
+      const result = await mcp.call<{
+        events?: Array<{ type?: string; at?: string }>;
+      }>("list_my_calendar_events", {
+        dateFrom: `${SEED_DATE}T08:00:00+08:00`,
+        dateTo: `${SEED_DATE}T09:00:00+08:00`,
+        locale: "zh-cn",
+      });
+
+      expect(
+        (result.events ?? []).some(
+          (event) =>
+            event.type === "exam" && event.at === `${SEED_DATE}T00:00:00+08:00`,
+        ),
+      ).toBe(true);
+    } finally {
+      await prisma.exam.deleteMany({ where: { jwId } });
+    }
+  });
+
   it("returns a descriptive error for a nonsense date string", async () => {
     const result = await mcp.call<{
       success?: boolean;
@@ -397,6 +473,26 @@ describe("query_schedules — flexible date filters", () => {
 // ---------------------------------------------------------------------------
 
 describe("get_my_dashboard — default mode compactness", () => {
+  it("atTime anchors nextClass, deadlines, and events", async () => {
+    const dashboard = await mcp.call<{
+      nextClass?: { type?: string; at?: string | null };
+      upcomingDeadlines?: {
+        total?: number;
+        items?: Array<{ type?: string; at?: string | null }>;
+      };
+      upcomingEvents?: { total?: number };
+    }>("get_my_dashboard", {
+      locale: "zh-cn",
+      mode: "summary",
+      atTime: SEED_AT_TIME,
+    });
+
+    expect(dashboard.nextClass?.type).toBe("schedule");
+    expect(dashboard.nextClass?.at?.slice(0, 10)).toBe(SEED_DATE);
+    expect(dashboard.upcomingDeadlines?.total).toBeGreaterThan(0);
+    expect(dashboard.upcomingEvents?.total).toBeGreaterThan(0);
+  });
+
   it("scheduleGroup and roomType are stripped from nextClass payload", async () => {
     const dashboard = await mcp.call<{
       nextClass?: {
@@ -409,7 +505,7 @@ describe("get_my_dashboard — default mode compactness", () => {
       };
       subscriptions?: { currentSemesterSectionsTotal?: number };
       todos?: { incompleteCount?: number };
-    }>("get_my_dashboard", { locale: "zh-cn" });
+    }>("get_my_dashboard", { locale: "zh-cn", atTime: SEED_AT_TIME });
 
     if (dashboard.nextClass?.payload) {
       expect(dashboard.nextClass.payload).not.toHaveProperty("scheduleGroup");
@@ -426,12 +522,14 @@ describe("get_my_dashboard — default mode compactness", () => {
       await mcp.callTool("get_my_dashboard", {
         locale: "zh-cn",
         mode: "default",
+        atTime: SEED_AT_TIME,
       }),
     );
     const sum = JSON.stringify(
       await mcp.callTool("get_my_dashboard", {
         locale: "zh-cn",
         mode: "summary",
+        atTime: SEED_AT_TIME,
       }),
     );
     expect(sum.length).toBeLessThan(def.length);

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -20,6 +20,20 @@ const SEED_AT_TIME = DEV_SEED_ANCHOR.recommendedAtTime;
 let devUserId: string;
 let mcp: McpHarness;
 
+function shanghaiIsoOnSeedDate(hhmm: number, addMinutes = 0) {
+  const hours = Math.trunc(hhmm / 100);
+  const minutes = hhmm % 100;
+  const date = new Date(`${SEED_DATE}T00:00:00+08:00`);
+  date.setHours(hours, minutes + addMinutes, 0, 0);
+  return date
+    .toLocaleString("sv-SE", {
+      timeZone: "Asia/Shanghai",
+      hour12: false,
+    })
+    .replace(" ", "T")
+    .concat("+08:00");
+}
+
 beforeAll(async () => {
   const user = await prisma.user.findFirst({
     where: { username: DEV_SEED.debugUsername },
@@ -208,6 +222,118 @@ describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools"
     ).toBe(true);
   });
 
+  it("list_my_calendar_events includes todos at an exact inclusive dateTo bound", async () => {
+    const dueAt = `${SEED_DATE}T06:45:00+08:00`;
+    const todo = await prisma.todo.create({
+      data: {
+        userId: devUserId,
+        title: "[integration-test] inclusive todo dueAt",
+        dueAt: new Date(dueAt),
+      },
+      select: { id: true },
+    });
+
+    try {
+      const result = await mcp.call<{
+        events?: Array<{
+          type?: string;
+          at?: string;
+          payload?: { id?: string };
+        }>;
+      }>("list_my_calendar_events", {
+        dateFrom: dueAt,
+        dateTo: dueAt,
+        locale: "zh-cn",
+      });
+
+      expect(
+        (result.events ?? []).some(
+          (event) =>
+            event.type === "todo_due" &&
+            event.at === dueAt &&
+            event.payload?.id === todo.id,
+        ),
+      ).toBe(true);
+    } finally {
+      await prisma.todo.deleteMany({ where: { id: todo.id } });
+    }
+  });
+
+  it("list_my_calendar_events includes timed events overlapping an exact window", async () => {
+    const schedule = await prisma.schedule.findFirst({
+      where: {
+        section: { jwId: DEV_SEED.section.jwId },
+        date: new Date(`${SEED_DATE}T00:00:00.000Z`),
+      },
+      select: { id: true, startTime: true, endTime: true },
+      orderBy: { startTime: "asc" },
+    });
+    if (!schedule) {
+      throw new Error(`Seed schedule for ${SEED_DATE} not found`);
+    }
+
+    const windowStart = shanghaiIsoOnSeedDate(schedule.startTime, 15);
+    const windowEnd = shanghaiIsoOnSeedDate(schedule.startTime, 30);
+    const endsAt = new Date(shanghaiIsoOnSeedDate(schedule.endTime));
+    expect(endsAt.getTime()).toBeGreaterThan(new Date(windowEnd).getTime());
+
+    const result = await mcp.call<{
+      events?: Array<{ type?: string; payload?: { id?: number } }>;
+    }>("list_my_calendar_events", {
+      dateFrom: windowStart,
+      dateTo: windowEnd,
+      locale: "zh-cn",
+    });
+
+    expect(
+      (result.events ?? []).some(
+        (event) =>
+          event.type === "schedule" && event.payload?.id === schedule.id,
+      ),
+    ).toBe(true);
+  });
+
+  it("list_my_calendar_events widens date-backed queries for exact windows", async () => {
+    const section = await prisma.section.findUnique({
+      where: { jwId: DEV_SEED.section.jwId },
+      select: { id: true },
+    });
+    if (!section) {
+      throw new Error(`Seed section ${DEV_SEED.section.jwId} not found`);
+    }
+
+    const jwId = 926042901;
+    await prisma.exam.deleteMany({ where: { jwId } });
+
+    try {
+      await prisma.exam.create({
+        data: {
+          jwId,
+          sectionId: section.id,
+          examDate: new Date(`${SEED_DATE}T00:00:00.000Z`),
+          startTime: null,
+          endTime: null,
+        },
+      });
+
+      const result = await mcp.call<{
+        events?: Array<{ type?: string; payload?: { jwId?: number | null } }>;
+      }>("list_my_calendar_events", {
+        dateFrom: `${SEED_DATE}T00:10:00+08:00`,
+        dateTo: `${SEED_DATE}T00:30:00+08:00`,
+        locale: "zh-cn",
+      });
+
+      expect(
+        (result.events ?? []).some(
+          (event) => event.type === "exam" && event.payload?.jwId === jwId,
+        ),
+      ).toBe(true);
+    } finally {
+      await prisma.exam.deleteMany({ where: { jwId } });
+    }
+  });
+
   it("list_my_calendar_events keeps no-time exams visible through their day", async () => {
     const section = await prisma.section.findUnique({
       where: { jwId: DEV_SEED.section.jwId },
@@ -245,6 +371,47 @@ describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools"
             event.type === "exam" && event.at === `${SEED_DATE}T00:00:00+08:00`,
         ),
       ).toBe(true);
+    } finally {
+      await prisma.exam.deleteMany({ where: { jwId } });
+    }
+  });
+
+  it("list_my_calendar_events respects endTime for exams without startTime", async () => {
+    const section = await prisma.section.findUnique({
+      where: { jwId: DEV_SEED.section.jwId },
+      select: { id: true },
+    });
+    if (!section) {
+      throw new Error(`Seed section ${DEV_SEED.section.jwId} not found`);
+    }
+
+    const jwId = 926042902;
+    await prisma.exam.deleteMany({ where: { jwId } });
+
+    try {
+      await prisma.exam.create({
+        data: {
+          jwId,
+          sectionId: section.id,
+          examDate: new Date(`${SEED_DATE}T00:00:00.000Z`),
+          startTime: null,
+          endTime: 1200,
+        },
+      });
+
+      const result = await mcp.call<{
+        events?: Array<{ type?: string; payload?: { jwId?: number | null } }>;
+      }>("list_my_calendar_events", {
+        dateFrom: `${SEED_DATE}T13:00:00+08:00`,
+        dateTo: `${SEED_DATE}T14:00:00+08:00`,
+        locale: "zh-cn",
+      });
+
+      expect(
+        (result.events ?? []).some(
+          (event) => event.type === "exam" && event.payload?.jwId === jwId,
+        ),
+      ).toBe(false);
     } finally {
       await prisma.exam.deleteMany({ where: { jwId } });
     }
@@ -337,6 +504,43 @@ describe("atTime override — time-sensitive tools are anchored to SEED_DATE", (
       if (deadline.at) {
         expect(deadline.at >= SEED_DATE).toBe(true);
       }
+    }
+  });
+
+  it("get_upcoming_deadlines treats date-only atTime as Shanghai day start", async () => {
+    const dueAt = `${SEED_DATE}T06:30:00+08:00`;
+    const todo = await prisma.todo.create({
+      data: {
+        userId: devUserId,
+        title: "[integration-test] early date-only deadline",
+        dueAt: new Date(dueAt),
+      },
+      select: { id: true },
+    });
+
+    try {
+      const result = await mcp.call<{
+        deadlines?: Array<{
+          type?: string;
+          at?: string;
+          payload?: { id?: string };
+        }>;
+      }>("get_upcoming_deadlines", {
+        locale: "zh-cn",
+        dayLimit: 1,
+        atTime: SEED_DATE,
+      });
+
+      expect(
+        (result.deadlines ?? []).some(
+          (deadline) =>
+            deadline.type === "todo_due" &&
+            deadline.at === dueAt &&
+            deadline.payload?.id === todo.id,
+        ),
+      ).toBe(true);
+    } finally {
+      await prisma.todo.deleteMany({ where: { id: todo.id } });
     }
   });
 

--- a/tools/dev/artifacts/dump-page-snapshots.ts
+++ b/tools/dev/artifacts/dump-page-snapshots.ts
@@ -18,6 +18,48 @@ import {
 } from "./oauth-cleanup";
 import { PAGE_SNAPSHOT_CASES, type PageSnapshotCase } from "./snapshot-cases";
 
+const MAX_ARTIFACT_SEGMENT_LENGTH = 80;
+
+function sanitizeUriSegment(value: string) {
+  return sanitizeFileSegment(value).slice(0, MAX_ARTIFACT_SEGMENT_LENGTH);
+}
+
+function pageArtifactSegments(uri: string) {
+  let url: URL;
+  try {
+    url = new URL(uri, "http://snapshot.local");
+  } catch {
+    return [sanitizeUriSegment(uri)];
+  }
+
+  const segments = url.pathname
+    .split("/")
+    .filter(Boolean)
+    .map(sanitizeUriSegment);
+  if (segments.length === 0) segments.push("_root");
+
+  const querySegments = [...url.searchParams.entries()].map(([key, value]) =>
+    sanitizeUriSegment(`${key}-${value}`),
+  );
+  if (querySegments.length > 0) {
+    segments.push("_query", ...querySegments);
+  }
+
+  return segments;
+}
+
+function pageArtifactDirectory(
+  root: string,
+  snapshotCase: PageSnapshotCase,
+  uri: string,
+) {
+  return path.join(
+    root,
+    ...pageArtifactSegments(uri),
+    sanitizeUriSegment(snapshotCase.id),
+  );
+}
+
 async function resolvePath(page: Page, snapshotCase: PageSnapshotCase) {
   if (!snapshotCase.resolvePath) return snapshotCase.path;
 
@@ -122,8 +164,7 @@ async function main() {
       });
       const page = await context.newPage();
       const startedAt = performance.now();
-      const dir = path.join(root, sanitizeFileSegment(snapshotCase.id));
-      await resetDirectory(dir);
+      let dir = pageArtifactDirectory(root, snapshotCase, snapshotCase.path);
       try {
         await signInForSnapshot(
           page,
@@ -131,6 +172,8 @@ async function main() {
           snapshotCase.resolvePath ? "/" : snapshotCase.path,
         );
         const requestedPath = await resolvePath(page, snapshotCase);
+        dir = pageArtifactDirectory(root, snapshotCase, requestedPath);
+        await resetDirectory(dir);
         const response = await gotoSnapshotPage(
           page,
           snapshotCase,
@@ -163,6 +206,7 @@ async function main() {
         entries.push(metadata);
         console.log(`page ${snapshotCase.id}: ${metadata.status}`);
       } catch (error) {
+        await resetDirectory(dir);
         const metadata = {
           id: snapshotCase.id,
           kind: "page",

--- a/tools/dev/artifacts/render-e2e-snapshot-comment.ts
+++ b/tools/dev/artifacts/render-e2e-snapshot-comment.ts
@@ -45,6 +45,8 @@ type RouteTreeNode = {
 const MAX_EMBEDDED_JSON_CHARS = 600;
 const SCREENSHOT_WIDTH = 480;
 const IGNORED_PAGE_QUERY_PARAMS = new Set(["snapshotAt"]);
+const PAGE_TABLE_WIDTHS = ["14%", "20%", "18%", "8%", "10%", "10%", "20%"];
+const RESPONSE_TABLE_WIDTHS = ["14%", "8%", "22%", "10%", "28%", "18%"];
 
 function usage() {
   return [
@@ -397,8 +399,17 @@ async function renderRouteTreeNode(
   );
 
   if (depth > 0) {
-    const summary = `${escapeHtml(node.label)}${entries.length > 0 ? ` (${entries.length})` : ""}`;
-    lines.push(`<details open><summary>${summary}</summary>`, "");
+    const entryCount =
+      entries.length > 0 ? ` <sub>${entries.length} item(s)</sub>` : "";
+    const headingLevel = Math.min(depth + 3, 6);
+    const heading = `${"#".repeat(headingLevel)} \`${node.label}\`${entryCount}`;
+    lines.push(
+      "<details open>",
+      `<summary><code>${escapeHtml(node.label)}</code>${entryCount}</summary>`,
+      "",
+      heading,
+      "",
+    );
   }
 
   if (entries.length > 0) {
@@ -457,10 +468,23 @@ function cardTable(cards: string[], emptyText: string) {
   return lines;
 }
 
-function entryTable(headers: string[], rows: string[][], emptyText: string) {
+function entryTable(
+  headers: string[],
+  rows: string[][],
+  emptyText: string,
+  widths: string[] = [],
+) {
   if (rows.length === 0) return [emptyText];
 
-  const lines = ['<table role="presentation" width="100%">', "<thead>", "<tr>"];
+  const lines = ['<table role="presentation" width="100%">'];
+  if (widths.length > 0) {
+    lines.push("<colgroup>");
+    for (const width of widths) {
+      lines.push(`<col width="${escapeAttribute(width)}">`);
+    }
+    lines.push("</colgroup>");
+  }
+  lines.push("<thead>", "<tr>");
   for (const header of headers) {
     lines.push(`<th align="left" valign="top">${escapeHtml(header)}</th>`);
   }
@@ -476,21 +500,13 @@ function entryTable(headers: string[], rows: string[][], emptyText: string) {
   return lines;
 }
 
-function foldedScreenshot(
+function screenshotPanel(
   entry: SnapshotEntry,
   options: Pick<Options, "artifactUrl" | "screenshotBaseUrl">,
 ) {
   const filePath = asString(entry.screenshot);
-  if (!filePath) return "";
-
-  return [
-    "<details>",
-    "<summary>screenshot</summary>",
-    "",
-    screenshotCell(entry, options),
-    "",
-    "</details>",
-  ].join("\n");
+  if (!filePath) return "<em>No screenshot captured.</em>";
+  return screenshotCell(entry, options);
 }
 
 function pageInfoTable(entry: SnapshotEntry) {
@@ -509,6 +525,7 @@ function pageInfoTable(entry: SnapshotEntry) {
       ],
     ],
     "No page metadata captured.",
+    PAGE_TABLE_WIDTHS,
   ).join("\n");
 }
 
@@ -516,9 +533,31 @@ function pageCards(
   entries: SnapshotEntry[],
   options: Pick<Options, "artifactUrl" | "screenshotBaseUrl">,
 ) {
-  return entries.map((entry) =>
-    [foldedScreenshot(entry, options), "", pageInfoTable(entry)].join("\n"),
-  );
+  return entries.map((entry) => {
+    const summary = [
+      `<strong>${escapeHtml(entry.id ?? "page")}</strong>`,
+      `<code>${escapeHtml(displayRoute(entry))}</code>`,
+      finePrint([
+        ["result", resultCell(entry)],
+        ["auth", entry.auth],
+      ]),
+    ]
+      .filter(Boolean)
+      .join(" &nbsp; ");
+    return [
+      `<details><summary>${summary}</summary>`,
+      "",
+      "##### Screenshot",
+      "",
+      screenshotPanel(entry, options),
+      "",
+      "##### Metadata",
+      "",
+      pageInfoTable(entry),
+      "",
+      "</details>",
+    ].join("\n");
+  });
 }
 
 async function responseRows(
@@ -594,6 +633,7 @@ async function main() {
         ["Case", "Method", "URI", "Result", "Response", "Metadata"],
         await responseRows(entries, options),
         "No API response snapshots here.",
+        RESPONSE_TABLE_WIDTHS,
       ),
     ),
     responseCards(mcpEntries, options),

--- a/tools/dev/artifacts/render-e2e-snapshot-comment.ts
+++ b/tools/dev/artifacts/render-e2e-snapshot-comment.ts
@@ -28,6 +28,7 @@ type SnapshotEntry = {
   response?: unknown;
   error?: unknown;
   durationMs?: unknown;
+  title?: unknown;
 };
 
 type SnapshotManifest = {
@@ -35,14 +36,15 @@ type SnapshotManifest = {
   entries?: unknown;
 };
 
-type PageTreeNode = {
+type RouteTreeNode = {
   label: string;
   entries: SnapshotEntry[];
-  children: Map<string, PageTreeNode>;
+  children: Map<string, RouteTreeNode>;
 };
 
 const MAX_EMBEDDED_JSON_CHARS = 600;
 const SCREENSHOT_WIDTH = 480;
+const IGNORED_PAGE_QUERY_PARAMS = new Set(["snapshotAt"]);
 
 function usage() {
   return [
@@ -281,8 +283,55 @@ function pageRoute(entry: SnapshotEntry) {
   return asString(entry.id) ?? "/";
 }
 
-function pageRouteSegments(entry: SnapshotEntry) {
-  const route = pageRoute(entry);
+function normalizedRoute(
+  route: string,
+  ignoredParams: Set<string> = new Set(),
+) {
+  try {
+    const url = new URL(route, "http://snapshot.local");
+    const params = [...url.searchParams.entries()].filter(
+      ([key]) => !ignoredParams.has(key),
+    );
+    const search =
+      params.length > 0
+        ? `?${params.map(([key, value]) => `${key}=${value}`).join("&")}`
+        : "";
+    return `${url.pathname}${search}`;
+  } catch {
+    return route;
+  }
+}
+
+function displayRoute(entry: SnapshotEntry) {
+  if (entry.kind === "page") {
+    return normalizedRoute(pageRoute(entry), IGNORED_PAGE_QUERY_PARAMS);
+  }
+  return normalizedRoute(entryRoute(entry));
+}
+
+function treeRoute(entry: SnapshotEntry) {
+  return displayRoute(entry);
+}
+
+function entryRoute(entry: SnapshotEntry) {
+  if (entry.kind === "page") return pageRoute(entry);
+
+  const candidates = [entry.path, entry.requestedPath, entry.pathTemplate];
+  for (const candidate of candidates) {
+    const value = asString(candidate);
+    if (!value) continue;
+    try {
+      const url = new URL(value, "http://snapshot.local");
+      return `${url.pathname}${url.search}`;
+    } catch {
+      return value;
+    }
+  }
+
+  return asString(entry.id) ?? "/";
+}
+
+function routeSegments(route: string) {
   let url: URL;
   try {
     url = new URL(route, "http://snapshot.local");
@@ -293,26 +342,31 @@ function pageRouteSegments(entry: SnapshotEntry) {
   const segments = url.pathname.split("/").filter(Boolean);
   if (segments.length === 0) segments.push("/");
 
-  if (url.search) {
-    segments.push(url.search);
+  const params = [...url.searchParams.entries()];
+  if (params.length > 0) {
+    segments.push(
+      `?${params.map(([key, value]) => `${key}=${value}`).join("&")}`,
+    );
   }
 
   return segments;
 }
 
-function comparePageEntries(a: SnapshotEntry, b: SnapshotEntry) {
-  return pageRoute(a).localeCompare(pageRoute(b), "en");
+function compareRouteEntries(a: SnapshotEntry, b: SnapshotEntry) {
+  const routeComparison = displayRoute(a).localeCompare(displayRoute(b), "en");
+  if (routeComparison !== 0) return routeComparison;
+  return String(a.id ?? "").localeCompare(String(b.id ?? ""), "en");
 }
 
-function createPageTreeNode(label: string): PageTreeNode {
+function createRouteTreeNode(label: string): RouteTreeNode {
   return { label, entries: [], children: new Map() };
 }
 
-function buildPageTree(entries: SnapshotEntry[]) {
-  const root = createPageTreeNode("/");
+function buildRouteTree(entries: SnapshotEntry[]) {
+  const root = createRouteTreeNode("/");
 
   for (const entry of entries) {
-    const segments = pageRouteSegments(entry);
+    const segments = routeSegments(treeRoute(entry));
     let node = root;
     for (const segment of segments) {
       const existing = node.children.get(segment);
@@ -321,7 +375,7 @@ function buildPageTree(entries: SnapshotEntry[]) {
         continue;
       }
 
-      const child = createPageTreeNode(segment);
+      const child = createRouteTreeNode(segment);
       node.children.set(segment, child);
       node = child;
     }
@@ -331,13 +385,13 @@ function buildPageTree(entries: SnapshotEntry[]) {
   return root;
 }
 
-function renderPageTreeNode(
-  node: PageTreeNode,
-  options: Pick<Options, "artifactUrl" | "screenshotBaseUrl">,
+async function renderRouteTreeNode(
+  node: RouteTreeNode,
+  renderEntries: (entries: SnapshotEntry[]) => Promise<string[]>,
   depth = 0,
-): string[] {
+): Promise<string[]> {
   const lines: string[] = [];
-  const entries = [...node.entries].sort(comparePageEntries);
+  const entries = [...node.entries].sort(compareRouteEntries);
   const children = [...node.children.values()].sort((a, b) =>
     a.label.localeCompare(b.label, "en"),
   );
@@ -348,14 +402,11 @@ function renderPageTreeNode(
   }
 
   if (entries.length > 0) {
-    lines.push(
-      ...cardTable(pageCards(entries, options), "No page screenshots here."),
-      "",
-    );
+    lines.push(...(await renderEntries(entries)), "");
   }
 
   for (const child of children) {
-    lines.push(...renderPageTreeNode(child, options, depth + 1));
+    lines.push(...(await renderRouteTreeNode(child, renderEntries, depth + 1)));
   }
 
   if (depth > 0) {
@@ -381,10 +432,22 @@ function detailsJson(summary: string, json: string | undefined) {
   ].join("\n");
 }
 
+function markdownTableCell(value: string) {
+  return value.replaceAll("|", "\\|").replaceAll("\n", "<br>");
+}
+
+function summaryTable(rows: Array<[string, string]>) {
+  const lines = ["| Field | Value |", "| --- | --- |"];
+  for (const [field, value] of rows) {
+    lines.push(`| ${markdownTableCell(field)} | ${markdownTableCell(value)} |`);
+  }
+  return lines;
+}
+
 function cardTable(cards: string[], emptyText: string) {
   if (cards.length === 0) return [emptyText];
 
-  const lines = ['<table role="presentation">', "<tbody>"];
+  const lines = ['<table role="presentation" width="100%">', "<tbody>"];
   for (const card of cards) {
     lines.push("<tr>");
     lines.push(`<td width="100%" valign="top">${card}</td>`);
@@ -394,30 +457,71 @@ function cardTable(cards: string[], emptyText: string) {
   return lines;
 }
 
+function entryTable(headers: string[], rows: string[][], emptyText: string) {
+  if (rows.length === 0) return [emptyText];
+
+  const lines = ['<table role="presentation" width="100%">', "<thead>", "<tr>"];
+  for (const header of headers) {
+    lines.push(`<th align="left" valign="top">${escapeHtml(header)}</th>`);
+  }
+  lines.push("</tr>", "</thead>", "<tbody>");
+  for (const row of rows) {
+    lines.push("<tr>");
+    for (const cell of row) {
+      lines.push(`<td valign="top">${cell}</td>`);
+    }
+    lines.push("</tr>");
+  }
+  lines.push("</tbody>", "</table>");
+  return lines;
+}
+
+function foldedScreenshot(
+  entry: SnapshotEntry,
+  options: Pick<Options, "artifactUrl" | "screenshotBaseUrl">,
+) {
+  const filePath = asString(entry.screenshot);
+  if (!filePath) return "";
+
+  return [
+    "<details>",
+    "<summary>screenshot</summary>",
+    "",
+    screenshotCell(entry, options),
+    "",
+    "</details>",
+  ].join("\n");
+}
+
+function pageInfoTable(entry: SnapshotEntry) {
+  const filePath = asString(entry.screenshot);
+  return entryTable(
+    ["Page", "URI", "Title", "Auth", "Result", "Duration", "Artifact"],
+    [
+      [
+        `<strong>${escapeHtml(entry.id ?? "page")}</strong>`,
+        `<code>${escapeHtml(displayRoute(entry))}</code>`,
+        escapeHtml(entry.title ?? "-"),
+        escapeHtml(entry.auth ?? "-"),
+        escapeHtml(resultCell(entry)),
+        escapeHtml(entry.durationMs ? `${entry.durationMs}ms` : "-"),
+        filePath ? `<code>${escapeHtml(filePath)}</code>` : "-",
+      ],
+    ],
+    "No page metadata captured.",
+  ).join("\n");
+}
+
 function pageCards(
   entries: SnapshotEntry[],
   options: Pick<Options, "artifactUrl" | "screenshotBaseUrl">,
 ) {
-  return entries.map((entry) => {
-    const filePath = asString(entry.screenshot);
-    return [
-      `<strong>${escapeHtml(entry.id ?? "page")}</strong>`,
-      "<br>",
-      `<code>${escapeHtml(pageRoute(entry))}</code>`,
-      "<br>",
-      screenshotCell(entry, options),
-      "<br>",
-      finePrint([
-        ["auth", entry.auth],
-        ["result", resultCell(entry)],
-        ["duration", entry.durationMs ? `${entry.durationMs}ms` : undefined],
-        ["screenshot", filePath],
-      ]),
-    ].join("");
-  });
+  return entries.map((entry) =>
+    [foldedScreenshot(entry, options), "", pageInfoTable(entry)].join("\n"),
+  );
 }
 
-async function responseCards(
+async function responseRows(
   entries: SnapshotEntry[],
   options: Pick<Options, "snapshotDir">,
 ) {
@@ -427,25 +531,32 @@ async function responseCards(
       const json = await readSnapshotJson(options.snapshotDir, responsePath);
       const previewJson = responsePreviewJson(entry, json);
       const type = entry.method ?? entry.kind;
+      const metadata = finePrint([
+        ["auth", entry.auth],
+        ["duration", entry.durationMs ? `${entry.durationMs}ms` : undefined],
+        ["artifact path", responsePath],
+      ]);
       return [
         `<strong>${escapeHtml(entry.id ?? "response")}</strong>`,
-        "<br>",
+        `<code>${escapeHtml(String(type))}</code>`,
+        `<code>${escapeHtml(displayRoute(entry))}</code>`,
+        finePrint([["result", resultCell(entry)]]) || "-",
         detailsJson(
           entry.kind === "api" ? "response body" : "tool result",
           previewJson,
         ),
-        "<br>",
-        finePrint([
-          ["type", type],
-          ["auth", entry.auth],
-          ["result", resultCell(entry)],
-          ["duration", entry.durationMs ? `${entry.durationMs}ms` : undefined],
-          ["path", entry.path],
-          ["artifact path", responsePath],
-        ]),
-      ].join("");
+        metadata || "-",
+      ];
     }),
   );
+}
+
+async function responseCards(
+  entries: SnapshotEntry[],
+  options: Pick<Options, "snapshotDir">,
+) {
+  const rows = await responseRows(entries, options);
+  return rows.map((row) => row.join("<br>"));
 }
 
 async function main() {
@@ -462,39 +573,54 @@ async function main() {
   const failedCount = [...pageEntries, ...apiEntries, ...mcpEntries].filter(
     entryFailed,
   ).length;
-  const workflowLink = options.workflowUrl
-    ? `Workflow run: [open](${options.workflowUrl})`
-    : "Workflow run: -";
-  const statusLine =
+  const workflowValue = options.workflowUrl
+    ? `[open](${options.workflowUrl})`
+    : "-";
+  const resultText =
     failedCount === 0
-      ? "Result: snapshot capture completed without failed entries."
-      : `Result: snapshot capture recorded ${failedCount} failed entries.`;
-  const [apiCards, mcpCards] = await Promise.all([
-    responseCards(apiEntries, options),
+      ? "snapshot capture completed without failed entries."
+      : `snapshot capture recorded ${failedCount} failed entries.`;
+  const capturedText = [
+    `${pageEntries.length} screenshots`,
+    `${apiEntries.length} API responses`,
+    `${mcpEntries.length} MCP responses`,
+  ].join("<br>");
+  const [pageTreeLines, apiTreeLines, mcpCards] = await Promise.all([
+    renderRouteTreeNode(buildRouteTree(pageEntries), async (entries) =>
+      cardTable(pageCards(entries, options), "No page screenshots here."),
+    ),
+    renderRouteTreeNode(buildRouteTree(apiEntries), async (entries) =>
+      entryTable(
+        ["Case", "Method", "URI", "Result", "Response", "Metadata"],
+        await responseRows(entries, options),
+        "No API response snapshots here.",
+      ),
+    ),
     responseCards(mcpEntries, options),
   ]);
-  const pageTree = buildPageTree(pageEntries);
 
   const lines = [
     "<!-- life-ustc-e2e-snapshot-artifacts -->",
-    `<details><summary>E2E snapshot artifacts for ${shortSha(options.commit)} (${options.status})</summary>`,
+    `<details open><summary>E2E snapshot artifacts for ${shortSha(options.commit)} (${options.status})</summary>`,
     "",
-    `Commit: \`${options.commit}\``,
-    `Artifact: [e2e-snapshot-artifacts](${options.artifactUrl})`,
-    workflowLink,
-    statusLine,
-    `Captured: ${pageEntries.length} screenshots, ${apiEntries.length} API responses, ${mcpEntries.length} MCP responses.`,
+    ...summaryTable([
+      ["Commit", `\`${options.commit}\``],
+      ["Artifact", `[e2e-snapshot-artifacts](${options.artifactUrl})`],
+      ["Workflow run", workflowValue],
+      ["Result", resultText],
+      ["Captured", capturedText],
+    ]),
     "",
     "### Screenshots",
     "",
     ...(pageEntries.length > 0
-      ? renderPageTreeNode(pageTree, options)
+      ? pageTreeLines
       : ["No page screenshots were generated."]),
     "",
     "### API Responses",
     "",
     ...(apiEntries.length > 0
-      ? cardTable(apiCards, "No API response snapshots were generated.")
+      ? apiTreeLines
       : ["No API response snapshots were generated."]),
     "",
     "### MCP Responses",

--- a/tools/dev/artifacts/render-e2e-snapshot-comment.ts
+++ b/tools/dev/artifacts/render-e2e-snapshot-comment.ts
@@ -45,8 +45,10 @@ type RouteTreeNode = {
 const MAX_EMBEDDED_JSON_CHARS = 600;
 const SCREENSHOT_WIDTH = 480;
 const IGNORED_PAGE_QUERY_PARAMS = new Set(["snapshotAt"]);
-const PAGE_TABLE_WIDTHS = ["14%", "20%", "18%", "8%", "10%", "10%", "20%"];
-const RESPONSE_TABLE_WIDTHS = ["14%", "8%", "22%", "10%", "28%", "18%"];
+const TREE_BRANCH = "|-- ";
+const TREE_LAST = "`-- ";
+const TREE_PIPE = "|   ";
+const TREE_BLANK = "    ";
 
 function usage() {
   return [
@@ -308,15 +310,18 @@ function displayRoute(entry: SnapshotEntry) {
   if (entry.kind === "page") {
     return normalizedRoute(pageRoute(entry), IGNORED_PAGE_QUERY_PARAMS);
   }
+  if (entry.kind === "mcp") return mcpRoute(entry);
   return normalizedRoute(entryRoute(entry));
 }
 
 function treeRoute(entry: SnapshotEntry) {
+  if (entry.kind === "mcp") return "/mcp";
   return displayRoute(entry);
 }
 
 function entryRoute(entry: SnapshotEntry) {
   if (entry.kind === "page") return pageRoute(entry);
+  if (entry.kind === "mcp") return mcpRoute(entry);
 
   const candidates = [entry.path, entry.requestedPath, entry.pathTemplate];
   for (const candidate of candidates) {
@@ -333,6 +338,11 @@ function entryRoute(entry: SnapshotEntry) {
   return asString(entry.id) ?? "/";
 }
 
+function mcpRoute(entry: SnapshotEntry) {
+  const id = asString(entry.id) ?? "response";
+  return `/mcp/${encodeURIComponent(id)}`;
+}
+
 function routeSegments(route: string) {
   let url: URL;
   try {
@@ -342,7 +352,6 @@ function routeSegments(route: string) {
   }
 
   const segments = url.pathname.split("/").filter(Boolean);
-  if (segments.length === 0) segments.push("/");
 
   const params = [...url.searchParams.entries()];
   if (params.length > 0) {
@@ -387,24 +396,15 @@ function buildRouteTree(entries: SnapshotEntry[]) {
   return root;
 }
 
-async function renderRouteEntryList(
-  entries: SnapshotEntry[],
-  renderEntries: (entries: SnapshotEntry[]) => Promise<string[]>,
-) {
-  if (entries.length === 0) return [];
-  return [
-    "<ul>",
-    "<li>",
-    ...(await renderEntries(entries)),
-    "</li>",
-    "</ul>",
-    "",
-  ];
-}
-
 async function renderRouteTreeNode(
   node: RouteTreeNode,
-  renderEntries: (entries: SnapshotEntry[]) => Promise<string[]>,
+  renderEntry: (
+    entry: SnapshotEntry,
+    prefix: string,
+    isLast: boolean,
+  ) => Promise<string[]>,
+  prefix = "",
+  connector = "",
   depth = 0,
 ): Promise<string[]> {
   const lines: string[] = [];
@@ -414,63 +414,64 @@ async function renderRouteTreeNode(
   );
 
   if (depth === 0) {
-    lines.push(...(await renderRouteEntryList(entries, renderEntries)));
+    lines.push(`<code>${escapeHtml(node.label)}</code><br>`);
+  } else {
+    lines.push(
+      `<code>${escapeHtml(prefix + connector + node.label)}</code><br>`,
+    );
+  }
 
-    if (children.length > 0) {
-      lines.push("<ul>");
-      for (const child of children) {
-        lines.push(
-          ...(await renderRouteTreeNode(child, renderEntries, depth + 1)),
-        );
-      }
-      lines.push("</ul>", "");
+  const childPrefix =
+    depth === 0
+      ? ""
+      : prefix + (connector === TREE_LAST ? TREE_BLANK : TREE_PIPE);
+  const items: Array<
+    | { kind: "entry"; entry: SnapshotEntry }
+    | { kind: "node"; node: RouteTreeNode }
+  > = [
+    ...entries.map((entry) => ({ kind: "entry" as const, entry })),
+    ...children.map((child) => ({ kind: "node" as const, node: child })),
+  ];
+
+  for (const [index, item] of items.entries()) {
+    const isLast = index === items.length - 1;
+    const connector = isLast ? TREE_LAST : TREE_BRANCH;
+    if (item.kind === "entry") {
+      lines.push(...(await renderEntry(item.entry, childPrefix, isLast)));
+      continue;
     }
-
-    return lines;
+    lines.push(
+      ...(await renderRouteTreeNode(
+        item.node,
+        renderEntry,
+        childPrefix,
+        connector,
+        depth + 1,
+      )),
+    );
   }
-
-  const entryCount =
-    entries.length > 0 ? ` <sub>${entries.length} item(s)</sub>` : "";
-  lines.push(
-    "<li>",
-    "<details open>",
-    `<summary><code>${escapeHtml(node.label)}</code>${entryCount}</summary>`,
-    "",
-  );
-
-  if (entries.length > 0) {
-    lines.push(...(await renderRouteEntryList(entries, renderEntries)));
-  }
-
-  if (children.length > 0) {
-    lines.push("<ul>");
-    for (const child of children) {
-      lines.push(
-        ...(await renderRouteTreeNode(child, renderEntries, depth + 1)),
-      );
-    }
-    lines.push("</ul>", "");
-  }
-
-  lines.push("</details>", "</li>");
 
   return lines;
 }
 
-function detailsJson(summary: string, json: string | undefined) {
-  if (!json) return "<em>No response JSON captured.</em>";
+function treeLine(prefix: string, isLast: boolean, label: unknown) {
+  return `<code>${escapeHtml(prefix + (isLast ? TREE_LAST : TREE_BRANCH) + String(label))}</code>`;
+}
+
+function childTreePrefix(prefix: string, isLast: boolean) {
+  return prefix + (isLast ? TREE_BLANK : TREE_PIPE);
+}
+
+function previewJsonBlock(json: string | undefined) {
+  if (!json) return ["<em>No response JSON captured.</em>"];
   const trimmed = json.trimEnd();
   const truncated =
     trimmed.length > MAX_EMBEDDED_JSON_CHARS
       ? `${trimmed.slice(0, MAX_EMBEDDED_JSON_CHARS)}\n... truncated ${trimmed.length - MAX_EMBEDDED_JSON_CHARS} chars ...`
       : trimmed;
   return [
-    `<details><summary>${escapeHtml(trimmed.length > MAX_EMBEDDED_JSON_CHARS ? `${summary} preview` : summary)}</summary>`,
-    "",
     `<pre><code class="language-json">${escapeHtml(truncated)}</code></pre>`,
-    "",
-    "</details>",
-  ].join("\n");
+  ];
 }
 
 function markdownTableCell(value: string) {
@@ -485,51 +486,6 @@ function summaryTable(rows: Array<[string, string]>) {
   return lines;
 }
 
-function cardTable(cards: string[], emptyText: string) {
-  if (cards.length === 0) return [emptyText];
-
-  const lines = ['<table role="presentation" width="100%">', "<tbody>"];
-  for (const card of cards) {
-    lines.push("<tr>");
-    lines.push(`<td width="100%" valign="top">${card}</td>`);
-    lines.push("</tr>");
-  }
-  lines.push("</tbody>", "</table>");
-  return lines;
-}
-
-function entryTable(
-  headers: string[],
-  rows: string[][],
-  emptyText: string,
-  widths: string[] = [],
-) {
-  if (rows.length === 0) return [emptyText];
-
-  const lines = ['<table role="presentation" width="100%">'];
-  if (widths.length > 0) {
-    lines.push("<colgroup>");
-    for (const width of widths) {
-      lines.push(`<col width="${escapeAttribute(width)}">`);
-    }
-    lines.push("</colgroup>");
-  }
-  lines.push("<thead>", "<tr>");
-  for (const header of headers) {
-    lines.push(`<th align="left" valign="top">${escapeHtml(header)}</th>`);
-  }
-  lines.push("</tr>", "</thead>", "<tbody>");
-  for (const row of rows) {
-    lines.push("<tr>");
-    for (const cell of row) {
-      lines.push(`<td valign="top">${cell}</td>`);
-    }
-    lines.push("</tr>");
-  }
-  lines.push("</tbody>", "</table>");
-  return lines;
-}
-
 function screenshotPanel(
   entry: SnapshotEntry,
   options: Pick<Options, "artifactUrl" | "screenshotBaseUrl">,
@@ -539,99 +495,100 @@ function screenshotPanel(
   return screenshotCell(entry, options);
 }
 
-function pageInfoTable(entry: SnapshotEntry) {
-  const filePath = asString(entry.screenshot);
-  return entryTable(
-    ["Page", "URI", "Title", "Auth", "Result", "Duration", "Artifact"],
-    [
-      [
-        `<strong>${escapeHtml(entry.id ?? "page")}</strong>`,
-        `<code>${escapeHtml(displayRoute(entry))}</code>`,
-        escapeHtml(entry.title ?? "-"),
-        escapeHtml(entry.auth ?? "-"),
-        escapeHtml(resultCell(entry)),
-        escapeHtml(entry.durationMs ? `${entry.durationMs}ms` : "-"),
-        filePath ? `<code>${escapeHtml(filePath)}</code>` : "-",
-      ],
-    ],
-    "No page metadata captured.",
-    PAGE_TABLE_WIDTHS,
-  ).join("\n");
+function entryLabel(entry: SnapshotEntry, fallback: string) {
+  return asString(entry.id) ?? fallback;
 }
 
-function pageCards(
-  entries: SnapshotEntry[],
+function pageMetadata(entry: SnapshotEntry) {
+  return finePrint([
+    ["uri", displayRoute(entry)],
+    ["result", resultCell(entry)],
+    ["auth", entry.auth],
+    ["title", entry.title],
+    ["duration", entry.durationMs ? `${entry.durationMs}ms` : undefined],
+  ]);
+}
+
+function screenshotTreeLines(
+  entry: SnapshotEntry,
+  options: Pick<Options, "artifactUrl" | "screenshotBaseUrl">,
+  prefix: string,
+) {
+  const filePath = asString(entry.screenshot);
+  const label = filePath ? path.basename(filePath) : "screenshot";
+  const artifact = filePath
+    ? ` <sub><code>${escapeHtml(snapshotRelativePath(filePath))}</code></sub>`
+    : "";
+
+  return [
+    `<details><summary>${treeLine(prefix, true, label)}${artifact}</summary>`,
+    "",
+    screenshotPanel(entry, options),
+    "",
+    "</details>",
+  ];
+}
+
+async function renderPageEntry(
+  entry: SnapshotEntry,
+  prefix: string,
+  isLast: boolean,
   options: Pick<Options, "artifactUrl" | "screenshotBaseUrl">,
 ) {
-  return entries.map((entry) => {
-    const summary = [
-      `<strong>${escapeHtml(entry.id ?? "page")}</strong>`,
-      `<code>${escapeHtml(displayRoute(entry))}</code>`,
-      finePrint([
-        ["result", resultCell(entry)],
-        ["auth", entry.auth],
-      ]),
-    ]
-      .filter(Boolean)
-      .join(" &nbsp; ");
-    return [
-      `<details><summary>${summary}</summary>`,
-      "",
-      "##### Screenshot",
-      "",
-      screenshotPanel(entry, options),
-      "",
-      "##### Metadata",
-      "",
-      pageInfoTable(entry),
-      "",
-      "</details>",
-    ].join("\n");
-  });
-}
-
-function pageList(cards: string[], emptyText: string) {
-  if (cards.length === 0) return [emptyText];
-
-  return cards.flatMap((card) => [card, ""]);
-}
-
-async function responseRows(
-  entries: SnapshotEntry[],
-  options: Pick<Options, "snapshotDir">,
-) {
-  return await Promise.all(
-    entries.map(async (entry) => {
-      const responsePath = asString(entry.response);
-      const json = await readSnapshotJson(options.snapshotDir, responsePath);
-      const previewJson = responsePreviewJson(entry, json);
-      const type = entry.method ?? entry.kind;
-      const metadata = finePrint([
-        ["auth", entry.auth],
-        ["duration", entry.durationMs ? `${entry.durationMs}ms` : undefined],
-        ["artifact path", responsePath],
-      ]);
-      return [
-        `<strong>${escapeHtml(entry.id ?? "response")}</strong>`,
-        `<code>${escapeHtml(String(type))}</code>`,
-        `<code>${escapeHtml(displayRoute(entry))}</code>`,
-        finePrint([["result", resultCell(entry)]]) || "-",
-        detailsJson(
-          entry.kind === "api" ? "response body" : "tool result",
-          previewJson,
-        ),
-        metadata || "-",
-      ];
-    }),
+  const lines = [
+    `${treeLine(prefix, isLast, entryLabel(entry, "page"))} ${pageMetadata(entry)}<br>`,
+  ];
+  lines.push(
+    ...screenshotTreeLines(entry, options, childTreePrefix(prefix, isLast)),
   );
+  return lines;
 }
 
-async function responseCards(
-  entries: SnapshotEntry[],
+function responseMetadata(entry: SnapshotEntry) {
+  return finePrint([
+    ["uri", displayRoute(entry)],
+    ["method", entry.method ?? entry.kind],
+    ["result", resultCell(entry)],
+    ["auth", entry.auth],
+    ["duration", entry.durationMs ? `${entry.durationMs}ms` : undefined],
+  ]);
+}
+
+async function responseSnapshotTreeLines(
+  entry: SnapshotEntry,
+  options: Pick<Options, "snapshotDir">,
+  prefix: string,
+) {
+  const responsePath = asString(entry.response);
+  const json = await readSnapshotJson(options.snapshotDir, responsePath);
+  const previewJson = responsePreviewJson(entry, json);
+  const label = responsePath ? path.basename(responsePath) : "response.json";
+  const artifact = responsePath
+    ? ` <sub><code>${escapeHtml(snapshotRelativePath(responsePath))}</code></sub>`
+    : "";
+  return [
+    `${treeLine(prefix, true, label)}${artifact}<br>`,
+    ...previewJsonBlock(previewJson),
+  ];
+}
+
+async function renderResponseEntry(
+  entry: SnapshotEntry,
+  prefix: string,
+  isLast: boolean,
   options: Pick<Options, "snapshotDir">,
 ) {
-  const rows = await responseRows(entries, options);
-  return rows.map((row) => row.join("<br>"));
+  const lines = [
+    `${treeLine(prefix, isLast, entryLabel(entry, "response"))} ${responseMetadata(entry)}<br>`,
+  ];
+  lines.push(
+    ...(await responseSnapshotTreeLines(
+      entry,
+      options,
+      childTreePrefix(prefix, isLast),
+    )),
+  );
+  return lines;
 }
 
 async function main() {
@@ -660,24 +617,27 @@ async function main() {
     `${apiEntries.length} API responses`,
     `${mcpEntries.length} MCP responses`,
   ].join("<br>");
-  const [pageTreeLines, apiTreeLines, mcpCards] = await Promise.all([
-    renderRouteTreeNode(buildRouteTree(pageEntries), async (entries) =>
-      pageList(pageCards(entries, options), "No page screenshots here."),
+  const [pageTreeLines, apiTreeLines, mcpTreeLines] = await Promise.all([
+    renderRouteTreeNode(
+      buildRouteTree(pageEntries),
+      async (entry, prefix, isLast) =>
+        renderPageEntry(entry, prefix, isLast, options),
     ),
-    renderRouteTreeNode(buildRouteTree(apiEntries), async (entries) =>
-      entryTable(
-        ["Case", "Method", "URI", "Result", "Response", "Metadata"],
-        await responseRows(entries, options),
-        "No API response snapshots here.",
-        RESPONSE_TABLE_WIDTHS,
-      ),
+    renderRouteTreeNode(
+      buildRouteTree(apiEntries),
+      async (entry, prefix, isLast) =>
+        renderResponseEntry(entry, prefix, isLast, options),
     ),
-    responseCards(mcpEntries, options),
+    renderRouteTreeNode(
+      buildRouteTree(mcpEntries),
+      async (entry, prefix, isLast) =>
+        renderResponseEntry(entry, prefix, isLast, options),
+    ),
   ]);
 
   const lines = [
     "<!-- life-ustc-e2e-snapshot-artifacts -->",
-    `<details open><summary>E2E snapshot artifacts for ${shortSha(options.commit)} (${options.status})</summary>`,
+    `## E2E snapshot artifacts for ${shortSha(options.commit)} (${options.status})`,
     "",
     ...summaryTable([
       ["Commit", `\`${options.commit}\``],
@@ -702,10 +662,8 @@ async function main() {
     "### MCP Responses",
     "",
     ...(mcpEntries.length > 0
-      ? cardTable(mcpCards, "No MCP response snapshots were generated.")
+      ? mcpTreeLines
       : ["No MCP response snapshots were generated."]),
-    "",
-    "</details>",
   ];
 
   await writeTextFile(options.output, lines.join("\n"));

--- a/tools/dev/artifacts/render-e2e-snapshot-comment.ts
+++ b/tools/dev/artifacts/render-e2e-snapshot-comment.ts
@@ -401,13 +401,9 @@ async function renderRouteTreeNode(
   if (depth > 0) {
     const entryCount =
       entries.length > 0 ? ` <sub>${entries.length} item(s)</sub>` : "";
-    const headingLevel = Math.min(depth + 3, 6);
-    const heading = `${"#".repeat(headingLevel)} \`${node.label}\`${entryCount}`;
     lines.push(
       "<details open>",
       `<summary><code>${escapeHtml(node.label)}</code>${entryCount}</summary>`,
-      "",
-      heading,
       "",
     );
   }
@@ -560,6 +556,12 @@ function pageCards(
   });
 }
 
+function pageList(cards: string[], emptyText: string) {
+  if (cards.length === 0) return [emptyText];
+
+  return cards.flatMap((card) => [card, ""]);
+}
+
 async function responseRows(
   entries: SnapshotEntry[],
   options: Pick<Options, "snapshotDir">,
@@ -626,7 +628,7 @@ async function main() {
   ].join("<br>");
   const [pageTreeLines, apiTreeLines, mcpCards] = await Promise.all([
     renderRouteTreeNode(buildRouteTree(pageEntries), async (entries) =>
-      cardTable(pageCards(entries, options), "No page screenshots here."),
+      pageList(pageCards(entries, options), "No page screenshots here."),
     ),
     renderRouteTreeNode(buildRouteTree(apiEntries), async (entries) =>
       entryTable(

--- a/tools/dev/artifacts/render-e2e-snapshot-comment.ts
+++ b/tools/dev/artifacts/render-e2e-snapshot-comment.ts
@@ -553,8 +553,11 @@ async function responseSnapshotTreeLines(
   return [
     "<ul>",
     "<li>",
-    `<code>${escapeHtml(label)}</code>${artifact}`,
+    `<details><summary><code>${escapeHtml(label)}</code>${artifact}</summary>`,
+    "",
     ...previewJsonBlock(previewJson),
+    "",
+    "</details>",
     "</li>",
     "</ul>",
   ];

--- a/tools/dev/artifacts/render-e2e-snapshot-comment.ts
+++ b/tools/dev/artifacts/render-e2e-snapshot-comment.ts
@@ -387,6 +387,21 @@ function buildRouteTree(entries: SnapshotEntry[]) {
   return root;
 }
 
+async function renderRouteEntryList(
+  entries: SnapshotEntry[],
+  renderEntries: (entries: SnapshotEntry[]) => Promise<string[]>,
+) {
+  if (entries.length === 0) return [];
+  return [
+    "<ul>",
+    "<li>",
+    ...(await renderEntries(entries)),
+    "</li>",
+    "</ul>",
+    "",
+  ];
+}
+
 async function renderRouteTreeNode(
   node: RouteTreeNode,
   renderEntries: (entries: SnapshotEntry[]) => Promise<string[]>,
@@ -398,27 +413,46 @@ async function renderRouteTreeNode(
     a.label.localeCompare(b.label, "en"),
   );
 
-  if (depth > 0) {
-    const entryCount =
-      entries.length > 0 ? ` <sub>${entries.length} item(s)</sub>` : "";
-    lines.push(
-      "<details open>",
-      `<summary><code>${escapeHtml(node.label)}</code>${entryCount}</summary>`,
-      "",
-    );
+  if (depth === 0) {
+    lines.push(...(await renderRouteEntryList(entries, renderEntries)));
+
+    if (children.length > 0) {
+      lines.push("<ul>");
+      for (const child of children) {
+        lines.push(
+          ...(await renderRouteTreeNode(child, renderEntries, depth + 1)),
+        );
+      }
+      lines.push("</ul>", "");
+    }
+
+    return lines;
   }
+
+  const entryCount =
+    entries.length > 0 ? ` <sub>${entries.length} item(s)</sub>` : "";
+  lines.push(
+    "<li>",
+    "<details open>",
+    `<summary><code>${escapeHtml(node.label)}</code>${entryCount}</summary>`,
+    "",
+  );
 
   if (entries.length > 0) {
-    lines.push(...(await renderEntries(entries)), "");
+    lines.push(...(await renderRouteEntryList(entries, renderEntries)));
   }
 
-  for (const child of children) {
-    lines.push(...(await renderRouteTreeNode(child, renderEntries, depth + 1)));
+  if (children.length > 0) {
+    lines.push("<ul>");
+    for (const child of children) {
+      lines.push(
+        ...(await renderRouteTreeNode(child, renderEntries, depth + 1)),
+      );
+    }
+    lines.push("</ul>", "");
   }
 
-  if (depth > 0) {
-    lines.push("</details>", "");
-  }
+  lines.push("</details>", "</li>");
 
   return lines;
 }

--- a/tools/dev/artifacts/render-e2e-snapshot-comment.ts
+++ b/tools/dev/artifacts/render-e2e-snapshot-comment.ts
@@ -516,12 +516,9 @@ function screenshotTreeLines(
 ) {
   const filePath = asString(entry.screenshot);
   const label = filePath ? path.basename(filePath) : "screenshot";
-  const artifact = filePath
-    ? ` <sub><code>${escapeHtml(snapshotRelativePath(filePath))}</code></sub>`
-    : "";
 
   return [
-    `<details><summary>${treeLine(prefix, true, label)}${artifact}</summary>`,
+    `<details><summary>${treeLine(prefix, true, label)}</summary>`,
     "",
     screenshotPanel(entry, options),
     "",

--- a/tools/dev/artifacts/render-e2e-snapshot-comment.ts
+++ b/tools/dev/artifacts/render-e2e-snapshot-comment.ts
@@ -45,10 +45,6 @@ type RouteTreeNode = {
 const MAX_EMBEDDED_JSON_CHARS = 600;
 const SCREENSHOT_WIDTH = 480;
 const IGNORED_PAGE_QUERY_PARAMS = new Set(["snapshotAt"]);
-const TREE_BRANCH = "|-- ";
-const TREE_LAST = "`-- ";
-const TREE_PIPE = "|   ";
-const TREE_BLANK = "    ";
 
 function usage() {
   return [
@@ -398,13 +394,8 @@ function buildRouteTree(entries: SnapshotEntry[]) {
 
 async function renderRouteTreeNode(
   node: RouteTreeNode,
-  renderEntry: (
-    entry: SnapshotEntry,
-    prefix: string,
-    isLast: boolean,
-  ) => Promise<string[]>,
-  prefix = "",
-  connector = "",
+  renderEntry: (entry: SnapshotEntry) => Promise<string[]>,
+  renderEntrySummary: (entry: SnapshotEntry) => string,
   depth = 0,
 ): Promise<string[]> {
   const lines: string[] = [];
@@ -412,54 +403,54 @@ async function renderRouteTreeNode(
   const children = [...node.children.values()].sort((a, b) =>
     a.label.localeCompare(b.label, "en"),
   );
+  const combinedEntry = entries.length === 1 ? entries[0] : undefined;
+  const nestedEntries = combinedEntry ? [] : entries;
 
-  if (depth === 0) {
-    lines.push(`<code>${escapeHtml(node.label)}</code><br>`);
-  } else {
-    lines.push(
-      `<code>${escapeHtml(prefix + connector + node.label)}</code><br>`,
-    );
-  }
+  if (depth === 0) lines.push("<ul>");
+  lines.push("<li>");
+  lines.push(routeNodeSummary(node.label, combinedEntry, renderEntrySummary));
+  if (combinedEntry) lines.push(...(await renderEntry(combinedEntry)));
 
-  const childPrefix =
-    depth === 0
-      ? ""
-      : prefix + (connector === TREE_LAST ? TREE_BLANK : TREE_PIPE);
-  const items: Array<
-    | { kind: "entry"; entry: SnapshotEntry }
-    | { kind: "node"; node: RouteTreeNode }
-  > = [
-    ...entries.map((entry) => ({ kind: "entry" as const, entry })),
-    ...children.map((child) => ({ kind: "node" as const, node: child })),
-  ];
-
-  for (const [index, item] of items.entries()) {
-    const isLast = index === items.length - 1;
-    const connector = isLast ? TREE_LAST : TREE_BRANCH;
-    if (item.kind === "entry") {
-      lines.push(...(await renderEntry(item.entry, childPrefix, isLast)));
-      continue;
+  if (nestedEntries.length > 0 || children.length > 0) {
+    lines.push("<ul>");
+    for (const entry of nestedEntries) {
+      lines.push("<li>");
+      lines.push(entrySummary(entry, renderEntrySummary));
+      lines.push(...(await renderEntry(entry)));
+      lines.push("</li>");
     }
-    lines.push(
-      ...(await renderRouteTreeNode(
-        item.node,
-        renderEntry,
-        childPrefix,
-        connector,
-        depth + 1,
-      )),
-    );
+    for (const child of children) {
+      lines.push(
+        ...(await renderRouteTreeNode(
+          child,
+          renderEntry,
+          renderEntrySummary,
+          depth + 1,
+        )),
+      );
+    }
+    lines.push("</ul>");
   }
 
+  lines.push("</li>");
+  if (depth === 0) lines.push("</ul>");
   return lines;
 }
 
-function treeLine(prefix: string, isLast: boolean, label: unknown) {
-  return `<code>${escapeHtml(prefix + (isLast ? TREE_LAST : TREE_BRANCH) + String(label))}</code>`;
+function routeNodeSummary(
+  label: string,
+  entry: SnapshotEntry | undefined,
+  renderEntrySummary: (entry: SnapshotEntry) => string,
+) {
+  const routeLabel = `<code>${escapeHtml(label)}</code>`;
+  return entry ? `${routeLabel} ${renderEntrySummary(entry)}` : routeLabel;
 }
 
-function childTreePrefix(prefix: string, isLast: boolean) {
-  return prefix + (isLast ? TREE_BLANK : TREE_PIPE);
+function entrySummary(
+  entry: SnapshotEntry,
+  renderEntrySummary: (entry: SnapshotEntry) => string,
+) {
+  return renderEntrySummary(entry);
 }
 
 function previewJsonBlock(json: string | undefined) {
@@ -501,7 +492,6 @@ function entryLabel(entry: SnapshotEntry, fallback: string) {
 
 function pageMetadata(entry: SnapshotEntry) {
   return finePrint([
-    ["uri", displayRoute(entry)],
     ["result", resultCell(entry)],
     ["auth", entry.auth],
     ["title", entry.title],
@@ -512,39 +502,37 @@ function pageMetadata(entry: SnapshotEntry) {
 function screenshotTreeLines(
   entry: SnapshotEntry,
   options: Pick<Options, "artifactUrl" | "screenshotBaseUrl">,
-  prefix: string,
 ) {
   const filePath = asString(entry.screenshot);
   const label = filePath ? path.basename(filePath) : "screenshot";
 
   return [
-    `<details><summary>${treeLine(prefix, true, label)}</summary>`,
+    "<ul>",
+    "<li>",
+    `<details><summary>${escapeHtml(label)}</summary>`,
     "",
     screenshotPanel(entry, options),
     "",
     "</details>",
+    "</li>",
+    "</ul>",
   ];
+}
+
+function pageSummary(entry: SnapshotEntry) {
+  return `<strong>${escapeHtml(entryLabel(entry, "page"))}</strong> ${pageMetadata(entry)}`;
 }
 
 async function renderPageEntry(
   entry: SnapshotEntry,
-  prefix: string,
-  isLast: boolean,
   options: Pick<Options, "artifactUrl" | "screenshotBaseUrl">,
 ) {
-  const lines = [
-    `${treeLine(prefix, isLast, entryLabel(entry, "page"))} ${pageMetadata(entry)}<br>`,
-  ];
-  lines.push(
-    ...screenshotTreeLines(entry, options, childTreePrefix(prefix, isLast)),
-  );
-  return lines;
+  return screenshotTreeLines(entry, options);
 }
 
 function responseMetadata(entry: SnapshotEntry) {
   return finePrint([
-    ["uri", displayRoute(entry)],
-    ["method", entry.method ?? entry.kind],
+    ["method", entry.kind === "api" ? entry.method : undefined],
     ["result", resultCell(entry)],
     ["auth", entry.auth],
     ["duration", entry.durationMs ? `${entry.durationMs}ms` : undefined],
@@ -554,7 +542,6 @@ function responseMetadata(entry: SnapshotEntry) {
 async function responseSnapshotTreeLines(
   entry: SnapshotEntry,
   options: Pick<Options, "snapshotDir">,
-  prefix: string,
 ) {
   const responsePath = asString(entry.response);
   const json = await readSnapshotJson(options.snapshotDir, responsePath);
@@ -564,28 +551,24 @@ async function responseSnapshotTreeLines(
     ? ` <sub><code>${escapeHtml(snapshotRelativePath(responsePath))}</code></sub>`
     : "";
   return [
-    `${treeLine(prefix, true, label)}${artifact}<br>`,
+    "<ul>",
+    "<li>",
+    `<code>${escapeHtml(label)}</code>${artifact}`,
     ...previewJsonBlock(previewJson),
+    "</li>",
+    "</ul>",
   ];
+}
+
+function responseSummary(entry: SnapshotEntry) {
+  return `<strong>${escapeHtml(entryLabel(entry, "response"))}</strong> ${responseMetadata(entry)}`;
 }
 
 async function renderResponseEntry(
   entry: SnapshotEntry,
-  prefix: string,
-  isLast: boolean,
   options: Pick<Options, "snapshotDir">,
 ) {
-  const lines = [
-    `${treeLine(prefix, isLast, entryLabel(entry, "response"))} ${responseMetadata(entry)}<br>`,
-  ];
-  lines.push(
-    ...(await responseSnapshotTreeLines(
-      entry,
-      options,
-      childTreePrefix(prefix, isLast),
-    )),
-  );
-  return lines;
+  return await responseSnapshotTreeLines(entry, options);
 }
 
 async function main() {
@@ -617,18 +600,18 @@ async function main() {
   const [pageTreeLines, apiTreeLines, mcpTreeLines] = await Promise.all([
     renderRouteTreeNode(
       buildRouteTree(pageEntries),
-      async (entry, prefix, isLast) =>
-        renderPageEntry(entry, prefix, isLast, options),
+      async (entry) => renderPageEntry(entry, options),
+      pageSummary,
     ),
     renderRouteTreeNode(
       buildRouteTree(apiEntries),
-      async (entry, prefix, isLast) =>
-        renderResponseEntry(entry, prefix, isLast, options),
+      async (entry) => renderResponseEntry(entry, options),
+      responseSummary,
     ),
     renderRouteTreeNode(
       buildRouteTree(mcpEntries),
-      async (entry, prefix, isLast) =>
-        renderResponseEntry(entry, prefix, isLast, options),
+      async (entry) => renderResponseEntry(entry, options),
+      responseSummary,
     ),
   ]);
 

--- a/tools/dev/artifacts/render-e2e-snapshot-comment.ts
+++ b/tools/dev/artifacts/render-e2e-snapshot-comment.ts
@@ -18,6 +18,9 @@ type SnapshotEntry = {
   auth?: unknown;
   method?: unknown;
   path?: unknown;
+  requestedPath?: unknown;
+  pathTemplate?: unknown;
+  finalUrl?: unknown;
   status?: unknown;
   expectedStatus?: unknown;
   ok?: unknown;
@@ -30,6 +33,12 @@ type SnapshotEntry = {
 type SnapshotManifest = {
   count?: unknown;
   entries?: unknown;
+};
+
+type PageTreeNode = {
+  label: string;
+  entries: SnapshotEntry[];
+  children: Map<string, PageTreeNode>;
 };
 
 const MAX_EMBEDDED_JSON_CHARS = 600;
@@ -257,6 +266,105 @@ function finePrint(items: Array<[string, unknown]>) {
   return content ? `<sub>${content}</sub>` : "";
 }
 
+function pageRoute(entry: SnapshotEntry) {
+  const candidates = [entry.finalUrl, entry.requestedPath, entry.pathTemplate];
+  for (const candidate of candidates) {
+    const value = asString(candidate);
+    if (!value) continue;
+    try {
+      const url = new URL(value, "http://snapshot.local");
+      return `${url.pathname}${url.search}`;
+    } catch {
+      return value;
+    }
+  }
+  return asString(entry.id) ?? "/";
+}
+
+function pageRouteSegments(entry: SnapshotEntry) {
+  const route = pageRoute(entry);
+  let url: URL;
+  try {
+    url = new URL(route, "http://snapshot.local");
+  } catch {
+    return [route || "/"];
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (segments.length === 0) segments.push("/");
+
+  if (url.search) {
+    segments.push(url.search);
+  }
+
+  return segments;
+}
+
+function comparePageEntries(a: SnapshotEntry, b: SnapshotEntry) {
+  return pageRoute(a).localeCompare(pageRoute(b), "en");
+}
+
+function createPageTreeNode(label: string): PageTreeNode {
+  return { label, entries: [], children: new Map() };
+}
+
+function buildPageTree(entries: SnapshotEntry[]) {
+  const root = createPageTreeNode("/");
+
+  for (const entry of entries) {
+    const segments = pageRouteSegments(entry);
+    let node = root;
+    for (const segment of segments) {
+      const existing = node.children.get(segment);
+      if (existing) {
+        node = existing;
+        continue;
+      }
+
+      const child = createPageTreeNode(segment);
+      node.children.set(segment, child);
+      node = child;
+    }
+    node.entries.push(entry);
+  }
+
+  return root;
+}
+
+function renderPageTreeNode(
+  node: PageTreeNode,
+  options: Pick<Options, "artifactUrl" | "screenshotBaseUrl">,
+  depth = 0,
+): string[] {
+  const lines: string[] = [];
+  const entries = [...node.entries].sort(comparePageEntries);
+  const children = [...node.children.values()].sort((a, b) =>
+    a.label.localeCompare(b.label, "en"),
+  );
+
+  if (depth > 0) {
+    const summary = `${escapeHtml(node.label)}${entries.length > 0 ? ` (${entries.length})` : ""}`;
+    lines.push(`<details open><summary>${summary}</summary>`, "");
+  }
+
+  if (entries.length > 0) {
+    lines.push(
+      ...cardTable(pageCards(entries, options), "No page screenshots here."),
+      "",
+    );
+  }
+
+  for (const child of children) {
+    lines.push(...renderPageTreeNode(child, options, depth + 1));
+  }
+
+  if (depth > 0) {
+    lines.push("</details>", "");
+  }
+
+  return lines;
+}
+
 function detailsJson(summary: string, json: string | undefined) {
   if (!json) return "<em>No response JSON captured.</em>";
   const trimmed = json.trimEnd();
@@ -294,6 +402,8 @@ function pageCards(
     const filePath = asString(entry.screenshot);
     return [
       `<strong>${escapeHtml(entry.id ?? "page")}</strong>`,
+      "<br>",
+      `<code>${escapeHtml(pageRoute(entry))}</code>`,
       "<br>",
       screenshotCell(entry, options),
       "<br>",
@@ -363,6 +473,7 @@ async function main() {
     responseCards(apiEntries, options),
     responseCards(mcpEntries, options),
   ]);
+  const pageTree = buildPageTree(pageEntries);
 
   const lines = [
     "<!-- life-ustc-e2e-snapshot-artifacts -->",
@@ -377,10 +488,7 @@ async function main() {
     "### Screenshots",
     "",
     ...(pageEntries.length > 0
-      ? cardTable(
-          pageCards(pageEntries, options),
-          "No page screenshots were generated.",
-        )
+      ? renderPageTreeNode(pageTree, options)
       : ["No page screenshots were generated."]),
     "",
     "### API Responses",

--- a/tools/dev/artifacts/snapshot-cases.ts
+++ b/tools/dev/artifacts/snapshot-cases.ts
@@ -33,6 +33,10 @@ export type McpSnapshotCase = {
   note?: string;
 };
 
+const SNAPSHOT_AT_QUERY = `snapshotAt=${encodeURIComponent(
+  DEV_SEED_ANCHOR.startOfDayAtTime,
+)}`;
+
 export const PAGE_SNAPSHOT_CASES: PageSnapshotCase[] = [
   { id: "home", path: "/", auth: "public" },
   { id: "signin", path: "/signin", auth: "public" },
@@ -100,16 +104,44 @@ export const PAGE_SNAPSHOT_CASES: PageSnapshotCase[] = [
     auth: "debug",
     resolvePath: "user-id",
   },
-  { id: "dashboard", path: "/?tab=overview", auth: "debug" },
-  { id: "dashboard-calendar", path: "/?tab=calendar", auth: "debug" },
-  { id: "dashboard-todos", path: "/?tab=todos", auth: "debug" },
-  { id: "dashboard-homeworks", path: "/?tab=homeworks", auth: "debug" },
-  { id: "dashboard-exams", path: "/?tab=exams", auth: "debug" },
-  { id: "dashboard-comments", path: "/?tab=comments", auth: "debug" },
-  { id: "dashboard-links", path: "/?tab=links", auth: "debug" },
+  {
+    id: "dashboard",
+    path: `/?tab=overview&${SNAPSHOT_AT_QUERY}`,
+    auth: "debug",
+  },
+  {
+    id: "dashboard-calendar",
+    path: `/?tab=calendar&${SNAPSHOT_AT_QUERY}`,
+    auth: "debug",
+  },
+  {
+    id: "dashboard-todos",
+    path: `/?tab=todos&${SNAPSHOT_AT_QUERY}`,
+    auth: "debug",
+  },
+  {
+    id: "dashboard-homeworks",
+    path: `/?tab=homeworks&${SNAPSHOT_AT_QUERY}`,
+    auth: "debug",
+  },
+  {
+    id: "dashboard-exams",
+    path: `/?tab=exams&${SNAPSHOT_AT_QUERY}`,
+    auth: "debug",
+  },
+  {
+    id: "dashboard-comments",
+    path: `/?tab=comments&${SNAPSHOT_AT_QUERY}`,
+    auth: "debug",
+  },
+  {
+    id: "dashboard-links",
+    path: `/?tab=links&${SNAPSHOT_AT_QUERY}`,
+    auth: "debug",
+  },
   {
     id: "dashboard-subscriptions-sections",
-    path: "/?tab=subscriptions",
+    path: `/?tab=subscriptions&${SNAPSHOT_AT_QUERY}`,
     auth: "debug",
   },
   { id: "admin", path: "/admin", auth: "admin" },
@@ -312,7 +344,11 @@ export const MCP_SNAPSHOT_CASES: McpSnapshotCase[] = [
   { name: "get_my_calendar_subscription", arguments: { locale: "zh-cn" } },
   {
     name: "get_my_dashboard",
-    arguments: { locale: "zh-cn", mode: "summary" },
+    arguments: {
+      locale: "zh-cn",
+      mode: "summary",
+      atTime: DEV_SEED_ANCHOR.startOfDayAtTime,
+    },
   },
   {
     name: "get_next_class",


### PR DESCRIPTION
## Summary
- add a snapshot-only dashboard clock anchor so seeded dashboard screenshots use `DEV_SEED_ANCHOR` instead of wall-clock time
- add `atTime` support for `get_my_dashboard` and `get_next_class` so MCP snapshots can render seeded next class/deadline/event data deterministically
- pass the snapshot anchor into the exams tab client filter so the default unfinished filter shows seeded exams

## Snapshot Evidence
- fresh `bun run snapshot:e2e` completed for pages/API/MCP
- `get_my_dashboard` snapshot now reports `nextClass`, 5 upcoming deadlines, and 10 upcoming events
- `/?tab=exams&snapshotAt=...` now shows the 3 seeded exam cards instead of the empty filtered state

## Verification
- `bun run test:integration`
- `bun run verify:fast`
- `bun run test:e2e:prepare`
- `PLAYWRIGHT_REUSE_SERVER=0 bun run test:e2e`

Note: `bun run verify:full` was first attempted while a manually-started standalone server was still running; Playwright reused that server with a localhost/127.0.0.1 origin mismatch, causing OAuth/MCP origin-sensitive failures. After stopping that server and rerunning E2E with `PLAYWRIGHT_REUSE_SERVER=0`, all 423 E2E tests passed.