### PR TITLE
ci: Copilot setup workflow

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -21,6 +21,8 @@ Keep Bun versions aligned with:
 - Use repo's `bun`-based commands; do not add Node setup steps
 - Production build: `docker build .`
 - Never commit secrets
+- `copilot-setup-steps.yml` must keep a direct job named exactly `copilot-setup-steps`; inline `runs-on`, `permissions`, `services`, `timeout-minutes`, and `steps` instead of delegating the job through a reusable workflow.
+- When changing Copilot setup, run it through `workflow_dispatch` or a PR check. If setup fails, Copilot can still start from the partially prepared environment, so setup logs are part of the verification evidence.
 
 ## Common Tasks
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -4,27 +4,57 @@ on:
   workflow_dispatch:
   push:
     paths:
+      - .github/actions/setup-bun-env/action.yml
       - .github/workflows/copilot-setup-steps.yml
       - .github/workflows/db-backed-bun-job.yml
   pull_request:
     paths:
+      - .github/actions/setup-bun-env/action.yml
       - .github/workflows/copilot-setup-steps.yml
       - .github/workflows/db-backed-bun-job.yml
 
 jobs:
   # The job name must be exactly `copilot-setup-steps`
   copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 59
     permissions:
       contents: read
-    uses: ./.github/workflows/db-backed-bun-job.yml
-    with:
-      database-name: life_ustc_copilot
-      timeout-minutes: 59
-      jwt-secret: copilot-local-secret
-      webhook-secret: copilot-local-secret
-      auth-secret: copilot-local-secret
-      extra-env: E2E_MOCK_S3=1
-      job-command: |
-        bun run prisma:deploy
-        bun run build:artifacts
-        bun run dev:seed-scenarios
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: life_ustc_copilot
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Configure job environment
+        shell: bash
+        run: |
+          {
+            echo "DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_copilot"
+            echo "JWT_SECRET=copilot-local-secret"
+            echo "WEBHOOK_SECRET=copilot-local-secret"
+            echo "AUTH_SECRET=copilot-local-secret"
+          } >> "$GITHUB_ENV"
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-bun-env
+
+      - name: Prepare database and generated artifacts
+        shell: bash
+        run: |
+          bun run prisma:deploy
+          bun run build:artifacts
+          bun run dev:seed-scenarios


### PR DESCRIPTION
## Goal

Make the Copilot setup workflow use a direct `copilot-setup-steps` job instead of delegating through a reusable workflow, and document that constraint for future workflow edits.

## Summary

- Expands `.github/workflows/copilot-setup-steps.yml` into a direct job with `runs-on`, permissions, Postgres service, setup action, and artifact/seed preparation steps.
- Adds the setup action path to workflow triggers so setup action changes exercise this workflow.
- Adds scoped workflow guidance in `.github/workflows/AGENTS.md` for preserving the direct job shape and capturing setup logs as verification evidence.

## Test plan

- `bun -e 'import YAML from "yaml"; ...'` parsed `.github/workflows/copilot-setup-steps.yml` successfully.
- `git diff --check -- .github/workflows/AGENTS.md .github/workflows/copilot-setup-steps.yml` passed.
- Commit hook ran `bun run check --write` and `commitlint`; both passed on the final scoped commit message.

## Not run

- `bun run check -- .github/workflows/copilot-setup-steps.yml .github/workflows/AGENTS.md` is not applicable because Biome ignores these paths.
- `bunx actionlint .github/workflows/copilot-setup-steps.yml` could not run because the package did not expose an executable through Bun.

## Risk areas

- GitHub Actions workflow shape for Copilot setup.
- Postgres service/env parity with the previous reusable workflow inputs.
