### PR TITLE
fix(openapi): harden generated client contract

### DIFF
--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -319,7 +319,8 @@
             "in": "query",
             "name": "limit",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           }
@@ -403,7 +404,7 @@
     },
     "/api/admin/descriptions": {
       "get": {
-        "operationId": "getDescription",
+        "operationId": "listAdminDescriptions",
         "summary": "List descriptions for moderation review.",
         "description": "",
         "tags": [
@@ -450,7 +451,8 @@
             "in": "query",
             "name": "limit",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           }
@@ -513,7 +515,8 @@
             "in": "query",
             "name": "limit",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           }
@@ -714,7 +717,8 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -722,7 +726,8 @@
             "in": "query",
             "name": "limit",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           }
@@ -1248,7 +1253,8 @@
             "in": "query",
             "name": "sectionId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -1256,7 +1262,8 @@
             "in": "query",
             "name": "teacherId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           }
@@ -1319,7 +1326,8 @@
             "in": "query",
             "name": "sectionId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -1327,7 +1335,8 @@
             "in": "query",
             "name": "teacherId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           }
@@ -1654,7 +1663,8 @@
             "in": "query",
             "name": "educationLevelId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -1662,7 +1672,8 @@
             "in": "query",
             "name": "categoryId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -1670,7 +1681,8 @@
             "in": "query",
             "name": "classTypeId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -1678,7 +1690,8 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -1686,7 +1699,8 @@
             "in": "query",
             "name": "limit",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           }
@@ -1728,7 +1742,8 @@
             "in": "path",
             "name": "jwId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": true,
             "example": "123"
@@ -2002,7 +2017,8 @@
             "in": "query",
             "name": "sectionId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2063,7 +2079,8 @@
             "in": "query",
             "name": "sectionId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2610,7 +2627,8 @@
             "in": "query",
             "name": "sectionId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2618,7 +2636,8 @@
             "in": "query",
             "name": "sectionJwId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2635,7 +2654,8 @@
             "in": "query",
             "name": "teacherId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2652,7 +2672,8 @@
             "in": "query",
             "name": "roomId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2660,7 +2681,8 @@
             "in": "query",
             "name": "roomJwId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2668,7 +2690,8 @@
             "in": "query",
             "name": "weekday",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2696,7 +2719,8 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2704,7 +2728,8 @@
             "in": "query",
             "name": "limit",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           }
@@ -2746,7 +2771,8 @@
             "in": "query",
             "name": "courseId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2754,7 +2780,8 @@
             "in": "query",
             "name": "courseJwId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2762,7 +2789,8 @@
             "in": "query",
             "name": "semesterId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2770,7 +2798,8 @@
             "in": "query",
             "name": "semesterJwId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2778,7 +2807,8 @@
             "in": "query",
             "name": "campusId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2786,7 +2816,8 @@
             "in": "query",
             "name": "departmentId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2794,7 +2825,8 @@
             "in": "query",
             "name": "teacherId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2835,7 +2867,8 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -2843,7 +2876,8 @@
             "in": "query",
             "name": "limit",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           }
@@ -2885,7 +2919,8 @@
             "in": "path",
             "name": "jwId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": true,
             "example": "123"
@@ -2928,7 +2963,8 @@
             "in": "path",
             "name": "jwId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": true,
             "example": "123"
@@ -2972,7 +3008,8 @@
             "in": "path",
             "name": "jwId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": true,
             "example": "123"
@@ -3016,7 +3053,8 @@
             "in": "path",
             "name": "jwId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": true,
             "example": "123"
@@ -3146,7 +3184,8 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -3154,7 +3193,8 @@
             "in": "query",
             "name": "limit",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           }
@@ -3229,7 +3269,8 @@
             "in": "query",
             "name": "departmentId",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -3245,7 +3286,8 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           },
@@ -3253,7 +3295,8 @@
             "in": "query",
             "name": "limit",
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int64"
             },
             "required": false
           }
@@ -4766,7 +4809,198 @@
         ],
         "additionalProperties": false
       },
-      "adminHomeworksResponseSchema": {},
+      "adminHomeworksResponseSchema": {
+        "type": "object",
+        "properties": {
+          "homeworks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "submissionDueAt": {
+                  "type": "string",
+                  "format": "date-time",
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+                  "nullable": true
+                },
+                "createdAt": {
+                  "type": "string",
+                  "format": "date-time",
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                },
+                "updatedAt": {
+                  "type": "string",
+                  "format": "date-time",
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                },
+                "deletedAt": {
+                  "type": "string",
+                  "format": "date-time",
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+                  "nullable": true
+                },
+                "section": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991,
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "course": {
+                      "type": "object",
+                      "properties": {
+                        "jwId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "jwId",
+                        "code",
+                        "nameCn"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "code",
+                    "course"
+                  ],
+                  "additionalProperties": false,
+                  "nullable": true
+                },
+                "createdBy": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "username": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "image": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "username",
+                    "image"
+                  ],
+                  "additionalProperties": false,
+                  "nullable": true
+                },
+                "updatedBy": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "username": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "image": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "username",
+                    "image"
+                  ],
+                  "additionalProperties": false,
+                  "nullable": true
+                },
+                "deletedBy": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "username": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "image": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "username",
+                    "image"
+                  ],
+                  "additionalProperties": false,
+                  "nullable": true
+                }
+              },
+              "required": [
+                "id",
+                "title",
+                "submissionDueAt",
+                "createdAt",
+                "updatedAt",
+                "deletedAt",
+                "section",
+                "createdBy",
+                "updatedBy",
+                "deletedBy"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "homeworks"
+        ],
+        "additionalProperties": false
+      },
       "adminSuspensionResponseSchema": {
         "type": "object",
         "properties": {

--- a/src/lib/api/schemas/admin-response-schemas.ts
+++ b/src/lib/api/schemas/admin-response-schemas.ts
@@ -140,6 +140,34 @@ export const adminDescriptionsResponseSchema = createCollectionSchema(
   adminDescriptionSchema,
 );
 
+const adminHomeworkSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  submissionDueAt: dateTimeSchema.nullable(),
+  createdAt: dateTimeSchema,
+  updatedAt: dateTimeSchema,
+  deletedAt: dateTimeSchema.nullable(),
+  section: z
+    .object({
+      id: z.number().int(),
+      jwId: z.number().int().nullable(),
+      code: z.string().nullable(),
+      course: z.object({
+        jwId: z.number().int(),
+        code: z.string(),
+        nameCn: z.string(),
+      }),
+    })
+    .nullable(),
+  createdBy: homeworkUserSummarySchema.nullable(),
+  updatedBy: homeworkUserSummarySchema.nullable(),
+  deletedBy: homeworkUserSummarySchema.nullable(),
+});
+
+export const adminHomeworksResponseSchema = z.object({
+  homeworks: z.array(adminHomeworkSchema),
+});
+
 const adminSuspensionSchema = z.object({
   id: z.string(),
   userId: z.string(),

--- a/src/lib/api/schemas/request-schema-primitives.ts
+++ b/src/lib/api/schemas/request-schema-primitives.ts
@@ -27,7 +27,8 @@ export const integerStringSchema = z
   .trim()
   .refine((value) => parseInteger(value) !== null, {
     message: "Invalid integer",
-  });
+  })
+  .meta({ openapiType: "integer" });
 
 export const commentReactionTypeSchema = z.enum([
   "upvote",

--- a/tests/e2e/src/app/api/openapi/test.ts
+++ b/tests/e2e/src/app/api/openapi/test.ts
@@ -56,6 +56,44 @@ test.describe("GET /api/openapi", () => {
     ).toBeTruthy();
   });
 
+  test("spec exposes concrete schemas for generated clients", async ({
+    request,
+  }) => {
+    const response = await request.get("/api/openapi");
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as {
+      paths?: Record<
+        string,
+        {
+          get?: {
+            parameters?: Array<{
+              name?: string;
+              schema?: { type?: string; format?: string };
+            }>;
+          };
+        }
+      >;
+      components?: { schemas?: Record<string, unknown> };
+    };
+
+    expect(
+      body.components?.schemas?.adminHomeworksResponseSchema,
+    ).toMatchObject({
+      type: "object",
+    });
+    expect(body.components?.schemas?.adminHomeworksResponseSchema).not.toEqual(
+      {},
+    );
+
+    const adminHomeworksLimit = body.paths?.[
+      "/api/admin/homeworks"
+    ]?.get?.parameters?.find((parameter) => parameter.name === "limit");
+    expect(adminHomeworksLimit?.schema).toMatchObject({
+      type: "integer",
+      format: "int64",
+    });
+  });
+
   test("redirect-only endpoints keep redirect response codes in the spec", async ({
     request,
   }) => {

--- a/tools/build/openapi/generate-spec.ts
+++ b/tools/build/openapi/generate-spec.ts
@@ -76,7 +76,7 @@ for (const [name, value] of Object.entries({
   }
 }
 
-function zodToJsonSchema(schema: z.ZodTypeAny): JsonSchema {
+function zodToJsonSchema(name: string, schema: z.ZodTypeAny): JsonSchema {
   try {
     const result = z.toJSONSchema(schema, {
       cycles: "ref",
@@ -84,15 +84,19 @@ function zodToJsonSchema(schema: z.ZodTypeAny): JsonSchema {
     }) as JsonSchema;
     const { $schema: _unused, ...rest } = result;
     return rest;
-  } catch {
-    return {};
+  } catch (error) {
+    throw new Error(`Failed to convert OpenAPI schema ${name}`, {
+      cause: error,
+    });
   }
 }
 
 function getSchemaJsonSchema(name: string): JsonSchema {
   const schema = allSchemas[name];
-  if (!schema) return {};
-  return zodToJsonSchema(schema);
+  if (!schema) {
+    throw new Error(`OpenAPI annotation references unknown schema: ${name}`);
+  }
+  return zodToJsonSchema(name, schema);
 }
 
 // ── Path parsing ───────────────────────────────────────────────────────────────
@@ -250,7 +254,7 @@ function buildParameters(annotations: HandlerAnnotations): OpenApiParameter[] {
       params.push({
         in: "path",
         name,
-        schema: { type: "string", ...propSchema },
+        schema: normalizeParameterSchema({ type: "string", ...propSchema }),
         required: required.includes(name),
         example: "123",
       });
@@ -266,13 +270,22 @@ function buildParameters(annotations: HandlerAnnotations): OpenApiParameter[] {
       params.push({
         in: "query",
         name,
-        schema: propSchema,
+        schema: normalizeParameterSchema(propSchema),
         required: required.includes(name),
       });
     }
   }
 
   return params;
+}
+
+function normalizeParameterSchema(schema: JsonSchema): JsonSchema {
+  if (schema.openapiType !== "integer") {
+    return schema;
+  }
+
+  const { openapiType: _unused, ...rest } = schema;
+  return { ...rest, type: "integer", format: "int64" };
 }
 
 // ── Response building ──────────────────────────────────────────────────────────

--- a/tools/build/openapi/postprocess-spec.ts
+++ b/tools/build/openapi/postprocess-spec.ts
@@ -172,7 +172,11 @@ function rewriteOperationId(
     return method === "get" ? "getBusPreferences" : "setBusPreferences";
   }
 
-  if (resource === "descriptions" && resourceSegments.length === 1) {
+  if (
+    !isAdmin &&
+    resource === "descriptions" &&
+    resourceSegments.length === 1
+  ) {
     return method === "get" ? "getDescription" : "upsertDescription";
   }
 


### PR DESCRIPTION
## Summary
- restore the OpenAPI contract hardening through a PR/rebase flow
- fail generation on unknown or unconvertible named schemas instead of emitting empty components
- add the missing admin homework response schema and expose integer-like route/query params as OpenAPI integers
- add OpenAPI E2E coverage for generated-client contract assumptions

## Verification
- bun run verify:fast