### PR TITLE
feat(api): batch homework completion API

### DIFF
--- a/.agents/skills/life-ustc-api-mcp-verification/SKILL.md
+++ b/.agents/skills/life-ustc-api-mcp-verification/SKILL.md
@@ -13,11 +13,12 @@ Use this skill to verify public API and MCP behavior by inspecting representativ
 
 1. Read root `AGENTS.md`, `docs/contracts/AGENTS.md`, and `src/lib/mcp/AGENTS.md` when MCP is involved.
 2. Identify the coupled surfaces: route handler, MCP tool, feature/server function, contract JSON, OpenAPI annotation, seed data, and tests.
-3. Pick representative public calls. Cover at least one success shape and one relevant validation, auth, permission, or not-found path when those behaviors changed.
-4. Exercise the route or MCP tool through the narrowest realistic public surface.
-5. Inspect the serialized status/body or `jsonToolResult` output and compare it with contracts, OpenAPI, and tests.
-6. Add or update tests where behavior is observed.
-7. Remove temporary probes, logs, scripts, and copied payloads before committing.
+3. Decide REST/MCP parity explicitly. If only one surface changes, record why the other stays unchanged in the PR body or final handoff.
+4. Pick representative public calls. Cover at least one success shape and one relevant validation, auth, permission, or not-found path when those behaviors changed.
+5. Exercise the route or MCP tool through the narrowest realistic public surface.
+6. Inspect the serialized status/body or `jsonToolResult` output and compare it with contracts, OpenAPI, and tests.
+7. Add or update tests where behavior is observed.
+8. Remove temporary probes, logs, scripts, and copied payloads before committing.
 
 ## REST Checks
 
@@ -47,3 +48,4 @@ Use the highest relevant gate:
 ## Handoff Evidence
 
 Summarize the representative call or tool exercised, the status/result shape inspected, contracts/tests updated, commands run, and any skipped output checks with the reason.
+Include the REST/MCP parity decision when only one public surface changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ static loader.
 ## Complete-Loop Checks
 
 - UI/layout changes: run the narrowest browser check that exercises the changed screen, inspect a screenshot/headed run/trace for the affected area, and iterate on visible regressions before handoff.
-- REST/MCP behavior changes: exercise at least one representative public request or MCP tool call when feasible, inspect the serialized success/error output, and compare it with contracts/tests.
+- REST/MCP behavior changes: decide whether both surfaces should change. If only one changes, document why; then exercise at least one representative public request or MCP tool call when feasible, inspect the serialized success/error output, and compare it with contracts/tests.
 - Keep screenshots, traces, temporary payloads, and ad hoc probes out of the repo unless they are intentional fixtures.
 
 ## Shared Test Seed

--- a/docs/contracts/homework.json
+++ b/docs/contracts/homework.json
@@ -184,6 +184,15 @@
             "path": "/api/homeworks/[id]/completion",
             "method": "PUT",
             "returns": "{ completed: Boolean, completedAt: DateTime? }"
+          },
+          {
+            "path": "/api/homeworks/completions",
+            "method": "PUT",
+            "returns": "{ results: Array<{ success: Boolean, homeworkId: String, completed: Boolean, completedAt?: DateTime?, error?: { code: String, message: String } }> }",
+            "notes": [
+              "Batch completion updates are partial by item: missing or deleted homework IDs return per-item errors while valid items still update.",
+              "MCP remains single-item through set_my_homework_completion; this REST batch route exists for HTTP clients that otherwise fan out single-item requests."
+            ]
           }
         ]
       },

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -1958,6 +1958,46 @@
         }
       }
     },
+    "/api/homeworks/completions": {
+      "put": {
+        "operationId": "put-api-homeworks-completions",
+        "summary": "Update homework completions in a batch",
+        "tags": [
+          "Homeworks"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/homeworkCompletionBatchRequestSchema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/homeworkCompletionBatchResponseSchema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/locale": {
       "post": {
         "operationId": "setLocale",
@@ -4805,6 +4845,35 @@
         },
         "required": [
           "completed"
+        ]
+      },
+      "homeworkCompletionBatchRequestSchema": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "minItems": 1,
+            "maxItems": 100,
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "homeworkId": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "completed": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "homeworkId",
+                "completed"
+              ]
+            }
+          }
+        },
+        "required": [
+          "items"
         ]
       },
       "localeUpdateRequestSchema": {
@@ -10297,6 +10366,97 @@
         "required": [
           "completed",
           "completedAt"
+        ],
+        "additionalProperties": false
+      },
+      "homeworkCompletionBatchResponseSchema": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        true
+                      ]
+                    },
+                    "homeworkId": {
+                      "type": "string"
+                    },
+                    "completed": {
+                      "type": "boolean"
+                    },
+                    "completedAt": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "homeworkId",
+                    "completed",
+                    "completedAt"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "enum": [
+                        false
+                      ]
+                    },
+                    "homeworkId": {
+                      "type": "string"
+                    },
+                    "completed": {
+                      "type": "boolean"
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "enum": [
+                            "not_found",
+                            "deleted"
+                          ]
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "homeworkId",
+                    "completed",
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "required": [
+          "results"
         ],
         "additionalProperties": false
       },

--- a/src/features/homeworks/server/homework-completion.ts
+++ b/src/features/homeworks/server/homework-completion.ts
@@ -1,0 +1,124 @@
+import { prisma } from "@/lib/db/prisma";
+
+export type HomeworkCompletionErrorCode = "not_found" | "deleted";
+
+export type HomeworkCompletionResult =
+  | {
+      success: true;
+      homeworkId: string;
+      completed: boolean;
+      completedAt: Date | null;
+    }
+  | {
+      success: false;
+      homeworkId: string;
+      completed: boolean;
+      error: {
+        code: HomeworkCompletionErrorCode;
+        message: string;
+      };
+    };
+
+export async function setHomeworkCompletion(input: {
+  completed: boolean;
+  homeworkId: string;
+  userId: string;
+}): Promise<HomeworkCompletionResult> {
+  const homework = await prisma.homework.findUnique({
+    where: { id: input.homeworkId },
+    select: { id: true, deletedAt: true },
+  });
+
+  if (!homework) {
+    return completionFailure(input, "not_found", "Homework not found");
+  }
+  if (homework.deletedAt) {
+    return completionFailure(input, "deleted", "Homework is deleted");
+  }
+
+  return writeHomeworkCompletion(input);
+}
+
+export async function setHomeworkCompletions(input: {
+  items: Array<{ completed: boolean; homeworkId: string }>;
+  userId: string;
+}) {
+  const homeworkIds = [...new Set(input.items.map((item) => item.homeworkId))];
+  const homeworks = await prisma.homework.findMany({
+    where: { id: { in: homeworkIds } },
+    select: { id: true, deletedAt: true },
+  });
+  const homeworkById = new Map(
+    homeworks.map((homework) => [homework.id, homework]),
+  );
+
+  const results: HomeworkCompletionResult[] = [];
+  for (const item of input.items) {
+    const completionInput = { ...item, userId: input.userId };
+    const homework = homeworkById.get(item.homeworkId);
+    if (!homework) {
+      results.push(
+        completionFailure(completionInput, "not_found", "Homework not found"),
+      );
+      continue;
+    }
+    if (homework.deletedAt) {
+      results.push(
+        completionFailure(completionInput, "deleted", "Homework is deleted"),
+      );
+      continue;
+    }
+    results.push(await writeHomeworkCompletion(completionInput));
+  }
+  return { results };
+}
+
+async function writeHomeworkCompletion(input: {
+  completed: boolean;
+  homeworkId: string;
+  userId: string;
+}): Promise<HomeworkCompletionResult> {
+  if (input.completed) {
+    const completion = await prisma.homeworkCompletion.upsert({
+      where: {
+        userId_homeworkId: {
+          userId: input.userId,
+          homeworkId: input.homeworkId,
+        },
+      },
+      update: { completedAt: new Date() },
+      create: { userId: input.userId, homeworkId: input.homeworkId },
+    });
+
+    return {
+      success: true,
+      homeworkId: input.homeworkId,
+      completed: true,
+      completedAt: completion.completedAt,
+    };
+  }
+
+  await prisma.homeworkCompletion.deleteMany({
+    where: { userId: input.userId, homeworkId: input.homeworkId },
+  });
+
+  return {
+    success: true,
+    homeworkId: input.homeworkId,
+    completed: false,
+    completedAt: null,
+  };
+}
+
+function completionFailure(
+  input: { completed: boolean; homeworkId: string },
+  code: HomeworkCompletionErrorCode,
+  message: string,
+): HomeworkCompletionResult {
+  return {
+    success: false,
+    homeworkId: input.homeworkId,
+    completed: input.completed,
+    error: { code, message },
+  };
+}

--- a/src/lib/api/routes/homework-completion-action.ts
+++ b/src/lib/api/routes/homework-completion-action.ts
@@ -1,3 +1,4 @@
+import { setHomeworkCompletion } from "@/features/homeworks/server/homework-completion";
 import { jsonResponse, notFound } from "@/lib/api/helpers";
 
 export async function updateHomeworkCompletionAction(input: {
@@ -5,37 +6,13 @@ export async function updateHomeworkCompletionAction(input: {
   homeworkId: string;
   userId: string;
 }) {
-  const { prisma } = await import("@/lib/db/prisma");
-  const homework = await prisma.homework.findUnique({
-    where: { id: input.homeworkId },
-    select: { id: true, deletedAt: true },
-  });
-
-  if (!homework || homework.deletedAt) {
+  const result = await setHomeworkCompletion(input);
+  if (!result.success) {
     return notFound();
   }
 
-  if (input.completed) {
-    const completion = await prisma.homeworkCompletion.upsert({
-      where: {
-        userId_homeworkId: {
-          userId: input.userId,
-          homeworkId: input.homeworkId,
-        },
-      },
-      update: { completedAt: new Date() },
-      create: { userId: input.userId, homeworkId: input.homeworkId },
-    });
-
-    return jsonResponse({
-      completed: true,
-      completedAt: completion.completedAt,
-    });
-  }
-
-  await prisma.homeworkCompletion.deleteMany({
-    where: { userId: input.userId, homeworkId: input.homeworkId },
+  return jsonResponse({
+    completed: result.completed,
+    completedAt: result.completedAt,
   });
-
-  return jsonResponse({ completed: false, completedAt: null });
 }

--- a/src/lib/api/routes/homework-completion.ts
+++ b/src/lib/api/routes/homework-completion.ts
@@ -1,10 +1,13 @@
+import { setHomeworkCompletions } from "@/features/homeworks/server/homework-completion";
 import {
   handleRouteError,
+  jsonResponse,
   parseRouteInput,
   parseRouteJsonBody,
 } from "@/lib/api/helpers";
 import { updateHomeworkCompletionAction } from "@/lib/api/routes/homework-completion-action";
 import {
+  homeworkCompletionBatchRequestSchema,
   homeworkCompletionRequestSchema,
   resourceIdPathParamsSchema,
 } from "@/lib/api/schemas/request-schemas";
@@ -46,5 +49,30 @@ export async function putHomeworkCompletionRoute(
     });
   } catch (error) {
     return handleRouteError("Failed to update completion", error);
+  }
+}
+
+export async function putHomeworkCompletionsRoute(request: Request) {
+  const parsedBody = await parseRouteJsonBody(
+    request,
+    homeworkCompletionBatchRequestSchema,
+    "Invalid completion batch payload",
+  );
+  if (parsedBody instanceof Response) {
+    return parsedBody;
+  }
+
+  const auth = await requireAuth(request);
+  if (auth instanceof Response) return auth;
+
+  try {
+    return jsonResponse(
+      await setHomeworkCompletions({
+        items: parsedBody.items,
+        userId: auth.userId,
+      }),
+    );
+  } catch (error) {
+    return handleRouteError("Failed to update completion batch", error);
   }
 }

--- a/src/lib/api/schemas/homeworks-response-schemas.ts
+++ b/src/lib/api/schemas/homeworks-response-schemas.ts
@@ -81,6 +81,28 @@ export const homeworkCompletionResponseSchema = z.object({
   completedAt: dateTimeSchema.nullable(),
 });
 
+export const homeworkCompletionBatchResponseSchema = z.object({
+  results: z.array(
+    z.discriminatedUnion("success", [
+      z.object({
+        success: z.literal(true),
+        homeworkId: z.string(),
+        completed: z.boolean(),
+        completedAt: dateTimeSchema.nullable(),
+      }),
+      z.object({
+        success: z.literal(false),
+        homeworkId: z.string(),
+        completed: z.boolean(),
+        error: z.object({
+          code: z.enum(["not_found", "deleted"]),
+          message: z.string(),
+        }),
+      }),
+    ]),
+  ),
+});
+
 export const subscribedHomeworksResponseSchema = z.object({
   viewer: viewerContextSchema,
   homeworks: z.array(homeworkListItemSchema),

--- a/src/lib/api/schemas/request-academic-mutation-schemas.ts
+++ b/src/lib/api/schemas/request-academic-mutation-schemas.ts
@@ -26,6 +26,18 @@ export const homeworkCompletionRequestSchema = z.object({
   completed: z.boolean(),
 });
 
+export const homeworkCompletionBatchRequestSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        homeworkId: z.string().trim().min(1),
+        completed: z.boolean(),
+      }),
+    )
+    .min(1)
+    .max(100),
+});
+
 export const homeworkUpdateRequestSchema = z.object({
   title: z.string().trim().min(1).max(200).optional(),
   publishedAt: z.union([z.string(), z.null()]).optional(),

--- a/src/lib/api/schemas/request-mutation-schemas.ts
+++ b/src/lib/api/schemas/request-mutation-schemas.ts
@@ -1,5 +1,6 @@
 export {
   type HomeworkCreateRequest,
+  homeworkCompletionBatchRequestSchema,
   homeworkCompletionRequestSchema,
   homeworkCreateRequestSchema,
   homeworkUpdateRequestSchema,

--- a/src/routes/api/homeworks/completions/+server.ts
+++ b/src/routes/api/homeworks/completions/+server.ts
@@ -1,0 +1,13 @@
+import { putHomeworkCompletionsRoute } from "@/lib/api/routes/homework-completion";
+import { svelteRequestHandler } from "@/lib/api/svelte-route";
+import { observedApiRoute } from "@/lib/log/api-observability";
+
+/**
+ * Update homework completions in a batch.
+ * @body homeworkCompletionBatchRequestSchema
+ * @response homeworkCompletionBatchResponseSchema
+ * @response 400:openApiErrorSchema
+ */
+export const PUT = svelteRequestHandler(
+  observedApiRoute(putHomeworkCompletionsRoute),
+);

--- a/tests/e2e/src/app/api/homeworks/completions/test.ts
+++ b/tests/e2e/src/app/api/homeworks/completions/test.ts
@@ -1,0 +1,137 @@
+/**
+ * E2E tests for PUT /api/homeworks/completions.
+ *
+ * ## PUT /api/homeworks/completions
+ * - Body: { items: [{ homeworkId: string, completed: boolean }] }
+ * - Response: { results: Array<{ success, homeworkId, completed, completedAt?, error? }> }
+ * - Auth required (401 if unauthenticated)
+ * - Returns per-item partial results for missing or deleted homework IDs
+ */
+import { expect, test } from "@playwright/test";
+import { signInAsDebugUser } from "../../../../../utils/auth";
+import { DEV_SEED } from "../../../../../utils/dev-seed";
+import { assertApiContract } from "../../../_shared/api-contract";
+
+async function resolveSeedSectionId(
+  request: import("@playwright/test").APIRequestContext,
+) {
+  const response = await request.post("/api/sections/match-codes", {
+    data: { codes: [DEV_SEED.section.code] },
+  });
+  expect(response.status()).toBe(200);
+  const body = (await response.json()) as {
+    sections?: Array<{ id?: number; code?: string | null }>;
+  };
+  const section = body.sections?.find((s) => s.code === DEV_SEED.section.code);
+  expect(section?.id).toBeDefined();
+  // biome-ignore lint/style/noNonNullAssertion: guarded by expect above
+  return section!.id!;
+}
+
+async function createTempHomework(
+  request: import("@playwright/test").APIRequestContext,
+  sectionId: number,
+  title: string,
+) {
+  const now = new Date();
+  const createResponse = await request.post("/api/homeworks", {
+    data: {
+      title,
+      sectionId: String(sectionId),
+      publishedAt: now.toISOString(),
+      submissionStartAt: now.toISOString(),
+      submissionDueAt: new Date(now.getTime() + 86_400_000).toISOString(),
+    },
+  });
+  expect(createResponse.status()).toBe(200);
+
+  const listResponse = await request.get(
+    `/api/homeworks?sectionId=${sectionId}`,
+  );
+  expect(listResponse.status()).toBe(200);
+  const listBody = (await listResponse.json()) as {
+    homeworks?: Array<{ id?: string; title?: string }>;
+  };
+  const homework = listBody.homeworks?.find((item) => item.title === title);
+  expect(homework?.id).toBeTruthy();
+  // biome-ignore lint/style/noNonNullAssertion: guarded by expect above
+  return homework!.id!;
+}
+
+test("/api/homeworks/completions", async ({ request }) => {
+  await assertApiContract(request, {
+    routePath: "/api/homeworks/completions",
+  });
+});
+
+test("/api/homeworks/completions PUT 未登录返回 401", async ({ request }) => {
+  const response = await request.put("/api/homeworks/completions", {
+    data: { items: [{ homeworkId: "invalid-e2e", completed: true }] },
+  });
+  expect(response.status()).toBe(401);
+});
+
+test("/api/homeworks/completions PUT 返回每项结果", async ({ page }) => {
+  await signInAsDebugUser(page, "/");
+  const sectionId = await resolveSeedSectionId(page.request);
+  const suffix = `${Date.now()}`;
+  const activeHomeworkId = await createTempHomework(
+    page.request,
+    sectionId,
+    `e2e-batch-active-${suffix}`,
+  );
+  const deletedHomeworkId = await createTempHomework(
+    page.request,
+    sectionId,
+    `e2e-batch-deleted-${suffix}`,
+  );
+
+  try {
+    const deleteResponse = await page.request.delete(
+      `/api/homeworks/${deletedHomeworkId}`,
+    );
+    expect(deleteResponse.status()).toBe(200);
+
+    const response = await page.request.put("/api/homeworks/completions", {
+      data: {
+        items: [
+          { homeworkId: activeHomeworkId, completed: true },
+          { homeworkId: deletedHomeworkId, completed: true },
+          { homeworkId: "missing-e2e-homework", completed: false },
+        ],
+      },
+    });
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as {
+      results?: Array<{
+        success?: boolean;
+        homeworkId?: string;
+        completed?: boolean;
+        completedAt?: string | null;
+        error?: { code?: string; message?: string };
+      }>;
+    };
+
+    expect(body.results).toHaveLength(3);
+    expect(body.results?.[0]).toMatchObject({
+      success: true,
+      homeworkId: activeHomeworkId,
+      completed: true,
+    });
+    expect(typeof body.results?.[0]?.completedAt).toBe("string");
+    expect(body.results?.[1]).toMatchObject({
+      success: false,
+      homeworkId: deletedHomeworkId,
+      completed: true,
+      error: { code: "deleted" },
+    });
+    expect(body.results?.[2]).toMatchObject({
+      success: false,
+      homeworkId: "missing-e2e-homework",
+      completed: false,
+      error: { code: "not_found" },
+    });
+  } finally {
+    await page.request.delete(`/api/homeworks/${activeHomeworkId}`);
+  }
+});

--- a/tests/unit/api-schemas.test.ts
+++ b/tests/unit/api-schemas.test.ts
@@ -4,6 +4,7 @@ import {
   commentReactionRequestSchema,
   coursesQuerySchema,
   descriptionUpsertRequestSchema,
+  homeworkCompletionBatchRequestSchema,
   homeworkCreateRequestSchema,
   localeUpdateRequestSchema,
   matchSectionCodesRequestSchema,
@@ -56,6 +57,30 @@ describe("homeworkCreateRequestSchema", () => {
       title: "",
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe("homeworkCompletionBatchRequestSchema", () => {
+  it("accepts completion updates", () => {
+    const result = homeworkCompletionBatchRequestSchema.safeParse({
+      items: [
+        { homeworkId: "homework-1", completed: true },
+        { homeworkId: "homework-2", completed: false },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty item lists and blank homework IDs", () => {
+    expect(
+      homeworkCompletionBatchRequestSchema.safeParse({ items: [] }).success,
+    ).toBe(false);
+    expect(
+      homeworkCompletionBatchRequestSchema.safeParse({
+        items: [{ homeworkId: "", completed: true }],
+      }).success,
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Resolves #37 by adding `PUT /api/homeworks/completions` for batch personal homework completion updates.
- Returns ordered partial per-item results for successful updates, deleted homework, and missing homework IDs.
- Moves shared completion mutation logic into `src/features/homeworks/server` and keeps the existing single-item endpoint compatible.
- Updates contract docs, request/response schemas, generated OpenAPI, focused E2E API coverage, and unit schema coverage.
- Updates agent guidance after subagent validation found an ambiguity: REST/MCP parity decisions must be explicit when only one surface changes.

## REST / MCP Parity Decision
- REST changes in this PR.
- MCP remains single-item via `set_my_homework_completion`.
- Reason: issue #37 targets HTTP clients and bot fan-out over REST; a batch MCP tool is not required to replace the bot loop and would expand public MCP surface separately.

## Verification
- `bun run biome check --write ...`
- `python /home/tiankaima/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/life-ustc-api-mcp-verification`
- `bunx vitest run tests/unit/api-schemas.test.ts`
- `bun --silent run tools/dev/check.ts contracts`
- `bun --silent run tools/dev/check.ts routes`
- `bun run build`
- `bun --silent run verify`

## Complete-Loop Evidence
- Generated OpenAPI now includes `/api/homeworks/completions` with `homeworkCompletionBatchRequestSchema` and `homeworkCompletionBatchResponseSchema`.
- Added E2E route coverage that inspects serialized batch output for active/deleted/missing items.
- Local execution of that E2E test was blocked by local Docker host-port DB connectivity: Docker-internal `psql` worked, but host Prisma/Node/psql connections to `127.0.0.1:5432` hung or reported P1001. CI should provide the public-route E2E evidence.

## Subagent Validation
- A subagent used the new guidance documents to plan issue #37.
- It confirmed the right triggered skills and surfaces.
- It found the REST/MCP parity ambiguity, which this PR fixes in `AGENTS.md` and `.agents/skills/life-ustc-api-mcp-verification/SKILL.md`.

## Residual Risk
- Batch updates are partial per item, not all-or-nothing. This is documented in the contract and response shape.
