### PR TITLE
feat(api): lightweight client REST surfaces

### DIFF
--- a/docs/contracts/bus.json
+++ b/docs/contracts/bus.json
@@ -92,12 +92,24 @@
       "title": "Bus Route Search",
       "auth": "anon",
       "web": "unavailable",
-      "rest": "unavailable",
+      "rest": {
+        "routes": [
+          {
+            "path": "/api/bus/routes",
+            "returns": "{ originCampus?, destinationCampus?, total: Int, routes: BusRouteSearchResult[] }",
+            "notes": [
+              "Filtered route discovery helper for origin/destination clients.",
+              "Preserves concrete route variants rather than merging routes with the same campus pair."
+            ]
+          }
+        ]
+      },
       "mcp": {
         "tools": [
           {
             "name": "search_bus_routes",
             "returns": "{ originCampus?, destinationCampus?, total: Int, routes: BusRouteSearchResult[] }",
+            "rest_equivalent": "GET /api/bus/routes",
             "notes": [
               "Filtered discovery helper for origin/destination prompts.",
               "Use list_bus_routes when the caller needs the entire current route catalog."
@@ -119,12 +131,26 @@
       "title": "Bus Next Departures",
       "auth": "user",
       "web": "unavailable",
-      "rest": "unavailable",
+      "rest": {
+        "routes": [
+          {
+            "path": "/api/bus/next",
+            "returns": "{ originCampus, destinationCampus, atTime, dayType, totalRoutes: Int, departures: BusDeparture[], nextAvailableDeparture?, message? }",
+            "auth": "anon",
+            "notes": [
+              "Requires originCampusId and destinationCampusId.",
+              "Supports atTime, dayType, includeDeparted, limit, versionKey, and locale query parameters.",
+              "Departures include status and minutesUntilDeparture so clients can mark departed rows and the next upcoming trip."
+            ]
+          }
+        ]
+      },
       "mcp": {
         "tools": [
           {
             "name": "get_next_buses",
             "returns": "{ originCampus, destinationCampus, atTime, dayType, totalRoutes: Int, departures: BusDeparture[] }",
+            "rest_equivalent": "GET /api/bus/next",
             "notes": [
               "Task-oriented convenience tool for 'when is the next bus?' prompts.",
               "Default parameters: dayType=auto, includeDeparted=false, limit=5.",

--- a/docs/contracts/overview.json
+++ b/docs/contracts/overview.json
@@ -33,12 +33,25 @@
           "/dashboard/links"
         ]
       },
-      "rest": "unavailable",
+      "rest": {
+        "routes": [
+          {
+            "path": "/api/me/overview",
+            "returns": "{ user, anchor, counts, schedules, todos, homeworks, exams }",
+            "notes": [
+              "Compact authenticated overview for bot, CLI, and mobile clients.",
+              "Supports atTime, homeworkWindowDays, limit, and locale query parameters.",
+              "Includes today schedule samples in addition to the counts and task/deadline samples exposed by get_my_overview."
+            ]
+          }
+        ]
+      },
       "mcp": {
         "tools": [
           {
             "name": "get_my_overview",
             "returns": "{ user, overview, samples }",
+            "rest_equivalent": "GET /api/me/overview",
             "notes": [
               "overview contains pending todo, homework, today's schedule, and upcoming exam counts.",
               "samples contains dueTodos[], dueHomeworks[], and upcomingExams[].",

--- a/docs/contracts/schedule.json
+++ b/docs/contracts/schedule.json
@@ -21,12 +21,25 @@
       "web": {
         "pages": ["/dashboard/calendar"]
       },
-      "rest": "unavailable",
+      "rest": {
+        "routes": [
+          {
+            "path": "/api/me/subscriptions/schedules",
+            "returns": "{ schedules: ScheduleEntry[] }",
+            "notes": [
+              "Resolves the current user's subscribed sections server-side.",
+              "Supports dateFrom/dateTo, weekday, limit, and locale filters.",
+              "Use /api/schedules for public schedule queries without personal subscription scope."
+            ]
+          }
+        ]
+      },
       "mcp": {
         "tools": [
           {
             "name": "list_my_schedules",
             "returns": "{ schedules: ScheduleEntry[] }",
+            "rest_equivalent": "GET /api/me/subscriptions/schedules",
             "notes": [
               "Returns schedules[]; each item contains date, weekday, startTime, endTime, section.course.namePrimary, section.code, room, teachers[], and scheduleGroup."
             ]

--- a/docs/contracts/subscription.json
+++ b/docs/contracts/subscription.json
@@ -72,6 +72,15 @@
             "notes": [
               "subscription.sections[] is the user's new set of subscribed sections."
             ]
+          },
+          {
+            "path": "/api/calendar-subscriptions/import-codes",
+            "method": "POST",
+            "returns": "{ success: Boolean, semester, matchedCodes, unmatchedCodes, ambiguousCodes, sections, addedCount, addedSections, alreadySubscribedCount, alreadySubscribedSections, subscription }",
+            "notes": [
+              "Combines section-code matching with an append-only subscription mutation.",
+              "Does not replace the caller's whole subscription set, so concurrent additions are not overwritten by stale client-side read-merge-replace flows."
+            ]
           }
         ]
       },
@@ -89,7 +98,7 @@
           {
             "name": "subscribe_my_sections_by_codes",
             "returns": "{ success: Boolean, semester, matchedCodes, unmatchedCodes, addedCount, alreadySubscribedCount, subscription }",
-            "rest_equivalent": "POST /api/calendar-subscriptions",
+            "rest_equivalent": "POST /api/calendar-subscriptions/import-codes",
             "notes": [
               "Convenience mutation that combines matching with subscription update.",
               "Use match_section_codes first when the caller needs a dry-run style preview.",

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -785,6 +785,125 @@
         }
       }
     },
+    "/api/bus/next": {
+      "get": {
+        "operationId": "get-api-bus-next",
+        "summary": "Get next shuttle bus departures for an origin and destination campus",
+        "tags": [
+          "Bus"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "originCampusId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "destinationCampusId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "atTime",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "dayType",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "auto",
+                "weekday",
+                "weekend"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "includeDeparted",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "versionKey",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en-us",
+                "zh-cn"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/busNextDeparturesResponseSchema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/bus/preferences": {
       "get": {
         "operationId": "getBusPreferences",
@@ -864,6 +983,84 @@
         }
       }
     },
+    "/api/bus/routes": {
+      "get": {
+        "operationId": "get-api-bus-routes",
+        "summary": "Search shuttle bus route variants",
+        "tags": [
+          "Bus"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "originCampusId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "destinationCampusId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "versionKey",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en-us",
+                "zh-cn"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/busRouteSearchResponseSchema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/calendar-subscriptions": {
       "post": {
         "operationId": "setCalendarSubscription",
@@ -923,6 +1120,66 @@
             }
           },
           "401": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/calendar-subscriptions/import-codes": {
+      "post": {
+        "operationId": "post-api-calendar-subscriptions-import-codes",
+        "summary": "Import section subscriptions by section codes",
+        "tags": [
+          "Calendar"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/matchSectionCodesRequestSchema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/calendarSubscriptionImportResponseSchema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "404": {
             "description": "Error response",
             "content": {
               "application/json": {
@@ -2284,6 +2541,84 @@
         }
       }
     },
+    "/api/me/overview": {
+      "get": {
+        "operationId": "get-api-me-overview",
+        "summary": "Get a compact current-user overview for lightweight clients",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "atTime",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "homeworkWindowDays",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en-us",
+                "zh-cn"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/compactOverviewResponseSchema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/me/subscriptions/homeworks": {
       "get": {
         "operationId": "getSubscribedHomeworks",
@@ -2298,6 +2633,92 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/subscribedHomeworksResponseSchema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/me/subscriptions/schedules": {
+      "get": {
+        "operationId": "get-api-me-subscriptions-schedules",
+        "summary": "List schedules across the current user's subscribed sections",
+        "tags": [
+          "Me"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "dateFrom",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "dateTo",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "weekday",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en-us",
+                "zh-cn"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/subscribedSchedulesResponseSchema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
                 }
               }
             }
@@ -4724,6 +5145,35 @@
           }
         }
       },
+      "matchSectionCodesRequestSchema": {
+        "type": "object",
+        "properties": {
+          "codes": {
+            "minItems": 1,
+            "maxItems": 500,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64,
+              "pattern": "^[A-Za-z0-9_.-]+$"
+            }
+          },
+          "semesterId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          }
+        },
+        "required": [
+          "codes"
+        ]
+      },
       "commentCreateRequestSchema": {
         "type": "object",
         "properties": {
@@ -5109,35 +5559,6 @@
         },
         "required": [
           "locale"
-        ]
-      },
-      "matchSectionCodesRequestSchema": {
-        "type": "object",
-        "properties": {
-          "codes": {
-            "minItems": 1,
-            "maxItems": 500,
-            "type": "array",
-            "items": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 64,
-              "pattern": "^[A-Za-z0-9_.-]+$"
-            }
-          },
-          "semesterId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "number"
-              }
-            ]
-          }
-        },
-        "required": [
-          "codes"
         ]
       },
       "todoCreateRequestSchema": {
@@ -6969,6 +7390,485 @@
         ],
         "additionalProperties": false
       },
+      "busNextDeparturesResponseSchema": {
+        "type": "object",
+        "properties": {
+          "originCampus": {
+            "nullable": true,
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "nameCn": {
+                "type": "string"
+              },
+              "nameEn": {
+                "nullable": true,
+                "type": "string"
+              },
+              "latitude": {
+                "type": "number"
+              },
+              "longitude": {
+                "type": "number"
+              },
+              "namePrimary": {
+                "type": "string"
+              },
+              "nameSecondary": {
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "nameCn",
+              "nameEn",
+              "latitude",
+              "longitude",
+              "namePrimary",
+              "nameSecondary"
+            ],
+            "additionalProperties": false
+          },
+          "destinationCampus": {
+            "nullable": true,
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "nameCn": {
+                "type": "string"
+              },
+              "nameEn": {
+                "nullable": true,
+                "type": "string"
+              },
+              "latitude": {
+                "type": "number"
+              },
+              "longitude": {
+                "type": "number"
+              },
+              "namePrimary": {
+                "type": "string"
+              },
+              "nameSecondary": {
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "nameCn",
+              "nameEn",
+              "latitude",
+              "longitude",
+              "namePrimary",
+              "nameSecondary"
+            ],
+            "additionalProperties": false
+          },
+          "atTime": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+          },
+          "dayType": {
+            "type": "string",
+            "enum": [
+              "weekday",
+              "weekend"
+            ]
+          },
+          "totalRoutes": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "departures": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tripId": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "routeId": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "route": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "descriptionPrimary": {
+                      "type": "string"
+                    },
+                    "descriptionSecondary": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "nameCn",
+                    "nameEn",
+                    "descriptionPrimary",
+                    "descriptionSecondary"
+                  ],
+                  "additionalProperties": false
+                },
+                "originCampus": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "latitude": {
+                      "type": "number"
+                    },
+                    "longitude": {
+                      "type": "number"
+                    },
+                    "namePrimary": {
+                      "type": "string"
+                    },
+                    "nameSecondary": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "nameCn",
+                    "nameEn",
+                    "latitude",
+                    "longitude",
+                    "namePrimary",
+                    "nameSecondary"
+                  ],
+                  "additionalProperties": false
+                },
+                "destinationCampus": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "latitude": {
+                      "type": "number"
+                    },
+                    "longitude": {
+                      "type": "number"
+                    },
+                    "namePrimary": {
+                      "type": "string"
+                    },
+                    "nameSecondary": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "nameCn",
+                    "nameEn",
+                    "latitude",
+                    "longitude",
+                    "namePrimary",
+                    "nameSecondary"
+                  ],
+                  "additionalProperties": false
+                },
+                "departureTime": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "arrivalTime": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "departureEstimated": {
+                  "type": "boolean"
+                },
+                "arrivalEstimated": {
+                  "type": "boolean"
+                },
+                "minutesUntilDeparture": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "dayType": {
+                  "type": "string",
+                  "enum": [
+                    "weekday",
+                    "weekend"
+                  ]
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "upcoming",
+                    "departed"
+                  ]
+                }
+              },
+              "required": [
+                "tripId",
+                "routeId",
+                "route",
+                "originCampus",
+                "destinationCampus",
+                "departureTime",
+                "arrivalTime",
+                "departureEstimated",
+                "arrivalEstimated",
+                "minutesUntilDeparture",
+                "dayType",
+                "status"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "nextAvailableDeparture": {
+            "nullable": true,
+            "type": "object",
+            "properties": {
+              "tripId": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "routeId": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "route": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "nameCn": {
+                    "type": "string"
+                  },
+                  "nameEn": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "descriptionPrimary": {
+                    "type": "string"
+                  },
+                  "descriptionSecondary": {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "nameCn",
+                  "nameEn",
+                  "descriptionPrimary",
+                  "descriptionSecondary"
+                ],
+                "additionalProperties": false
+              },
+              "originCampus": {
+                "nullable": true,
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "nameCn": {
+                    "type": "string"
+                  },
+                  "nameEn": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "latitude": {
+                    "type": "number"
+                  },
+                  "longitude": {
+                    "type": "number"
+                  },
+                  "namePrimary": {
+                    "type": "string"
+                  },
+                  "nameSecondary": {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "nameCn",
+                  "nameEn",
+                  "latitude",
+                  "longitude",
+                  "namePrimary",
+                  "nameSecondary"
+                ],
+                "additionalProperties": false
+              },
+              "destinationCampus": {
+                "nullable": true,
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "nameCn": {
+                    "type": "string"
+                  },
+                  "nameEn": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "latitude": {
+                    "type": "number"
+                  },
+                  "longitude": {
+                    "type": "number"
+                  },
+                  "namePrimary": {
+                    "type": "string"
+                  },
+                  "nameSecondary": {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "nameCn",
+                  "nameEn",
+                  "latitude",
+                  "longitude",
+                  "namePrimary",
+                  "nameSecondary"
+                ],
+                "additionalProperties": false
+              },
+              "departureTime": {
+                "nullable": true,
+                "type": "string"
+              },
+              "arrivalTime": {
+                "nullable": true,
+                "type": "string"
+              },
+              "departureEstimated": {
+                "type": "boolean"
+              },
+              "arrivalEstimated": {
+                "type": "boolean"
+              },
+              "minutesUntilDeparture": {
+                "nullable": true,
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "dayType": {
+                "type": "string",
+                "enum": [
+                  "weekday",
+                  "weekend"
+                ]
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "upcoming",
+                  "departed"
+                ]
+              }
+            },
+            "required": [
+              "tripId",
+              "routeId",
+              "route",
+              "originCampus",
+              "destinationCampus",
+              "departureTime",
+              "arrivalTime",
+              "departureEstimated",
+              "arrivalEstimated",
+              "minutesUntilDeparture",
+              "dayType",
+              "status"
+            ],
+            "additionalProperties": false
+          },
+          "message": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "originCampus",
+          "destinationCampus",
+          "atTime",
+          "dayType",
+          "totalRoutes",
+          "departures",
+          "nextAvailableDeparture",
+          "message"
+        ],
+        "additionalProperties": false
+      },
       "busPreferenceResponseSchema": {
         "type": "object",
         "properties": {
@@ -7001,6 +7901,301 @@
         },
         "required": [
           "preference"
+        ],
+        "additionalProperties": false
+      },
+      "busRouteSearchResponseSchema": {
+        "type": "object",
+        "properties": {
+          "originCampus": {
+            "nullable": true,
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "nameCn": {
+                "type": "string"
+              },
+              "nameEn": {
+                "nullable": true,
+                "type": "string"
+              },
+              "latitude": {
+                "type": "number"
+              },
+              "longitude": {
+                "type": "number"
+              },
+              "namePrimary": {
+                "type": "string"
+              },
+              "nameSecondary": {
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "nameCn",
+              "nameEn",
+              "latitude",
+              "longitude",
+              "namePrimary",
+              "nameSecondary"
+            ],
+            "additionalProperties": false
+          },
+          "destinationCampus": {
+            "nullable": true,
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "nameCn": {
+                "type": "string"
+              },
+              "nameEn": {
+                "nullable": true,
+                "type": "string"
+              },
+              "latitude": {
+                "type": "number"
+              },
+              "longitude": {
+                "type": "number"
+              },
+              "namePrimary": {
+                "type": "string"
+              },
+              "nameSecondary": {
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "nameCn",
+              "nameEn",
+              "latitude",
+              "longitude",
+              "namePrimary",
+              "nameSecondary"
+            ],
+            "additionalProperties": false
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "routes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "nameCn": {
+                  "type": "string"
+                },
+                "nameEn": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "descriptionPrimary": {
+                  "type": "string"
+                },
+                "descriptionSecondary": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "originCampus": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "latitude": {
+                      "type": "number"
+                    },
+                    "longitude": {
+                      "type": "number"
+                    },
+                    "namePrimary": {
+                      "type": "string"
+                    },
+                    "nameSecondary": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "nameCn",
+                    "nameEn",
+                    "latitude",
+                    "longitude",
+                    "namePrimary",
+                    "nameSecondary"
+                  ],
+                  "additionalProperties": false
+                },
+                "destinationCampus": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "latitude": {
+                      "type": "number"
+                    },
+                    "longitude": {
+                      "type": "number"
+                    },
+                    "namePrimary": {
+                      "type": "string"
+                    },
+                    "nameSecondary": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "nameCn",
+                    "nameEn",
+                    "latitude",
+                    "longitude",
+                    "namePrimary",
+                    "nameSecondary"
+                  ],
+                  "additionalProperties": false
+                },
+                "stopCount": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "weekdayTrips": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "weekendTrips": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "stops": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "stopOrder": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "campus": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "nameCn": {
+                            "type": "string"
+                          },
+                          "nameEn": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "latitude": {
+                            "type": "number"
+                          },
+                          "longitude": {
+                            "type": "number"
+                          },
+                          "namePrimary": {
+                            "type": "string"
+                          },
+                          "nameSecondary": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "nameCn",
+                          "nameEn",
+                          "latitude",
+                          "longitude",
+                          "namePrimary",
+                          "nameSecondary"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "stopOrder",
+                      "campus"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": [
+                "id",
+                "nameCn",
+                "nameEn",
+                "descriptionPrimary",
+                "descriptionSecondary",
+                "originCampus",
+                "destinationCampus",
+                "stopCount",
+                "weekdayTrips",
+                "weekendTrips",
+                "stops"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "originCampus",
+          "destinationCampus",
+          "total",
+          "routes"
         ],
         "additionalProperties": false
       },
@@ -8394,6 +9589,2710 @@
             "additionalProperties": false
           }
         ]
+      },
+      "calendarSubscriptionImportResponseSchema": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "semester": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "nameCn": {
+                "nullable": true,
+                "type": "string"
+              },
+              "code": {
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "nameCn",
+              "code"
+            ],
+            "additionalProperties": false
+          },
+          "matchedCodes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "unmatchedCodes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ambiguousCodes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "jwId": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "code": {
+                  "type": "string"
+                },
+                "bizTypeId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "credits": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "period": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "periodsPerWeek": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "timesPerWeek": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "stdCount": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "limitCount": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "graduateAndPostgraduate": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "dateTimePlaceText": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "dateTimePlacePersonText": {
+                  "nullable": true
+                },
+                "actualPeriods": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "theoryPeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "practicePeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "experimentPeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "machinePeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "designPeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "testPeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "scheduleState": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "suggestScheduleWeeks": {
+                  "nullable": true
+                },
+                "suggestScheduleWeekInfo": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "scheduleJsonParams": {
+                  "nullable": true
+                },
+                "selectedStdCount": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "remark": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "scheduleRemark": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "courseId": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "semesterId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "campusId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "examModeId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "openDepartmentId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "teachLanguageId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "roomTypeId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "course": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "categoryId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "classTypeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "classifyId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "educationLevelId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "gradationId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "typeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "category": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "classType": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "classify": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "educationLevel": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "gradation": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "code",
+                    "nameCn",
+                    "nameEn",
+                    "categoryId",
+                    "classTypeId",
+                    "classifyId",
+                    "educationLevelId",
+                    "gradationId",
+                    "typeId",
+                    "category",
+                    "classType",
+                    "classify",
+                    "educationLevel",
+                    "gradation",
+                    "type"
+                  ],
+                  "additionalProperties": false
+                },
+                "semester": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "startDate": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    },
+                    "endDate": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "nameCn",
+                    "code",
+                    "startDate",
+                    "endDate"
+                  ],
+                  "additionalProperties": false
+                },
+                "campus": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "code": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "nameCn",
+                    "nameEn",
+                    "code"
+                  ],
+                  "additionalProperties": false
+                },
+                "openDepartment": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "isCollege": {
+                      "nullable": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "code",
+                    "nameCn",
+                    "nameEn",
+                    "isCollege"
+                  ],
+                  "additionalProperties": false
+                },
+                "teachers": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "personId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "teacherId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "code": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "nameCn": {
+                        "type": "string"
+                      },
+                      "nameEn": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "age": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "email": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "telephone": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "mobile": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "address": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "postcode": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "qq": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "wechat": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "departmentId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "teacherTitleId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "personId",
+                      "teacherId",
+                      "code",
+                      "nameCn",
+                      "nameEn",
+                      "age",
+                      "email",
+                      "telephone",
+                      "mobile",
+                      "address",
+                      "postcode",
+                      "qq",
+                      "wechat",
+                      "departmentId",
+                      "teacherTitleId"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": [
+                "id",
+                "jwId",
+                "code",
+                "bizTypeId",
+                "credits",
+                "period",
+                "periodsPerWeek",
+                "timesPerWeek",
+                "stdCount",
+                "limitCount",
+                "graduateAndPostgraduate",
+                "dateTimePlaceText",
+                "dateTimePlacePersonText",
+                "actualPeriods",
+                "theoryPeriods",
+                "practicePeriods",
+                "experimentPeriods",
+                "machinePeriods",
+                "designPeriods",
+                "testPeriods",
+                "scheduleState",
+                "suggestScheduleWeeks",
+                "suggestScheduleWeekInfo",
+                "scheduleJsonParams",
+                "selectedStdCount",
+                "remark",
+                "scheduleRemark",
+                "courseId",
+                "semesterId",
+                "campusId",
+                "examModeId",
+                "openDepartmentId",
+                "teachLanguageId",
+                "roomTypeId",
+                "course",
+                "semester",
+                "campus",
+                "openDepartment",
+                "teachers"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "addedCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "addedSections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "jwId": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "code": {
+                  "type": "string"
+                },
+                "bizTypeId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "credits": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "period": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "periodsPerWeek": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "timesPerWeek": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "stdCount": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "limitCount": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "graduateAndPostgraduate": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "dateTimePlaceText": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "dateTimePlacePersonText": {
+                  "nullable": true
+                },
+                "actualPeriods": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "theoryPeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "practicePeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "experimentPeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "machinePeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "designPeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "testPeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "scheduleState": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "suggestScheduleWeeks": {
+                  "nullable": true
+                },
+                "suggestScheduleWeekInfo": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "scheduleJsonParams": {
+                  "nullable": true
+                },
+                "selectedStdCount": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "remark": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "scheduleRemark": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "courseId": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "semesterId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "campusId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "examModeId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "openDepartmentId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "teachLanguageId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "roomTypeId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "course": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "categoryId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "classTypeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "classifyId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "educationLevelId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "gradationId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "typeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "category": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "classType": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "classify": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "educationLevel": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "gradation": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "code",
+                    "nameCn",
+                    "nameEn",
+                    "categoryId",
+                    "classTypeId",
+                    "classifyId",
+                    "educationLevelId",
+                    "gradationId",
+                    "typeId",
+                    "category",
+                    "classType",
+                    "classify",
+                    "educationLevel",
+                    "gradation",
+                    "type"
+                  ],
+                  "additionalProperties": false
+                },
+                "semester": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "startDate": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    },
+                    "endDate": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "nameCn",
+                    "code",
+                    "startDate",
+                    "endDate"
+                  ],
+                  "additionalProperties": false
+                },
+                "campus": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "code": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "nameCn",
+                    "nameEn",
+                    "code"
+                  ],
+                  "additionalProperties": false
+                },
+                "openDepartment": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "isCollege": {
+                      "nullable": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "code",
+                    "nameCn",
+                    "nameEn",
+                    "isCollege"
+                  ],
+                  "additionalProperties": false
+                },
+                "teachers": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "personId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "teacherId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "code": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "nameCn": {
+                        "type": "string"
+                      },
+                      "nameEn": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "age": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "email": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "telephone": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "mobile": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "address": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "postcode": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "qq": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "wechat": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "departmentId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "teacherTitleId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "personId",
+                      "teacherId",
+                      "code",
+                      "nameCn",
+                      "nameEn",
+                      "age",
+                      "email",
+                      "telephone",
+                      "mobile",
+                      "address",
+                      "postcode",
+                      "qq",
+                      "wechat",
+                      "departmentId",
+                      "teacherTitleId"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": [
+                "id",
+                "jwId",
+                "code",
+                "bizTypeId",
+                "credits",
+                "period",
+                "periodsPerWeek",
+                "timesPerWeek",
+                "stdCount",
+                "limitCount",
+                "graduateAndPostgraduate",
+                "dateTimePlaceText",
+                "dateTimePlacePersonText",
+                "actualPeriods",
+                "theoryPeriods",
+                "practicePeriods",
+                "experimentPeriods",
+                "machinePeriods",
+                "designPeriods",
+                "testPeriods",
+                "scheduleState",
+                "suggestScheduleWeeks",
+                "suggestScheduleWeekInfo",
+                "scheduleJsonParams",
+                "selectedStdCount",
+                "remark",
+                "scheduleRemark",
+                "courseId",
+                "semesterId",
+                "campusId",
+                "examModeId",
+                "openDepartmentId",
+                "teachLanguageId",
+                "roomTypeId",
+                "course",
+                "semester",
+                "campus",
+                "openDepartment",
+                "teachers"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "alreadySubscribedCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "alreadySubscribedSections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "jwId": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "code": {
+                  "type": "string"
+                },
+                "bizTypeId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "credits": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "period": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "periodsPerWeek": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "timesPerWeek": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "stdCount": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "limitCount": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "graduateAndPostgraduate": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "dateTimePlaceText": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "dateTimePlacePersonText": {
+                  "nullable": true
+                },
+                "actualPeriods": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "theoryPeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "practicePeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "experimentPeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "machinePeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "designPeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "testPeriods": {
+                  "nullable": true,
+                  "type": "number"
+                },
+                "scheduleState": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "suggestScheduleWeeks": {
+                  "nullable": true
+                },
+                "suggestScheduleWeekInfo": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "scheduleJsonParams": {
+                  "nullable": true
+                },
+                "selectedStdCount": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "remark": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "scheduleRemark": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "courseId": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "semesterId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "campusId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "examModeId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "openDepartmentId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "teachLanguageId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "roomTypeId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "course": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "categoryId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "classTypeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "classifyId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "educationLevelId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "gradationId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "typeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "category": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "classType": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "classify": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "educationLevel": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "gradation": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "code",
+                    "nameCn",
+                    "nameEn",
+                    "categoryId",
+                    "classTypeId",
+                    "classifyId",
+                    "educationLevelId",
+                    "gradationId",
+                    "typeId",
+                    "category",
+                    "classType",
+                    "classify",
+                    "educationLevel",
+                    "gradation",
+                    "type"
+                  ],
+                  "additionalProperties": false
+                },
+                "semester": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "startDate": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    },
+                    "endDate": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "nameCn",
+                    "code",
+                    "startDate",
+                    "endDate"
+                  ],
+                  "additionalProperties": false
+                },
+                "campus": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "code": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "nameCn",
+                    "nameEn",
+                    "code"
+                  ],
+                  "additionalProperties": false
+                },
+                "openDepartment": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "isCollege": {
+                      "nullable": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "code",
+                    "nameCn",
+                    "nameEn",
+                    "isCollege"
+                  ],
+                  "additionalProperties": false
+                },
+                "teachers": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "personId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "teacherId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "code": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "nameCn": {
+                        "type": "string"
+                      },
+                      "nameEn": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "age": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "email": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "telephone": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "mobile": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "address": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "postcode": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "qq": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "wechat": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "departmentId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "teacherTitleId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "personId",
+                      "teacherId",
+                      "code",
+                      "nameCn",
+                      "nameEn",
+                      "age",
+                      "email",
+                      "telephone",
+                      "mobile",
+                      "address",
+                      "postcode",
+                      "qq",
+                      "wechat",
+                      "departmentId",
+                      "teacherTitleId"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": [
+                "id",
+                "jwId",
+                "code",
+                "bizTypeId",
+                "credits",
+                "period",
+                "periodsPerWeek",
+                "timesPerWeek",
+                "stdCount",
+                "limitCount",
+                "graduateAndPostgraduate",
+                "dateTimePlaceText",
+                "dateTimePlacePersonText",
+                "actualPeriods",
+                "theoryPeriods",
+                "practicePeriods",
+                "experimentPeriods",
+                "machinePeriods",
+                "designPeriods",
+                "testPeriods",
+                "scheduleState",
+                "suggestScheduleWeeks",
+                "suggestScheduleWeekInfo",
+                "scheduleJsonParams",
+                "selectedStdCount",
+                "remark",
+                "scheduleRemark",
+                "courseId",
+                "semesterId",
+                "campusId",
+                "examModeId",
+                "openDepartmentId",
+                "teachLanguageId",
+                "roomTypeId",
+                "course",
+                "semester",
+                "campus",
+                "openDepartment",
+                "teachers"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "subscription": {
+            "nullable": true,
+            "type": "object",
+            "properties": {
+              "userId": {
+                "type": "string"
+              },
+              "sections": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "bizTypeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "credits": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "period": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "periodsPerWeek": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "timesPerWeek": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "stdCount": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "limitCount": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "graduateAndPostgraduate": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "dateTimePlaceText": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "dateTimePlacePersonText": {
+                      "nullable": true
+                    },
+                    "actualPeriods": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "theoryPeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "practicePeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "experimentPeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "machinePeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "designPeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "testPeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "scheduleState": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "suggestScheduleWeeks": {
+                      "nullable": true
+                    },
+                    "suggestScheduleWeekInfo": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "scheduleJsonParams": {
+                      "nullable": true
+                    },
+                    "selectedStdCount": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "remark": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "scheduleRemark": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "courseId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "semesterId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "campusId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "examModeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "openDepartmentId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "teachLanguageId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "roomTypeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "course": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "categoryId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "classTypeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "classifyId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "educationLevelId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "gradationId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "typeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "category": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "nameCn",
+                            "nameEn"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "classType": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "nameCn",
+                            "nameEn"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "classify": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "nameCn",
+                            "nameEn"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "educationLevel": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "nameCn",
+                            "nameEn"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "gradation": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "nameCn",
+                            "nameEn"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "type": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "nameCn",
+                            "nameEn"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "code",
+                        "nameCn",
+                        "nameEn",
+                        "categoryId",
+                        "classTypeId",
+                        "classifyId",
+                        "educationLevelId",
+                        "gradationId",
+                        "typeId",
+                        "category",
+                        "classType",
+                        "classify",
+                        "educationLevel",
+                        "gradation",
+                        "type"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "semester": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "startDate": {
+                          "nullable": true,
+                          "type": "string",
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                        },
+                        "endDate": {
+                          "nullable": true,
+                          "type": "string",
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "nameCn",
+                        "code",
+                        "startDate",
+                        "endDate"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "campus": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "code": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "nameCn",
+                        "nameEn",
+                        "code"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "openDepartment": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "isCollege": {
+                          "nullable": true,
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "code",
+                        "nameCn",
+                        "nameEn",
+                        "isCollege"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "teachers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "personId": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "teacherId": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "code": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "nameCn": {
+                            "type": "string"
+                          },
+                          "nameEn": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "age": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "email": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "telephone": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "mobile": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "address": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "postcode": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "qq": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "wechat": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "departmentId": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "teacherTitleId": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "personId",
+                          "teacherId",
+                          "code",
+                          "nameCn",
+                          "nameEn",
+                          "age",
+                          "email",
+                          "telephone",
+                          "mobile",
+                          "address",
+                          "postcode",
+                          "qq",
+                          "wechat",
+                          "departmentId",
+                          "teacherTitleId"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "code",
+                    "bizTypeId",
+                    "credits",
+                    "period",
+                    "periodsPerWeek",
+                    "timesPerWeek",
+                    "stdCount",
+                    "limitCount",
+                    "graduateAndPostgraduate",
+                    "dateTimePlaceText",
+                    "dateTimePlacePersonText",
+                    "actualPeriods",
+                    "theoryPeriods",
+                    "practicePeriods",
+                    "experimentPeriods",
+                    "machinePeriods",
+                    "designPeriods",
+                    "testPeriods",
+                    "scheduleState",
+                    "suggestScheduleWeeks",
+                    "suggestScheduleWeekInfo",
+                    "scheduleJsonParams",
+                    "selectedStdCount",
+                    "remark",
+                    "scheduleRemark",
+                    "courseId",
+                    "semesterId",
+                    "campusId",
+                    "examModeId",
+                    "openDepartmentId",
+                    "teachLanguageId",
+                    "roomTypeId",
+                    "course",
+                    "semester",
+                    "campus",
+                    "openDepartment",
+                    "teachers"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "calendarPath": {
+                "type": "string"
+              },
+              "calendarUrl": {
+                "type": "string"
+              },
+              "note": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "userId",
+              "sections",
+              "calendarPath",
+              "calendarUrl",
+              "note"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "success",
+          "semester",
+          "matchedCodes",
+          "unmatchedCodes",
+          "ambiguousCodes",
+          "sections",
+          "addedCount",
+          "addedSections",
+          "alreadySubscribedCount",
+          "alreadySubscribedSections",
+          "subscription"
+        ],
+        "additionalProperties": false
       },
       "commentsListResponseSchema": {
         "type": "object",
@@ -11936,6 +15835,2230 @@
         ],
         "additionalProperties": false
       },
+      "compactOverviewResponseSchema": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "type": "object",
+            "properties": {
+              "userId": {
+                "nullable": true,
+                "type": "string"
+              },
+              "name": {
+                "nullable": true,
+                "type": "string"
+              },
+              "image": {
+                "nullable": true,
+                "type": "string"
+              },
+              "isAdmin": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "userId",
+              "name",
+              "image",
+              "isAdmin"
+            ],
+            "additionalProperties": false
+          },
+          "anchor": {
+            "type": "object",
+            "properties": {
+              "atTime": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "todayStart": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "tomorrowStart": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "homeworkWindowDays": {
+                "type": "integer",
+                "exclusiveMinimum": true,
+                "maximum": 9007199254740991
+              },
+              "homeworkWindowEnd": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "limit": {
+                "type": "integer",
+                "exclusiveMinimum": true,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": [
+              "atTime",
+              "todayStart",
+              "tomorrowStart",
+              "homeworkWindowDays",
+              "homeworkWindowEnd",
+              "limit"
+            ],
+            "additionalProperties": false
+          },
+          "counts": {
+            "type": "object",
+            "properties": {
+              "todos": {
+                "type": "object",
+                "properties": {
+                  "incomplete": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "completed": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "overdue": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "incomplete",
+                  "completed",
+                  "overdue"
+                ],
+                "additionalProperties": false
+              },
+              "pendingHomeworks": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "dueSoonHomeworks": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "todaySchedules": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "upcomingExams": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": [
+              "todos",
+              "pendingHomeworks",
+              "dueSoonHomeworks",
+              "todaySchedules",
+              "upcomingExams"
+            ],
+            "additionalProperties": false
+          },
+          "schedules": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "periods": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "date": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    },
+                    "weekday": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "startTime": {
+                      "type": "string"
+                    },
+                    "endTime": {
+                      "type": "string"
+                    },
+                    "experiment": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "customPlace": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "lessonType": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "weekIndex": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "exerciseClass": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "startUnit": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "endUnit": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "roomId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "sectionId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "scheduleGroupId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "room": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "floor": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "virtual": {
+                          "type": "boolean"
+                        },
+                        "seatsForSection": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "remark": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "seats": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "buildingId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "roomTypeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "namePrimary": {
+                          "type": "string"
+                        },
+                        "nameSecondary": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "building": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "jwId": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "campusId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "namePrimary": {
+                              "type": "string"
+                            },
+                            "nameSecondary": {
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "campus": {
+                              "nullable": true,
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991
+                                },
+                                "jwId": {
+                                  "nullable": true,
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991
+                                },
+                                "nameCn": {
+                                  "type": "string"
+                                },
+                                "nameEn": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "code": {
+                                  "nullable": true,
+                                  "type": "string"
+                                },
+                                "namePrimary": {
+                                  "type": "string"
+                                },
+                                "nameSecondary": {
+                                  "nullable": true,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "jwId",
+                                "nameCn",
+                                "nameEn",
+                                "code",
+                                "namePrimary",
+                                "nameSecondary"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "jwId",
+                            "nameCn",
+                            "nameEn",
+                            "code",
+                            "campusId",
+                            "namePrimary",
+                            "nameSecondary",
+                            "campus"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "roomType": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "jwId": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "namePrimary": {
+                              "type": "string"
+                            },
+                            "nameSecondary": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "jwId",
+                            "nameCn",
+                            "nameEn",
+                            "code",
+                            "namePrimary",
+                            "nameSecondary"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "nameCn",
+                        "nameEn",
+                        "code",
+                        "floor",
+                        "virtual",
+                        "seatsForSection",
+                        "remark",
+                        "seats",
+                        "buildingId",
+                        "roomTypeId",
+                        "namePrimary",
+                        "nameSecondary",
+                        "building",
+                        "roomType"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "teachers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "personId": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "teacherId": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "code": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "nameCn": {
+                            "type": "string"
+                          },
+                          "nameEn": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "age": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "email": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "telephone": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "mobile": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "address": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "postcode": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "qq": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "wechat": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "departmentId": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "teacherTitleId": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "namePrimary": {
+                            "type": "string"
+                          },
+                          "nameSecondary": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "department": {
+                            "nullable": true,
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              },
+                              "code": {
+                                "type": "string"
+                              },
+                              "nameCn": {
+                                "type": "string"
+                              },
+                              "nameEn": {
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "isCollege": {
+                                "nullable": true,
+                                "type": "boolean"
+                              },
+                              "namePrimary": {
+                                "type": "string"
+                              },
+                              "nameSecondary": {
+                                "nullable": true,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "code",
+                              "nameCn",
+                              "nameEn",
+                              "isCollege",
+                              "namePrimary",
+                              "nameSecondary"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "personId",
+                          "teacherId",
+                          "code",
+                          "nameCn",
+                          "nameEn",
+                          "age",
+                          "email",
+                          "telephone",
+                          "mobile",
+                          "address",
+                          "postcode",
+                          "qq",
+                          "wechat",
+                          "departmentId",
+                          "teacherTitleId",
+                          "namePrimary",
+                          "nameSecondary",
+                          "department"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "section": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "bizTypeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "credits": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "period": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "periodsPerWeek": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "timesPerWeek": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "stdCount": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "limitCount": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "graduateAndPostgraduate": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "dateTimePlaceText": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "dateTimePlacePersonText": {
+                          "nullable": true
+                        },
+                        "actualPeriods": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "theoryPeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "practicePeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "experimentPeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "machinePeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "designPeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "testPeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "scheduleState": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "suggestScheduleWeeks": {
+                          "nullable": true
+                        },
+                        "suggestScheduleWeekInfo": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "scheduleJsonParams": {
+                          "nullable": true
+                        },
+                        "selectedStdCount": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "remark": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "scheduleRemark": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "courseId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "semesterId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "campusId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "examModeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "openDepartmentId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "teachLanguageId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "roomTypeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "course": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "jwId": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "categoryId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "classTypeId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "classifyId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "educationLevelId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "gradationId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "typeId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "namePrimary": {
+                              "type": "string"
+                            },
+                            "nameSecondary": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "jwId",
+                            "code",
+                            "nameCn",
+                            "nameEn",
+                            "categoryId",
+                            "classTypeId",
+                            "classifyId",
+                            "educationLevelId",
+                            "gradationId",
+                            "typeId",
+                            "namePrimary",
+                            "nameSecondary"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "semester": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "jwId": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "startDate": {
+                              "nullable": true,
+                              "type": "string",
+                              "format": "date-time",
+                              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                            },
+                            "endDate": {
+                              "nullable": true,
+                              "type": "string",
+                              "format": "date-time",
+                              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "jwId",
+                            "nameCn",
+                            "code",
+                            "startDate",
+                            "endDate"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "code",
+                        "bizTypeId",
+                        "credits",
+                        "period",
+                        "periodsPerWeek",
+                        "timesPerWeek",
+                        "stdCount",
+                        "limitCount",
+                        "graduateAndPostgraduate",
+                        "dateTimePlaceText",
+                        "dateTimePlacePersonText",
+                        "actualPeriods",
+                        "theoryPeriods",
+                        "practicePeriods",
+                        "experimentPeriods",
+                        "machinePeriods",
+                        "designPeriods",
+                        "testPeriods",
+                        "scheduleState",
+                        "suggestScheduleWeeks",
+                        "suggestScheduleWeekInfo",
+                        "scheduleJsonParams",
+                        "selectedStdCount",
+                        "remark",
+                        "scheduleRemark",
+                        "courseId",
+                        "semesterId",
+                        "campusId",
+                        "examModeId",
+                        "openDepartmentId",
+                        "teachLanguageId",
+                        "roomTypeId",
+                        "course",
+                        "semester"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "scheduleGroup": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "no": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "limitCount": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "stdCount": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "actualPeriods": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "isDefault": {
+                          "type": "boolean"
+                        },
+                        "sectionId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "no",
+                        "limitCount",
+                        "stdCount",
+                        "actualPeriods",
+                        "isDefault",
+                        "sectionId"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "periods",
+                    "date",
+                    "weekday",
+                    "startTime",
+                    "endTime",
+                    "experiment",
+                    "customPlace",
+                    "lessonType",
+                    "weekIndex",
+                    "exerciseClass",
+                    "startUnit",
+                    "endUnit",
+                    "roomId",
+                    "sectionId",
+                    "scheduleGroupId",
+                    "room",
+                    "teachers",
+                    "section",
+                    "scheduleGroup"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "total",
+              "items"
+            ],
+            "additionalProperties": false
+          },
+          "todos": {
+            "type": "object",
+            "properties": {
+              "counts": {
+                "type": "object",
+                "properties": {
+                  "incomplete": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "completed": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "overdue": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "incomplete",
+                  "completed",
+                  "overdue"
+                ],
+                "additionalProperties": false
+              },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "content": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "string",
+                      "enum": [
+                        "low",
+                        "medium",
+                        "high"
+                      ]
+                    },
+                    "completed": {
+                      "type": "boolean"
+                    },
+                    "dueAt": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "content",
+                    "priority",
+                    "completed",
+                    "dueAt",
+                    "createdAt",
+                    "updatedAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "counts",
+              "items"
+            ],
+            "additionalProperties": false
+          },
+          "homeworks": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "isMajor": {
+                      "type": "boolean"
+                    },
+                    "requiresTeam": {
+                      "type": "boolean"
+                    },
+                    "publishedAt": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    },
+                    "submissionStartAt": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    },
+                    "submissionDueAt": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    },
+                    "deletedAt": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    },
+                    "sectionId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "createdById": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "updatedById": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "deletedById": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "section": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "bizTypeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "credits": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "period": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "periodsPerWeek": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "timesPerWeek": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "stdCount": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "limitCount": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "graduateAndPostgraduate": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "dateTimePlaceText": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "dateTimePlacePersonText": {
+                          "nullable": true
+                        },
+                        "actualPeriods": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "theoryPeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "practicePeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "experimentPeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "machinePeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "designPeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "testPeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "scheduleState": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "suggestScheduleWeeks": {
+                          "nullable": true
+                        },
+                        "suggestScheduleWeekInfo": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "scheduleJsonParams": {
+                          "nullable": true
+                        },
+                        "selectedStdCount": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "remark": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "scheduleRemark": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "courseId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "semesterId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "campusId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "examModeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "openDepartmentId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "teachLanguageId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "roomTypeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "course": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "jwId": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "categoryId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "classTypeId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "classifyId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "educationLevelId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "gradationId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "typeId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "namePrimary": {
+                              "type": "string"
+                            },
+                            "nameSecondary": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "jwId",
+                            "code",
+                            "nameCn",
+                            "nameEn",
+                            "categoryId",
+                            "classTypeId",
+                            "classifyId",
+                            "educationLevelId",
+                            "gradationId",
+                            "typeId",
+                            "namePrimary",
+                            "nameSecondary"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "semester": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "jwId": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "startDate": {
+                              "nullable": true,
+                              "type": "string",
+                              "format": "date-time",
+                              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                            },
+                            "endDate": {
+                              "nullable": true,
+                              "type": "string",
+                              "format": "date-time",
+                              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "jwId",
+                            "nameCn",
+                            "code",
+                            "startDate",
+                            "endDate"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "code",
+                        "bizTypeId",
+                        "credits",
+                        "period",
+                        "periodsPerWeek",
+                        "timesPerWeek",
+                        "stdCount",
+                        "limitCount",
+                        "graduateAndPostgraduate",
+                        "dateTimePlaceText",
+                        "dateTimePlacePersonText",
+                        "actualPeriods",
+                        "theoryPeriods",
+                        "practicePeriods",
+                        "experimentPeriods",
+                        "machinePeriods",
+                        "designPeriods",
+                        "testPeriods",
+                        "scheduleState",
+                        "suggestScheduleWeeks",
+                        "suggestScheduleWeekInfo",
+                        "scheduleJsonParams",
+                        "selectedStdCount",
+                        "remark",
+                        "scheduleRemark",
+                        "courseId",
+                        "semesterId",
+                        "campusId",
+                        "examModeId",
+                        "openDepartmentId",
+                        "teachLanguageId",
+                        "roomTypeId",
+                        "course",
+                        "semester"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "description": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "content": {
+                          "type": "string"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                        },
+                        "lastEditedAt": {
+                          "nullable": true,
+                          "type": "string",
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                        },
+                        "lastEditedById": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "sectionId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "courseId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "teacherId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "homeworkId": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "content",
+                        "createdAt",
+                        "updatedAt",
+                        "lastEditedAt",
+                        "lastEditedById",
+                        "sectionId",
+                        "courseId",
+                        "teacherId",
+                        "homeworkId"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "createdBy": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "username": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "image": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "username",
+                        "image"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "updatedBy": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "username": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "image": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "username",
+                        "image"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "deletedBy": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "username": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "image": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "username",
+                        "image"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "completion": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "completedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                        }
+                      },
+                      "required": [
+                        "completedAt"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "commentCount": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "isMajor",
+                    "requiresTeam",
+                    "publishedAt",
+                    "submissionStartAt",
+                    "submissionDueAt",
+                    "createdAt",
+                    "updatedAt",
+                    "deletedAt",
+                    "sectionId",
+                    "createdById",
+                    "updatedById",
+                    "deletedById",
+                    "section",
+                    "description",
+                    "createdBy",
+                    "updatedBy",
+                    "deletedBy",
+                    "completion",
+                    "commentCount"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "total",
+              "items"
+            ],
+            "additionalProperties": false
+          },
+          "exams": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "examType": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "startTime": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "endTime": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "examDate": {
+                      "nullable": true,
+                      "type": "string",
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                    },
+                    "examTakeCount": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "examMode": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "examBatchId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "sectionId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "examBatch": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "nameCn",
+                        "nameEn"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "examRooms": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "room": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "examId": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "room",
+                          "count",
+                          "examId"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "section": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "bizTypeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "credits": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "period": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "periodsPerWeek": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "timesPerWeek": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "stdCount": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "limitCount": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "graduateAndPostgraduate": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "dateTimePlaceText": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "dateTimePlacePersonText": {
+                          "nullable": true
+                        },
+                        "actualPeriods": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "theoryPeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "practicePeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "experimentPeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "machinePeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "designPeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "testPeriods": {
+                          "nullable": true,
+                          "type": "number"
+                        },
+                        "scheduleState": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "suggestScheduleWeeks": {
+                          "nullable": true
+                        },
+                        "suggestScheduleWeekInfo": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "scheduleJsonParams": {
+                          "nullable": true
+                        },
+                        "selectedStdCount": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "remark": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "scheduleRemark": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "courseId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "semesterId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "campusId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "examModeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "openDepartmentId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "teachLanguageId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "roomTypeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "course": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "jwId": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "categoryId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "classTypeId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "classifyId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "educationLevelId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "gradationId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "typeId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "namePrimary": {
+                              "type": "string"
+                            },
+                            "nameSecondary": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "jwId",
+                            "code",
+                            "nameCn",
+                            "nameEn",
+                            "categoryId",
+                            "classTypeId",
+                            "classifyId",
+                            "educationLevelId",
+                            "gradationId",
+                            "typeId",
+                            "namePrimary",
+                            "nameSecondary"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "semester": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "jwId": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "startDate": {
+                              "nullable": true,
+                              "type": "string",
+                              "format": "date-time",
+                              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                            },
+                            "endDate": {
+                              "nullable": true,
+                              "type": "string",
+                              "format": "date-time",
+                              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "jwId",
+                            "nameCn",
+                            "code",
+                            "startDate",
+                            "endDate"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "code",
+                        "bizTypeId",
+                        "credits",
+                        "period",
+                        "periodsPerWeek",
+                        "timesPerWeek",
+                        "stdCount",
+                        "limitCount",
+                        "graduateAndPostgraduate",
+                        "dateTimePlaceText",
+                        "dateTimePlacePersonText",
+                        "actualPeriods",
+                        "theoryPeriods",
+                        "practicePeriods",
+                        "experimentPeriods",
+                        "machinePeriods",
+                        "designPeriods",
+                        "testPeriods",
+                        "scheduleState",
+                        "suggestScheduleWeeks",
+                        "suggestScheduleWeekInfo",
+                        "scheduleJsonParams",
+                        "selectedStdCount",
+                        "remark",
+                        "scheduleRemark",
+                        "courseId",
+                        "semesterId",
+                        "campusId",
+                        "examModeId",
+                        "openDepartmentId",
+                        "teachLanguageId",
+                        "roomTypeId",
+                        "course",
+                        "semester"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "examType",
+                    "startTime",
+                    "endTime",
+                    "examDate",
+                    "examTakeCount",
+                    "examMode",
+                    "examBatchId",
+                    "sectionId",
+                    "examBatch",
+                    "examRooms",
+                    "section"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "total",
+              "items"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "user",
+          "anchor",
+          "counts",
+          "schedules",
+          "todos",
+          "homeworks",
+          "exams"
+        ],
+        "additionalProperties": false
+      },
       "subscribedHomeworksResponseSchema": {
         "type": "object",
         "properties": {
@@ -12678,6 +18801,887 @@
           "homeworks",
           "auditLogs",
           "sectionIds"
+        ],
+        "additionalProperties": false
+      },
+      "subscribedSchedulesResponseSchema": {
+        "type": "object",
+        "properties": {
+          "schedules": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "periods": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "date": {
+                  "nullable": true,
+                  "type": "string",
+                  "format": "date-time",
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                },
+                "weekday": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "startTime": {
+                  "type": "string"
+                },
+                "endTime": {
+                  "type": "string"
+                },
+                "experiment": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "customPlace": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "lessonType": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "weekIndex": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "exerciseClass": {
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "startUnit": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "endUnit": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "roomId": {
+                  "nullable": true,
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "sectionId": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "scheduleGroupId": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "room": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "nameCn": {
+                      "type": "string"
+                    },
+                    "nameEn": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "floor": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "virtual": {
+                      "type": "boolean"
+                    },
+                    "seatsForSection": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "remark": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "seats": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "buildingId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "roomTypeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "namePrimary": {
+                      "type": "string"
+                    },
+                    "nameSecondary": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "building": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "campusId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "namePrimary": {
+                          "type": "string"
+                        },
+                        "nameSecondary": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "campus": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "jwId": {
+                              "nullable": true,
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "code": {
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "namePrimary": {
+                              "type": "string"
+                            },
+                            "nameSecondary": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "jwId",
+                            "nameCn",
+                            "nameEn",
+                            "code",
+                            "namePrimary",
+                            "nameSecondary"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "nameCn",
+                        "nameEn",
+                        "code",
+                        "campusId",
+                        "namePrimary",
+                        "nameSecondary",
+                        "campus"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "roomType": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "namePrimary": {
+                          "type": "string"
+                        },
+                        "nameSecondary": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "nameCn",
+                        "nameEn",
+                        "code",
+                        "namePrimary",
+                        "nameSecondary"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "nameCn",
+                    "nameEn",
+                    "code",
+                    "floor",
+                    "virtual",
+                    "seatsForSection",
+                    "remark",
+                    "seats",
+                    "buildingId",
+                    "roomTypeId",
+                    "namePrimary",
+                    "nameSecondary",
+                    "building",
+                    "roomType"
+                  ],
+                  "additionalProperties": false
+                },
+                "teachers": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "personId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "teacherId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "code": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "nameCn": {
+                        "type": "string"
+                      },
+                      "nameEn": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "age": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "email": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "telephone": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "mobile": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "address": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "postcode": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "qq": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "wechat": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "departmentId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "teacherTitleId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "namePrimary": {
+                        "type": "string"
+                      },
+                      "nameSecondary": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "department": {
+                        "nullable": true,
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "code": {
+                            "type": "string"
+                          },
+                          "nameCn": {
+                            "type": "string"
+                          },
+                          "nameEn": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "isCollege": {
+                            "nullable": true,
+                            "type": "boolean"
+                          },
+                          "namePrimary": {
+                            "type": "string"
+                          },
+                          "nameSecondary": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "code",
+                          "nameCn",
+                          "nameEn",
+                          "isCollege",
+                          "namePrimary",
+                          "nameSecondary"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "personId",
+                      "teacherId",
+                      "code",
+                      "nameCn",
+                      "nameEn",
+                      "age",
+                      "email",
+                      "telephone",
+                      "mobile",
+                      "address",
+                      "postcode",
+                      "qq",
+                      "wechat",
+                      "departmentId",
+                      "teacherTitleId",
+                      "namePrimary",
+                      "nameSecondary",
+                      "department"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "section": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "bizTypeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "credits": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "period": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "periodsPerWeek": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "timesPerWeek": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "stdCount": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "limitCount": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "graduateAndPostgraduate": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "dateTimePlaceText": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "dateTimePlacePersonText": {
+                      "nullable": true
+                    },
+                    "actualPeriods": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "theoryPeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "practicePeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "experimentPeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "machinePeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "designPeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "testPeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "scheduleState": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "suggestScheduleWeeks": {
+                      "nullable": true
+                    },
+                    "suggestScheduleWeekInfo": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "scheduleJsonParams": {
+                      "nullable": true
+                    },
+                    "selectedStdCount": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "remark": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "scheduleRemark": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "courseId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "semesterId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "campusId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "examModeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "openDepartmentId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "teachLanguageId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "roomTypeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "course": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "categoryId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "classTypeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "classifyId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "educationLevelId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "gradationId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "typeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "namePrimary": {
+                          "type": "string"
+                        },
+                        "nameSecondary": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "code",
+                        "nameCn",
+                        "nameEn",
+                        "categoryId",
+                        "classTypeId",
+                        "classifyId",
+                        "educationLevelId",
+                        "gradationId",
+                        "typeId",
+                        "namePrimary",
+                        "nameSecondary"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "semester": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "startDate": {
+                          "nullable": true,
+                          "type": "string",
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                        },
+                        "endDate": {
+                          "nullable": true,
+                          "type": "string",
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "nameCn",
+                        "code",
+                        "startDate",
+                        "endDate"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "code",
+                    "bizTypeId",
+                    "credits",
+                    "period",
+                    "periodsPerWeek",
+                    "timesPerWeek",
+                    "stdCount",
+                    "limitCount",
+                    "graduateAndPostgraduate",
+                    "dateTimePlaceText",
+                    "dateTimePlacePersonText",
+                    "actualPeriods",
+                    "theoryPeriods",
+                    "practicePeriods",
+                    "experimentPeriods",
+                    "machinePeriods",
+                    "designPeriods",
+                    "testPeriods",
+                    "scheduleState",
+                    "suggestScheduleWeeks",
+                    "suggestScheduleWeekInfo",
+                    "scheduleJsonParams",
+                    "selectedStdCount",
+                    "remark",
+                    "scheduleRemark",
+                    "courseId",
+                    "semesterId",
+                    "campusId",
+                    "examModeId",
+                    "openDepartmentId",
+                    "teachLanguageId",
+                    "roomTypeId",
+                    "course",
+                    "semester"
+                  ],
+                  "additionalProperties": false
+                },
+                "scheduleGroup": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "no": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "limitCount": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "stdCount": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "actualPeriods": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "isDefault": {
+                      "type": "boolean"
+                    },
+                    "sectionId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "no",
+                    "limitCount",
+                    "stdCount",
+                    "actualPeriods",
+                    "isDefault",
+                    "sectionId"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "id",
+                "periods",
+                "date",
+                "weekday",
+                "startTime",
+                "endTime",
+                "experiment",
+                "customPlace",
+                "lessonType",
+                "weekIndex",
+                "exerciseClass",
+                "startUnit",
+                "endUnit",
+                "roomId",
+                "sectionId",
+                "scheduleGroupId",
+                "room",
+                "teachers",
+                "section",
+                "scheduleGroup"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "schedules"
         ],
         "additionalProperties": false
       },

--- a/src/features/bus/lib/bus-visible-departures.ts
+++ b/src/features/bus/lib/bus-visible-departures.ts
@@ -1,6 +1,17 @@
 import type { BusApplicableRoute } from "./bus-applicable-routes";
 import type { BusCampusSummary } from "./bus-types";
 
+function compareDepartureMinutes(
+  left: number | null,
+  right: number | null,
+  direction: "asc" | "desc",
+) {
+  const lm = left ?? Number.MAX_SAFE_INTEGER;
+  const rm = right ?? Number.MAX_SAFE_INTEGER;
+  if (lm === rm) return 0;
+  return direction === "asc" ? lm - rm : rm - lm;
+}
+
 export function buildVisibleBusDepartures({
   applicableRoutes,
   destinationCampus,
@@ -36,9 +47,15 @@ export function buildVisibleBusDepartures({
       })),
     )
     .sort((left, right) => {
-      const lm = left.minutesUntilDeparture ?? Number.MAX_SAFE_INTEGER;
-      const rm = right.minutesUntilDeparture ?? Number.MAX_SAFE_INTEGER;
-      return lm !== rm ? lm - rm : left.routeId - right.routeId;
+      if (left.status !== right.status) {
+        return left.status === "upcoming" ? -1 : 1;
+      }
+      const timeOrder = compareDepartureMinutes(
+        left.minutesUntilDeparture,
+        right.minutesUntilDeparture,
+        left.status === "upcoming" ? "asc" : "desc",
+      );
+      return timeOrder !== 0 ? timeOrder : left.routeId - right.routeId;
     })
     .slice(0, limit);
 }

--- a/src/features/home/server/compact-overview-read-model.ts
+++ b/src/features/home/server/compact-overview-read-model.ts
@@ -7,10 +7,11 @@ import { parseDateInput } from "@/lib/time/parse-date-input";
 import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
 import { formatShanghaiDate } from "@/lib/time/shanghai-format";
 import {
+  countUpcomingSubscribedExams,
   getSubscribedSectionIds,
-  listSubscribedExams,
   listSubscribedHomeworks,
   listSubscribedSchedules,
+  listUpcomingSubscribedExams,
 } from "./subscription-read-model";
 
 const DEFAULT_OVERVIEW_LIMIT = 3;
@@ -84,11 +85,9 @@ export async function getCompactOverview(
               sectionId: { in: sectionIds },
             },
           }),
-          prisma.exam.count({
-            where: {
-              examDate: { gte: todayStart },
-              sectionId: { in: sectionIds },
-            },
+          countUpcomingSubscribedExams({
+            atTime: now,
+            sectionIds,
           }),
           prisma.homework.count({
             where: {
@@ -115,9 +114,8 @@ export async function getCompactOverview(
             requireDueDate: true,
             sectionIds,
           }),
-          listSubscribedExams(userId, {
-            dateFrom: todayStart,
-            includeDateUnknown: false,
+          listUpcomingSubscribedExams(userId, {
+            atTime: now,
             limit,
             locale,
             sectionIds,

--- a/src/features/home/server/compact-overview-read-model.ts
+++ b/src/features/home/server/compact-overview-read-model.ts
@@ -1,0 +1,169 @@
+import { withHomeworkItemState } from "@/features/homeworks/server/homework-item-state";
+import { listTodoSummary } from "@/features/todos/server/todo-service";
+import { type AppLocale, DEFAULT_LOCALE } from "@/i18n/config";
+import { prisma } from "@/lib/db/prisma";
+import { serializeScheduleTimeFields } from "@/lib/schedule-serialization";
+import { parseDateInput } from "@/lib/time/parse-date-input";
+import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
+import { formatShanghaiDate } from "@/lib/time/shanghai-format";
+import {
+  getSubscribedSectionIds,
+  listSubscribedExams,
+  listSubscribedHomeworks,
+  listSubscribedSchedules,
+} from "./subscription-read-model";
+
+const DEFAULT_OVERVIEW_LIMIT = 3;
+const DEFAULT_HOMEWORK_WINDOW_DAYS = 7;
+
+function requiredDate(value: Date | null | undefined, label: string) {
+  if (value instanceof Date) return value;
+  throw new Error(`Failed to derive ${label}`);
+}
+
+function shanghaiDateOnlyStart(input: Date) {
+  return requiredDate(parseDateInput(formatShanghaiDate(input)), "day start");
+}
+
+export async function getCompactOverview(
+  userId: string,
+  {
+    atTime = new Date(),
+    homeworkWindowDays = DEFAULT_HOMEWORK_WINDOW_DAYS,
+    limit = DEFAULT_OVERVIEW_LIMIT,
+    locale = DEFAULT_LOCALE,
+  }: {
+    atTime?: Date;
+    homeworkWindowDays?: number;
+    limit?: number;
+    locale?: AppLocale;
+  } = {},
+) {
+  const now = atTime;
+  const todayStart = shanghaiDateOnlyStart(now);
+  const tomorrowStart = new Date(todayStart.getTime() + 24 * 60 * 60 * 1000);
+  const homeworkWindowEnd = shanghaiDayjs(now)
+    .add(homeworkWindowDays, "day")
+    .toDate();
+
+  const [user, sectionIds, todos] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, image: true, isAdmin: true, name: true },
+    }),
+    getSubscribedSectionIds(userId),
+    listTodoSummary({
+      now,
+      take: limit,
+      userId,
+      where: { userId, completed: false },
+    }),
+  ]);
+
+  const [
+    pendingHomeworksCount,
+    todaySchedulesCount,
+    upcomingExamsCount,
+    dueSoonHomeworksCount,
+    schedules,
+    dueSoonHomeworksRaw,
+    upcomingExams,
+  ] =
+    sectionIds.length > 0
+      ? await Promise.all([
+          prisma.homework.count({
+            where: {
+              deletedAt: null,
+              homeworkCompletions: { none: { userId } },
+              sectionId: { in: sectionIds },
+            },
+          }),
+          prisma.schedule.count({
+            where: {
+              date: { gte: todayStart, lt: tomorrowStart },
+              sectionId: { in: sectionIds },
+            },
+          }),
+          prisma.exam.count({
+            where: {
+              examDate: { gte: todayStart },
+              sectionId: { in: sectionIds },
+            },
+          }),
+          prisma.homework.count({
+            where: {
+              deletedAt: null,
+              homeworkCompletions: { none: { userId } },
+              sectionId: { in: sectionIds },
+              submissionDueAt: { gte: now, lte: homeworkWindowEnd },
+            },
+          }),
+          listSubscribedSchedules(userId, {
+            dateFrom: todayStart,
+            dateTo: todayStart,
+            limit,
+            locale,
+            sectionIds,
+          }),
+          listSubscribedHomeworks(userId, {
+            completed: false,
+            dueAtFrom: now,
+            dueAtTo: homeworkWindowEnd,
+            includeEditors: true,
+            limit,
+            locale,
+            requireDueDate: true,
+            sectionIds,
+          }),
+          listSubscribedExams(userId, {
+            dateFrom: todayStart,
+            includeDateUnknown: false,
+            limit,
+            locale,
+            sectionIds,
+          }),
+        ])
+      : [0, 0, 0, 0, [], [], []];
+
+  const dueSoonHomeworks = await withHomeworkItemState(dueSoonHomeworksRaw);
+
+  return {
+    user: {
+      userId: user?.id ?? userId,
+      name: user?.name ?? null,
+      image: user?.image ?? null,
+      isAdmin: user?.isAdmin ?? false,
+    },
+    anchor: {
+      atTime: now,
+      todayStart,
+      tomorrowStart,
+      homeworkWindowDays,
+      homeworkWindowEnd,
+      limit,
+    },
+    counts: {
+      todos: todos.counts,
+      pendingHomeworks: pendingHomeworksCount,
+      dueSoonHomeworks: dueSoonHomeworksCount,
+      todaySchedules: todaySchedulesCount,
+      upcomingExams: upcomingExamsCount,
+    },
+    schedules: {
+      total: todaySchedulesCount,
+      items: schedules.map(serializeScheduleTimeFields),
+    },
+    todos: {
+      counts: todos.counts,
+      items: todos.todos,
+    },
+    homeworks: {
+      total: dueSoonHomeworksCount,
+      items: dueSoonHomeworks,
+    },
+    exams: {
+      total: upcomingExamsCount,
+      items: upcomingExams,
+    },
+  };
+}

--- a/src/features/home/server/subscription-read-model.ts
+++ b/src/features/home/server/subscription-read-model.ts
@@ -17,8 +17,10 @@ export {
   type UserSectionSubscriptionState,
 } from "./subscription-read-model-shared";
 export {
+  countUpcomingSubscribedExams,
   listSubscribedExams,
   listSubscribedSchedules,
+  listUpcomingSubscribedExams,
 } from "./subscription-schedule-exam-read-model";
 export {
   getSubscriptionsTabData,

--- a/src/features/home/server/subscription-schedule-exam-read-model.ts
+++ b/src/features/home/server/subscription-schedule-exam-read-model.ts
@@ -1,5 +1,8 @@
 import { DEFAULT_LOCALE } from "@/i18n/config";
-import { getPrisma } from "@/lib/db/prisma";
+import { getPrisma, prisma } from "@/lib/db/prisma";
+import { parseDateInput } from "@/lib/time/parse-date-input";
+import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
+import { formatShanghaiDate } from "@/lib/time/shanghai-format";
 import { withSubscribedSections } from "./subscription-read-model-shared";
 
 function dateRangeFilter(dateFrom?: Date, dateTo?: Date) {
@@ -26,6 +29,39 @@ function examDateWhere(input: {
     };
   }
   return input.includeDateUnknown ? {} : { examDate: { not: null } };
+}
+
+function upcomingKnownExamWhere(input: {
+  atTime: Date;
+  sectionIds: readonly number[];
+}) {
+  const referenceNow = shanghaiDayjs(input.atTime);
+  const todayStart = parseDateInput(formatShanghaiDate(input.atTime));
+  if (!(todayStart instanceof Date)) {
+    throw new Error("Failed to derive exam date cutoff");
+  }
+  const tomorrowStart = new Date(todayStart.getTime() + 24 * 60 * 60 * 1000);
+  const nowHHmm = referenceNow.hour() * 100 + referenceNow.minute();
+  const sectionIds = Array.from(input.sectionIds);
+
+  return {
+    sectionId: { in: sectionIds },
+    OR: [
+      { examDate: { gte: tomorrowStart } },
+      {
+        AND: [
+          { examDate: { gte: todayStart, lt: tomorrowStart } },
+          {
+            OR: [
+              { endTime: null, startTime: null },
+              { endTime: { gte: nowHHmm } },
+              { endTime: null, startTime: { gte: nowHHmm } },
+            ],
+          },
+        ],
+      },
+    ],
+  };
 }
 
 export async function listSubscribedSchedules(
@@ -77,6 +113,19 @@ export async function listSubscribedSchedules(
   );
 }
 
+export async function countUpcomingSubscribedExams({
+  atTime,
+  sectionIds,
+}: {
+  atTime: Date;
+  sectionIds: readonly number[];
+}) {
+  if (sectionIds.length === 0) return 0;
+  return prisma.exam.count({
+    where: upcomingKnownExamWhere({ atTime, sectionIds }),
+  });
+}
+
 export async function listSubscribedExams(
   userId: string,
   {
@@ -104,6 +153,39 @@ export async function listSubscribedExams(
           sectionId: { in: ids },
           ...examDateWhere({ dateFrom, dateTo, includeDateUnknown }),
         },
+        include: {
+          examBatch: true,
+          examRooms: true,
+          section: { include: { course: true, semester: true } },
+        },
+        orderBy: [{ examDate: "asc" }, { startTime: "asc" }, { jwId: "asc" }],
+        ...(limit ? { take: limit } : {}),
+      });
+    },
+    sectionIds,
+  );
+}
+
+export async function listUpcomingSubscribedExams(
+  userId: string,
+  {
+    atTime,
+    locale = DEFAULT_LOCALE,
+    limit,
+    sectionIds,
+  }: {
+    atTime: Date;
+    locale?: string;
+    limit?: number;
+    sectionIds?: readonly number[];
+  },
+) {
+  return withSubscribedSections(
+    userId,
+    async (ids) => {
+      const localizedPrisma = getPrisma(locale);
+      return localizedPrisma.exam.findMany({
+        where: upcomingKnownExamWhere({ atTime, sectionIds: ids }),
         include: {
           examBatch: true,
           examRooms: true,

--- a/src/features/home/server/subscription-write-model.ts
+++ b/src/features/home/server/subscription-write-model.ts
@@ -5,7 +5,6 @@ import {
   getUserSectionSubscriptionState,
 } from "./subscription-read-model";
 import {
-  mergeSectionIds,
   removeSectionIds,
   uniqueSectionIds,
 } from "./subscription-section-id-helpers";
@@ -36,6 +35,24 @@ async function getMutableUserSubscriptions(userId: string) {
   });
 }
 
+async function connectUserSectionIds(
+  userId: string,
+  sectionIds: readonly number[],
+) {
+  if (sectionIds.length === 0) {
+    return;
+  }
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      subscribedSections: {
+        connect: uniqueSectionIds(sectionIds).map((id) => ({ id })),
+      },
+    },
+  });
+}
+
 export async function replaceUserSectionSubscriptions(
   userId: string,
   sectionIds: number[],
@@ -61,12 +78,12 @@ export async function addUserSectionSubscriptions(
     return null;
   }
 
-  await replaceUserSectionIds(
+  const existingIds = new Set(
+    user.subscribedSections.map((section) => section.id),
+  );
+  await connectUserSectionIds(
     userId,
-    mergeSectionIds(
-      user.subscribedSections.map((section) => section.id),
-      sectionIds,
-    ),
+    sectionIds.filter((id) => !existingIds.has(id)),
   );
 
   return getUserSectionSubscriptionState(userId);

--- a/src/lib/api/routes/bus.ts
+++ b/src/lib/api/routes/bus.ts
@@ -1,10 +1,27 @@
-import { handleRouteError, jsonResponse, notFound } from "@/lib/api/helpers";
+import {
+  handleRouteError,
+  jsonResponse,
+  notFound,
+  parseRouteSearchParams,
+} from "@/lib/api/helpers";
 import {
   parseBusPreferenceBody,
   parseBusRouteQuery,
 } from "@/lib/api/routes/bus-route-request";
+import {
+  parseOptionalDateQuery,
+  parsePositiveIntegerQuery,
+} from "@/lib/api/routes/query-value-parsing";
 import { getRequestLocale } from "@/lib/api/routes/request-locale";
-import { busQueryResponseSchema } from "@/lib/api/schemas/response-schemas";
+import {
+  busNextDeparturesQuerySchema,
+  busRouteSearchQuerySchema,
+} from "@/lib/api/schemas/request-schemas";
+import {
+  busNextDeparturesResponseSchema,
+  busQueryResponseSchema,
+  busRouteSearchResponseSchema,
+} from "@/lib/api/schemas/response-schemas";
 import { requireAuth, resolveApiUserId } from "@/lib/auth/api-auth";
 
 export async function getBusRoute(request: Request) {
@@ -34,6 +51,119 @@ export async function getBusRoute(request: Request) {
     return jsonResponse(validated);
   } catch (error) {
     return handleRouteError("Failed to query shuttle bus schedules", error);
+  }
+}
+
+export async function getBusRoutesSearchRoute(request: Request) {
+  const parsedQuery = parseRouteSearchParams(
+    new URL(request.url).searchParams,
+    busRouteSearchQuerySchema,
+    "Invalid bus route search query",
+    { logErrors: true },
+  );
+  if (parsedQuery instanceof Response) return parsedQuery;
+
+  const originCampusId = parsePositiveIntegerQuery(
+    "originCampusId",
+    parsedQuery.originCampusId,
+    { message: "Invalid bus route search query" },
+  );
+  if (originCampusId instanceof Response) return originCampusId;
+
+  const destinationCampusId = parsePositiveIntegerQuery(
+    "destinationCampusId",
+    parsedQuery.destinationCampusId,
+    { message: "Invalid bus route search query" },
+  );
+  if (destinationCampusId instanceof Response) return destinationCampusId;
+
+  try {
+    const { searchBusRoutes } = await import("@/features/bus/lib/bus-service");
+    const result = await searchBusRoutes({
+      destinationCampusId,
+      locale: parsedQuery.locale ?? getRequestLocale(request),
+      originCampusId,
+      versionKey: parsedQuery.versionKey ?? null,
+    });
+
+    if (!result) {
+      return notFound("Bus schedule is not available");
+    }
+
+    return jsonResponse(busRouteSearchResponseSchema.parse(result));
+  } catch (error) {
+    return handleRouteError("Failed to search shuttle bus routes", error);
+  }
+}
+
+export async function getBusNextDeparturesRoute(request: Request) {
+  const parsedQuery = parseRouteSearchParams(
+    new URL(request.url).searchParams,
+    busNextDeparturesQuerySchema,
+    "Invalid bus next-departures query",
+    { logErrors: true },
+  );
+  if (parsedQuery instanceof Response) return parsedQuery;
+
+  const originCampusId = parsePositiveIntegerQuery(
+    "originCampusId",
+    parsedQuery.originCampusId,
+    { message: "Invalid bus next-departures query" },
+  );
+  if (originCampusId instanceof Response) return originCampusId;
+
+  const destinationCampusId = parsePositiveIntegerQuery(
+    "destinationCampusId",
+    parsedQuery.destinationCampusId,
+    { message: "Invalid bus next-departures query" },
+  );
+  if (destinationCampusId instanceof Response) return destinationCampusId;
+
+  if (originCampusId === undefined || destinationCampusId === undefined) {
+    return handleRouteError(
+      "Invalid bus next-departures query",
+      "originCampusId and destinationCampusId are required",
+      400,
+    );
+  }
+
+  const atTime = parseOptionalDateQuery(
+    "atTime",
+    parsedQuery.atTime,
+    "Invalid bus next-departures query",
+  );
+  if (atTime instanceof Response) return atTime;
+
+  const limit = parsePositiveIntegerQuery("limit", parsedQuery.limit, {
+    defaultValue: 5,
+    max: 50,
+    message: "Invalid bus next-departures query",
+  });
+  if (limit instanceof Response) return limit;
+
+  try {
+    const { getNextBusDepartures } = await import(
+      "@/features/bus/lib/bus-service"
+    );
+    const result = await getNextBusDepartures({
+      atTime: atTime?.toISOString(),
+      dayType: parsedQuery.dayType ?? "auto",
+      destinationCampusId,
+      includeDeparted: parsedQuery.includeDeparted === "true",
+      limit,
+      locale: parsedQuery.locale ?? getRequestLocale(request),
+      originCampusId,
+      userId: await resolveApiUserId(request),
+      versionKey: parsedQuery.versionKey ?? null,
+    });
+
+    if (!result) {
+      return notFound("Bus schedule is not available");
+    }
+
+    return jsonResponse(busNextDeparturesResponseSchema.parse(result));
+  } catch (error) {
+    return handleRouteError("Failed to fetch next shuttle buses", error);
   }
 }
 

--- a/src/lib/api/routes/calendar-subscriptions.ts
+++ b/src/lib/api/routes/calendar-subscriptions.ts
@@ -1,8 +1,11 @@
 import {
   handleRouteError,
   jsonResponse,
+  notFound,
   parseRouteJsonBody,
 } from "@/lib/api/helpers";
+import { parseSectionMatchCodesRequest } from "@/lib/api/routes/academic-section-route-request";
+import { getRequestLocale } from "@/lib/api/routes/request-locale";
 import { calendarSubscriptionCreateRequestSchema } from "@/lib/api/schemas/request-schemas";
 import { requireAuth } from "@/lib/auth/api-auth";
 
@@ -54,5 +57,70 @@ export async function postCalendarSubscriptionsRoute(request: Request) {
     return jsonResponse({ subscription });
   } catch (error) {
     return handleRouteError("Failed to update calendar subscription", error);
+  }
+}
+
+export async function postCalendarSubscriptionImportCodesRoute(
+  request: Request,
+) {
+  try {
+    const auth = await requireAuth(request);
+    if (auth instanceof Response) return auth;
+    const { userId } = auth;
+
+    const parsedBody = await parseSectionMatchCodesRequest(request);
+    if (parsedBody instanceof Response) {
+      return parsedBody;
+    }
+
+    const locale = getRequestLocale(request);
+    const [
+      { findSectionCodeMatches },
+      { getSubscribedSectionIds, getUserCalendarSubscription },
+      { addUserSectionSubscriptions },
+    ] = await Promise.all([
+      import("@/lib/course-section-queries"),
+      import("@/features/home/server/subscription-read-model"),
+      import("@/features/home/server/subscriptions"),
+    ]);
+
+    const matches = await findSectionCodeMatches(
+      parsedBody.codes,
+      locale,
+      parsedBody.semesterId,
+    );
+    if (!matches) {
+      return notFound("No semester found");
+    }
+
+    const existingIds = new Set(await getSubscribedSectionIds(userId));
+    const addedSections = matches.sections.filter(
+      (section) => !existingIds.has(section.id),
+    );
+    const alreadySubscribedSections = matches.sections.filter((section) =>
+      existingIds.has(section.id),
+    );
+
+    await addUserSectionSubscriptions(
+      userId,
+      matches.sections.map((section) => section.id),
+    );
+    const subscription = await getUserCalendarSubscription(userId, locale);
+
+    return jsonResponse({
+      success: true,
+      semester: matches.semester,
+      matchedCodes: matches.matchedCodes,
+      unmatchedCodes: matches.unmatchedCodes,
+      ambiguousCodes: [],
+      sections: matches.sections,
+      addedCount: addedSections.length,
+      addedSections,
+      alreadySubscribedCount: alreadySubscribedSections.length,
+      alreadySubscribedSections,
+      subscription,
+    });
+  } catch (error) {
+    return handleRouteError("Failed to import section subscriptions", error);
   }
 }

--- a/src/lib/api/routes/me-overview-route.ts
+++ b/src/lib/api/routes/me-overview-route.ts
@@ -1,0 +1,67 @@
+import {
+  handleRouteError,
+  jsonResponse,
+  parseRouteSearchParams,
+} from "@/lib/api/helpers";
+import {
+  parseOptionalDateQuery,
+  parsePositiveIntegerQuery,
+} from "@/lib/api/routes/query-value-parsing";
+import { getRequestLocale } from "@/lib/api/routes/request-locale";
+import { compactOverviewQuerySchema } from "@/lib/api/schemas/request-schemas";
+import { requireAuth } from "@/lib/auth/api-auth";
+
+export async function getMyCompactOverviewRoute(request: Request) {
+  const auth = await requireAuth(request);
+  if (auth instanceof Response) return auth;
+  const { userId } = auth;
+
+  const parsedQuery = parseRouteSearchParams(
+    new URL(request.url).searchParams,
+    compactOverviewQuerySchema,
+    "Invalid overview query",
+    { logErrors: true },
+  );
+  if (parsedQuery instanceof Response) return parsedQuery;
+
+  const atTime = parseOptionalDateQuery(
+    "atTime",
+    parsedQuery.atTime,
+    "Invalid overview query",
+  );
+  if (atTime instanceof Response) return atTime;
+
+  const homeworkWindowDays = parsePositiveIntegerQuery(
+    "homeworkWindowDays",
+    parsedQuery.homeworkWindowDays,
+    {
+      defaultValue: 7,
+      max: 90,
+      message: "Invalid overview query",
+    },
+  );
+  if (homeworkWindowDays instanceof Response) return homeworkWindowDays;
+
+  const limit = parsePositiveIntegerQuery("limit", parsedQuery.limit, {
+    defaultValue: 3,
+    max: 50,
+    message: "Invalid overview query",
+  });
+  if (limit instanceof Response) return limit;
+
+  try {
+    const { getCompactOverview } = await import(
+      "@/features/home/server/compact-overview-read-model"
+    );
+    const overview = await getCompactOverview(userId, {
+      atTime,
+      homeworkWindowDays,
+      limit,
+      locale: parsedQuery.locale ?? getRequestLocale(request),
+    });
+
+    return jsonResponse(overview);
+  } catch (error) {
+    return handleRouteError("Failed to fetch overview", error);
+  }
+}

--- a/src/lib/api/routes/query-value-parsing.ts
+++ b/src/lib/api/routes/query-value-parsing.ts
@@ -1,0 +1,35 @@
+import { badRequest, parseInteger } from "@/lib/api/helpers";
+import { parseDateInput } from "@/lib/time/parse-date-input";
+
+export function parseOptionalDateQuery(
+  name: string,
+  value: string | undefined,
+  message: string,
+) {
+  if (!value) return undefined;
+  const parsed = parseDateInput(value);
+  return parsed instanceof Date
+    ? parsed
+    : badRequest(`${message}: invalid ${name}`);
+}
+
+export function parsePositiveIntegerQuery(
+  name: string,
+  value: string | undefined,
+  {
+    defaultValue,
+    max,
+    message,
+  }: {
+    defaultValue?: number;
+    max?: number;
+    message: string;
+  },
+) {
+  if (!value) return defaultValue;
+  const parsed = parseInteger(value);
+  if (parsed === null || parsed < 1 || (max !== undefined && parsed > max)) {
+    return badRequest(`${message}: invalid ${name}`);
+  }
+  return parsed;
+}

--- a/src/lib/api/routes/subscribed-schedule-routes.ts
+++ b/src/lib/api/routes/subscribed-schedule-routes.ts
@@ -1,0 +1,73 @@
+import {
+  handleRouteError,
+  jsonResponse,
+  parseRouteSearchParams,
+} from "@/lib/api/helpers";
+import {
+  parseOptionalDateQuery,
+  parsePositiveIntegerQuery,
+} from "@/lib/api/routes/query-value-parsing";
+import { getRequestLocale } from "@/lib/api/routes/request-locale";
+import { subscribedSchedulesQuerySchema } from "@/lib/api/schemas/request-schemas";
+import { requireAuth } from "@/lib/auth/api-auth";
+import { serializeScheduleTimeFields } from "@/lib/schedule-serialization";
+
+export async function getMySubscribedSchedulesRoute(request: Request) {
+  const auth = await requireAuth(request);
+  if (auth instanceof Response) return auth;
+  const { userId } = auth;
+
+  const parsedQuery = parseRouteSearchParams(
+    new URL(request.url).searchParams,
+    subscribedSchedulesQuerySchema,
+    "Invalid subscribed schedules query",
+    { logErrors: true },
+  );
+  if (parsedQuery instanceof Response) return parsedQuery;
+
+  const dateFrom = parseOptionalDateQuery(
+    "dateFrom",
+    parsedQuery.dateFrom,
+    "Invalid subscribed schedules query",
+  );
+  if (dateFrom instanceof Response) return dateFrom;
+
+  const dateTo = parseOptionalDateQuery(
+    "dateTo",
+    parsedQuery.dateTo,
+    "Invalid subscribed schedules query",
+  );
+  if (dateTo instanceof Response) return dateTo;
+
+  const weekday = parsePositiveIntegerQuery("weekday", parsedQuery.weekday, {
+    max: 7,
+    message: "Invalid subscribed schedules query",
+  });
+  if (weekday instanceof Response) return weekday;
+
+  const limit = parsePositiveIntegerQuery("limit", parsedQuery.limit, {
+    defaultValue: 150,
+    max: 300,
+    message: "Invalid subscribed schedules query",
+  });
+  if (limit instanceof Response) return limit;
+
+  try {
+    const { listSubscribedSchedules } = await import(
+      "@/features/home/server/subscription-read-model"
+    );
+    const schedules = await listSubscribedSchedules(userId, {
+      dateFrom,
+      dateTo,
+      limit,
+      locale: parsedQuery.locale ?? getRequestLocale(request),
+      weekday,
+    });
+
+    return jsonResponse({
+      schedules: schedules.map(serializeScheduleTimeFields),
+    });
+  } catch (error) {
+    return handleRouteError("Failed to fetch subscribed schedules", error);
+  }
+}

--- a/src/lib/api/schemas/academic-exam-response-schemas.ts
+++ b/src/lib/api/schemas/academic-exam-response-schemas.ts
@@ -1,4 +1,9 @@
 import * as z from "zod";
+import { localizedCourseBaseSchema } from "./academic-course-response-schemas";
+import {
+  sectionBaseSchema,
+  semesterSchema,
+} from "./academic-section-base-response-schemas";
 import { dateTimeSchema } from "./response-schema-primitives";
 
 export const examRoomSchema = z.object({
@@ -27,4 +32,11 @@ export const examSchema = z.object({
   sectionId: z.number().int(),
   examBatch: examBatchSchema.nullable(),
   examRooms: z.array(examRoomSchema),
+});
+
+export const subscribedExamSchema = examSchema.extend({
+  section: sectionBaseSchema.extend({
+    course: localizedCourseBaseSchema,
+    semester: semesterSchema.nullable(),
+  }),
 });

--- a/src/lib/api/schemas/bus-response-schemas.ts
+++ b/src/lib/api/schemas/bus-response-schemas.ts
@@ -2,6 +2,11 @@ import * as z from "zod";
 import { busCampusSchema } from "./misc-response-schema-core";
 import { dateTimeSchema } from "./response-schema-primitives";
 
+const busCampusSummarySchema = busCampusSchema.extend({
+  namePrimary: z.string(),
+  nameSecondary: z.string().nullable(),
+});
+
 const busTripStopTimeSummarySchema = z.object({
   stopOrder: z.number().int(),
   campusId: z.number().int(),
@@ -20,12 +25,17 @@ const busRouteSummarySchema = z.object({
   stops: z.array(
     z.object({
       stopOrder: z.number().int(),
-      campus: busCampusSchema.extend({
-        namePrimary: z.string(),
-        nameSecondary: z.string().nullable(),
-      }),
+      campus: busCampusSummarySchema,
     }),
   ),
+});
+
+const busRouteCoreSchema = busRouteSummarySchema.pick({
+  id: true,
+  nameCn: true,
+  nameEn: true,
+  descriptionPrimary: true,
+  descriptionSecondary: true,
 });
 
 const busTripSummarySchema = z.object({
@@ -75,12 +85,7 @@ export const busQueryResponseSchema = z.object({
         .nullable(),
     }),
   ),
-  campuses: z.array(
-    busCampusSchema.extend({
-      namePrimary: z.string(),
-      nameSecondary: z.string().nullable(),
-    }),
-  ),
+  campuses: z.array(busCampusSummarySchema),
   routes: z.array(busRouteSummarySchema),
   trips: z.array(busTripSummarySchema),
   preferences: z
@@ -104,4 +109,51 @@ export const busPreferenceResponseSchema = z.object({
     preferredDestinationCampusId: z.number().int().nullable(),
     showDepartedTrips: z.boolean(),
   }),
+});
+
+export const busRouteSearchResponseSchema = z.object({
+  originCampus: busCampusSummarySchema.nullable(),
+  destinationCampus: busCampusSummarySchema.nullable(),
+  total: z.number().int().nonnegative(),
+  routes: z.array(
+    busRouteCoreSchema.extend({
+      originCampus: busCampusSummarySchema.nullable(),
+      destinationCampus: busCampusSummarySchema.nullable(),
+      stopCount: z.number().int().nonnegative(),
+      weekdayTrips: z.number().int().nonnegative(),
+      weekendTrips: z.number().int().nonnegative(),
+      stops: z.array(
+        z.object({
+          stopOrder: z.number().int(),
+          campus: busCampusSummarySchema,
+        }),
+      ),
+    }),
+  ),
+});
+
+const busNextDepartureSchema = z.object({
+  tripId: z.number().int(),
+  routeId: z.number().int(),
+  route: busRouteCoreSchema,
+  originCampus: busCampusSummarySchema.nullable(),
+  destinationCampus: busCampusSummarySchema.nullable(),
+  departureTime: z.string().nullable(),
+  arrivalTime: z.string().nullable(),
+  departureEstimated: z.boolean(),
+  arrivalEstimated: z.boolean(),
+  minutesUntilDeparture: z.number().int().nullable(),
+  dayType: z.enum(["weekday", "weekend"]),
+  status: z.enum(["upcoming", "departed"]),
+});
+
+export const busNextDeparturesResponseSchema = z.object({
+  originCampus: busCampusSummarySchema.nullable(),
+  destinationCampus: busCampusSummarySchema.nullable(),
+  atTime: dateTimeSchema,
+  dayType: z.enum(["weekday", "weekend"]),
+  totalRoutes: z.number().int().nonnegative(),
+  departures: z.array(busNextDepartureSchema),
+  nextAvailableDeparture: busNextDepartureSchema.nullable(),
+  message: z.string().nullable(),
 });

--- a/src/lib/api/schemas/misc-query-schemas.ts
+++ b/src/lib/api/schemas/misc-query-schemas.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import { APP_LOCALES } from "@/i18n/config";
 import {
   integerStringSchema,
   todoPrioritySchema,
@@ -6,6 +7,24 @@ import {
 
 export const busQuerySchema = z.object({
   versionKey: z.string().trim().min(1).optional(),
+});
+
+export const busRouteSearchQuerySchema = z.object({
+  originCampusId: integerStringSchema.optional(),
+  destinationCampusId: integerStringSchema.optional(),
+  versionKey: z.string().trim().min(1).optional(),
+  locale: z.enum(APP_LOCALES).optional(),
+});
+
+export const busNextDeparturesQuerySchema = z.object({
+  originCampusId: integerStringSchema,
+  destinationCampusId: integerStringSchema,
+  atTime: z.string().trim().min(1).optional(),
+  dayType: z.enum(["auto", "weekday", "weekend"]).optional(),
+  includeDeparted: z.enum(["true", "false"]).optional(),
+  limit: integerStringSchema.optional(),
+  versionKey: z.string().trim().min(1).optional(),
+  locale: z.enum(APP_LOCALES).optional(),
 });
 
 export const busPreferenceRequestSchema = z.object({
@@ -26,6 +45,21 @@ export const dashboardLinkVisitQuerySchema = z.object({
 export const semestersQuerySchema = z.object({
   page: integerStringSchema.optional(),
   limit: integerStringSchema.optional(),
+});
+
+export const subscribedSchedulesQuerySchema = z.object({
+  dateFrom: z.string().trim().min(1).optional(),
+  dateTo: z.string().trim().min(1).optional(),
+  weekday: integerStringSchema.optional(),
+  limit: integerStringSchema.optional(),
+  locale: z.enum(APP_LOCALES).optional(),
+});
+
+export const compactOverviewQuerySchema = z.object({
+  atTime: z.string().trim().min(1).optional(),
+  homeworkWindowDays: integerStringSchema.optional(),
+  limit: integerStringSchema.optional(),
+  locale: z.enum(APP_LOCALES).optional(),
 });
 
 export const todosQuerySchema = z.object({

--- a/src/lib/api/schemas/misc-response-schema-core.ts
+++ b/src/lib/api/schemas/misc-response-schema-core.ts
@@ -35,6 +35,24 @@ export const calendarSubscriptionCreateResponseSchema = z.object({
   subscription: calendarSubscriptionSchema.nullable(),
 });
 
+export const calendarSubscriptionImportResponseSchema = z.object({
+  success: z.boolean(),
+  semester: z.object({
+    id: z.number().int(),
+    nameCn: z.string().nullable(),
+    code: z.string().nullable(),
+  }),
+  matchedCodes: z.array(z.string()),
+  unmatchedCodes: z.array(z.string()),
+  ambiguousCodes: z.array(z.string()),
+  sections: z.array(sectionCompactSchema),
+  addedCount: z.number().int().nonnegative(),
+  addedSections: z.array(sectionCompactSchema),
+  alreadySubscribedCount: z.number().int().nonnegative(),
+  alreadySubscribedSections: z.array(sectionCompactSchema),
+  subscription: calendarSubscriptionSchema.nullable(),
+});
+
 export const matchSectionCodesResponseSchema = z.object({
   semester: z.object({
     id: z.number().int(),

--- a/src/lib/api/schemas/overview-response-schemas.ts
+++ b/src/lib/api/schemas/overview-response-schemas.ts
@@ -1,0 +1,60 @@
+import * as z from "zod";
+import { subscribedExamSchema } from "./academic-exam-response-schemas";
+import { homeworkItemSchema } from "./homeworks-response-schemas";
+import {
+  todoCountsSchema,
+  viewerContextSchema,
+} from "./misc-response-schema-core";
+import { dateTimeSchema } from "./response-schema-primitives";
+import { scheduleEntrySchema } from "./schedule-response-schema-core";
+
+export const compactOverviewResponseSchema = z.object({
+  user: viewerContextSchema.pick({
+    userId: true,
+    name: true,
+    image: true,
+    isAdmin: true,
+  }),
+  anchor: z.object({
+    atTime: dateTimeSchema,
+    todayStart: dateTimeSchema,
+    tomorrowStart: dateTimeSchema,
+    homeworkWindowDays: z.number().int().positive(),
+    homeworkWindowEnd: dateTimeSchema,
+    limit: z.number().int().positive(),
+  }),
+  counts: z.object({
+    todos: todoCountsSchema,
+    pendingHomeworks: z.number().int().nonnegative(),
+    dueSoonHomeworks: z.number().int().nonnegative(),
+    todaySchedules: z.number().int().nonnegative(),
+    upcomingExams: z.number().int().nonnegative(),
+  }),
+  schedules: z.object({
+    total: z.number().int().nonnegative(),
+    items: z.array(scheduleEntrySchema),
+  }),
+  todos: z.object({
+    counts: todoCountsSchema,
+    items: z.array(
+      z.object({
+        id: z.string(),
+        title: z.string(),
+        content: z.string().nullable(),
+        priority: z.enum(["low", "medium", "high"]),
+        completed: z.boolean(),
+        dueAt: dateTimeSchema.nullable(),
+        createdAt: dateTimeSchema,
+        updatedAt: dateTimeSchema,
+      }),
+    ),
+  }),
+  homeworks: z.object({
+    total: z.number().int().nonnegative(),
+    items: z.array(homeworkItemSchema),
+  }),
+  exams: z.object({
+    total: z.number().int().nonnegative(),
+    items: z.array(subscribedExamSchema),
+  }),
+});

--- a/src/lib/api/schemas/request-query-schemas.ts
+++ b/src/lib/api/schemas/request-query-schemas.ts
@@ -17,10 +17,14 @@ export {
   sectionsCalendarQuerySchema,
 } from "./content-query-schemas";
 export {
+  busNextDeparturesQuerySchema,
   busPreferenceRequestSchema,
   busQuerySchema,
+  busRouteSearchQuerySchema,
+  compactOverviewQuerySchema,
   dashboardLinkVisitQuerySchema,
   semestersQuerySchema,
+  subscribedSchedulesQuerySchema,
   todosQuerySchema,
   uploadObjectQuerySchema,
 } from "./misc-query-schemas";

--- a/src/lib/api/schemas/response-schemas.ts
+++ b/src/lib/api/schemas/response-schemas.ts
@@ -5,6 +5,7 @@ export * from "./comments-response-schemas";
 export * from "./descriptions-response-schemas";
 export * from "./homeworks-response-schemas";
 export * from "./misc-response-schema-core";
+export * from "./overview-response-schemas";
 export * from "./response-schema-primitives";
 export * from "./schedule-response-schema-core";
 export * from "./uploads-response-schemas";

--- a/src/lib/api/schemas/schedule-response-schema-core.ts
+++ b/src/lib/api/schemas/schedule-response-schema-core.ts
@@ -48,7 +48,7 @@ const localizedTeacherWithDepartmentSchema = teacherSchema.extend({
     .nullable(),
 });
 
-const scheduleWithRelationsSchema = scheduleBaseSchema.extend({
+export const scheduleEntrySchema = scheduleBaseSchema.extend({
   room: localizedRoomWithBuildingCampusSchema.nullable(),
   teachers: z.array(localizedTeacherWithDepartmentSchema),
   section: sectionBaseSchema.extend({
@@ -58,6 +58,9 @@ const scheduleWithRelationsSchema = scheduleBaseSchema.extend({
   scheduleGroup: scheduleGroupSchema,
 });
 
-export const paginatedScheduleResponseSchema = createPaginatedSchema(
-  scheduleWithRelationsSchema,
-);
+export const paginatedScheduleResponseSchema =
+  createPaginatedSchema(scheduleEntrySchema);
+
+export const subscribedSchedulesResponseSchema = z.object({
+  schedules: z.array(scheduleEntrySchema),
+});

--- a/src/lib/mcp/tools/my-data-overview-action.ts
+++ b/src/lib/mcp/tools/my-data-overview-action.ts
@@ -31,6 +31,7 @@ export async function getMyOverviewAction(
   }
   const { now, todayStart, tomorrowStart } = getTodayBounds(atTimeDate.value);
   const counts = await loadMyOverviewCounts({
+    now,
     sectionIds,
     todayStart,
     tomorrowStart,

--- a/src/lib/mcp/tools/my-data-overview-loaders.ts
+++ b/src/lib/mcp/tools/my-data-overview-loaders.ts
@@ -1,6 +1,7 @@
 import {
-  listSubscribedExams,
+  countUpcomingSubscribedExams,
   listSubscribedHomeworks,
+  listUpcomingSubscribedExams,
 } from "@/features/home/server/subscription-read-model";
 import { withHomeworkItemState } from "@/features/homeworks/server/homework-item-state";
 import { prisma } from "@/lib/db/prisma";
@@ -13,11 +14,13 @@ function countWhenSubscribed(
 }
 
 export async function loadMyOverviewCounts({
+  now,
   sectionIds,
   todayStart,
   tomorrowStart,
   userId,
 }: {
+  now: Date;
   sectionIds: number[];
   todayStart: Date;
   tomorrowStart: Date;
@@ -48,12 +51,7 @@ export async function loadMyOverviewCounts({
       }),
     ),
     countWhenSubscribed(sectionIds, () =>
-      prisma.exam.count({
-        where: {
-          sectionId: { in: sectionIds },
-          examDate: { gte: todayStart },
-        },
-      }),
+      countUpcomingSubscribedExams({ atTime: now, sectionIds }),
     ),
   ]);
 
@@ -100,10 +98,9 @@ export async function loadMyOverviewSamples({
       limit: 5,
       sectionIds,
     }),
-    listSubscribedExams(userId, {
+    listUpcomingSubscribedExams(userId, {
+      atTime: now,
       locale,
-      dateFrom: now,
-      includeDateUnknown: false,
       limit: 5,
       sectionIds,
     }),

--- a/src/routes/api/bus/next/+server.ts
+++ b/src/routes/api/bus/next/+server.ts
@@ -1,0 +1,14 @@
+import { getBusNextDeparturesRoute } from "@/lib/api/routes/bus";
+import { svelteRequestHandler } from "@/lib/api/svelte-route";
+import { observedApiRoute } from "@/lib/log/api-observability";
+
+/**
+ * Get next shuttle bus departures for an origin and destination campus.
+ * @params busNextDeparturesQuerySchema
+ * @response busNextDeparturesResponseSchema
+ * @response 400:openApiErrorSchema
+ * @response 404:openApiErrorSchema
+ */
+export const GET = svelteRequestHandler(
+  observedApiRoute(getBusNextDeparturesRoute),
+);

--- a/src/routes/api/bus/routes/+server.ts
+++ b/src/routes/api/bus/routes/+server.ts
@@ -1,0 +1,14 @@
+import { getBusRoutesSearchRoute } from "@/lib/api/routes/bus";
+import { svelteRequestHandler } from "@/lib/api/svelte-route";
+import { observedApiRoute } from "@/lib/log/api-observability";
+
+/**
+ * Search shuttle bus route variants.
+ * @params busRouteSearchQuerySchema
+ * @response busRouteSearchResponseSchema
+ * @response 400:openApiErrorSchema
+ * @response 404:openApiErrorSchema
+ */
+export const GET = svelteRequestHandler(
+  observedApiRoute(getBusRoutesSearchRoute),
+);

--- a/src/routes/api/calendar-subscriptions/import-codes/+server.ts
+++ b/src/routes/api/calendar-subscriptions/import-codes/+server.ts
@@ -1,0 +1,15 @@
+import { postCalendarSubscriptionImportCodesRoute } from "@/lib/api/routes/calendar-subscriptions";
+import { svelteRequestHandler } from "@/lib/api/svelte-route";
+import { observedApiRoute } from "@/lib/log/api-observability";
+
+/**
+ * Import section subscriptions by section codes.
+ * @body matchSectionCodesRequestSchema
+ * @response calendarSubscriptionImportResponseSchema
+ * @response 401:openApiErrorSchema
+ * @response 400:openApiErrorSchema
+ * @response 404:openApiErrorSchema
+ */
+export const POST = svelteRequestHandler(
+  observedApiRoute(postCalendarSubscriptionImportCodesRoute),
+);

--- a/src/routes/api/me/overview/+server.ts
+++ b/src/routes/api/me/overview/+server.ts
@@ -1,0 +1,14 @@
+import { getMyCompactOverviewRoute } from "@/lib/api/routes/me-overview-route";
+import { svelteRequestHandler } from "@/lib/api/svelte-route";
+import { observedApiRoute } from "@/lib/log/api-observability";
+
+/**
+ * Get a compact current-user overview for lightweight clients.
+ * @params compactOverviewQuerySchema
+ * @response compactOverviewResponseSchema
+ * @response 401:openApiErrorSchema
+ * @response 400:openApiErrorSchema
+ */
+export const GET = svelteRequestHandler(
+  observedApiRoute(getMyCompactOverviewRoute),
+);

--- a/src/routes/api/me/subscriptions/schedules/+server.ts
+++ b/src/routes/api/me/subscriptions/schedules/+server.ts
@@ -1,0 +1,14 @@
+import { getMySubscribedSchedulesRoute } from "@/lib/api/routes/subscribed-schedule-routes";
+import { svelteRequestHandler } from "@/lib/api/svelte-route";
+import { observedApiRoute } from "@/lib/log/api-observability";
+
+/**
+ * List schedules across the current user's subscribed sections.
+ * @params subscribedSchedulesQuerySchema
+ * @response subscribedSchedulesResponseSchema
+ * @response 401:openApiErrorSchema
+ * @response 400:openApiErrorSchema
+ */
+export const GET = svelteRequestHandler(
+  observedApiRoute(getMySubscribedSchedulesRoute),
+);

--- a/tests/e2e/src/app/_shared/api-contract.ts
+++ b/tests/e2e/src/app/_shared/api-contract.ts
@@ -20,7 +20,10 @@ const probeOnlyRoutes = new Set([
   "/api/uploads/complete",
   "/api/uploads/object",
   "/api/calendar-subscriptions",
+  "/api/calendar-subscriptions/import-codes",
   "/api/calendar-subscriptions/current",
+  "/api/me/overview",
+  "/api/me/subscriptions/schedules",
   "/api/admin/comments",
   "/api/admin/comments/[id]",
   "/api/admin/users",
@@ -249,6 +252,35 @@ export async function assertApiContract(
         (((await response.json()) as { data?: unknown[] }).data?.length ?? 0) >
           0,
       ).toBe(true);
+      return;
+    }
+
+    case "/api/bus/routes": {
+      const response = await request.get(
+        `/api/bus/routes?originCampusId=${DEV_SEED.bus.originCampusId}&destinationCampusId=${DEV_SEED.bus.destinationCampusId}&versionKey=${DEV_SEED.bus.versionKey}`,
+      );
+      expect(response.status()).toBe(200);
+      const body = (await response.json()) as {
+        routes?: Array<{ id?: number; stops?: unknown[] }>;
+        total?: number;
+      };
+      expect((body.total ?? 0) > 0).toBe(true);
+      expect(
+        body.routes?.some((route) => route.id === DEV_SEED.bus.routeId),
+      ).toBe(true);
+      return;
+    }
+
+    case "/api/bus/next": {
+      const response = await request.get(
+        `/api/bus/next?originCampusId=${DEV_SEED.bus.originCampusId}&destinationCampusId=${DEV_SEED.bus.destinationCampusId}&atTime=${encodeURIComponent(DEV_SEED.seedAnchorAtTime)}&dayType=weekday&versionKey=${DEV_SEED.bus.versionKey}`,
+      );
+      expect(response.status()).toBe(200);
+      const body = (await response.json()) as {
+        departures?: Array<{ routeId?: number; status?: string }>;
+      };
+      expect((body.departures?.length ?? 0) > 0).toBe(true);
+      expect(body.departures?.[0]?.status).toBe("upcoming");
       return;
     }
 

--- a/tests/e2e/src/app/api/bus/test.ts
+++ b/tests/e2e/src/app/api/bus/test.ts
@@ -22,7 +22,7 @@
  */
 import { expect, test } from "@playwright/test";
 import { signInAsDebugUser } from "../../../../utils/auth";
-import { DEV_SEED } from "../../../../utils/dev-seed";
+import { DEV_SEED, DEV_SEED_ANCHOR } from "../../../../utils/dev-seed";
 import { assertApiContract } from "../../_shared/api-contract";
 
 const BASE = "/api/bus";
@@ -229,7 +229,7 @@ test.describe("GET /api/bus/next", () => {
     request,
   }) => {
     const response = await request.get(
-      `${NEXT_BASE}?originCampusId=${DEV_SEED.bus.originCampusId}&destinationCampusId=${DEV_SEED.bus.destinationCampusId}&atTime=${encodeURIComponent(DEV_SEED.seedAnchorAtTime)}&dayType=weekday&includeDeparted=true&limit=5&${SEED_VERSION}`,
+      `${NEXT_BASE}?originCampusId=${DEV_SEED.bus.originCampusId}&destinationCampusId=${DEV_SEED.bus.destinationCampusId}&atTime=${encodeURIComponent(DEV_SEED_ANCHOR.recommendedAtTime)}&dayType=weekday&includeDeparted=true&limit=1&${SEED_VERSION}`,
     );
     expect(response.status()).toBe(200);
     const body = (await response.json()) as BusNextResponse;
@@ -238,15 +238,14 @@ test.describe("GET /api/bus/next", () => {
     expect(body.destinationCampus?.id).toBe(DEV_SEED.bus.destinationCampusId);
     expect(body.dayType).toBe("weekday");
     expect((body.totalRoutes ?? 0) > 0).toBe(true);
-    expect((body.departures?.length ?? 0) > 0).toBe(true);
-    expect(body.departures?.some((trip) => trip.status === "upcoming")).toBe(
-      true,
+    expect(body.departures).toHaveLength(1);
+    expect(body.departures?.[0]?.status).toBe("upcoming");
+    expect(body.departures?.[0]?.departureTime).not.toBe(
+      DEV_SEED.bus.recommendedDeparture,
     );
-    expect(
-      body.departures?.some(
-        (trip) => typeof trip.minutesUntilDeparture === "number",
-      ),
-    ).toBe(true);
+    expect(body.departures?.[0]?.minutesUntilDeparture).toBeGreaterThanOrEqual(
+      0,
+    );
   });
 
   test("missing required campus IDs returns 400", async ({ request }) => {

--- a/tests/e2e/src/app/api/bus/test.ts
+++ b/tests/e2e/src/app/api/bus/test.ts
@@ -8,6 +8,12 @@
  * - Includes both weekday and weekend trips without server-side filtering/ranking
  * - Returns 404 when no schedule data exists for the requested version
  *
+ * ## GET /api/bus/routes
+ * Public filtered route discovery.
+ *
+ * ## GET /api/bus/next
+ * Public ranked next departures for one origin/destination pair.
+ *
  * ## GET/POST /api/bus/preferences
  * Authenticated endpoint for user bus planner defaults.
  * - GET: returns current preference or default values
@@ -17,9 +23,12 @@
 import { expect, test } from "@playwright/test";
 import { signInAsDebugUser } from "../../../../utils/auth";
 import { DEV_SEED } from "../../../../utils/dev-seed";
+import { assertApiContract } from "../../_shared/api-contract";
 
 const BASE = "/api/bus";
 const PREF_BASE = "/api/bus/preferences";
+const ROUTES_BASE = "/api/bus/routes";
+const NEXT_BASE = "/api/bus/next";
 const SEED_VERSION = `versionKey=${DEV_SEED.bus.versionKey}`;
 
 type BusResponse = {
@@ -47,6 +56,32 @@ type PreferenceResponse = {
     preferredDestinationCampusId?: number | null;
     showDepartedTrips?: boolean;
   };
+};
+
+type BusRouteSearchResponse = {
+  originCampus?: { id?: number; namePrimary?: string } | null;
+  destinationCampus?: { id?: number; namePrimary?: string } | null;
+  total?: number;
+  routes?: Array<{
+    id?: number;
+    stopCount?: number;
+    weekdayTrips?: number;
+    weekendTrips?: number;
+    stops?: Array<{ campus?: { id?: number } }>;
+  }>;
+};
+
+type BusNextResponse = {
+  originCampus?: { id?: number } | null;
+  destinationCampus?: { id?: number } | null;
+  dayType?: string;
+  totalRoutes?: number;
+  departures?: Array<{
+    routeId?: number;
+    status?: string;
+    minutesUntilDeparture?: number | null;
+    departureTime?: string | null;
+  }>;
 };
 
 async function saveBusPreference(
@@ -154,6 +189,69 @@ test.describe("GET /api/bus", () => {
       `${BASE}?versionKey=missing-bus-version`,
     );
     expect(response.status()).toBe(404);
+  });
+});
+
+test.describe("GET /api/bus/routes", () => {
+  test("contract", async ({ request }) => {
+    await assertApiContract(request, { routePath: ROUTES_BASE });
+  });
+
+  test("returns concrete route variants for an origin/destination", async ({
+    request,
+  }) => {
+    const response = await request.get(
+      `${ROUTES_BASE}?originCampusId=${DEV_SEED.bus.originCampusId}&destinationCampusId=${DEV_SEED.bus.destinationCampusId}&${SEED_VERSION}`,
+    );
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as BusRouteSearchResponse;
+
+    expect(body.originCampus?.id).toBe(DEV_SEED.bus.originCampusId);
+    expect(body.destinationCampus?.id).toBe(DEV_SEED.bus.destinationCampusId);
+    expect((body.total ?? 0) > 0).toBe(true);
+
+    const seedRoute = body.routes?.find(
+      (route) => route.id === DEV_SEED.bus.routeId,
+    );
+    expect(seedRoute).toBeDefined();
+    expect(seedRoute?.stopCount).toBeGreaterThan(1);
+    expect(seedRoute?.weekdayTrips).toBeGreaterThan(0);
+    expect(seedRoute?.stops?.[0]?.campus?.id).toBe(DEV_SEED.bus.originCampusId);
+  });
+});
+
+test.describe("GET /api/bus/next", () => {
+  test("contract", async ({ request }) => {
+    await assertApiContract(request, { routePath: NEXT_BASE });
+  });
+
+  test("returns ranked next departures with status metadata", async ({
+    request,
+  }) => {
+    const response = await request.get(
+      `${NEXT_BASE}?originCampusId=${DEV_SEED.bus.originCampusId}&destinationCampusId=${DEV_SEED.bus.destinationCampusId}&atTime=${encodeURIComponent(DEV_SEED.seedAnchorAtTime)}&dayType=weekday&includeDeparted=true&limit=5&${SEED_VERSION}`,
+    );
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as BusNextResponse;
+
+    expect(body.originCampus?.id).toBe(DEV_SEED.bus.originCampusId);
+    expect(body.destinationCampus?.id).toBe(DEV_SEED.bus.destinationCampusId);
+    expect(body.dayType).toBe("weekday");
+    expect((body.totalRoutes ?? 0) > 0).toBe(true);
+    expect((body.departures?.length ?? 0) > 0).toBe(true);
+    expect(body.departures?.some((trip) => trip.status === "upcoming")).toBe(
+      true,
+    );
+    expect(
+      body.departures?.some(
+        (trip) => typeof trip.minutesUntilDeparture === "number",
+      ),
+    ).toBe(true);
+  });
+
+  test("missing required campus IDs returns 400", async ({ request }) => {
+    const response = await request.get(NEXT_BASE);
+    expect(response.status()).toBe(400);
   });
 });
 

--- a/tests/e2e/src/app/api/calendar-subscriptions/test.ts
+++ b/tests/e2e/src/app/api/calendar-subscriptions/test.ts
@@ -26,6 +26,7 @@ import { DEV_SEED } from "../../../../utils/dev-seed";
 import { assertApiContract } from "../../_shared/api-contract";
 
 const BASE = "/api/calendar-subscriptions";
+const IMPORT_BASE = "/api/calendar-subscriptions/import-codes";
 
 test.describe("POST /api/calendar-subscriptions", () => {
   test.describe.configure({ mode: "serial" });
@@ -34,11 +35,88 @@ test.describe("POST /api/calendar-subscriptions", () => {
     await assertApiContract(request, { routePath: BASE });
   });
 
+  test("import-codes contract", async ({ request }) => {
+    await assertApiContract(request, { routePath: IMPORT_BASE });
+  });
+
   test("returns 401 when not authenticated", async ({ request }) => {
     const response = await request.post(BASE, {
       data: { sectionIds: [1] },
     });
     expect(response.status()).toBe(401);
+  });
+
+  test("import-codes returns 401 when not authenticated", async ({
+    request,
+  }) => {
+    const response = await request.post(IMPORT_BASE, {
+      data: { codes: [DEV_SEED.section.code] },
+    });
+    expect(response.status()).toBe(401);
+  });
+
+  test("import-codes appends matched section codes and reports repeats", async ({
+    page,
+  }) => {
+    await signInAsDebugUser(page, "/");
+
+    const currentRes = await page.request.get(
+      "/api/calendar-subscriptions/current",
+    );
+    const currentBody = (await currentRes.json()) as {
+      subscription?: { sections?: Array<{ id?: number }> } | null;
+    };
+    const originalIds =
+      currentBody.subscription?.sections?.map((s) => s.id as number) ?? [];
+
+    try {
+      await page.request.post(BASE, { data: { sectionIds: [] } });
+
+      const firstResponse = await page.request.post(IMPORT_BASE, {
+        data: {
+          codes: [DEV_SEED.section.code, "MISSING.CODE"],
+        },
+      });
+      expect(firstResponse.status()).toBe(200);
+      const firstBody = (await firstResponse.json()) as {
+        addedCount?: number;
+        addedSections?: Array<{ id?: number; code?: string }>;
+        alreadySubscribedCount?: number;
+        matchedCodes?: string[];
+        subscription?: { sections?: Array<{ id?: number; code?: string }> };
+        unmatchedCodes?: string[];
+      };
+
+      expect(firstBody.matchedCodes).toContain(DEV_SEED.section.code);
+      expect(firstBody.unmatchedCodes).toContain("MISSING.CODE");
+      expect(firstBody.addedCount).toBe(1);
+      expect(firstBody.alreadySubscribedCount).toBe(0);
+      expect(firstBody.addedSections?.[0]?.code).toBe(DEV_SEED.section.code);
+      expect(
+        firstBody.subscription?.sections?.some(
+          (section) => section.code === DEV_SEED.section.code,
+        ),
+      ).toBe(true);
+
+      const secondResponse = await page.request.post(IMPORT_BASE, {
+        data: { codes: [DEV_SEED.section.code] },
+      });
+      expect(secondResponse.status()).toBe(200);
+      const secondBody = (await secondResponse.json()) as {
+        addedCount?: number;
+        alreadySubscribedCount?: number;
+        alreadySubscribedSections?: Array<{ code?: string }>;
+      };
+      expect(secondBody.addedCount).toBe(0);
+      expect(secondBody.alreadySubscribedCount).toBe(1);
+      expect(secondBody.alreadySubscribedSections?.[0]?.code).toBe(
+        DEV_SEED.section.code,
+      );
+    } finally {
+      await page.request.post(BASE, {
+        data: { sectionIds: originalIds },
+      });
+    }
   });
 
   test("subscribes to seed section and returns correct shape", async ({

--- a/tests/e2e/src/app/api/me/overview/test.ts
+++ b/tests/e2e/src/app/api/me/overview/test.ts
@@ -7,9 +7,11 @@
 import { expect, test } from "@playwright/test";
 import { signInAsDebugUser } from "../../../../../utils/auth";
 import { DEV_SEED } from "../../../../../utils/dev-seed";
+import { withE2ePrisma } from "../../../../../utils/e2e-db/prisma";
 import { assertApiContract } from "../../../_shared/api-contract";
 
 const BASE = "/api/me/overview";
+const PAST_SAME_DAY_EXAM_JW_ID = 88_051_001;
 
 test.describe("GET /api/me/overview", () => {
   test("contract", async ({ request }) => {
@@ -66,6 +68,69 @@ test.describe("GET /api/me/overview", () => {
     ).toBe(true);
     expect((body.homeworks?.items?.length ?? 0) > 0).toBe(true);
     expect((body.exams?.items?.length ?? 0) > 0).toBe(true);
+  });
+
+  test("excludes same-day exams that already ended", async ({ page }) => {
+    await signInAsDebugUser(page, "/");
+
+    const atTime = "2026-04-29T12:00:00+08:00";
+    const url = `${BASE}?atTime=${encodeURIComponent(atTime)}&limit=30`;
+    const beforeResponse = await page.request.get(url);
+    expect(beforeResponse.status()).toBe(200);
+    const beforeBody = (await beforeResponse.json()) as {
+      counts?: { upcomingExams?: number };
+    };
+
+    await withE2ePrisma(async (prisma) => {
+      const section = await prisma.section.findUniqueOrThrow({
+        where: { jwId: DEV_SEED.section.jwId },
+        select: { id: true },
+      });
+      await prisma.exam.upsert({
+        where: { jwId: PAST_SAME_DAY_EXAM_JW_ID },
+        update: {
+          examDate: new Date("2026-04-29T00:00:00.000Z"),
+          endTime: 1000,
+          examMode: "closed",
+          examTakeCount: 1,
+          examType: 1,
+          sectionId: section.id,
+          startTime: 900,
+        },
+        create: {
+          jwId: PAST_SAME_DAY_EXAM_JW_ID,
+          examDate: new Date("2026-04-29T00:00:00.000Z"),
+          endTime: 1000,
+          examMode: "closed",
+          examTakeCount: 1,
+          examType: 1,
+          sectionId: section.id,
+          startTime: 900,
+        },
+      });
+    });
+
+    try {
+      const response = await page.request.get(url);
+      expect(response.status()).toBe(200);
+      const body = (await response.json()) as {
+        counts?: { upcomingExams?: number };
+        exams?: { items?: Array<{ jwId?: number }> };
+      };
+
+      expect(body.counts?.upcomingExams).toBe(beforeBody.counts?.upcomingExams);
+      expect(
+        body.exams?.items?.some(
+          (exam) => exam.jwId === PAST_SAME_DAY_EXAM_JW_ID,
+        ),
+      ).toBe(false);
+    } finally {
+      await withE2ePrisma((prisma) =>
+        prisma.exam.deleteMany({
+          where: { jwId: PAST_SAME_DAY_EXAM_JW_ID },
+        }),
+      );
+    }
   });
 
   test("invalid atTime returns 400", async ({ page }) => {

--- a/tests/e2e/src/app/api/me/overview/test.ts
+++ b/tests/e2e/src/app/api/me/overview/test.ts
@@ -1,0 +1,77 @@
+/**
+ * E2E tests for GET /api/me/overview
+ *
+ * Authenticated compact overview for lightweight clients. The response combines
+ * schedule, todo, homework, and exam samples without client-side fan-out.
+ */
+import { expect, test } from "@playwright/test";
+import { signInAsDebugUser } from "../../../../../utils/auth";
+import { DEV_SEED } from "../../../../../utils/dev-seed";
+import { assertApiContract } from "../../../_shared/api-contract";
+
+const BASE = "/api/me/overview";
+
+test.describe("GET /api/me/overview", () => {
+  test("contract", async ({ request }) => {
+    await assertApiContract(request, { routePath: BASE });
+  });
+
+  test("returns 401 when not authenticated", async ({ request }) => {
+    const response = await request.get(BASE);
+    expect(response.status()).toBe(401);
+  });
+
+  test("returns compact counts and top items", async ({ page }) => {
+    await signInAsDebugUser(page, "/");
+
+    const response = await page.request.get(
+      `${BASE}?atTime=${encodeURIComponent(DEV_SEED.seedAnchorAtTime)}&homeworkWindowDays=7&limit=3`,
+    );
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as {
+      anchor?: { homeworkWindowDays?: number; limit?: number };
+      counts?: {
+        todos?: { incomplete?: number; overdue?: number };
+        pendingHomeworks?: number;
+        dueSoonHomeworks?: number;
+        todaySchedules?: number;
+        upcomingExams?: number;
+      };
+      schedules?: {
+        total?: number;
+        items?: Array<{ section?: { code?: string } }>;
+      };
+      todos?: { items?: Array<{ title?: string }> };
+      homeworks?: { items?: Array<{ title?: string }> };
+      exams?: { items?: Array<{ section?: { code?: string } }> };
+      user?: { userId?: string; name?: string | null };
+    };
+
+    expect(body.user?.name).toBe(DEV_SEED.debugName);
+    expect(body.anchor?.homeworkWindowDays).toBe(7);
+    expect(body.anchor?.limit).toBe(3);
+    expect((body.counts?.todos?.incomplete ?? 0) > 0).toBe(true);
+    expect((body.counts?.pendingHomeworks ?? 0) > 0).toBe(true);
+    expect((body.counts?.todaySchedules ?? 0) > 0).toBe(true);
+    expect((body.counts?.upcomingExams ?? 0) > 0).toBe(true);
+    expect(
+      body.schedules?.items?.some(
+        (schedule) => schedule.section?.code === DEV_SEED.section.code,
+      ),
+    ).toBe(true);
+    expect(
+      body.todos?.items?.some(
+        (todo) => todo.title === DEV_SEED.todos.dueTodayTitle,
+      ),
+    ).toBe(true);
+    expect((body.homeworks?.items?.length ?? 0) > 0).toBe(true);
+    expect((body.exams?.items?.length ?? 0) > 0).toBe(true);
+  });
+
+  test("invalid atTime returns 400", async ({ page }) => {
+    await signInAsDebugUser(page, "/");
+
+    const response = await page.request.get(`${BASE}?atTime=not-a-date`);
+    expect(response.status()).toBe(400);
+  });
+});

--- a/tests/e2e/src/app/api/me/subscriptions/schedules/test.ts
+++ b/tests/e2e/src/app/api/me/subscriptions/schedules/test.ts
@@ -1,0 +1,61 @@
+/**
+ * E2E tests for GET /api/me/subscriptions/schedules
+ *
+ * Authenticated one-call schedule query across the current user's subscribed
+ * sections. This replaces client-side fan-out over /api/schedules.
+ */
+import { expect, test } from "@playwright/test";
+import { signInAsDebugUser } from "../../../../../../utils/auth";
+import { DEV_SEED } from "../../../../../../utils/dev-seed";
+import { assertApiContract } from "../../../../_shared/api-contract";
+
+const BASE = "/api/me/subscriptions/schedules";
+
+test.describe("GET /api/me/subscriptions/schedules", () => {
+  test("contract", async ({ request }) => {
+    await assertApiContract(request, { routePath: BASE });
+  });
+
+  test("returns 401 when not authenticated", async ({ request }) => {
+    const response = await request.get(BASE);
+    expect(response.status()).toBe(401);
+  });
+
+  test("returns subscribed schedules in one authenticated response", async ({
+    page,
+  }) => {
+    await signInAsDebugUser(page, "/");
+
+    const response = await page.request.get(
+      `${BASE}?dateFrom=${DEV_SEED.seedAnchorAtTime.slice(0, 10)}&dateTo=${DEV_SEED.seedAnchorAtTime.slice(0, 10)}&limit=5`,
+    );
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as {
+      schedules?: Array<{
+        date?: string | null;
+        section?: { code?: string; course?: { nameCn?: string } };
+        startTime?: string;
+        endTime?: string;
+      }>;
+    };
+
+    expect((body.schedules?.length ?? 0) > 0).toBe(true);
+    const seedSchedule = body.schedules?.find(
+      (schedule) => schedule.section?.code === DEV_SEED.section.code,
+    );
+    expect(seedSchedule).toBeDefined();
+    expect(
+      seedSchedule?.date?.startsWith(DEV_SEED.seedAnchorAtTime.slice(0, 10)),
+    ).toBe(true);
+    expect(seedSchedule?.section?.course?.nameCn).toBe(DEV_SEED.course.nameCn);
+    expect(seedSchedule?.startTime).toMatch(/^\d{2}:\d{2}$/);
+    expect(seedSchedule?.endTime).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  test("invalid date query returns 400", async ({ page }) => {
+    await signInAsDebugUser(page, "/");
+
+    const response = await page.request.get(`${BASE}?dateFrom=not-a-date`);
+    expect(response.status()).toBe(400);
+  });
+});

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -28,6 +28,7 @@ const SEED_PLUS_SIX_DAYS = seedDatePlusDays(6);
 const SEED_PLUS_SEVEN_DAYS = seedDatePlusDays(7);
 const SEED_PLUS_ELEVEN_DAYS = seedDatePlusDays(11);
 const SEED_PLUS_TWELVE_DAYS = seedDatePlusDays(12);
+const PAST_SAME_DAY_EXAM_JW_ID = 88_051_002;
 
 let devUserId: string;
 let mcp: McpHarness;
@@ -647,6 +648,66 @@ describe("atTime override — time-sensitive tools are anchored to SEED_DATE", (
     // The seed day has seeded schedules so today's count should be > 0
     expect((result.overview?.todaySchedulesCount ?? 0) > 0).toBe(true);
     expect(typeof result.overview?.upcomingExamsCount).toBe("number");
+  });
+
+  it("get_my_overview excludes same-day exams that already ended", async () => {
+    const atTime = `${SEED_DATE}T12:00:00+08:00`;
+    const before = await mcp.call<{
+      overview?: { upcomingExamsCount?: number };
+    }>("get_my_overview", {
+      locale: "zh-cn",
+      atTime,
+    });
+
+    const section = await prisma.section.findUniqueOrThrow({
+      where: { jwId: DEV_SEED.section.jwId },
+      select: { id: true },
+    });
+    await prisma.exam.upsert({
+      where: { jwId: PAST_SAME_DAY_EXAM_JW_ID },
+      update: {
+        examDate: new Date(`${SEED_DATE}T00:00:00.000Z`),
+        endTime: 1000,
+        examMode: "closed",
+        examTakeCount: 1,
+        examType: 1,
+        sectionId: section.id,
+        startTime: 900,
+      },
+      create: {
+        jwId: PAST_SAME_DAY_EXAM_JW_ID,
+        examDate: new Date(`${SEED_DATE}T00:00:00.000Z`),
+        endTime: 1000,
+        examMode: "closed",
+        examTakeCount: 1,
+        examType: 1,
+        sectionId: section.id,
+        startTime: 900,
+      },
+    });
+
+    try {
+      const result = await mcp.call<{
+        overview?: { upcomingExamsCount?: number };
+        samples?: { upcomingExams?: Array<{ jwId?: number }> };
+      }>("get_my_overview", {
+        locale: "zh-cn",
+        atTime,
+      });
+
+      expect(result.overview?.upcomingExamsCount).toBe(
+        before.overview?.upcomingExamsCount,
+      );
+      expect(
+        result.samples?.upcomingExams?.some(
+          (exam) => exam.jwId === PAST_SAME_DAY_EXAM_JW_ID,
+        ),
+      ).toBe(false);
+    } finally {
+      await prisma.exam.deleteMany({
+        where: { jwId: PAST_SAME_DAY_EXAM_JW_ID },
+      });
+    }
   });
 });
 

--- a/tests/unit/bus-service.test.ts
+++ b/tests/unit/bus-service.test.ts
@@ -1,5 +1,102 @@
 import { describe, expect, it } from "vitest";
+import { buildNextBusDeparturesFromData } from "@/features/bus/lib/bus-service";
 import { parseBusTimeMinutes } from "@/features/bus/lib/bus-time";
+import type {
+  BusCampusSummary,
+  BusTimetableData,
+  BusTripSummary,
+} from "@/features/bus/lib/bus-types";
+
+const east: BusCampusSummary = {
+  id: 1,
+  nameCn: "东区",
+  nameEn: "East",
+  namePrimary: "东区",
+  nameSecondary: "East",
+  latitude: 0,
+  longitude: 0,
+};
+
+const west: BusCampusSummary = {
+  id: 2,
+  nameCn: "西区",
+  nameEn: "West",
+  namePrimary: "西区",
+  nameSecondary: "West",
+  latitude: 0,
+  longitude: 0,
+};
+
+function createTrip(id: number, departureTime: string): BusTripSummary {
+  const departureMinutes = parseBusTimeMinutes(departureTime);
+  const arrivalMinutes =
+    departureMinutes == null ? null : departureMinutes + 20;
+  const arrivalTime =
+    arrivalMinutes == null
+      ? null
+      : `${String(Math.floor(arrivalMinutes / 60)).padStart(2, "0")}:${String(
+          arrivalMinutes % 60,
+        ).padStart(2, "0")}`;
+
+  return {
+    id,
+    routeId: 8,
+    dayType: "weekday",
+    position: id,
+    stopTimes: [
+      {
+        stopOrder: 1,
+        campusId: east.id,
+        campusName: east.namePrimary,
+        time: departureTime,
+        minutesSinceMidnight: departureMinutes,
+        isPassThrough: false,
+      },
+      {
+        stopOrder: 2,
+        campusId: west.id,
+        campusName: west.namePrimary,
+        time: arrivalTime,
+        minutesSinceMidnight: arrivalMinutes,
+        isPassThrough: false,
+      },
+    ],
+    departureTime,
+    departureMinutes,
+    arrivalTime,
+    arrivalMinutes,
+  };
+}
+
+function createNextDepartureData(): BusTimetableData {
+  return {
+    locale: "zh-cn",
+    fetchedAt: "2026-04-22T01:30:00.000Z",
+    version: null,
+    availableVersions: [],
+    campuses: [east, west],
+    routes: [
+      {
+        id: 8,
+        nameCn: "东区 -> 西区",
+        nameEn: null,
+        descriptionPrimary: "东区 -> 西区",
+        descriptionSecondary: null,
+        stops: [
+          { stopOrder: 1, campus: east },
+          { stopOrder: 2, campus: west },
+        ],
+      },
+    ],
+    trips: [
+      createTrip(1, "08:00"),
+      createTrip(2, "09:00"),
+      createTrip(3, "10:00"),
+    ],
+    preferences: null,
+    notice: null,
+  };
+}
 
 describe("bus service", () => {
   it("parses exact HH:mm timetable values", () => {
@@ -14,5 +111,21 @@ describe("bus service", () => {
     expect(parseBusTimeMinutes("08:5")).toBeNull();
     expect(parseBusTimeMinutes("24:00")).toBeNull();
     expect(parseBusTimeMinutes("08:60")).toBeNull();
+  });
+
+  it("keeps upcoming next departures ahead of departed rows", () => {
+    const result = buildNextBusDeparturesFromData(createNextDepartureData(), {
+      originCampusId: east.id,
+      destinationCampusId: west.id,
+      atTime: "2026-04-22T01:30:00.000Z",
+      dayType: "weekday",
+      includeDeparted: true,
+      limit: 1,
+    });
+
+    expect(result.departures).toHaveLength(1);
+    expect(result.departures[0]?.departureTime).toBe("10:00");
+    expect(result.departures[0]?.status).toBe("upcoming");
+    expect(result.departures[0]?.minutesUntilDeparture).toBe(30);
   });
 });


### PR DESCRIPTION
## Goal

Close the remaining lightweight-client API gaps by adding REST equivalents for subscribed schedules, compact overview, bus route search/next departures, and section-code subscription import.

Closes #35.
Closes #36.
Closes #38.
Closes #39.

## Changed Surfaces

- Added `GET /api/me/subscriptions/schedules` and `GET /api/me/overview`.
- Added `GET /api/bus/routes` and `GET /api/bus/next`.
- Added `POST /api/calendar-subscriptions/import-codes`.
- Reused existing feature read/write models for REST/MCP parity where applicable.
- Updated contract JSON, generated OpenAPI, response/query schemas, and E2E API coverage.

## Evidence

- Default gate: `bun run verify` passed.
- Production/OpenAPI generation: `bun run build` passed.
- Focused API loop: Docker dev DB, migrations, seed, E2E prepare, then focused Playwright API specs passed: 38 tests across bus, calendar subscriptions, authenticated overview, authenticated schedules, and OpenAPI.
- Bus review regression: `bunx vitest run tests/unit/bus-service.test.ts` passed; rebuilt and reran `tests/e2e/src/app/api/bus/test.ts`, 15 Playwright API tests passed.
- Overview review regression: `bun run vitest run --config vitest.integration.config.ts tests/integration/mcp-tools.test.ts` passed; rebuilt and reran `tests/e2e/src/app/api/me/overview/test.ts`, 5 Playwright API tests passed.
- Remote checks: current commit `bae5847` is green for CI, E2E matrix, CodeQL, E2E artifact workflow, and Cloudflare Workers build.

## Docs / Contracts

- Updated `docs/contracts/{bus,overview,schedule,subscription}.json`.
- Regenerated `public/openapi.generated.json` from route annotations.
- MCP tool behavior is unchanged except overview exam filtering now shares the REST upcoming-exam cutoff; contracts document the matching REST equivalents for shared read-model surfaces.

## Risk Areas

- Authenticated `/api/me/*` and subscription import routes require cookie/Bearer API auth.
- Public bus next-departure route accepts optional auth only for preference-aware service context.
- Subscription import appends matched sections instead of replacing the whole subscription set.
- Compact overview and MCP overview now exclude same-day exams once their end/start time has passed.

## Cleanup

No scratch reports, temporary probes, or unrelated rewrites are included. Local Docker dev services started for verification were stopped after focused E2E runs.