### PR TITLE
fix(ci): prepare app before verification conventions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "seed": "bun run tools/dev/seed/seed-dev-scenarios.ts",
     "test": "vitest run",
     "verify": "bun run verify:default",
-    "verify:default": "bun run verify:conventions && bun run verify:types && bun run test",
+    "verify:default": "bun run verify:types && bun run verify:conventions && bun run test",
     "verify:conventions": "bun run biome check && bun run openapi:check && bun run check:contracts && bun run check:i18n && bun run check:routes",
     "verify:types": "bun run app:prepare && bun run svelte-check --tsconfig ./tsconfig.json && bun run tsc --noEmit -p tsconfig.typecheck.json && bun run tsc --noEmit -p tsconfig.typecheck.tests.json && bun run tsc --noEmit -p tsconfig.typecheck.operational.json",
     "verify:full": "bun run verify:default && bun run verify:integration && bun run verify:e2e",


### PR DESCRIPTION
## Goal

Fix the unresolved review thread from #52 where `bun run verify` could fail from a clean checkout because `openapi:check` ran before SvelteKit generated `.svelte-kit/tsconfig.json` aliases.

Review thread: https://github.com/Life-USTC/server/pull/52#discussion_r3448096439

## Changed Surfaces

- `package.json` verification script ordering only.
- `verify:default` now runs `verify:types` first, which includes `app:prepare`, before `verify:conventions` runs `openapi:check`.

## Evidence

- Reproduced the failure by temporarily moving `.svelte-kit` outside the repo and running `bun run openapi:check`.
- `bun run verify` from the same clean `.svelte-kit` state passed after this change.
- `git diff --check`

## Docs / Contracts

No docs or contract changes needed; this only changes local/CI verification ordering.

## Risk Areas

Low. The same checks still run; only the default ordering changes so generated SvelteKit aliases exist before OpenAPI validation.

## Cleanup

No scratch artifacts, generated-file edits, or unrelated rewrites remain.
