### PR TITLE
refactor(ui): share page adapters through feature surfaces

### DIFF
--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -1776,6 +1776,7 @@
     "errorTitleRequired": "Please enter a title",
     "errorTitleTooLong": "Title is too long (max 200 characters)",
     "errorContentTooLong": "Description is too long (max 4000 characters)",
+    "errorInvalidPriority": "Invalid priority",
     "errorInvalidDueAt": "Invalid due date"
   },
   "welcome": {

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -1742,6 +1742,7 @@
     "errorTitleRequired": "请输入标题",
     "errorTitleTooLong": "标题过长（最多 200 字）",
     "errorContentTooLong": "内容过长（最多 4000 字）",
+    "errorInvalidPriority": "优先级无效",
     "errorInvalidDueAt": "截止时间无效"
   },
   "welcome": {

--- a/src/features/dashboard/lib/dashboard-limits.ts
+++ b/src/features/dashboard/lib/dashboard-limits.ts
@@ -6,7 +6,3 @@ export {
   TODO_CONTENT_MAX_LENGTH,
   TODO_TITLE_MAX_LENGTH,
 } from "@/features/todos/lib/todo-limits";
-
-import { TODO_PRIORITY_VALUES } from "@/features/todos/lib/todo-priority";
-
-export const TODO_PRIORITIES = new Set<string>(TODO_PRIORITY_VALUES);

--- a/src/features/dashboard/server/dashboard-homework-page-actions.ts
+++ b/src/features/dashboard/server/dashboard-homework-page-actions.ts
@@ -15,7 +15,7 @@ import { getViewerAuthDataForUserId } from "@/lib/auth/viewer-context";
 import { getDashboardActionCopy } from "./dashboard-action-copy";
 
 type DashboardActionEvent = {
-  locals: { locale: string };
+  locals: { locale: AppLocale };
   request: Request;
 };
 
@@ -23,7 +23,7 @@ export async function createHomeworkDashboardAction({
   locals,
   request,
 }: DashboardActionEvent) {
-  const copy = getDashboardActionCopy(locals.locale as AppLocale).homeworks;
+  const copy = getDashboardActionCopy(locals.locale).homeworks;
   const userId = await getDashboardUserId(request);
   if (!userId) return fail(401, { error: copy.errorUnauthorized });
   const viewerAuth = await getViewerAuthDataForUserId(userId);

--- a/src/features/dashboard/server/dashboard-page-load-public.ts
+++ b/src/features/dashboard/server/dashboard-page-load-public.ts
@@ -3,10 +3,11 @@ import type {
   DashboardPublicCounts,
 } from "@/features/dashboard/server/dashboard-page-load-types";
 import type { DashboardLinkSummary } from "@/features/home/server/dashboard-link-data";
+import type { AppLocale } from "@/i18n/config";
 
 export async function loadAnonymousDashboardPageData(input: {
   counts: DashboardPublicCounts;
-  locale: string;
+  locale: AppLocale;
   overviewLinks: DashboardLinkSummary[];
   pageCopy: DashboardPageCopy;
   publicLinks: DashboardLinkSummary[];

--- a/src/features/dashboard/server/dashboard-page-load-types.ts
+++ b/src/features/dashboard/server/dashboard-page-load-types.ts
@@ -1,4 +1,6 @@
 import type { DashboardLinkSummary } from "@/features/home/server/dashboard-link-data";
+import type { AppLocale } from "@/i18n/config";
+import type { AppSession } from "@/lib/auth/session";
 import type { getDashboardPageCopy } from "./dashboard-page-copy";
 
 export type DashboardPageCopy = ReturnType<typeof getDashboardPageCopy>;
@@ -11,8 +13,8 @@ export type DashboardPublicCounts = {
 
 export type DashboardPageLoadEvent = {
   locals: {
-    authUser?: App.Locals["authUser"];
-    locale: string;
+    authUser?: AppSession["user"] | null;
+    locale: AppLocale;
     requestId?: string;
   };
   request: Request;

--- a/src/features/dashboard/server/dashboard-page-load.ts
+++ b/src/features/dashboard/server/dashboard-page-load.ts
@@ -9,7 +9,6 @@ import {
   parsePositiveCalendarSemester,
   parseSnapshotReferenceTime,
 } from "@/features/dashboard/server/dashboard-page-server";
-import type { AppLocale } from "@/i18n/config";
 import { logAppEvent } from "@/lib/log/app-logger";
 
 function recordDashboardLoadFinish(input: {
@@ -38,7 +37,7 @@ export async function loadDashboardPage({
   url,
 }: DashboardPageLoadEvent) {
   const startMs = Date.now();
-  const locale = locals.locale as AppLocale;
+  const locale = locals.locale;
   const pageCopy = getDashboardPageCopy(locale);
   const userId = locals.authUser?.id ?? (await getDashboardUserId(request));
   const calendarSemesterId =

--- a/src/features/dashboard/server/dashboard-page-server.ts
+++ b/src/features/dashboard/server/dashboard-page-server.ts
@@ -10,7 +10,6 @@ export {
   HOMEWORK_DESCRIPTION_MAX_LENGTH,
   HOMEWORK_TITLE_MAX_LENGTH,
   TODO_CONTENT_MAX_LENGTH,
-  TODO_PRIORITIES,
   TODO_TITLE_MAX_LENGTH,
 } from "@/features/dashboard/lib/dashboard-limits";
 

--- a/src/features/dashboard/server/dashboard-todo-form.ts
+++ b/src/features/dashboard/server/dashboard-todo-form.ts
@@ -2,24 +2,17 @@ import { fail } from "@sveltejs/kit";
 import {
   parseOptionalLocalDateTime,
   TODO_CONTENT_MAX_LENGTH,
-  TODO_PRIORITIES,
   TODO_TITLE_MAX_LENGTH,
 } from "@/features/dashboard/server/dashboard-page-server";
+import { parseTodoPriorityInput } from "@/features/todos/lib/todo-priority";
 
 type TodoActionCopy = {
   errorContentTooLong: string;
   errorInvalidDueAt: string;
+  errorInvalidPriority: string;
   errorTitleRequired: string;
   errorTitleTooLong: string;
 };
-
-function todoPriorityFromForm(value: FormDataEntryValue | null) {
-  const priorityRaw = String(value ?? "medium");
-  return (TODO_PRIORITIES.has(priorityRaw) ? priorityRaw : "medium") as
-    | "low"
-    | "medium"
-    | "high";
-}
 
 export async function readTodoForm(request: Request, copy: TodoActionCopy) {
   const form = await request.formData();
@@ -36,13 +29,17 @@ export async function readTodoForm(request: Request, copy: TodoActionCopy) {
 
   const dueAt = parseOptionalLocalDateTime(form.get("dueAt"));
   if (!dueAt.ok) return { error: fail(400, { error: copy.errorInvalidDueAt }) };
+  const priority = parseTodoPriorityInput(form.get("priority"));
+  if (!priority.ok) {
+    return { error: fail(400, { error: copy.errorInvalidPriority }) };
+  }
 
   return {
     form,
     todo: {
       content: content || null,
       dueAt: dueAt.value,
-      priority: todoPriorityFromForm(form.get("priority")),
+      priority: priority.value,
       title,
     },
   };

--- a/src/features/dashboard/server/dashboard-todo-page-actions.ts
+++ b/src/features/dashboard/server/dashboard-todo-page-actions.ts
@@ -5,7 +5,6 @@ import {
   deleteOwnedTodo,
   updateOwnedTodo,
 } from "@/features/todos/server/todo-service";
-import type { AppLocale } from "@/i18n/config";
 import { getDashboardActionCopy } from "./dashboard-action-copy";
 import type { DashboardPageLoadEvent } from "./dashboard-page-load-types";
 import { readTodoForm } from "./dashboard-todo-form";
@@ -16,7 +15,7 @@ export async function createTodoDashboardAction({
   locals,
   request,
 }: DashboardActionEvent) {
-  const copy = getDashboardActionCopy(locals.locale as AppLocale).todos;
+  const copy = getDashboardActionCopy(locals.locale).todos;
   const userId = await getDashboardUserId(request);
   if (!userId) return fail(401, { error: copy.saveFailed });
 
@@ -31,7 +30,7 @@ export async function updateTodoDashboardAction({
   locals,
   request,
 }: DashboardActionEvent) {
-  const copy = getDashboardActionCopy(locals.locale as AppLocale).todos;
+  const copy = getDashboardActionCopy(locals.locale).todos;
   const userId = await getDashboardUserId(request);
   if (!userId) return fail(401, { error: copy.saveFailed });
 
@@ -58,7 +57,7 @@ export async function toggleTodoDashboardAction({
   locals,
   request,
 }: DashboardActionEvent) {
-  const copy = getDashboardActionCopy(locals.locale as AppLocale).todos;
+  const copy = getDashboardActionCopy(locals.locale).todos;
   const userId = await getDashboardUserId(request);
   if (!userId) return fail(401, { error: copy.saveFailed });
   const form = await request.formData();
@@ -81,7 +80,7 @@ export async function deleteTodoDashboardAction({
   locals,
   request,
 }: DashboardActionEvent) {
-  const copy = getDashboardActionCopy(locals.locale as AppLocale).todos;
+  const copy = getDashboardActionCopy(locals.locale).todos;
   const userId = await getDashboardUserId(request);
   if (!userId) return fail(401, { error: copy.saveFailed });
   const form = await request.formData();

--- a/src/features/settings/server/settings-page-actions.ts
+++ b/src/features/settings/server/settings-page-actions.ts
@@ -1,0 +1,48 @@
+import type { Cookies } from "@sveltejs/kit";
+import {
+  deleteSettingsAccountAction,
+  linkSettingsAccountAction,
+  unlinkSettingsAccountAction,
+} from "@/features/settings/server/settings-account-actions";
+import { updateSettingsProfileAction } from "@/features/settings/server/settings-profile-action";
+import type { AppLocale } from "@/i18n/config";
+
+type SettingsActionEvent = {
+  cookies: Cookies;
+  locals: {
+    locale: AppLocale;
+  };
+  request: Request;
+  url: URL;
+};
+
+export const settingsPageActions = {
+  updateProfile: async ({
+    cookies,
+    locals,
+    request,
+    url,
+  }: SettingsActionEvent) =>
+    updateSettingsProfileAction({
+      cookies,
+      locale: locals.locale,
+      request,
+      url,
+    }),
+  unlinkAccount: async ({ locals, request, url }: SettingsActionEvent) =>
+    unlinkSettingsAccountAction({ locale: locals.locale, request, url }),
+  linkAccount: async ({ cookies, locals, request, url }: SettingsActionEvent) =>
+    linkSettingsAccountAction({ cookies, locale: locals.locale, request, url }),
+  deleteAccount: async ({
+    cookies,
+    locals,
+    request,
+    url,
+  }: SettingsActionEvent) =>
+    deleteSettingsAccountAction({
+      cookies,
+      locale: locals.locale,
+      request,
+      url,
+    }),
+};

--- a/src/features/settings/server/settings-page-load.ts
+++ b/src/features/settings/server/settings-page-load.ts
@@ -1,0 +1,22 @@
+import { getSettingsPageData } from "@/features/settings/server/settings-page-data";
+import { getSettingsPageCopy } from "@/features/settings/server/settings-page-server";
+import type { AppLocale } from "@/i18n/config";
+
+export type SettingsPageLoadInput = {
+  locals: {
+    locale: AppLocale;
+  };
+  request: Request;
+  url: URL;
+};
+
+export async function loadSettingsPage({
+  locals,
+  request,
+  url,
+}: SettingsPageLoadInput) {
+  return {
+    ...(await getSettingsPageData(request, url)),
+    copy: getSettingsPageCopy(locals.locale),
+  };
+}

--- a/src/features/todos/lib/todo-priority.ts
+++ b/src/features/todos/lib/todo-priority.ts
@@ -9,3 +9,22 @@ export const TODO_PRIORITY_VALUES = [
 export type TodoPriorityValue = (typeof TODO_PRIORITY_VALUES)[number];
 
 export const DEFAULT_TODO_PRIORITY = "medium" satisfies TodoPriorityValue;
+
+export const TODO_PRIORITIES = new Set<TodoPriorityValue>(TODO_PRIORITY_VALUES);
+
+export function isTodoPriorityValue(value: string): value is TodoPriorityValue {
+  return TODO_PRIORITIES.has(value as TodoPriorityValue);
+}
+
+export function parseTodoPriorityInput(
+  value: unknown,
+): { ok: true; value: TodoPriorityValue } | { ok: false } {
+  if (value === null || value === undefined || value === "") {
+    return { ok: true, value: DEFAULT_TODO_PRIORITY };
+  }
+
+  const priority = String(value);
+  return isTodoPriorityValue(priority)
+    ? { ok: true, value: priority }
+    : { ok: false };
+}

--- a/src/lib/api/routes/todo-actions.ts
+++ b/src/lib/api/routes/todo-actions.ts
@@ -1,10 +1,11 @@
+import type { TodoPriorityValue } from "@/features/todos/lib/todo-priority";
 import {
   createTodo,
   deleteOwnedTodo,
   listTodoSummary,
   updateOwnedTodo,
 } from "@/features/todos/server/todo-service";
-import type { Prisma, TodoPriority } from "@/generated/prisma/client";
+import type { Prisma } from "@/generated/prisma/client";
 import {
   badRequest,
   forbidden,
@@ -23,7 +24,7 @@ export async function createTodoAction(
   userId: string,
   parsedBody: {
     content?: string | null;
-    priority?: string;
+    priority?: TodoPriorityValue;
     title: string;
   },
   dueAt: Date | null | undefined,
@@ -32,7 +33,7 @@ export async function createTodoAction(
     userId,
     title: parsedBody.title,
     content: parsedBody.content,
-    priority: parsedBody.priority as TodoPriority | undefined,
+    priority: parsedBody.priority,
     dueAt,
   });
 
@@ -45,7 +46,7 @@ export async function updateTodoAction(
   parsedBody: {
     completed?: boolean;
     content?: string | null;
-    priority?: string;
+    priority?: TodoPriorityValue;
     title?: string;
   },
   dueAt: Date | null | undefined,
@@ -60,7 +61,7 @@ export async function updateTodoAction(
       dueAt,
       hasContent: Object.hasOwn(parsedBody, "content"),
       hasDueAt,
-      priority: parsedBody.priority as TodoPriority | undefined,
+      priority: parsedBody.priority,
       title: parsedBody.title,
     },
   });

--- a/src/lib/api/routes/todo-query-builder.ts
+++ b/src/lib/api/routes/todo-query-builder.ts
@@ -1,4 +1,5 @@
-import type { Prisma, TodoPriority } from "@/generated/prisma/client";
+import type { TodoPriorityValue } from "@/features/todos/lib/todo-priority";
+import type { Prisma } from "@/generated/prisma/client";
 import { parseDateInput } from "@/lib/time/parse-date-input";
 
 export function buildTodoWhere(
@@ -7,14 +8,13 @@ export function buildTodoWhere(
     completed?: string;
     dueAfter?: string;
     dueBefore?: string;
-    priority?: string;
+    priority?: TodoPriorityValue;
   },
 ) {
   const where: Prisma.TodoWhereInput = { userId };
   if (parsedQuery.completed === "true") where.completed = true;
   else if (parsedQuery.completed === "false") where.completed = false;
-  if (parsedQuery.priority)
-    where.priority = parsedQuery.priority as TodoPriority;
+  if (parsedQuery.priority) where.priority = parsedQuery.priority;
   if (parsedQuery.dueBefore || parsedQuery.dueAfter) {
     const dueAtFilter: Prisma.TodoWhereInput["dueAt"] = {};
     if (parsedQuery.dueBefore) {

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -1,12 +1,8 @@
 import { redirect } from "@sveltejs/kit";
+import { dashboardPageActions } from "@/features/dashboard/server/dashboard-page-actions";
+import { loadDashboardPage } from "@/features/dashboard/server/dashboard-page-load";
 import { buildSignInPageUrl } from "@/lib/auth/auth-routing";
-import {
-  actions as dashboardActions,
-  load as loadDashboard,
-} from "../+page.server";
-import type { PageServerLoad } from "./$types";
-
-type DashboardLoadEvent = Parameters<typeof loadDashboard>[0];
+import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
   if (!event.locals.authUser?.id) {
@@ -16,7 +12,11 @@ export const load: PageServerLoad = async (event) => {
     );
   }
 
-  return loadDashboard(event as unknown as DashboardLoadEvent);
+  return loadDashboardPage({
+    locals: event.locals,
+    request: event.request,
+    url: event.url,
+  });
 };
 
-export const actions = dashboardActions;
+export const actions: Actions = dashboardPageActions;

--- a/src/routes/dashboard/[tab]/+page.server.ts
+++ b/src/routes/dashboard/[tab]/+page.server.ts
@@ -1,22 +1,29 @@
-import { error } from "@sveltejs/kit";
+import { error, redirect } from "@sveltejs/kit";
 import { isSignedDashboardTab } from "@/features/dashboard/lib/dashboard-nav";
-import {
-  actions as dashboardActions,
-  load as loadDashboard,
-} from "../+page.server";
-import type { PageServerLoad } from "./$types";
-
-type DashboardLoadEvent = Parameters<typeof loadDashboard>[0];
+import { dashboardPageActions } from "@/features/dashboard/server/dashboard-page-actions";
+import { loadDashboardPage } from "@/features/dashboard/server/dashboard-page-load";
+import { buildSignInPageUrl } from "@/lib/auth/auth-routing";
+import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
   if (!isSignedDashboardTab(event.params.tab)) {
     error(404, "Dashboard page not found");
   }
+  if (!event.locals.authUser?.id) {
+    throw redirect(
+      303,
+      buildSignInPageUrl(`${event.url.pathname}${event.url.search}`),
+    );
+  }
 
   const url = new URL(event.url);
   url.searchParams.set("tab", event.params.tab);
 
-  return loadDashboard({ ...event, url } as unknown as DashboardLoadEvent);
+  return loadDashboardPage({
+    locals: event.locals,
+    request: event.request,
+    url,
+  });
 };
 
-export const actions = dashboardActions;
+export const actions: Actions = dashboardPageActions;

--- a/src/routes/dashboard/subscriptions/+page.server.ts
+++ b/src/routes/dashboard/subscriptions/+page.server.ts
@@ -1,12 +1,8 @@
 import { redirect } from "@sveltejs/kit";
+import { dashboardPageActions } from "@/features/dashboard/server/dashboard-page-actions";
+import { loadDashboardPage } from "@/features/dashboard/server/dashboard-page-load";
 import { buildSignInPageUrl } from "@/lib/auth/auth-routing";
-import {
-  actions as dashboardActions,
-  load as loadDashboard,
-} from "../+page.server";
-import type { PageServerLoad } from "./$types";
-
-type DashboardLoadEvent = Parameters<typeof loadDashboard>[0];
+import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
   if (!event.locals.authUser?.id) {
@@ -19,7 +15,11 @@ export const load: PageServerLoad = async (event) => {
   const url = new URL(event.url);
   url.searchParams.set("tab", "subscriptions");
 
-  return loadDashboard({ ...event, url } as unknown as DashboardLoadEvent);
+  return loadDashboardPage({
+    locals: event.locals,
+    request: event.request,
+    url,
+  });
 };
 
-export const actions = dashboardActions;
+export const actions: Actions = dashboardPageActions;

--- a/src/routes/dashboard/subscriptions/sections/+page.server.ts
+++ b/src/routes/dashboard/subscriptions/sections/+page.server.ts
@@ -1,9 +1,9 @@
 import { redirect } from "@sveltejs/kit";
-import { actions as dashboardActions } from "../../../+page.server";
-import type { PageServerLoad } from "./$types";
+import { dashboardPageActions } from "@/features/dashboard/server/dashboard-page-actions";
+import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
   redirect(308, `/dashboard/subscriptions${event.url.search}`);
 };
 
-export const actions = dashboardActions;
+export const actions: Actions = dashboardPageActions;

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -1,37 +1,6 @@
-import { getSettingsPageData } from "@/features/settings/server/settings-page-data";
-import {
-  deleteSettingsAccountAction,
-  getSettingsPageCopy,
-  linkSettingsAccountAction,
-  unlinkSettingsAccountAction,
-  updateSettingsProfileAction,
-} from "@/features/settings/server/settings-page-server";
+import { settingsPageActions } from "@/features/settings/server/settings-page-actions";
+import { loadSettingsPage } from "@/features/settings/server/settings-page-load";
 import type { Actions, PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = async ({ locals, request, url }) => {
-  return {
-    ...(await getSettingsPageData(request, url)),
-    copy: getSettingsPageCopy(locals.locale),
-  };
-};
-
-export const actions: Actions = {
-  updateProfile: async ({ cookies, locals, request, url }) =>
-    updateSettingsProfileAction({
-      cookies,
-      locale: locals.locale,
-      request,
-      url,
-    }),
-  unlinkAccount: async ({ locals, request, url }) =>
-    unlinkSettingsAccountAction({ locale: locals.locale, request, url }),
-  linkAccount: async ({ cookies, locals, request, url }) =>
-    linkSettingsAccountAction({ cookies, locale: locals.locale, request, url }),
-  deleteAccount: async ({ cookies, locals, request, url }) =>
-    deleteSettingsAccountAction({
-      cookies,
-      locale: locals.locale,
-      request,
-      url,
-    }),
-};
+export const load: PageServerLoad = loadSettingsPage;
+export const actions: Actions = settingsPageActions;

--- a/src/routes/settings/[tab]/+page.server.ts
+++ b/src/routes/settings/[tab]/+page.server.ts
@@ -1,9 +1,8 @@
 import { error } from "@sveltejs/kit";
 import { isSettingsTab } from "@/features/settings/lib/settings-tabs";
-import { actions, load as loadSettings } from "../+page.server";
-import type { PageServerLoad } from "./$types";
-
-type SettingsLoadEvent = Parameters<typeof loadSettings>[0];
+import { settingsPageActions } from "@/features/settings/server/settings-page-actions";
+import { loadSettingsPage } from "@/features/settings/server/settings-page-load";
+import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
   if (!isSettingsTab(event.params.tab)) {
@@ -13,7 +12,11 @@ export const load: PageServerLoad = async (event) => {
   const url = new URL(event.url);
   url.searchParams.set("tab", event.params.tab);
 
-  return loadSettings({ ...event, url } as unknown as SettingsLoadEvent);
+  return loadSettingsPage({
+    locals: event.locals,
+    request: event.request,
+    url,
+  });
 };
 
-export { actions };
+export const actions: Actions = settingsPageActions;

--- a/tests/unit/dashboard-todo-form.test.ts
+++ b/tests/unit/dashboard-todo-form.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { readTodoForm } from "@/features/dashboard/server/dashboard-todo-form";
+
+const copy = {
+  errorContentTooLong: "content too long",
+  errorInvalidDueAt: "invalid due date",
+  errorInvalidPriority: "invalid priority",
+  errorTitleRequired: "title required",
+  errorTitleTooLong: "title too long",
+};
+
+function todoRequest(input: { priority?: string; title?: string }) {
+  const body = new FormData();
+  body.set("title", input.title ?? "Read Chapter 1");
+  if (input.priority !== undefined) {
+    body.set("priority", input.priority);
+  }
+
+  return new Request("https://life.example/dashboard/todos?/createTodo", {
+    body,
+    method: "POST",
+  });
+}
+
+describe("dashboard todo form", () => {
+  it("defaults missing priority to the todo feature default", async () => {
+    const parsed = await readTodoForm(todoRequest({}), copy);
+
+    expect("error" in parsed).toBe(false);
+    if ("error" in parsed) return;
+    expect(parsed.todo.priority).toBe("medium");
+  });
+
+  it("rejects invalid priority instead of silently coercing it", async () => {
+    const parsed = await readTodoForm(
+      todoRequest({ priority: "urgent" }),
+      copy,
+    );
+
+    expect("error" in parsed).toBe(true);
+    if (!("error" in parsed)) return;
+    const { error } = parsed;
+    if (!error) throw new Error("Expected invalid priority failure");
+    expect(error.status).toBe(400);
+    expect(error.data).toEqual({ error: "invalid priority" });
+  });
+});


### PR DESCRIPTION
## Goal

Clean up the next set of structural seams found during the repo design review: route adapters calling other route modules, dashboard/settings loader casts, and duplicated todo priority parsing.

## Changed Surfaces

- Dashboard and settings page routes now call feature-owned loader/action surfaces instead of importing sibling/parent `+page.server` modules.
- Settings page load/actions moved into `src/features/settings/server`.
- Dashboard server loader/action locale inputs use explicit app locale types instead of `as AppLocale` casts.
- Todo priority parsing is owned by `src/features/todos`, and dashboard forged form submissions now reject invalid priority like REST/MCP validation.
- Added localized invalid-priority messages and focused unit coverage for dashboard todo form parsing.

## Evidence

- Structural review subagents inspected API/feature boundaries, dashboard/todo parity, and loader cast seams.
- A follow-up subagent reviewed the final diff and reported no blocking issues.
- `bun run test -- tests/unit/dashboard-todo-form.test.ts tests/unit/dashboard-homework-page-actions.test.ts tests/unit/api-schemas.test.ts`
- `bun run verify`
- `git diff --check`

## Docs / Contracts

No contract update needed. REST/MCP priority validation already rejected invalid values; this aligns the dashboard form path with that existing behavior. Message files were updated for the new dashboard form error.

## Risk Areas

Low to medium. `/dashboard`, `/dashboard/[tab]`, `/dashboard/subscriptions`, and `/settings/[tab]` routing/auth behavior is preserved while replacing route-module reuse. The only behavior change is forged dashboard todo forms with invalid priority now fail instead of silently becoming medium priority.

## Cleanup

No scratch artifacts, generated-file edits, or unrelated rewrites remain.
