### PR TITLE
refactor(api): admin users and OAuth OpenAPI schemas

### DIFF
--- a/docs/contracts/oauth.json
+++ b/docs/contracts/oauth.json
@@ -150,7 +150,7 @@
           {
             "path": "/api/auth/oauth2/token",
             "method": "POST",
-            "returns": "{ access_token, token_type, expires_in, refresh_token?, scope? } | { error }",
+            "returns": "{ access_token, token_type, expires_in, expires_at?, refresh_token?, scope?, id_token? } | { error }",
             "notes": [
               "The device polls this endpoint with grant_type=urn:ietf:params:oauth:grant-type:device_code and device_code to obtain an access token.",
               "During polling, returns authorization_pending, slow_down, expired_token, access_denied, invalid_scope, or invalid_grant error codes based on state."

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -945,7 +945,14 @@
         },
         "responses": {
           "200": {
-            "description": "Response 200"
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/oauthDeviceAuthorizationResponseSchema"
+                }
+              }
+            }
           },
           "400": {
             "description": "Error response",
@@ -998,7 +1005,14 @@
         },
         "responses": {
           "200": {
-            "description": "Response 200"
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/oauthTokenResponseSchema"
+                }
+              }
+            }
           },
           "400": {
             "description": "Error response",
@@ -7979,6 +7993,83 @@
         },
         "required": [
           "user"
+        ],
+        "additionalProperties": false
+      },
+      "oauthDeviceAuthorizationResponseSchema": {
+        "type": "object",
+        "properties": {
+          "device_code": {
+            "type": "string"
+          },
+          "user_code": {
+            "type": "string"
+          },
+          "verification_uri": {
+            "type": "string",
+            "format": "uri"
+          },
+          "verification_uri_complete": {
+            "type": "string",
+            "format": "uri"
+          },
+          "expires_in": {
+            "type": "integer",
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991
+          },
+          "interval": {
+            "type": "integer",
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": [
+          "device_code",
+          "user_code",
+          "verification_uri",
+          "verification_uri_complete",
+          "expires_in",
+          "interval"
+        ],
+        "additionalProperties": false
+      },
+      "oauthTokenResponseSchema": {
+        "type": "object",
+        "properties": {
+          "access_token": {
+            "type": "string"
+          },
+          "token_type": {
+            "type": "string",
+            "enum": [
+              "Bearer"
+            ]
+          },
+          "expires_in": {
+            "type": "integer",
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991
+          },
+          "expires_at": {
+            "type": "integer",
+            "exclusiveMinimum": true,
+            "maximum": 9007199254740991
+          },
+          "refresh_token": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "id_token": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "access_token",
+          "token_type",
+          "expires_in"
         ],
         "additionalProperties": false
       },

--- a/src/features/admin/server/admin-api-service.ts
+++ b/src/features/admin/server/admin-api-service.ts
@@ -1,19 +1,8 @@
+import { getAdminUserListItem } from "@/features/admin/server/admin-user-read-model";
 import type { CommentStatus } from "@/generated/prisma/client";
 import { fireAuditLog } from "@/lib/audit/write-audit-log";
 import { prisma } from "@/lib/db/prisma";
-import { ilike } from "@/lib/query-filter-helpers";
 import { parseDateInput } from "@/lib/time/parse-date-input";
-
-type AdminUsersParsedQuery = {
-  pagination: {
-    page: number;
-    pageSize: number;
-    skip: number;
-  };
-  query: {
-    search?: string | null;
-  };
-};
 
 type AdminUpdateUserBody = {
   isAdmin?: boolean;
@@ -44,43 +33,6 @@ function normalizeAdminUsername(value: unknown) {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed ? trimmed : null;
-}
-
-function buildAdminUsersWhere(search: string) {
-  return search
-    ? {
-        OR: [
-          { id: ilike(search) },
-          { name: ilike(search) },
-          { username: ilike(search) },
-          {
-            verifiedEmails: {
-              some: {
-                email: ilike(search),
-              },
-            },
-          },
-        ],
-      }
-    : {};
-}
-
-function adminUserListItem(user: {
-  createdAt: Date;
-  id: string;
-  isAdmin: boolean;
-  name: string | null;
-  username: string | null;
-  verifiedEmails?: Array<{ email: string }>;
-}) {
-  return {
-    id: user.id,
-    name: user.name,
-    username: user.username,
-    isAdmin: user.isAdmin,
-    email: user.verifiedEmails?.[0]?.email ?? null,
-    createdAt: user.createdAt,
-  };
 }
 
 async function buildAdminUserUpdateData(
@@ -127,40 +79,6 @@ function parseSuspensionDate(value: string | null | undefined) {
   return { expiresAt: parsed, ok: true as const };
 }
 
-export async function listAdminUsers({
-  pagination,
-  query,
-}: AdminUsersParsedQuery) {
-  const search = query.search ?? "";
-  const where = buildAdminUsersWhere(search);
-
-  const [users, total] = await Promise.all([
-    prisma.user.findMany({
-      where,
-      select: {
-        id: true,
-        name: true,
-        username: true,
-        isAdmin: true,
-        createdAt: true,
-        verifiedEmails: {
-          select: { email: true },
-          take: 1,
-        },
-      },
-      orderBy: { createdAt: "desc" },
-      skip: pagination.skip,
-      take: pagination.pageSize,
-    }),
-    prisma.user.count({ where }),
-  ]);
-
-  return {
-    total,
-    users: users.map(adminUserListItem),
-  };
-}
-
 export async function updateAdminUser(
   id: string,
   parsedBody: AdminUpdateUserBody,
@@ -179,27 +97,15 @@ export async function updateAdminUser(
   const updated = await prisma.user.update({
     where: { id },
     data: parsed.data,
-    select: {
-      id: true,
-      name: true,
-      username: true,
-      isAdmin: true,
-      createdAt: true,
-    },
+    select: { id: true },
   });
 
-  const email = await prisma.verifiedEmail.findFirst({
-    where: { userId: id },
-    orderBy: { createdAt: "desc" },
-    select: { email: true },
-  });
+  const user = await getAdminUserListItem(updated.id);
+  if (!user) return { ok: false as const, reason: "not_found" as const };
 
   return {
     ok: true as const,
-    user: adminUserListItem({
-      ...updated,
-      verifiedEmails: email ? [email] : [],
-    }),
+    user,
   };
 }
 

--- a/src/features/admin/server/admin-user-read-model.ts
+++ b/src/features/admin/server/admin-user-read-model.ts
@@ -1,0 +1,157 @@
+import type { Prisma, PrismaClient } from "@/generated/prisma/client";
+import { prisma as defaultPrisma } from "@/lib/db/prisma";
+import { ilike } from "@/lib/query-filter-helpers";
+
+type AdminUsersParsedQuery = {
+  pagination: {
+    pageSize: number;
+    skip: number;
+  };
+  query?: {
+    search?: string | null;
+  };
+};
+
+type AdminUserReadPrisma = Pick<PrismaClient, "user">;
+
+type AdminUserListRow = {
+  createdAt: Date;
+  id: string;
+  isAdmin: boolean;
+  name: string | null;
+  username: string | null;
+  verifiedEmails: Array<{ email: string }>;
+  suspensions?: Array<{
+    expiresAt: Date | null;
+    id: string;
+    reason: string | null;
+  }>;
+};
+
+export type AdminUserListItem = {
+  createdAt: Date;
+  email: string | null;
+  id: string;
+  isAdmin: boolean;
+  name: string | null;
+  username: string | null;
+  activeSuspension?: {
+    expiresAt: Date | null;
+    id: string;
+    reason: string | null;
+  } | null;
+};
+
+const adminUserListSelect = {
+  id: true,
+  name: true,
+  username: true,
+  isAdmin: true,
+  createdAt: true,
+  verifiedEmails: {
+    select: { email: true },
+    orderBy: { createdAt: "desc" },
+    take: 1,
+  },
+} satisfies Prisma.UserSelect;
+
+function normalizeAdminUsersSearch(search: string | null | undefined) {
+  return search?.trim() ?? "";
+}
+
+export function buildAdminUsersWhere(
+  search: string | null | undefined,
+): Prisma.UserWhereInput {
+  const normalized = normalizeAdminUsersSearch(search);
+  return normalized
+    ? {
+        OR: [
+          { id: ilike(normalized) },
+          { name: ilike(normalized) },
+          { username: ilike(normalized) },
+          { verifiedEmails: { some: { email: ilike(normalized) } } },
+        ],
+      }
+    : {};
+}
+
+export function toAdminUserListItem(user: AdminUserListRow): AdminUserListItem {
+  const activeSuspension = user.suspensions?.[0];
+
+  return {
+    id: user.id,
+    name: user.name,
+    username: user.username,
+    isAdmin: user.isAdmin,
+    email: user.verifiedEmails[0]?.email ?? null,
+    createdAt: user.createdAt,
+    ...(user.suspensions === undefined
+      ? {}
+      : {
+          activeSuspension: activeSuspension
+            ? {
+                id: activeSuspension.id,
+                reason: activeSuspension.reason,
+                expiresAt: activeSuspension.expiresAt,
+              }
+            : null,
+        }),
+  };
+}
+
+function buildAdminUserListSelect(includeActiveSuspension: boolean) {
+  if (!includeActiveSuspension) return adminUserListSelect;
+
+  return {
+    ...adminUserListSelect,
+    suspensions: {
+      where: {
+        liftedAt: null,
+        OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+      },
+      select: { id: true, reason: true, expiresAt: true },
+      orderBy: { createdAt: "desc" },
+      take: 1,
+    },
+  } satisfies Prisma.UserSelect;
+}
+
+export async function listAdminUsers({
+  pagination,
+  query,
+  includeActiveSuspension = false,
+  prismaClient = defaultPrisma,
+}: AdminUsersParsedQuery & {
+  includeActiveSuspension?: boolean;
+  prismaClient?: AdminUserReadPrisma;
+}) {
+  const where = buildAdminUsersWhere(query?.search);
+
+  const [users, total] = await Promise.all([
+    prismaClient.user.findMany({
+      where,
+      select: buildAdminUserListSelect(includeActiveSuspension),
+      orderBy: { createdAt: "desc" },
+      skip: pagination.skip,
+      take: pagination.pageSize,
+    }) as Promise<AdminUserListRow[]>,
+    prismaClient.user.count({ where }),
+  ]);
+
+  return {
+    total,
+    users: users.map(toAdminUserListItem),
+  };
+}
+
+export async function getAdminUserListItem(
+  id: string,
+  prismaClient: AdminUserReadPrisma = defaultPrisma,
+) {
+  const user = (await prismaClient.user.findUnique({
+    where: { id },
+    select: adminUserListSelect,
+  })) as AdminUserListRow | null;
+
+  return user ? toAdminUserListItem(user) : null;
+}

--- a/src/features/admin/server/admin-users-page-data.ts
+++ b/src/features/admin/server/admin-users-page-data.ts
@@ -3,9 +3,8 @@ import {
   getPrismaClient,
   requireAdminPage,
 } from "@/features/admin/server/admin-page-auth";
-import type { Prisma } from "@/generated/prisma/client";
+import { listAdminUsers } from "@/features/admin/server/admin-user-read-model";
 import { parsePositivePage, toLoadData } from "@/lib/load-data-utils";
-import { ilike } from "@/lib/query-filter-helpers";
 import { toShanghaiIsoString } from "@/lib/time/serialize-date-output";
 
 export async function getAdminUsersPage(request: Request, url: URL) {
@@ -13,43 +12,14 @@ export async function getAdminUsersPage(request: Request, url: URL) {
   const prisma = await getPrismaClient();
   const page = parsePositivePage(url.searchParams.get("page"));
   const search = url.searchParams.get("search")?.trim() ?? "";
-  const where: Prisma.UserWhereInput = search
-    ? {
-        OR: [
-          { id: ilike(search) },
-          { name: ilike(search) },
-          { username: ilike(search) },
-          { verifiedEmails: { some: { email: ilike(search) } } },
-        ],
-      }
-    : {};
   const skip = (page - 1) * ADMIN_USERS_PAGE_SIZE;
 
-  const [users, total] = await Promise.all([
-    prisma.user.findMany({
-      where,
-      select: {
-        id: true,
-        name: true,
-        username: true,
-        isAdmin: true,
-        createdAt: true,
-        verifiedEmails: { select: { email: true }, take: 1 },
-        suspensions: {
-          where: {
-            liftedAt: null,
-            OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
-          },
-          select: { id: true, reason: true, expiresAt: true },
-          take: 1,
-        },
-      },
-      orderBy: { createdAt: "desc" },
-      skip,
-      take: ADMIN_USERS_PAGE_SIZE,
-    }),
-    prisma.user.count({ where }),
-  ]);
+  const { total, users } = await listAdminUsers({
+    pagination: { pageSize: ADMIN_USERS_PAGE_SIZE, skip },
+    query: { search },
+    includeActiveSuspension: true,
+    prismaClient: prisma,
+  });
 
   const totalPages = Math.max(1, Math.ceil(total / ADMIN_USERS_PAGE_SIZE));
 
@@ -58,14 +28,14 @@ export async function getAdminUsersPage(request: Request, url: URL) {
       id: user.id,
       name: user.name,
       username: user.username,
-      email: user.verifiedEmails[0]?.email ?? null,
+      email: user.email,
       isAdmin: user.isAdmin,
       createdAt: toShanghaiIsoString(user.createdAt),
-      activeSuspension: user.suspensions[0]
+      activeSuspension: user.activeSuspension
         ? {
-            ...user.suspensions[0],
-            expiresAt: user.suspensions[0].expiresAt
-              ? toShanghaiIsoString(user.suspensions[0].expiresAt)
+            ...user.activeSuspension,
+            expiresAt: user.activeSuspension.expiresAt
+              ? toShanghaiIsoString(user.activeSuspension.expiresAt)
               : null,
           }
         : null,

--- a/src/lib/api/routes/admin-users.ts
+++ b/src/lib/api/routes/admin-users.ts
@@ -1,8 +1,6 @@
-import {
-  listAdminUsers,
-  updateAdminUser,
-} from "@/features/admin/server/admin-api-service";
+import { updateAdminUser } from "@/features/admin/server/admin-api-service";
 import { ADMIN_USERS_PAGE_SIZE } from "@/features/admin/server/admin-constants";
+import { listAdminUsers } from "@/features/admin/server/admin-user-read-model";
 import {
   badRequest,
   buildPaginatedResponse,

--- a/src/lib/api/schemas/oauth-response-schemas.ts
+++ b/src/lib/api/schemas/oauth-response-schemas.ts
@@ -1,0 +1,20 @@
+import * as z from "zod";
+
+export const oauthDeviceAuthorizationResponseSchema = z.object({
+  device_code: z.string(),
+  user_code: z.string(),
+  verification_uri: z.string().url(),
+  verification_uri_complete: z.string().url(),
+  expires_in: z.number().int().positive(),
+  interval: z.number().int().positive(),
+});
+
+export const oauthTokenResponseSchema = z.object({
+  access_token: z.string(),
+  token_type: z.literal("Bearer"),
+  expires_in: z.number().int().positive(),
+  expires_at: z.number().int().positive().optional(),
+  refresh_token: z.string().optional(),
+  scope: z.string().optional(),
+  id_token: z.string().optional(),
+});

--- a/src/lib/api/schemas/response-schemas.ts
+++ b/src/lib/api/schemas/response-schemas.ts
@@ -5,6 +5,7 @@ export * from "./comments-response-schemas";
 export * from "./descriptions-response-schemas";
 export * from "./homeworks-response-schemas";
 export * from "./misc-response-schema-core";
+export * from "./oauth-response-schemas";
 export * from "./overview-response-schemas";
 export * from "./response-schema-primitives";
 export * from "./schedule-response-schema-core";

--- a/src/routes/api/auth/oauth2/device-authorization/+server.ts
+++ b/src/routes/api/auth/oauth2/device-authorization/+server.ts
@@ -9,7 +9,7 @@ export const OPTIONS = svelteRequestHandler(deviceAuthorizationOptionsRoute);
 /**
  * Start OAuth 2.0 device authorization.
  * @body oauthDeviceAuthorizationRequestSchema
- * @response 200
+ * @response 200:oauthDeviceAuthorizationResponseSchema
  * @response 400:openApiErrorSchema
  */
 export const POST = svelteRequestHandler(deviceAuthorizationPostRoute);

--- a/src/routes/api/auth/oauth2/token/+server.ts
+++ b/src/routes/api/auth/oauth2/token/+server.ts
@@ -4,7 +4,7 @@ import { svelteRequestHandler } from "@/lib/api/svelte-route";
 /**
  * Exchange OAuth 2.0 authorization/device/refresh grants for tokens.
  * @body oauthTokenRequestSchema
- * @response 200
+ * @response 200:oauthTokenResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
  */

--- a/tests/unit/admin-user-read-model.test.ts
+++ b/tests/unit/admin-user-read-model.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAdminUsersWhere,
+  toAdminUserListItem,
+} from "@/features/admin/server/admin-user-read-model";
+
+describe("admin user read model", () => {
+  it("builds one shared search filter for id, name, username, and email", () => {
+    expect(buildAdminUsersWhere("  alice  ")).toEqual({
+      OR: [
+        { id: { contains: "alice", mode: "insensitive" } },
+        { name: { contains: "alice", mode: "insensitive" } },
+        { username: { contains: "alice", mode: "insensitive" } },
+        {
+          verifiedEmails: {
+            some: { email: { contains: "alice", mode: "insensitive" } },
+          },
+        },
+      ],
+    });
+  });
+
+  it("keeps suspension data out of API rows unless selected", () => {
+    const baseUser = {
+      id: "user-1",
+      name: "Alice",
+      username: "alice",
+      isAdmin: false,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      verifiedEmails: [{ email: "alice@example.com" }],
+    };
+
+    expect(toAdminUserListItem(baseUser)).toEqual({
+      id: "user-1",
+      name: "Alice",
+      username: "alice",
+      isAdmin: false,
+      email: "alice@example.com",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
+    expect(
+      toAdminUserListItem({
+        ...baseUser,
+        suspensions: [
+          {
+            id: "suspension-1",
+            reason: "policy",
+            expiresAt: new Date("2026-02-01T00:00:00.000Z"),
+          },
+        ],
+      }),
+    ).toEqual({
+      id: "user-1",
+      name: "Alice",
+      username: "alice",
+      isAdmin: false,
+      email: "alice@example.com",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      activeSuspension: {
+        id: "suspension-1",
+        reason: "policy",
+        expiresAt: new Date("2026-02-01T00:00:00.000Z"),
+      },
+    });
+  });
+});

--- a/tests/unit/openapi-scenario-examples.test.ts
+++ b/tests/unit/openapi-scenario-examples.test.ts
@@ -28,15 +28,45 @@ const OPENAPI_HTTP_METHODS = [
 
 type GeneratedOperation = {
   description?: string;
+  responses?: Record<
+    string,
+    {
+      content?: Record<
+        string,
+        {
+          schema?: GeneratedSchema;
+        }
+      >;
+    }
+  >;
   summary?: string;
 };
 
+type GeneratedSchema = {
+  $ref?: string;
+  properties?: Record<string, unknown>;
+  required?: string[];
+};
+
 type GeneratedOpenApiDocument = {
+  components?: {
+    schemas?: Record<string, GeneratedSchema>;
+  };
   paths: Record<
     string,
     Partial<Record<(typeof OPENAPI_HTTP_METHODS)[number], GeneratedOperation>>
   >;
 };
+
+function resolveGeneratedSchema(
+  spec: GeneratedOpenApiDocument,
+  schema: GeneratedSchema | undefined,
+) {
+  const ref = schema?.$ref;
+  if (!ref) return schema;
+  const schemaName = ref.match(/^#\/components\/schemas\/(.+)$/)?.[1];
+  return schemaName ? spec.components?.schemas?.[schemaName] : undefined;
+}
 
 describe("buildScenarioOpenApiExamples", () => {
   it("uses scenario fixture values for catalog response examples", () => {
@@ -150,6 +180,57 @@ describe("buildScenarioOpenApiExamples", () => {
     );
     expect(spec.paths["/api/mcp"]?.options?.summary).toBe(
       "Return MCP transport CORS preflight headers",
+    );
+  });
+
+  it("documents OAuth success response bodies", () => {
+    const spec = generatedOpenApiDocument as GeneratedOpenApiDocument;
+    const deviceSchema = resolveGeneratedSchema(
+      spec,
+      spec.paths["/api/auth/oauth2/device-authorization"]?.post?.responses?.[
+        "200"
+      ]?.content?.["application/json"]?.schema,
+    );
+    const tokenSchema = resolveGeneratedSchema(
+      spec,
+      spec.paths["/api/auth/oauth2/token"]?.post?.responses?.["200"]?.content?.[
+        "application/json"
+      ]?.schema,
+    );
+
+    expect(deviceSchema?.required).toEqual(
+      expect.arrayContaining([
+        "device_code",
+        "user_code",
+        "verification_uri",
+        "verification_uri_complete",
+        "expires_in",
+        "interval",
+      ]),
+    );
+    expect(Object.keys(deviceSchema?.properties ?? {})).toEqual(
+      expect.arrayContaining([
+        "device_code",
+        "user_code",
+        "verification_uri",
+        "verification_uri_complete",
+        "expires_in",
+        "interval",
+      ]),
+    );
+    expect(tokenSchema?.required).toEqual(
+      expect.arrayContaining(["access_token", "token_type", "expires_in"]),
+    );
+    expect(Object.keys(tokenSchema?.properties ?? {}).sort()).toEqual(
+      [
+        "access_token",
+        "expires_in",
+        "expires_at",
+        "id_token",
+        "refresh_token",
+        "scope",
+        "token_type",
+      ].sort(),
     );
   });
 });


### PR DESCRIPTION
## Goal

Remove two concrete surface drifts found in the post-merge review loop:

- Keep admin user listing/search/query behavior in one shared read model for the admin page and REST API.
- Document OAuth device authorization and token success response bodies in generated OpenAPI, matching the runtime token shapes.

## Changed Surfaces

- Added `src/features/admin/server/admin-user-read-model.ts` and wired `/admin/users`, `GET /api/admin/users`, and admin user update responses through the shared list item/search behavior.
- Added OAuth success response schemas and route annotations for `/api/auth/oauth2/device-authorization` and `/api/auth/oauth2/token`.
- Updated `docs/contracts/oauth.json` and regenerated `public/openapi.generated.json`.
- Added unit coverage for the shared admin-user search/list projection and generated OAuth response schemas.

## Evidence

- `bun run vitest run tests/unit/admin-user-read-model.test.ts tests/unit/openapi-scenario-examples.test.ts`
- `bun run openapi:check`
- `bun run check:contracts`
- `bun run verify`
- `PLAYWRIGHT_PORT=3010 bun run verify:full` passed 488 E2E tests after default and integration gates. Port 3000 was occupied by a non-project Docker container (`napcat`), so the documented alternate Playwright port was used.
- Subagent review: admin read-model pass had no findings; final combined review had no actionable findings and confirmed the prior OAuth token-shape issue was resolved.

## Docs / Contracts

- Updated `docs/contracts/oauth.json` for token success fields: `expires_at?` and `id_token?` are documented alongside existing token fields.
- Regenerated OpenAPI now exposes JSON schemas for OAuth device authorization and token 200 responses.

## Risk Areas

- OAuth/OpenAPI: token schema intentionally includes optional Better Auth fields for authorization-code/refresh flows while keeping required bearer token fields.
- Admin user listing: page-only active suspension data remains page-only; REST response shape stays unchanged.
- No Prisma schema or migration changes.

## Cleanup

- `git diff --check` passed.
- Docker dev Postgres started for `verify:full` was stopped with `docker compose -f docker-compose.dev.yml down`.
- No scratch artifacts or unrelated files are included.
