### PR TITLE
fix(oauth): OAuth error headers

### DIFF
--- a/src/lib/api/routes/auth-token.ts
+++ b/src/lib/api/routes/auth-token.ts
@@ -59,12 +59,16 @@ async function normalizeOAuthTokenErrorResponse(response: Response) {
 
   const body = await parseJsonBody(response);
   const error_description = getOAuthErrorDescription(body);
+  const headers = new Headers(response.headers);
+  headers.delete("Content-Length");
+  headers.set("Content-Type", "application/json; charset=utf-8");
+
   return jsonResponse(
     {
       error: getOAuthErrorCode(response.status, body),
       ...(error_description ? { error_description } : {}),
     },
-    { status: response.status },
+    { status: response.status, statusText: response.statusText, headers },
   );
 }
 

--- a/tests/unit/oauth-token-route.test.ts
+++ b/tests/unit/oauth-token-route.test.ts
@@ -55,4 +55,44 @@ describe("OAuth token route", () => {
       error_description: "[body.grant_type] Invalid option",
     });
   });
+
+  it("preserves delegated OAuth error headers", async () => {
+    betterAuthHandlerMock.mockResolvedValueOnce(
+      Response.json(
+        {
+          message: "Invalid client credentials",
+        },
+        {
+          status: 401,
+          headers: {
+            "Cache-Control": "no-store",
+            "Content-Length": "999",
+            "WWW-Authenticate": 'Basic realm="OAuth token"',
+          },
+        },
+      ),
+    );
+
+    const response = await tokenPostRoute(
+      new Request("http://localhost/api/auth/oauth2/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: "grant_type=client_credentials",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(response.headers.get("www-authenticate")).toBe(
+      'Basic realm="OAuth token"',
+    );
+    expect(await response.json()).toEqual({
+      error: "invalid_client",
+      error_description: "Invalid client credentials",
+    });
+  });
 });


### PR DESCRIPTION
## Goal

Address the unresolved Codex review thread from PR #61: delegated OAuth token error normalization should keep original response headers such as `WWW-Authenticate` while still returning the documented OAuth JSON error body.

## Changed Surfaces

- `src/lib/api/routes/auth-token.ts`: normalized delegated non-OK token responses now copy headers, drop stale `Content-Length`, set JSON content type, and preserve status text.
- `tests/unit/oauth-token-route.test.ts`: adds coverage for a delegated 401 response preserving `WWW-Authenticate` and cache headers.

## Evidence

- `bun run test -- tests/unit/oauth-token-route.test.ts tests/unit/api-schemas.test.ts tests/unit/openapi-scenario-examples.test.ts` passed.
- `bun run verify` passed.

## Docs / Contracts

No docs or contract changes needed. This preserves headers for the OAuth error shape already documented and merged in PR #61.

## Risk Areas

OAuth token error responses. The focused unit test covers the client-auth 401 header path flagged by review.

## Cleanup

- `git diff --check` passed before commit.
- No scratch artifacts or unrelated files included.
