### PR TITLE
refactor(dashboard): dashboard form validation

### DIFF
--- a/src/features/dashboard/lib/dashboard-controller-helpers.ts
+++ b/src/features/dashboard/lib/dashboard-controller-helpers.ts
@@ -2,7 +2,7 @@ export {
   buildCalendarWeekdayLabels,
   buildSignedTabs,
 } from "./dashboard-controller-labels";
-export { todoPriorityOrder } from "./dashboard-controller-limits";
+export const todoPriorityOrder = ["medium", "high", "low"] as const;
 export {
   isAnonymousDashboardData,
   isSignedDashboardData,

--- a/src/features/dashboard/lib/dashboard-controller-homework-form-actions.ts
+++ b/src/features/dashboard/lib/dashboard-controller-homework-form-actions.ts
@@ -1,9 +1,5 @@
 import type { SubmitFunction } from "@sveltejs/kit";
 import {
-  HOMEWORK_DESCRIPTION_MAX_LENGTH,
-  HOMEWORK_TITLE_MAX_LENGTH,
-} from "./dashboard-limits";
-import {
   actionResultError,
   validateCreateHomeworkForm as validateCreateHomeworkFormData,
 } from "./forms";
@@ -15,10 +11,7 @@ export function validateDashboardCreateHomeworkForm(
   formData: FormData,
   homeworksCopy: HomeworksCopy,
 ) {
-  return validateCreateHomeworkFormData(formData, homeworksCopy, {
-    titleMaxLength: HOMEWORK_TITLE_MAX_LENGTH,
-    descriptionMaxLength: HOMEWORK_DESCRIPTION_MAX_LENGTH,
-  });
+  return validateCreateHomeworkFormData(formData, homeworksCopy);
 }
 
 export function createDashboardHomeworkAction({

--- a/src/features/dashboard/lib/dashboard-controller-limits.ts
+++ b/src/features/dashboard/lib/dashboard-controller-limits.ts
@@ -1,8 +1,0 @@
-export {
-  HOMEWORK_DESCRIPTION_MAX_LENGTH,
-  HOMEWORK_TITLE_MAX_LENGTH,
-  TODO_CONTENT_MAX_LENGTH,
-  TODO_TITLE_MAX_LENGTH,
-} from "./dashboard-limits";
-
-export const todoPriorityOrder = ["medium", "high", "low"] as const;

--- a/src/features/dashboard/lib/dashboard-controller-todo-form-actions.ts
+++ b/src/features/dashboard/lib/dashboard-controller-todo-form-actions.ts
@@ -1,9 +1,5 @@
 import type { SubmitFunction } from "@sveltejs/kit";
 import {
-  TODO_CONTENT_MAX_LENGTH,
-  TODO_TITLE_MAX_LENGTH,
-} from "./dashboard-limits";
-import {
   actionResultError,
   validateTodoForm as validateTodoFormData,
 } from "./forms";
@@ -16,10 +12,7 @@ export function validateDashboardTodoForm(
   formData: FormData,
   todosCopy: TodoCopy,
 ) {
-  return validateTodoFormData(formData, todosCopy, {
-    titleMaxLength: TODO_TITLE_MAX_LENGTH,
-    contentMaxLength: TODO_CONTENT_MAX_LENGTH,
-  });
+  return validateTodoFormData(formData, todosCopy);
 }
 
 export function createDashboardTodoAction({

--- a/src/features/dashboard/lib/dashboard-limits.ts
+++ b/src/features/dashboard/lib/dashboard-limits.ts
@@ -1,8 +1,0 @@
-export {
-  HOMEWORK_DESCRIPTION_MAX_LENGTH,
-  HOMEWORK_TITLE_MAX_LENGTH,
-} from "@/features/homeworks/lib/homework-limits";
-export {
-  TODO_CONTENT_MAX_LENGTH,
-  TODO_TITLE_MAX_LENGTH,
-} from "@/features/todos/lib/todo-limits";

--- a/src/features/dashboard/lib/forms.ts
+++ b/src/features/dashboard/lib/forms.ts
@@ -1,3 +1,14 @@
+import {
+  getHomeworkDateValidationError,
+  getHomeworkDescriptionValidationError,
+  getHomeworkTitleValidationError,
+} from "@/features/homeworks/lib/homework-schema";
+import {
+  getTodoContentValidationError,
+  getTodoDueAtValidationError,
+  getTodoTitleValidationError,
+} from "@/features/todos/lib/todo-schema";
+
 type TodoFormCopy = {
   errorTitleRequired: string;
   errorTitleTooLong: string;
@@ -15,21 +26,6 @@ type HomeworkFormCopy = {
   createFailed: string;
 };
 
-type TodoFormLimits = {
-  titleMaxLength: number;
-  contentMaxLength: number;
-};
-
-type HomeworkFormLimits = {
-  titleMaxLength: number;
-  descriptionMaxLength: number;
-};
-
-export function optionalDateTimeIsValid(value: FormDataEntryValue | null) {
-  const text = String(value ?? "").trim();
-  return !text || !Number.isNaN(new Date(text).getTime());
-}
-
 export function actionResultError(
   result: { data?: { error?: unknown } },
   fallback: string,
@@ -39,19 +35,16 @@ export function actionResultError(
     : fallback;
 }
 
-export function validateTodoForm(
-  formData: FormData,
-  copy: TodoFormCopy,
-  limits: TodoFormLimits,
-) {
+export function validateTodoForm(formData: FormData, copy: TodoFormCopy) {
   const title = String(formData.get("title") ?? "").trim();
-  if (!title) return copy.errorTitleRequired;
-  if (title.length > limits.titleMaxLength) return copy.errorTitleTooLong;
+  const titleError = getTodoTitleValidationError(title);
+  if (titleError === "required") return copy.errorTitleRequired;
+  if (titleError === "too_long") return copy.errorTitleTooLong;
   const content = String(formData.get("content") ?? "").trim();
-  if (content.length > limits.contentMaxLength) {
+  if (getTodoContentValidationError(content)) {
     return copy.errorContentTooLong;
   }
-  if (!optionalDateTimeIsValid(formData.get("dueAt"))) {
+  if (getTodoDueAtValidationError(formData.get("dueAt"))) {
     return copy.errorInvalidDueAt;
   }
   return "";
@@ -60,24 +53,24 @@ export function validateTodoForm(
 export function validateCreateHomeworkForm(
   formData: FormData,
   copy: HomeworkFormCopy,
-  limits: HomeworkFormLimits,
 ) {
   const title = String(formData.get("title") ?? "").trim();
-  if (!title) return copy.errorTitleRequired;
-  if (title.length > limits.titleMaxLength) {
+  const titleError = getHomeworkTitleValidationError(title);
+  if (titleError === "required") return copy.errorTitleRequired;
+  if (titleError === "too_long") {
     return copy.errorTitleTooLong;
   }
   const description = String(formData.get("description") ?? "").trim();
-  if (description.length > limits.descriptionMaxLength) {
+  if (getHomeworkDescriptionValidationError(description)) {
     return copy.errorDescriptionTooLong;
   }
   if (!String(formData.get("sectionId") ?? "").trim()) {
     return copy.errorSectionNotFound;
   }
   if (
-    !optionalDateTimeIsValid(formData.get("publishedAt")) ||
-    !optionalDateTimeIsValid(formData.get("submissionStartAt")) ||
-    !optionalDateTimeIsValid(formData.get("submissionDueAt"))
+    getHomeworkDateValidationError(formData.get("publishedAt")) ||
+    getHomeworkDateValidationError(formData.get("submissionStartAt")) ||
+    getHomeworkDateValidationError(formData.get("submissionDueAt"))
   ) {
     return copy.errorInvalidSubmissionDue;
   }

--- a/src/features/dashboard/server/dashboard-homework-page-actions.ts
+++ b/src/features/dashboard/server/dashboard-homework-page-actions.ts
@@ -1,10 +1,10 @@
 import { fail, redirect } from "@sveltejs/kit";
-import {
-  HOMEWORK_DESCRIPTION_MAX_LENGTH,
-  HOMEWORK_TITLE_MAX_LENGTH,
-} from "@/features/dashboard/lib/dashboard-limits";
 import { parseOptionalLocalDateTime } from "@/features/dashboard/server/dashboard-form-dates";
 import { getDashboardUserId } from "@/features/dashboard/server/dashboard-page-server";
+import {
+  getHomeworkDescriptionValidationError,
+  getHomeworkTitleValidationError,
+} from "@/features/homeworks/lib/homework-schema";
 import {
   type CreateHomeworkInput,
   createHomeworkForSection,
@@ -27,12 +27,15 @@ export async function createHomeworkDashboardAction({
   if (!userId) return fail(401, { error: copy.errorUnauthorized });
   const form = await request.formData();
   const title = String(form.get("title") ?? "").trim();
-  if (!title) return fail(400, { error: copy.errorTitleRequired });
-  if (title.length > HOMEWORK_TITLE_MAX_LENGTH) {
+  const titleError = getHomeworkTitleValidationError(title);
+  if (titleError === "required") {
+    return fail(400, { error: copy.errorTitleRequired });
+  }
+  if (titleError === "too_long") {
     return fail(400, { error: copy.errorTitleTooLong });
   }
   const description = String(form.get("description") ?? "").trim();
-  if (description.length > HOMEWORK_DESCRIPTION_MAX_LENGTH) {
+  if (getHomeworkDescriptionValidationError(description)) {
     return fail(400, { error: copy.errorDescriptionTooLong });
   }
   const sectionId = Number(form.get("sectionId"));

--- a/src/features/dashboard/server/dashboard-todo-form.ts
+++ b/src/features/dashboard/server/dashboard-todo-form.ts
@@ -1,10 +1,10 @@
 import { fail } from "@sveltejs/kit";
-import {
-  TODO_CONTENT_MAX_LENGTH,
-  TODO_TITLE_MAX_LENGTH,
-} from "@/features/todos/lib/todo-limits";
 import { parseTodoPriorityInput } from "@/features/todos/lib/todo-priority";
-import { parseOptionalLocalDateTime } from "./dashboard-form-dates";
+import {
+  getTodoContentValidationError,
+  getTodoTitleValidationError,
+  parseTodoDueAtInput,
+} from "@/features/todos/lib/todo-schema";
 
 type TodoActionCopy = {
   errorContentTooLong: string;
@@ -17,18 +17,23 @@ type TodoActionCopy = {
 export async function readTodoForm(request: Request, copy: TodoActionCopy) {
   const form = await request.formData();
   const title = String(form.get("title") ?? "").trim();
-  if (!title) return { error: fail(400, { error: copy.errorTitleRequired }) };
-  if (title.length > TODO_TITLE_MAX_LENGTH) {
+  const titleError = getTodoTitleValidationError(title);
+  if (titleError === "required") {
+    return { error: fail(400, { error: copy.errorTitleRequired }) };
+  }
+  if (titleError === "too_long") {
     return { error: fail(400, { error: copy.errorTitleTooLong }) };
   }
 
   const content = String(form.get("content") ?? "").trim();
-  if (content.length > TODO_CONTENT_MAX_LENGTH) {
+  if (getTodoContentValidationError(content)) {
     return { error: fail(400, { error: copy.errorContentTooLong }) };
   }
 
-  const dueAt = parseOptionalLocalDateTime(form.get("dueAt"));
-  if (!dueAt.ok) return { error: fail(400, { error: copy.errorInvalidDueAt }) };
+  const dueAt = parseTodoDueAtInput(form.get("dueAt"));
+  if (dueAt === undefined) {
+    return { error: fail(400, { error: copy.errorInvalidDueAt }) };
+  }
   const priority = parseTodoPriorityInput(form.get("priority"));
   if (!priority.ok) {
     return { error: fail(400, { error: copy.errorInvalidPriority }) };
@@ -38,7 +43,7 @@ export async function readTodoForm(request: Request, copy: TodoActionCopy) {
     form,
     todo: {
       content: content || null,
-      dueAt: dueAt.value,
+      dueAt,
       priority: priority.value,
       title,
     },

--- a/src/features/homeworks/lib/homework-schema.ts
+++ b/src/features/homeworks/lib/homework-schema.ts
@@ -1,0 +1,51 @@
+import * as z from "zod";
+import { parseDateInput } from "@/lib/time/parse-date-input";
+import {
+  HOMEWORK_DESCRIPTION_MAX_LENGTH,
+  HOMEWORK_TITLE_MAX_LENGTH,
+} from "./homework-limits";
+
+export const homeworkTitleSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(HOMEWORK_TITLE_MAX_LENGTH);
+
+export const homeworkDescriptionInputSchema = z
+  .string()
+  .trim()
+  .max(HOMEWORK_DESCRIPTION_MAX_LENGTH)
+  .optional()
+  .nullable();
+
+export const homeworkDateInputSchema = z
+  .union([z.string(), z.null()])
+  .optional();
+
+export type HomeworkTitleValidationError = "required" | "too_long";
+export type HomeworkDescriptionValidationError = "too_long";
+export type HomeworkDateValidationError = "invalid";
+
+export function getHomeworkTitleValidationError(
+  title: string,
+): HomeworkTitleValidationError | null {
+  const trimmedTitle = title.trim();
+  if (!trimmedTitle) return "required";
+  if (trimmedTitle.length > HOMEWORK_TITLE_MAX_LENGTH) return "too_long";
+  return null;
+}
+
+export function getHomeworkDescriptionValidationError(
+  description: string,
+): HomeworkDescriptionValidationError | null {
+  if (description.trim().length > HOMEWORK_DESCRIPTION_MAX_LENGTH) {
+    return "too_long";
+  }
+  return null;
+}
+
+export function getHomeworkDateValidationError(
+  value: unknown,
+): HomeworkDateValidationError | null {
+  return parseDateInput(value) === undefined ? "invalid" : null;
+}

--- a/src/features/section-detail/lib/section-detail-homework-form.ts
+++ b/src/features/section-detail/lib/section-detail-homework-form.ts
@@ -1,7 +1,7 @@
 import {
-  HOMEWORK_DESCRIPTION_MAX_LENGTH,
-  HOMEWORK_TITLE_MAX_LENGTH,
-} from "@/features/homeworks/lib/homework-limits";
+  getHomeworkDescriptionValidationError,
+  getHomeworkTitleValidationError,
+} from "@/features/homeworks/lib/homework-schema";
 import { parseShanghaiDateTimeLocalInput } from "@/lib/time/shanghai-format";
 import type { SectionDetailPageData } from "./section-detail-controller-helpers";
 
@@ -34,11 +34,12 @@ function validateSectionHomeworkInput(
   },
   homeworkCopy: HomeworkCopy,
 ) {
-  if (!input.title) return homeworkCopy.titleRequired;
-  if (input.title.length > HOMEWORK_TITLE_MAX_LENGTH) {
+  const titleError = getHomeworkTitleValidationError(input.title);
+  if (titleError === "required") return homeworkCopy.titleRequired;
+  if (titleError === "too_long") {
     return homeworkCopy.errorTitleTooLong;
   }
-  if (input.description.length > HOMEWORK_DESCRIPTION_MAX_LENGTH) {
+  if (getHomeworkDescriptionValidationError(input.description)) {
     return homeworkCopy.errorDescriptionTooLong;
   }
   const publishedAt = parseShanghaiDateTimeLocalInput(input.publishedAt);

--- a/src/features/todos/lib/todo-schema.ts
+++ b/src/features/todos/lib/todo-schema.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import { parseDateInput } from "@/lib/time/parse-date-input";
 import { TODO_CONTENT_MAX_LENGTH, TODO_TITLE_MAX_LENGTH } from "./todo-limits";
 import { TODO_PRIORITY_VALUES } from "./todo-priority";
 
@@ -11,6 +12,7 @@ export const todoTitleSchema = z
   .max(TODO_TITLE_MAX_LENGTH);
 export const todoContentSchema = z
   .string()
+  .trim()
   .max(TODO_CONTENT_MAX_LENGTH)
   .optional()
   .nullable();
@@ -30,3 +32,33 @@ export const todoUpdateInputSchema = z.object({
   dueAt: todoDueAtInputSchema,
   completed: z.boolean().optional(),
 });
+
+export type TodoTitleValidationError = "required" | "too_long";
+export type TodoContentValidationError = "too_long";
+export type TodoDueAtValidationError = "invalid";
+
+export function getTodoTitleValidationError(
+  title: string,
+): TodoTitleValidationError | null {
+  const trimmedTitle = title.trim();
+  if (!trimmedTitle) return "required";
+  if (trimmedTitle.length > TODO_TITLE_MAX_LENGTH) return "too_long";
+  return null;
+}
+
+export function getTodoContentValidationError(
+  content: string,
+): TodoContentValidationError | null {
+  if (content.trim().length > TODO_CONTENT_MAX_LENGTH) return "too_long";
+  return null;
+}
+
+export function parseTodoDueAtInput(value: unknown) {
+  return parseDateInput(value);
+}
+
+export function getTodoDueAtValidationError(
+  value: unknown,
+): TodoDueAtValidationError | null {
+  return parseTodoDueAtInput(value) === undefined ? "invalid" : null;
+}

--- a/src/lib/api/schemas/request-academic-mutation-schemas.ts
+++ b/src/lib/api/schemas/request-academic-mutation-schemas.ts
@@ -1,8 +1,9 @@
 import * as z from "zod";
 import {
-  HOMEWORK_DESCRIPTION_MAX_LENGTH,
-  HOMEWORK_TITLE_MAX_LENGTH,
-} from "@/features/homeworks/lib/homework-limits";
+  homeworkDateInputSchema,
+  homeworkDescriptionInputSchema,
+  homeworkTitleSchema,
+} from "@/features/homeworks/lib/homework-schema";
 import {
   parseOptionalIntLike,
   sectionCodeSchema,
@@ -16,15 +17,11 @@ export const matchSectionCodesRequestSchema = z.object({
 });
 
 const homeworkCreateBaseRequestSchema = z.object({
-  title: z.string().trim().min(1).max(HOMEWORK_TITLE_MAX_LENGTH),
-  description: z
-    .string()
-    .max(HOMEWORK_DESCRIPTION_MAX_LENGTH)
-    .optional()
-    .nullable(),
-  publishedAt: z.union([z.string(), z.null()]).optional(),
-  submissionStartAt: z.union([z.string(), z.null()]).optional(),
-  submissionDueAt: z.union([z.string(), z.null()]).optional(),
+  title: homeworkTitleSchema,
+  description: homeworkDescriptionInputSchema,
+  publishedAt: homeworkDateInputSchema,
+  submissionStartAt: homeworkDateInputSchema,
+  submissionDueAt: homeworkDateInputSchema,
   isMajor: z.boolean().optional(),
   requiresTeam: z.boolean().optional(),
 });
@@ -57,15 +54,11 @@ export const homeworkCompletionBatchRequestSchema = z.object({
 });
 
 export const homeworkUpdateRequestSchema = z.object({
-  title: z.string().trim().min(1).max(HOMEWORK_TITLE_MAX_LENGTH).optional(),
-  description: z
-    .string()
-    .max(HOMEWORK_DESCRIPTION_MAX_LENGTH)
-    .optional()
-    .nullable(),
-  publishedAt: z.union([z.string(), z.null()]).optional(),
-  submissionStartAt: z.union([z.string(), z.null()]).optional(),
-  submissionDueAt: z.union([z.string(), z.null()]).optional(),
+  title: homeworkTitleSchema.optional(),
+  description: homeworkDescriptionInputSchema,
+  publishedAt: homeworkDateInputSchema,
+  submissionStartAt: homeworkDateInputSchema,
+  submissionDueAt: homeworkDateInputSchema,
   isMajor: z.boolean().optional(),
   requiresTeam: z.boolean().optional(),
 });

--- a/src/lib/mcp/tools/section-data/homework-create-tool.ts
+++ b/src/lib/mcp/tools/section-data/homework-create-tool.ts
@@ -1,9 +1,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod";
 import {
-  HOMEWORK_DESCRIPTION_MAX_LENGTH,
-  HOMEWORK_TITLE_MAX_LENGTH,
-} from "@/features/homeworks/lib/homework-limits";
+  homeworkDateInputSchema,
+  homeworkDescriptionInputSchema,
+  homeworkTitleSchema,
+} from "@/features/homeworks/lib/homework-schema";
 import {
   mcpLocaleInputSchema,
   mcpModeInputSchema,
@@ -18,17 +19,13 @@ export function registerCreateHomeworkOnSectionTool(server: McpServer) {
         "Create a homework under one section by section JW ID. Requires unsuspended signed-in user; does not mutate JW/import facts.",
       inputSchema: {
         sectionJwId: z.number().int().positive(),
-        title: z.string().trim().min(1).max(HOMEWORK_TITLE_MAX_LENGTH),
-        description: z
-          .string()
-          .max(HOMEWORK_DESCRIPTION_MAX_LENGTH)
-          .optional()
-          .nullable(),
+        title: homeworkTitleSchema,
+        description: homeworkDescriptionInputSchema,
         isMajor: z.boolean().optional(),
         requiresTeam: z.boolean().optional(),
-        publishedAt: z.union([z.string(), z.null()]).optional(),
-        submissionStartAt: z.union([z.string(), z.null()]).optional(),
-        submissionDueAt: z.union([z.string(), z.null()]).optional(),
+        publishedAt: homeworkDateInputSchema,
+        submissionStartAt: homeworkDateInputSchema,
+        submissionDueAt: homeworkDateInputSchema,
         locale: mcpLocaleInputSchema,
         mode: mcpModeInputSchema,
       },

--- a/src/lib/mcp/tools/section-data/homework-update-tool.ts
+++ b/src/lib/mcp/tools/section-data/homework-update-tool.ts
@@ -1,9 +1,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod";
 import {
-  HOMEWORK_DESCRIPTION_MAX_LENGTH,
-  HOMEWORK_TITLE_MAX_LENGTH,
-} from "@/features/homeworks/lib/homework-limits";
+  homeworkDateInputSchema,
+  homeworkDescriptionInputSchema,
+  homeworkTitleSchema,
+} from "@/features/homeworks/lib/homework-schema";
 import {
   mcpLocaleInputSchema,
   mcpModeInputSchema,
@@ -18,22 +19,13 @@ export function registerUpdateHomeworkOnSectionTool(server: McpServer) {
         "Update a homework by ID and optionally replace/upsert its description. Requires collaborator permissions and unsuspended user.",
       inputSchema: {
         homeworkId: z.string().trim().min(1),
-        title: z
-          .string()
-          .trim()
-          .min(1)
-          .max(HOMEWORK_TITLE_MAX_LENGTH)
-          .optional(),
-        description: z
-          .string()
-          .max(HOMEWORK_DESCRIPTION_MAX_LENGTH)
-          .optional()
-          .nullable(),
+        title: homeworkTitleSchema.optional(),
+        description: homeworkDescriptionInputSchema,
         isMajor: z.boolean().optional(),
         requiresTeam: z.boolean().optional(),
-        publishedAt: z.union([z.string(), z.null()]).optional(),
-        submissionStartAt: z.union([z.string(), z.null()]).optional(),
-        submissionDueAt: z.union([z.string(), z.null()]).optional(),
+        publishedAt: homeworkDateInputSchema,
+        submissionStartAt: homeworkDateInputSchema,
+        submissionDueAt: homeworkDateInputSchema,
         locale: mcpLocaleInputSchema,
         mode: mcpModeInputSchema,
       },

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 import DashboardPage from "../+page.svelte";
-import type { PageData } from "../$types";
+import type { ActionData, PageData } from "./$types";
 
 export let data: PageData;
+export let form: ActionData | undefined = undefined;
 </script>
 
-<DashboardPage {data} />
+<DashboardPage {data} {form} />

--- a/src/routes/dashboard/[tab]/+page.svelte
+++ b/src/routes/dashboard/[tab]/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-import type { PageData } from "../../$types";
 import DashboardPage from "../+page.svelte";
+import type { ActionData, PageData } from "./$types";
 
 export let data: PageData;
+export let form: ActionData | undefined = undefined;
 </script>
 
-<DashboardPage {data} />
+<DashboardPage {data} {form} />

--- a/src/routes/dashboard/subscriptions/+page.svelte
+++ b/src/routes/dashboard/subscriptions/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-import type { PageData } from "../../$types";
 import DashboardPage from "../+page.svelte";
+import type { ActionData, PageData } from "./$types";
 
 export let data: PageData;
+export let form: ActionData | undefined = undefined;
 </script>
 
-<DashboardPage {data} />
+<DashboardPage {data} {form} />

--- a/src/routes/dashboard/subscriptions/sections/+page.svelte
+++ b/src/routes/dashboard/subscriptions/sections/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 import DashboardPage from "../../../+page.svelte";
-import type { PageData } from "../../../$types";
+import type { ActionData, PageData } from "./$types";
 
 export let data: PageData;
+export let form: ActionData | undefined = undefined;
 </script>
 
-<DashboardPage {data} />
+<DashboardPage {data} {form} />

--- a/tests/e2e/src/app/api/todos/test.ts
+++ b/tests/e2e/src/app/api/todos/test.ts
@@ -19,6 +19,7 @@
  * - Full create → verify in list → cleanup via DELETE
  */
 import { expect, test } from "@playwright/test";
+import { TODO_CONTENT_MAX_LENGTH } from "@/features/todos/lib/todo-limits";
 import { signInAsDebugUser } from "../../../../utils/auth";
 import { DEV_SEED, DEV_SEED_ANCHOR } from "../../../../utils/dev-seed";
 import { assertApiContract } from "../../_shared/api-contract";
@@ -137,10 +138,11 @@ test("/api/todos POST 登录后可创建新待办并清理", async ({ page }) =>
   await signInAsDebugUser(page, "/");
 
   const title = `e2e-api-todo-${Date.now()}`;
+  const content = "x".repeat(TODO_CONTENT_MAX_LENGTH);
   const createResponse = await page.request.post("/api/todos", {
     data: {
       title,
-      content: "from api test",
+      content: ` ${content} `,
       priority: "high",
     },
   });
@@ -153,12 +155,18 @@ test("/api/todos POST 登录后可创建新待办并清理", async ({ page }) =>
     const listResponse = await page.request.get("/api/todos");
     expect(listResponse.status()).toBe(200);
     const listBody = (await listResponse.json()) as {
-      todos?: Array<{ id?: string; title?: string; priority?: string }>;
+      todos?: Array<{
+        content?: string | null;
+        id?: string;
+        priority?: string;
+        title?: string;
+      }>;
     };
     expect(
       listBody.todos?.some(
         (todo) =>
           todo.id === createdId &&
+          todo.content === content &&
           todo.title === title &&
           todo.priority === "high",
       ),

--- a/tests/e2e/src/app/dashboard/todos/test.ts
+++ b/tests/e2e/src/app/dashboard/todos/test.ts
@@ -92,6 +92,32 @@ test.describe("dashboard todos", () => {
     await captureStepScreenshot(page, testInfo, "dashboard-todos-completed");
   });
 
+  test("server action errors render on nested todos route", async ({
+    page,
+  }, testInfo) => {
+    await signInAsDebugUser(page, "/dashboard/todos");
+
+    const postResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        response.url().includes("/dashboard/todos?/createTodo"),
+    );
+    await page.evaluate(() => {
+      const form = document.createElement("form");
+      form.method = "POST";
+      form.action = "/dashboard/todos?/createTodo";
+      document.body.append(form);
+      form.requestSubmit();
+    });
+
+    await expect((await postResponse).status()).toBe(400);
+    await expect(
+      page.getByText(/请输入标题|Please enter a title/i).first(),
+    ).toBeVisible();
+
+    await captureStepScreenshot(page, testInfo, "dashboard-todos-action-error");
+  });
+
   test("can create and delete a todo", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, "/dashboard/todos");

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -11,6 +11,7 @@
 
 import { DEV_SEED, DEV_SEED_ANCHOR } from "@tools/dev/seed/dev-seed";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { TODO_CONTENT_MAX_LENGTH } from "@/features/todos/lib/todo-limits";
 import { prisma } from "@/lib/db/prisma";
 import { createMcpHarness, type McpHarness } from "./utils/mcp-harness";
 
@@ -138,6 +139,25 @@ describe("todo CRUD — update_my_todo returns updated entity", () => {
     expect(result.todo?.completed).toBe(true);
     // updatedAt should be a valid Shanghai-offset datetime
     expect(result.todo?.updatedAt).toMatch(/\+08:00$/);
+  });
+
+  it("update_my_todo validates normalized content length", async () => {
+    const content = "x".repeat(TODO_CONTENT_MAX_LENGTH);
+    const result = await mcp.call<{
+      success?: boolean;
+      todo?: {
+        id?: string;
+        content?: string | null;
+      } | null;
+    }>("update_my_todo", {
+      id: todoId,
+      content: ` ${content} `,
+      mode: "full",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.todo?.id).toBe(todoId);
+    expect(result.todo?.content).toBe(content);
   });
 
   it("update_my_todo clears content when content is explicitly null", async () => {

--- a/tests/unit/api-schemas.test.ts
+++ b/tests/unit/api-schemas.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { HOMEWORK_DESCRIPTION_MAX_LENGTH } from "@/features/homeworks/lib/homework-limits";
+import { TODO_CONTENT_MAX_LENGTH } from "@/features/todos/lib/todo-limits";
 import {
   calendarSubscriptionCreateRequestSchema,
   commentReactionRequestSchema,
@@ -10,6 +12,7 @@ import {
   matchSectionCodesRequestSchema,
   schedulesQuerySchema,
   sectionsQuerySchema,
+  todoCreateRequestSchema,
   todosQuerySchema,
   uploadCreateRequestSchema,
 } from "@/lib/api/schemas/request-schemas";
@@ -68,6 +71,35 @@ describe("homeworkCreateRequestSchema", () => {
       title: "",
     });
     expect(result.success).toBe(false);
+  });
+
+  it("validates homework description after trimming surrounding whitespace", () => {
+    const description = "x".repeat(HOMEWORK_DESCRIPTION_MAX_LENGTH);
+    const result = homeworkCreateRequestSchema.safeParse({
+      sectionId: "12",
+      title: "作业 1",
+      description: ` ${description} `,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.description).toBe(description);
+    }
+  });
+});
+
+describe("todoCreateRequestSchema", () => {
+  it("validates todo content after trimming surrounding whitespace", () => {
+    const content = "x".repeat(TODO_CONTENT_MAX_LENGTH);
+    const result = todoCreateRequestSchema.safeParse({
+      title: "Read Chapter 1",
+      content: ` ${content} `,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.content).toBe(content);
+    }
   });
 });
 

--- a/tests/unit/dashboard-form-validation.test.ts
+++ b/tests/unit/dashboard-form-validation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateCreateHomeworkForm,
+  validateTodoForm,
+} from "@/features/dashboard/lib/forms";
+
+const todoCopy = {
+  errorContentTooLong: "content too long",
+  errorInvalidDueAt: "invalid due date",
+  errorTitleRequired: "title required",
+  errorTitleTooLong: "title too long",
+  saveFailed: "save failed",
+};
+
+const homeworkCopy = {
+  createFailed: "create failed",
+  errorDescriptionTooLong: "description too long",
+  errorInvalidSubmissionDue: "invalid submission due",
+  errorSectionNotFound: "section not found",
+  errorTitleRequired: "title required",
+  errorTitleTooLong: "title too long",
+};
+
+describe("dashboard form validation", () => {
+  it("uses strict todo due date parsing", () => {
+    const formData = new FormData();
+    formData.set("title", "Read Chapter 1");
+    formData.set("dueAt", "2026-02-30T10:00");
+
+    expect(validateTodoForm(formData, todoCopy)).toBe("invalid due date");
+  });
+
+  it("uses strict homework date parsing", () => {
+    const formData = new FormData();
+    formData.set("sectionId", "1");
+    formData.set("title", "Project 1");
+    formData.set("submissionDueAt", "2026-02-30T10:00");
+
+    expect(validateCreateHomeworkForm(formData, homeworkCopy)).toBe(
+      "invalid submission due",
+    );
+  });
+});

--- a/tests/unit/dashboard-todo-form.test.ts
+++ b/tests/unit/dashboard-todo-form.test.ts
@@ -44,4 +44,25 @@ describe("dashboard todo form", () => {
     expect(error.status).toBe(400);
     expect(error.data).toEqual({ error: "invalid priority" });
   });
+
+  it("rejects impossible due dates with the todo feature parser", async () => {
+    const body = new FormData();
+    body.set("title", "Read Chapter 1");
+    body.set("dueAt", "2026-02-30T10:00");
+
+    const parsed = await readTodoForm(
+      new Request("https://life.example/dashboard/todos?/createTodo", {
+        body,
+        method: "POST",
+      }),
+      copy,
+    );
+
+    expect("error" in parsed).toBe(true);
+    if (!("error" in parsed)) return;
+    const { error } = parsed;
+    if (!error) throw new Error("Expected invalid due date failure");
+    expect(error.status).toBe(400);
+    expect(error.data).toEqual({ error: "invalid due date" });
+  });
 });


### PR DESCRIPTION
## Goal

Consolidate duplicated homework/todo form validation so dashboard client actions, dashboard server actions, REST schemas, and MCP tool schemas share feature-owned rules. Also fix nested dashboard route wrappers so SvelteKit action `form` errors reach the dashboard controller.

## Changed Surfaces

- Added feature-owned homework schema/validation helpers in `src/features/homeworks/lib/homework-schema.ts`.
- Reused shared homework/todo validation from dashboard forms, section-detail homework forms, REST request schemas, and MCP homework tools.
- Removed dashboard-only limit re-export files that duplicated feature limits.
- Forwarded `form` through `/dashboard/*` wrapper pages so server action failures render on nested dashboard routes.
- Added unit, MCP integration, and E2E coverage for strict dates, normalized text length, REST serialization, and nested-route action errors.

## Evidence

- `bun run verify`
- `PLAYWRIGHT_PORT=4173 bun run verify:full`
- Focused complete-loop checks before the full gate:
  - `bun run vitest run --config vitest.integration.config.ts tests/integration/mcp-tools.test.ts -t "todo CRUD"`
  - `PLAYWRIGHT_PORT=4173 bun run e2e:test -- tests/e2e/src/app/api/todos/test.ts -g "/api/todos POST 登录后可创建新待办并清理"`
  - `PLAYWRIGHT_PORT=4173 bun run e2e:test -- tests/e2e/src/app/dashboard/todos/test.ts -g "server action errors render on nested todos route"`
- UI complete-loop evidence: inspected a Chromium screenshot of `/dashboard/todos` showing the rendered title-required action error after native POST to `/dashboard/todos?/createTodo`; screenshot was removed after inspection.
- API/MCP complete-loop evidence: REST create/list E2E verifies normalized todo content in serialized API output; MCP integration verifies `update_my_todo` returns normalized content in serialized tool output.
- Two subagent reviews checked the dashboard/form diff and API/MCP/schema diff; no material findings after the trim-alignment patch.

## Docs / Contracts

No docs or contract JSON changes. Public field shapes, permissions, OpenAPI annotations, and output contracts are unchanged; `openapi:check`, `check:contracts`, and full verification passed.

## Risk Areas

- Dashboard nested route action error propagation.
- REST/MCP text normalization and date validation parity.
- Browser E2E used `PLAYWRIGHT_PORT=4173` because local ports 3000 and 3001 were occupied by unrelated loopback listeners that reset connections.

## Cleanup

No scratch screenshots, ad hoc probes, or generated-file edits are left in the repo. Docker services started for local verification were stopped.
