### PR TITLE
fix(openapi): align request body docs

### DIFF
--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -384,6 +384,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -679,6 +680,7 @@
           "Admin"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -858,6 +860,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -963,6 +966,18 @@
                 }
               }
             }
+          }
+        }
+      },
+      "options": {
+        "operationId": "options-api-auth-oauth2-device-authorization",
+        "summary": "Return OAuth device authorization CORS preflight headers",
+        "tags": [
+          "Api"
+        ],
+        "responses": {
+          "204": {
+            "description": "Response 204"
           }
         }
       }
@@ -1234,6 +1249,7 @@
           "Bus"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -1362,6 +1378,7 @@
           "Calendar"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -1443,6 +1460,7 @@
           "Calendar"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -1572,6 +1590,7 @@
           "Comments"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -1693,6 +1712,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -1834,6 +1854,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -2487,6 +2508,7 @@
           "Descriptions"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -2633,6 +2655,7 @@
           "Homeworks"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -2714,6 +2737,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -2855,6 +2879,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -2915,6 +2940,7 @@
           "Homeworks"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -2965,6 +2991,7 @@
           "Locale"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -4426,6 +4453,7 @@
           "Sections"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -5271,6 +5299,7 @@
           "Todos"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -5332,6 +5361,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -5481,6 +5511,7 @@
           "Uploads"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -5552,6 +5583,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -5715,6 +5747,7 @@
           "Uploads"
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -5785,6 +5818,17 @@
             "required": true
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful response",

--- a/src/routes/api/auth/oauth2/device-authorization/+server.ts
+++ b/src/routes/api/auth/oauth2/device-authorization/+server.ts
@@ -4,6 +4,10 @@ import {
 } from "@/lib/api/routes/auth-device-authorization";
 import { svelteRequestHandler } from "@/lib/api/svelte-route";
 
+/**
+ * Return OAuth device authorization CORS preflight headers.
+ * @response 204
+ */
 export const OPTIONS = svelteRequestHandler(deviceAuthorizationOptionsRoute);
 
 /**

--- a/src/routes/api/uploads/object/+server.ts
+++ b/src/routes/api/uploads/object/+server.ts
@@ -5,6 +5,7 @@ import type { RequestHandler } from "./$types";
 /**
  * Write upload object.
  * @params uploadObjectQuerySchema
+ * @body binary
  * @response 200:successResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema

--- a/tests/e2e/src/app/api/openapi/test.ts
+++ b/tests/e2e/src/app/api/openapi/test.ts
@@ -91,7 +91,7 @@ test.describe("GET /api/openapi", () => {
     });
   });
 
-  test("binary and redirect endpoints keep response codes in the spec", async ({
+  test("request bodies and redirect endpoints stay accurate in the spec", async ({
     request,
   }) => {
     const response = await request.get("/api/openapi");
@@ -101,11 +101,41 @@ test.describe("GET /api/openapi", () => {
         string,
         {
           get?: { responses?: Record<string, unknown> };
-          post?: { responses?: Record<string, unknown> };
+          options?: { responses?: Record<string, unknown> };
+          post?: {
+            requestBody?: {
+              required?: boolean;
+              content?: Record<
+                string,
+                { schema?: { $ref?: string; type?: string; format?: string } }
+              >;
+            };
+            responses?: Record<string, unknown>;
+          };
+          put?: {
+            requestBody?: {
+              required?: boolean;
+              content?: Record<
+                string,
+                { schema?: { $ref?: string; type?: string; format?: string } }
+              >;
+            };
+          };
         }
       >;
     };
 
+    expect(body.paths?.["/api/todos"]?.post?.requestBody?.required).toBe(true);
+    expect(
+      body.paths?.["/api/todos"]?.post?.requestBody?.content?.[
+        "application/json"
+      ]?.schema?.$ref,
+    ).toBe("#/components/schemas/todoCreateRequestSchema");
+    expect(
+      body.paths?.["/api/uploads/object"]?.put?.requestBody?.content?.[
+        "application/octet-stream"
+      ]?.schema,
+    ).toEqual({ type: "string", format: "binary" });
     expect(
       body.paths?.["/api/uploads/{id}/download"]?.get?.responses?.["200"],
     ).toBeTruthy();
@@ -117,6 +147,10 @@ test.describe("GET /api/openapi", () => {
     ).toBeTruthy();
     expect(
       body.paths?.["/api/dashboard-links/visit"]?.post?.responses?.["303"],
+    ).toBeTruthy();
+    expect(
+      body.paths?.["/api/auth/oauth2/device-authorization"]?.options
+        ?.responses?.["204"],
     ).toBeTruthy();
   });
 

--- a/tests/unit/openapi-scenario-examples.test.ts
+++ b/tests/unit/openapi-scenario-examples.test.ts
@@ -28,24 +28,35 @@ const OPENAPI_HTTP_METHODS = [
 
 type GeneratedOperation = {
   description?: string;
+  parameters?: Array<{
+    name?: string;
+    example?: unknown;
+    schema?: GeneratedSchema;
+  }>;
+  requestBody?: {
+    required?: boolean;
+    content?: Record<string, GeneratedMediaType>;
+  };
   responses?: Record<
     string,
     {
-      content?: Record<
-        string,
-        {
-          schema?: GeneratedSchema;
-        }
-      >;
+      content?: Record<string, GeneratedMediaType>;
     }
   >;
   summary?: string;
 };
 
+type GeneratedMediaType = {
+  example?: unknown;
+  schema?: GeneratedSchema;
+};
+
 type GeneratedSchema = {
   $ref?: string;
+  format?: string;
   properties?: Record<string, unknown>;
   required?: string[];
+  type?: string;
 };
 
 type GeneratedOpenApiDocument = {
@@ -181,6 +192,42 @@ describe("buildScenarioOpenApiExamples", () => {
     expect(spec.paths["/api/mcp"]?.options?.summary).toBe(
       "Return MCP transport CORS preflight headers",
     );
+  });
+
+  it("documents request bodies and implemented preflight routes", () => {
+    const spec = generatedOpenApiDocument as GeneratedOpenApiDocument;
+
+    const todoCreateBody = spec.paths["/api/todos"]?.post?.requestBody;
+    expect(todoCreateBody?.required).toBe(true);
+    expect(todoCreateBody?.content?.["application/json"]?.schema?.$ref).toBe(
+      "#/components/schemas/todoCreateRequestSchema",
+    );
+
+    const uploadObjectBody =
+      spec.paths["/api/uploads/object"]?.put?.requestBody;
+    expect(uploadObjectBody?.required).toBe(true);
+    expect(
+      uploadObjectBody?.content?.["application/octet-stream"]?.schema,
+    ).toEqual({
+      type: "string",
+      format: "binary",
+    });
+
+    const deviceAuthorizationPost =
+      spec.paths["/api/auth/oauth2/device-authorization"]?.post;
+    expect(deviceAuthorizationPost?.requestBody?.required).toBe(true);
+    expect(
+      deviceAuthorizationPost?.requestBody?.content?.[
+        "application/x-www-form-urlencoded"
+      ]?.schema?.$ref,
+    ).toBe("#/components/schemas/oauthDeviceAuthorizationRequestSchema");
+
+    const deviceAuthorizationOptions =
+      spec.paths["/api/auth/oauth2/device-authorization"]?.options;
+    expect(deviceAuthorizationOptions?.summary).toBe(
+      "Return OAuth device authorization CORS preflight headers",
+    );
+    expect(deviceAuthorizationOptions?.responses?.["204"]).toBeTruthy();
   });
 
   it("documents OAuth success response bodies", () => {

--- a/tools/build/openapi/generate-spec.ts
+++ b/tools/build/openapi/generate-spec.ts
@@ -314,8 +314,21 @@ function buildRequestBody(
   usedSchemas: Set<string>,
 ): unknown {
   if (!annotations.body) return undefined;
+
+  if (annotations.body === "binary") {
+    return {
+      required: true,
+      content: {
+        "application/octet-stream": {
+          schema: { type: "string", format: "binary" },
+        },
+      },
+    };
+  }
+
   usedSchemas.add(annotations.body);
   return {
+    required: true,
     content: {
       "application/json": {
         schema: getComponentSchema(annotations.body),


### PR DESCRIPTION
## Goal

Align generated OpenAPI with implemented request-body behavior and the existing OAuth device preflight route.

## Changed Surfaces

- OpenAPI generator: `@body` request bodies are emitted as required; `@body binary` emits an octet-stream binary request body.
- Route annotations: upload object PUT documents its binary body; OAuth device authorization documents implemented `OPTIONS 204`.
- Generated spec and tests: regenerated `public/openapi.generated.json`, added unit and `/api/openapi` E2E assertions for the drift cases.

## Evidence

- OpenAPI/static checks: `bun run openapi:check`, `bun run check:contracts`, `bun run check:routes`.
- Focused tests: `bun run test -- tests/unit/openapi-scenario-examples.test.ts`; `PLAYWRIGHT_PORT=4173 bun run e2e:test -- tests/e2e/src/app/api/openapi/test.ts`.
- Full gate: `PLAYWRIGHT_PORT=4173 bun run verify:full` passed after starting local Postgres with `docker compose -f docker-compose.dev.yml up -d`.
- Public output inspected: generated JSON shows required JSON bodies, required octet-stream upload body, and OAuth device `OPTIONS 204`.
- Subagent review: two focused review subagents reported no blocking design, drift, or parity issues.

## Docs / Contracts

- Regenerated `public/openapi.generated.json`.
- No hand-maintained contract JSON changed; upload and OAuth contracts already matched the implemented behavior, and this fixes generated OpenAPI drift.

## Risk Areas

- API clients may now correctly see annotated request bodies as required.
- Upload object PUT is now documented as `application/octet-stream` binary input.
- MCP parity unchanged: uploads have no MCP capability, and this PR only changes REST/OpenAPI documentation.

## Cleanup

- No scratch artifacts, one-time probes, unrelated rewrites, or manual generated-file edits remain.
