### PR TITLE
fix(api): share client error messages

### DIFF
--- a/src/features/admin/lib/admin-users-display.ts
+++ b/src/features/admin/lib/admin-users-display.ts
@@ -1,3 +1,4 @@
+import { readApiErrorMessage } from "@/lib/api/client";
 import { toShanghaiIsoString } from "@/lib/time/serialize-date-output";
 import {
   addShanghaiTime,
@@ -67,10 +68,5 @@ export async function adminUserResponseMessage(
   response: Response,
   fallback: string,
 ) {
-  try {
-    const body = await response.json();
-    return String(body?.message ?? body?.error?.message ?? fallback);
-  } catch {
-    return fallback;
-  }
+  return readApiErrorMessage(response, fallback);
 }

--- a/src/features/admin/lib/moderation-action-display.ts
+++ b/src/features/admin/lib/moderation-action-display.ts
@@ -1,3 +1,4 @@
+import { readApiErrorMessage } from "@/lib/api/client";
 import { toShanghaiIsoString } from "@/lib/time/serialize-date-output";
 import {
   addShanghaiTime,
@@ -9,10 +10,7 @@ export function formAlertVariant(kind: unknown) {
 }
 
 export function responseMessage(response: Response, fallback: string) {
-  return response
-    .json()
-    .then((body) => String(body?.message ?? body?.error?.message ?? fallback))
-    .catch(() => fallback);
+  return readApiErrorMessage(response, fallback);
 }
 
 export function expiresAtFromModerationDuration(

--- a/src/features/dashboard/lib/dashboard-link-pin-client.ts
+++ b/src/features/dashboard/lib/dashboard-link-pin-client.ts
@@ -1,3 +1,5 @@
+import { readApiErrorMessage } from "@/lib/api/client";
+
 type PinnableDashboardLink = {
   isPinned: boolean;
   slug: string;
@@ -34,14 +36,15 @@ export async function submitDashboardLinkPinRequest(input: {
     body: formData,
     headers: { accept: "application/json" },
   });
+
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response, input.fallbackMessage));
+  }
+
   const payload = (await response.json()) as {
     error?: string | null;
     pinnedSlugs?: string[];
   };
-
-  if (!response.ok) {
-    throw new Error(payload.error ?? input.fallbackMessage);
-  }
 
   return payload.pinnedSlugs ?? [];
 }

--- a/src/features/dashboard/lib/todo-api-actions.ts
+++ b/src/features/dashboard/lib/todo-api-actions.ts
@@ -1,31 +1,6 @@
-export async function todoResponseMessage(
-  response: Response,
-  fallback: string,
-) {
-  try {
-    const body = (await response.json()) as {
-      message?: unknown;
-      error?: { message?: unknown } | string;
-    };
-    if (typeof body.message === "string" && body.message.trim()) {
-      return body.message;
-    }
-    if (typeof body.error === "string" && body.error.trim()) {
-      return body.error;
-    }
-    if (
-      body.error &&
-      typeof body.error === "object" &&
-      typeof body.error.message === "string" &&
-      body.error.message.trim()
-    ) {
-      return body.error.message;
-    }
-  } catch {
-    // Keep the UI fallback when the API returns a non-JSON error body.
-  }
-  return fallback;
-}
+import { readApiErrorMessage } from "@/lib/api/client";
+
+export const todoResponseMessage = readApiErrorMessage;
 
 export async function updateTodoCompletion(input: {
   completed: boolean;

--- a/src/lib/api/api-error-message.ts
+++ b/src/lib/api/api-error-message.ts
@@ -72,3 +72,14 @@ export function extractApiErrorMessage(errorBody: unknown): string | null {
 
   return null;
 }
+
+export async function readApiErrorMessage(
+  response: Response,
+  fallback: string,
+) {
+  try {
+    return extractApiErrorMessage(await response.json()) ?? fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,6 +1,9 @@
 "use client";
 
-export { extractApiErrorMessage } from "@/lib/api/api-error-message";
+export {
+  extractApiErrorMessage,
+  readApiErrorMessage,
+} from "@/lib/api/api-error-message";
 export { apiClient } from "@/lib/api/client-methods";
 export type {
   ApiError,

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractApiErrorMessage } from "@/lib/api/client";
+import { extractApiErrorMessage, readApiErrorMessage } from "@/lib/api/client";
 
 describe("api client helpers", () => {
   it("extracts plain and Error messages", () => {
@@ -50,5 +50,26 @@ describe("api client helpers", () => {
   it("returns null when no usable message is present", () => {
     expect(extractApiErrorMessage(undefined)).toBeNull();
     expect(extractApiErrorMessage({ error: "   ", errors: [] })).toBeNull();
+  });
+
+  it("reads API error messages from response bodies", async () => {
+    await expect(
+      readApiErrorMessage(
+        new Response(JSON.stringify({ error: "  server failed  " }), {
+          headers: { "content-type": "application/json" },
+          status: 400,
+        }),
+        "fallback",
+      ),
+    ).resolves.toBe("server failed");
+  });
+
+  it("falls back when response bodies are not JSON error payloads", async () => {
+    await expect(
+      readApiErrorMessage(
+        new Response("plain text failure", { status: 500 }),
+        "fallback",
+      ),
+    ).resolves.toBe("fallback");
   });
 });


### PR DESCRIPTION
## Goal

Remove duplicated client-side API error parsing and make admin/dashboard actions surface REST error payloads consistently.

## Changed Surfaces

- Shared API client: added `readApiErrorMessage(response, fallback)` next to `extractApiErrorMessage`.
- Admin and dashboard clients: delegated local response-message parsing to the shared helper.
- Dashboard link pinning now uses the same fallback behavior for non-JSON error responses.
- Unit tests cover response-level JSON extraction and non-JSON fallback behavior.

## Evidence

- Focused checks: `bun run biome check --write <changed files>`; `bun run test -- tests/unit/api-client.test.ts tests/unit/admin-suspension-expiration.test.ts`.
- Default gate: `bun run verify`.
- Subagent review: no blocking issues; verified shared location, no response double-read path, and focused test coverage.

## Docs / Contracts

- No docs/contracts/OpenAPI changes. This is client-side parsing consolidation; REST response contracts are unchanged.

## Risk Areas

- Admin and dashboard error toasts/messages now show string `{ error }` payloads instead of falling back generically.
- No auth, Prisma, MCP, upload, or i18n behavior changes.

## Cleanup

- No scratch artifacts, one-time probes, generated-file edits, or unrelated rewrites remain.
