### PR TITLE
fix(api): observe readiness responses

### DIFF
--- a/src/routes/api/readiness/+server.ts
+++ b/src/routes/api/readiness/+server.ts
@@ -1,5 +1,7 @@
 import { jsonResponse, notFoundText } from "@/lib/api/helpers";
+import { svelteRequestHandler } from "@/lib/api/svelte-route";
 import { canReadInternalEndpoint } from "@/lib/http/access-control";
+import { observedApiRoute } from "@/lib/log/api-observability";
 import { storageReadiness } from "@/lib/storage/r2-object";
 
 const startedAt = Date.now();
@@ -19,13 +21,7 @@ function checkStorageConfig() {
   return storageReadiness();
 }
 
-/**
- * Check internal dependency readiness.
- * @response readinessResponseSchema
- * @response 503:readinessResponseSchema
- * @response 404
- */
-export async function GET({ request }: { request: Request }) {
+async function getReadinessRoute(request: Request) {
   if (
     !canReadInternalEndpoint(request, [
       "READINESS_BEARER_TOKEN",
@@ -51,3 +47,11 @@ export async function GET({ request }: { request: Request }) {
     { status: ready ? 200 : 503 },
   );
 }
+
+/**
+ * Check internal dependency readiness.
+ * @response readinessResponseSchema
+ * @response 503:readinessResponseSchema
+ * @response 404
+ */
+export const GET = svelteRequestHandler(observedApiRoute(getReadinessRoute));

--- a/tests/unit/readiness-route.test.ts
+++ b/tests/unit/readiness-route.test.ts
@@ -1,4 +1,9 @@
+import type { RequestEvent } from "@sveltejs/kit";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  renderPrometheusMetrics,
+  resetRuntimeMetricsForTest,
+} from "@/lib/metrics/runtime-metrics";
 
 const { queryRawMock, storageReadinessMock } = vi.hoisted(() => ({
   queryRawMock: vi.fn(),
@@ -18,8 +23,13 @@ vi.mock("@/lib/storage/r2-object", () => ({
   storageReadiness: storageReadinessMock,
 }));
 
+function eventWithRequest(request: Request) {
+  return { request } as RequestEvent;
+}
+
 describe("/api/readiness", () => {
   afterEach(() => {
+    resetRuntimeMetricsForTest();
     queryRawMock.mockReset();
     storageReadinessMock.mockClear();
     vi.restoreAllMocks();
@@ -31,11 +41,13 @@ describe("/api/readiness", () => {
     vi.spyOn(console, "info").mockImplementation(() => {});
     const { GET } = await import("@/routes/api/readiness/+server");
 
-    const response = await GET({
-      request: new Request("http://127.0.0.1:3000/api/readiness", {
-        headers: { "x-request-id": "request-1" },
-      }),
-    });
+    const response = await GET(
+      eventWithRequest(
+        new Request("http://127.0.0.1:3000/api/readiness", {
+          headers: { "x-request-id": "request-1" },
+        }),
+      ),
+    );
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -47,17 +59,54 @@ describe("/api/readiness", () => {
       },
     });
     expect(typeof body.uptimeSeconds).toBe("number");
+
+    expect(renderPrometheusMetrics()).toContain(
+      'life_ustc_api_requests_total{auth_mode="anonymous",method="GET",route="/api/readiness",status="200"} 1',
+    );
+  });
+
+  it("records degraded readiness responses as api errors", async () => {
+    queryRawMock.mockRejectedValue(new Error("database unavailable"));
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    const { GET } = await import("@/routes/api/readiness/+server");
+
+    const response = await GET(
+      eventWithRequest(
+        new Request("http://127.0.0.1:3000/api/readiness", {
+          headers: { "x-request-id": "request-503" },
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "degraded",
+      checks: {
+        database: { status: "error" },
+        storage: { status: "ok" },
+      },
+    });
+
+    const metrics = renderPrometheusMetrics();
+    expect(metrics).toContain(
+      'life_ustc_api_requests_total{auth_mode="anonymous",method="GET",route="/api/readiness",status="503"} 1',
+    );
+    expect(metrics).toContain(
+      'life_ustc_api_errors_total{method="GET",route="/api/readiness",status="503"} 1',
+    );
   });
 
   it("hides readiness from remote requests without a token", async () => {
     vi.spyOn(console, "info").mockImplementation(() => {});
     const { GET } = await import("@/routes/api/readiness/+server");
 
-    const response = await GET({
-      request: new Request("https://example.test/api/readiness", {
-        headers: { host: "example.test" },
-      }),
-    });
+    const response = await GET(
+      eventWithRequest(
+        new Request("https://example.test/api/readiness", {
+          headers: { host: "example.test" },
+        }),
+      ),
+    );
 
     expect(response.status).toBe(404);
     expect(queryRawMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Goal

Bring `/api/readiness` onto the same API observability wrapper used by ordinary REST routes, so successful and degraded readiness responses emit finish/error metrics instead of only request-start telemetry.

## Changed Surfaces

- `src/routes/api/readiness/+server.ts`: extracts the existing readiness logic to a request-only handler and exports `GET` through `svelteRequestHandler(observedApiRoute(...))`.
- `tests/unit/readiness-route.test.ts`: covers 200 readiness metrics and 503 degraded readiness error metrics.

## Evidence

- Focused route/observability tests: `bun run test -- tests/unit/readiness-route.test.ts tests/unit/api-observability.test.ts`
- OpenAPI annotation check: `bun run openapi:check`
- Default gate: `bun run verify`
- Subagent review: no blocking contract/OpenAPI/MCP/runtime issues found; noted hidden remote 404 readiness probes will now be counted consistently with other observed API errors.

## Docs / Contracts

No docs/contracts changes. The public readiness response body, status contract, and OpenAPI annotations are unchanged; this only aligns runtime observability behavior. No MCP surface applies.

## Risk Areas

- Observability: `/api/readiness` 404 responses from unauthorized remote requests now have finish/error metrics because the route uses the same wrapper as other API routes. This is intentional consistency, but can add noise if public scanners hit the endpoint.
- Auth/security: access-control behavior is unchanged; remote unauthorized requests still receive 404 and do not touch DB readiness checks.

## Cleanup

No scratch artifacts, one-time probes, unrelated rewrites, or manual generated-file edits remain.