### PR TITLE
fix(homeworks): share client update flows

### DIFF
--- a/src/features/dashboard/lib/dashboard-controller-homework-actions.ts
+++ b/src/features/dashboard/lib/dashboard-controller-homework-actions.ts
@@ -1,5 +1,8 @@
+import {
+  applyHomeworkCompletionResult,
+  updateHomeworkCompletion,
+} from "@/features/homeworks/lib/homework-completion-client";
 import type { HomeworkItem } from "./dashboard-controller-helpers";
-import { updateHomeworkCompletion } from "./homeworks";
 
 export async function toggleDashboardHomeworkCompletion(input: {
   errorMessage: string;
@@ -7,14 +10,9 @@ export async function toggleDashboardHomeworkCompletion(input: {
 }) {
   const result = await updateHomeworkCompletion({
     completed: !input.homework.completion,
-    errorMessage: input.errorMessage,
+    fallbackMessage: input.errorMessage,
     homeworkId: input.homework.id,
   });
 
-  return {
-    ...input.homework,
-    completion: result.completed
-      ? { completedAt: result.completedAt ?? new Date().toISOString() }
-      : null,
-  };
+  return applyHomeworkCompletionResult(input.homework, result);
 }

--- a/src/features/dashboard/lib/homeworks.ts
+++ b/src/features/dashboard/lib/homeworks.ts
@@ -1,8 +1,3 @@
-export type HomeworkCompletionResult = {
-  completed: boolean;
-  completedAt: string | null;
-};
-
 type HomeworkCompletionState = {
   completion?: unknown | null;
 };
@@ -82,21 +77,4 @@ export function homeworkCompletionActionLabel(
   },
 ) {
   return homework.completion ? labels.markIncomplete : labels.markComplete;
-}
-
-export async function updateHomeworkCompletion(input: {
-  completed: boolean;
-  errorMessage: string;
-  homeworkId: number | string;
-}): Promise<HomeworkCompletionResult> {
-  const response = await fetch(
-    `/api/homeworks/${input.homeworkId}/completion`,
-    {
-      method: "PUT",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ completed: input.completed }),
-    },
-  );
-  if (!response.ok) throw new Error(input.errorMessage);
-  return (await response.json()) as HomeworkCompletionResult;
 }

--- a/src/features/homeworks/lib/homework-completion-client.ts
+++ b/src/features/homeworks/lib/homework-completion-client.ts
@@ -1,0 +1,62 @@
+import type * as z from "zod";
+import { readApiErrorMessage } from "@/lib/api/client";
+import { homeworkCompletionResponseSchema } from "@/lib/api/schemas/homeworks-response-schemas";
+
+export type HomeworkCompletionResult = z.infer<
+  typeof homeworkCompletionResponseSchema
+>;
+
+type HomeworkCompletionState = {
+  completion?: unknown | null;
+};
+
+export function applyHomeworkCompletionResult<
+  Homework extends HomeworkCompletionState,
+>(homework: Homework, result: HomeworkCompletionResult): Homework {
+  return {
+    ...homework,
+    completion: result.completed
+      ? { completedAt: result.completedAt ?? new Date().toISOString() }
+      : null,
+  } as Homework;
+}
+
+async function readCompletionPayload(
+  response: Response,
+  fallbackMessage: string,
+) {
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response, fallbackMessage));
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error(fallbackMessage);
+  }
+
+  const parsed = homeworkCompletionResponseSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw new Error(fallbackMessage);
+  }
+
+  return parsed.data;
+}
+
+export async function updateHomeworkCompletion(input: {
+  completed: boolean;
+  fallbackMessage: string;
+  homeworkId: number | string;
+}): Promise<HomeworkCompletionResult> {
+  const response = await fetch(
+    `/api/homeworks/${input.homeworkId}/completion`,
+    {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ completed: input.completed }),
+    },
+  );
+
+  return readCompletionPayload(response, input.fallbackMessage);
+}

--- a/src/features/section-detail/lib/homeworks.ts
+++ b/src/features/section-detail/lib/homeworks.ts
@@ -8,15 +8,7 @@ export type SectionHomeworkRequest = {
   title: string;
 };
 
-export type HomeworkCompletionResult = {
-  completed: boolean;
-  completedAt: string | null;
-};
-
-export type SectionHomeworkUpdateResult =
-  | "ok"
-  | "homework-error"
-  | "description-error";
+export type SectionHomeworkUpdateResult = "ok" | "homework-error";
 
 export async function loadSectionHomeworks<Viewer, Homework, AuditLog>(
   sectionId: number | string,
@@ -61,6 +53,7 @@ export async function updateSectionHomework(
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
       title: input.title,
+      description: input.description,
       publishedAt: input.publishedAt || null,
       submissionStartAt: input.submissionStartAt || null,
       submissionDueAt: input.submissionDueAt || null,
@@ -68,31 +61,7 @@ export async function updateSectionHomework(
       requiresTeam: input.requiresTeam,
     }),
   });
-  if (!response.ok) return "homework-error";
-
-  const descriptionResponse = await fetch("/api/descriptions", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      targetType: "homework",
-      targetId: homeworkId,
-      content: input.description,
-    }),
-  });
-  return descriptionResponse.ok ? "ok" : "description-error";
-}
-
-export async function updateSectionHomeworkCompletion(
-  homeworkId: number | string,
-  completed: boolean,
-): Promise<HomeworkCompletionResult | null> {
-  const response = await fetch(`/api/homeworks/${homeworkId}/completion`, {
-    method: "PUT",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ completed }),
-  });
-  if (!response.ok) return null;
-  return (await response.json()) as HomeworkCompletionResult;
+  return response.ok ? "ok" : "homework-error";
 }
 
 export async function deleteSectionHomework(homeworkId: number | string) {

--- a/src/features/section-detail/lib/section-detail-homework-state.ts
+++ b/src/features/section-detail/lib/section-detail-homework-state.ts
@@ -1,4 +1,7 @@
-import type { HomeworkCompletionResult } from "./homeworks";
+import {
+  applyHomeworkCompletionResult,
+  type HomeworkCompletionResult,
+} from "@/features/homeworks/lib/homework-completion-client";
 import type { SectionHomework } from "./section-detail-controller-helpers";
 
 export function applySectionHomeworkCompletion(input: {
@@ -9,12 +12,7 @@ export function applySectionHomeworkCompletion(input: {
 }) {
   const homeworks = input.homeworks.map((item) =>
     item.id === input.homeworkId
-      ? {
-          ...item,
-          completion: input.result.completed
-            ? { completedAt: input.result.completedAt }
-            : null,
-        }
+      ? applyHomeworkCompletionResult(item, input.result)
       : item,
   );
 

--- a/src/features/section-detail/lib/section-detail-homework-submit-actions.ts
+++ b/src/features/section-detail/lib/section-detail-homework-submit-actions.ts
@@ -62,11 +62,6 @@ export function createSectionHomeworkSubmitActions(
       input.setEditHomeworkMessage(homeworkCopy.updateFailed);
       return;
     }
-    if (updateResult === "description-error") {
-      input.setEditHomeworkMessage(homeworkCopy.updateFailed);
-      await loadHomeworks();
-      return;
-    }
 
     input.cancelEditHomework();
     await loadHomeworks();

--- a/src/features/section-detail/lib/section-detail-homework-toggle-action.ts
+++ b/src/features/section-detail/lib/section-detail-homework-toggle-action.ts
@@ -1,4 +1,4 @@
-import { updateSectionHomeworkCompletion } from "./homeworks";
+import { updateHomeworkCompletion } from "@/features/homeworks/lib/homework-completion-client";
 import type { SectionHomework } from "./section-detail-controller-helpers";
 import type { SectionDetailHomeworkActionInput } from "./section-detail-homework-action-types";
 import { applySectionHomeworkCompletion } from "./section-detail-homework-state";
@@ -7,19 +7,25 @@ export function createSectionHomeworkToggleAction(
   input: SectionDetailHomeworkActionInput,
 ) {
   async function toggleHomeworkCompletion(homework: SectionHomework) {
-    const result = await updateSectionHomeworkCompletion(
-      homework.id,
-      !homework.completion,
-    );
-    if (!result) return;
-    const next = applySectionHomeworkCompletion({
-      homeworkId: homework.id,
-      homeworks: input.getHomeworks(),
-      result,
-      selectedHomework: input.getSelectedHomework(),
-    });
-    input.setHomeworks(next.homeworks);
-    input.setSelectedHomework(next.selectedHomework);
+    const copy = input.getHomeworkCopy();
+    input.setHomeworkMessage("");
+    try {
+      const result = await updateHomeworkCompletion({
+        completed: !homework.completion,
+        fallbackMessage: copy.completionFailed,
+        homeworkId: homework.id,
+      });
+      const next = applySectionHomeworkCompletion({
+        homeworkId: homework.id,
+        homeworks: input.getHomeworks(),
+        result,
+        selectedHomework: input.getSelectedHomework(),
+      });
+      input.setHomeworks(next.homeworks);
+      input.setSelectedHomework(next.selectedHomework);
+    } catch {
+      input.setHomeworkMessage(copy.completionFailed);
+    }
   }
 
   return { toggleHomeworkCompletion };

--- a/tests/unit/dashboard-homework-actions.test.ts
+++ b/tests/unit/dashboard-homework-actions.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HomeworkItem } from "@/features/dashboard/lib/dashboard-controller-helpers";
+
+const updateHomeworkCompletionMock = vi.fn();
+
+vi.mock("@/features/homeworks/lib/homework-completion-client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/features/homeworks/lib/homework-completion-client")
+  >("@/features/homeworks/lib/homework-completion-client");
+  return {
+    ...actual,
+    updateHomeworkCompletion: updateHomeworkCompletionMock,
+  };
+});
+
+describe("dashboard homework actions", () => {
+  beforeEach(() => {
+    updateHomeworkCompletionMock.mockReset();
+  });
+
+  it("updates homework completion through the shared client", async () => {
+    const homework = {
+      id: "homework-1",
+      completion: null,
+      submissionDueAt: null,
+      title: "Homework",
+    } as HomeworkItem;
+    updateHomeworkCompletionMock.mockResolvedValue({
+      completed: true,
+      completedAt: "2026-06-22T10:00:00.000Z",
+    });
+
+    const { toggleDashboardHomeworkCompletion } = await import(
+      "@/features/dashboard/lib/dashboard-controller-homework-actions"
+    );
+
+    await expect(
+      toggleDashboardHomeworkCompletion({
+        errorMessage: "completion failed",
+        homework,
+      }),
+    ).resolves.toEqual({
+      ...homework,
+      completion: { completedAt: "2026-06-22T10:00:00.000Z" },
+    });
+
+    expect(updateHomeworkCompletionMock).toHaveBeenCalledWith({
+      completed: true,
+      fallbackMessage: "completion failed",
+      homeworkId: "homework-1",
+    });
+  });
+});

--- a/tests/unit/homework-completion-client.test.ts
+++ b/tests/unit/homework-completion-client.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { updateHomeworkCompletion } from "@/features/homeworks/lib/homework-completion-client";
+
+const jsonResponse = (body: unknown, init?: ResponseInit) =>
+  new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+
+describe("homework completion client", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("updates completion through the shared route client", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        completed: true,
+        completedAt: "2026-06-22T10:00:00.000Z",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      updateHomeworkCompletion({
+        completed: true,
+        fallbackMessage: "completion failed",
+        homeworkId: "homework-1",
+      }),
+    ).resolves.toEqual({
+      completed: true,
+      completedAt: "2026-06-22T10:00:00.000Z",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/homeworks/homework-1/completion",
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ completed: true }),
+      },
+    );
+  });
+
+  it("uses API error payloads before fallback messages", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({ error: "  homework not found  " }, { status: 404 }),
+      ),
+    );
+
+    await expect(
+      updateHomeworkCompletion({
+        completed: false,
+        fallbackMessage: "completion failed",
+        homeworkId: "missing",
+      }),
+    ).rejects.toThrow("homework not found");
+  });
+
+  it("falls back when error payloads are not JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("plain failure", { status: 500 })),
+    );
+
+    await expect(
+      updateHomeworkCompletion({
+        completed: false,
+        fallbackMessage: "completion failed",
+        homeworkId: "homework-1",
+      }),
+    ).rejects.toThrow("completion failed");
+  });
+
+  it("rejects malformed successful payloads", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ completed: true })),
+    );
+
+    await expect(
+      updateHomeworkCompletion({
+        completed: true,
+        fallbackMessage: "completion failed",
+        homeworkId: "homework-1",
+      }),
+    ).rejects.toThrow("completion failed");
+  });
+});

--- a/tests/unit/section-detail-homework-toggle-action.test.ts
+++ b/tests/unit/section-detail-homework-toggle-action.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SectionHomework } from "@/features/section-detail/lib/section-detail-controller-helpers";
+import type { SectionDetailHomeworkActionInput } from "@/features/section-detail/lib/section-detail-homework-action-types";
+
+const updateHomeworkCompletionMock = vi.fn();
+
+vi.mock("@/features/homeworks/lib/homework-completion-client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/features/homeworks/lib/homework-completion-client")
+  >("@/features/homeworks/lib/homework-completion-client");
+  return {
+    ...actual,
+    updateHomeworkCompletion: updateHomeworkCompletionMock,
+  };
+});
+
+function homeworkCopy(): ReturnType<
+  SectionDetailHomeworkActionInput["getHomeworkCopy"]
+> {
+  return new Proxy<Record<string, string>>(
+    { completionFailed: "completion failed" },
+    {
+      get: (target, property) =>
+        typeof property === "string" ? (target[property] ?? property) : "",
+    },
+  ) as unknown as ReturnType<
+    SectionDetailHomeworkActionInput["getHomeworkCopy"]
+  >;
+}
+
+function actionInput(
+  overrides: Partial<SectionDetailHomeworkActionInput>,
+): SectionDetailHomeworkActionInput {
+  return {
+    cancelEditHomework: vi.fn(),
+    closeCreateHomeworkDialog: vi.fn(),
+    getCreateHomeworkPublishedAt: () => "",
+    getCreateHomeworkSubmissionDueAt: () => "",
+    getCreateHomeworkSubmissionStartAt: () => "",
+    getDeleteHomeworkTarget: () => null,
+    getEditHomeworkPublishedAt: () => "",
+    getEditHomeworkSubmissionDueAt: () => "",
+    getEditHomeworkSubmissionStartAt: () => "",
+    getHomeworkCopy: homeworkCopy,
+    getHomeworkViewer: () => ({
+      isAdmin: false,
+      isAuthenticated: true,
+      isSuspended: false,
+    }),
+    getHomeworks: () => [],
+    getSectionId: () => 1,
+    getSelectedHomework: () => null,
+    setDeleteHomeworkTarget: vi.fn(),
+    setEditHomeworkMessage: vi.fn(),
+    setHomeworkAuditLogs: vi.fn(),
+    setHomeworkMessage: vi.fn(),
+    setHomeworkViewer: vi.fn(),
+    setHomeworks: vi.fn(),
+    setSelectedHomework: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("section detail homework toggle action", () => {
+  beforeEach(() => {
+    updateHomeworkCompletionMock.mockReset();
+  });
+
+  it("updates homework completion through the shared client", async () => {
+    const homework = {
+      id: "homework-1",
+      completion: null,
+      title: "Homework",
+    } as SectionHomework;
+    const homeworks = [homework];
+    const setHomeworks = vi.fn();
+    const setSelectedHomework = vi.fn();
+    const setHomeworkMessage = vi.fn();
+    updateHomeworkCompletionMock.mockResolvedValue({
+      completed: true,
+      completedAt: "2026-06-22T10:00:00.000Z",
+    });
+
+    const { createSectionHomeworkToggleAction } = await import(
+      "@/features/section-detail/lib/section-detail-homework-toggle-action"
+    );
+
+    const { toggleHomeworkCompletion } = createSectionHomeworkToggleAction(
+      actionInput({
+        getHomeworks: () => homeworks,
+        getSelectedHomework: () => homework,
+        setHomeworkMessage,
+        setHomeworks,
+        setSelectedHomework,
+      }),
+    );
+
+    await toggleHomeworkCompletion(homework);
+
+    expect(updateHomeworkCompletionMock).toHaveBeenCalledWith({
+      completed: true,
+      fallbackMessage: "completion failed",
+      homeworkId: "homework-1",
+    });
+    expect(setHomeworkMessage).toHaveBeenCalledWith("");
+    expect(setHomeworks).toHaveBeenCalledWith([
+      expect.objectContaining({
+        completion: { completedAt: "2026-06-22T10:00:00.000Z" },
+      }),
+    ]);
+    expect(setSelectedHomework).toHaveBeenCalledWith(
+      expect.objectContaining({
+        completion: { completedAt: "2026-06-22T10:00:00.000Z" },
+      }),
+    );
+  });
+
+  it("surfaces localized completion failures instead of raw API messages", async () => {
+    const homework = {
+      id: "homework-1",
+      completion: { completedAt: "2026-06-22T10:00:00.000Z" },
+      title: "Homework",
+    } as SectionHomework;
+    const setHomeworks = vi.fn();
+    const setSelectedHomework = vi.fn();
+    const setHomeworkMessage = vi.fn();
+    updateHomeworkCompletionMock.mockRejectedValue(
+      new Error("homework not found"),
+    );
+
+    const { createSectionHomeworkToggleAction } = await import(
+      "@/features/section-detail/lib/section-detail-homework-toggle-action"
+    );
+
+    const { toggleHomeworkCompletion } = createSectionHomeworkToggleAction({
+      ...actionInput({
+        getHomeworks: () => [homework],
+        getSelectedHomework: () => homework,
+        setHomeworkMessage,
+        setHomeworks,
+        setSelectedHomework,
+      }),
+    });
+
+    await toggleHomeworkCompletion(homework);
+
+    expect(updateHomeworkCompletionMock).toHaveBeenCalledWith({
+      completed: false,
+      fallbackMessage: "completion failed",
+      homeworkId: "homework-1",
+    });
+    expect(setHomeworkMessage).toHaveBeenLastCalledWith("completion failed");
+    expect(setHomeworks).not.toHaveBeenCalled();
+    expect(setSelectedHomework).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/section-detail-homeworks-client.test.ts
+++ b/tests/unit/section-detail-homeworks-client.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type SectionHomeworkRequest,
+  updateSectionHomework,
+} from "@/features/section-detail/lib/homeworks";
+
+const homeworkInput: SectionHomeworkRequest = {
+  description: "Updated description",
+  isMajor: true,
+  publishedAt: "2026-06-22T08:00:00.000Z",
+  requiresTeam: false,
+  submissionDueAt: "2026-06-29T08:00:00.000Z",
+  submissionStartAt: null,
+  title: "Updated homework",
+};
+
+describe("section detail homeworks client", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("updates homework and description through one homework PATCH", async () => {
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      updateSectionHomework("homework-1", homeworkInput),
+    ).resolves.toBe("ok");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith("/api/homeworks/homework-1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Updated homework",
+        description: "Updated description",
+        publishedAt: "2026-06-22T08:00:00.000Z",
+        submissionStartAt: null,
+        submissionDueAt: "2026-06-29T08:00:00.000Z",
+        isMajor: true,
+        requiresTeam: false,
+      }),
+    });
+  });
+
+  it("maps failed homework PATCH requests to one update failure", async () => {
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      updateSectionHomework("homework-1", homeworkInput),
+    ).resolves.toBe("homework-error");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Goal

Remove homework client drift between dashboard and section-detail surfaces, and make section-detail homework edits use the existing transactional homework update route.

## Changed Surfaces

- Added `src/features/homeworks/lib/homework-completion-client.ts` for validated completion updates and shared completion-state mapping.
- Updated dashboard and section-detail completion actions to use the shared homeworks client.
- Updated section-detail homework edits to send `description` through `PATCH /api/homeworks/:id` instead of a second `/api/descriptions` request.
- Removed the section-detail partial-success path where homework fields could save but description failed separately.
- Added focused unit coverage for the shared client, dashboard caller, section-detail toggle action, and one-call section-detail homework update request.

## Evidence

Focused behavior coverage:
- `bun run test -- tests/unit/homework-completion-client.test.ts tests/unit/section-detail-homework-toggle-action.test.ts tests/unit/section-detail-homeworks-client.test.ts tests/unit/dashboard-homework-actions.test.ts`

Type and formatting checks:
- `bun run tsc --noEmit -p tsconfig.typecheck.json`
- `bun run tsc --noEmit -p tsconfig.typecheck.tests.json`
- `git diff --check`

Default repo gate:
- `bun run verify` passed: 91 unit test files, 428 tests.

Subagent review:
- Feature-boundary review found the section-detail split homework/description update path; this PR removes it.
- Diff review found raw API error copy and schema/mapping drift risks; this PR now shows localized completion failure copy, reuses `homeworkCompletionResponseSchema`, and shares completion-state mapping.
- Final diff review found only a Biome import-order blocker; fixed before `bun run verify`.

## Docs / Contracts

No docs or contract changes. The public REST/MCP behavior is unchanged; this aligns existing UI clients with the already documented homework PATCH and completion response shapes.

## Risk Areas

- Section-detail homework update now depends on `PATCH /api/homeworks/:id` for description writes, matching REST and MCP behavior.
- Section-detail completion failures now show the localized fallback copy instead of silently ignoring failures or exposing raw API text.

## Cleanup

- No scratch files or generated-source edits remain.
- Local branch contains one intentional commit on top of `main`.
