### PR TITLE
fix(static): subscription import append flow

### DIFF
--- a/docs/contracts/subscription.json
+++ b/docs/contracts/subscription.json
@@ -79,6 +79,17 @@
             ]
           },
           {
+            "path": "/api/calendar-subscriptions",
+            "method": "PATCH",
+            "returns": "{ subscription: CalendarSubscription, addedCount: Int, alreadySubscribedCount: Int }",
+            "notes": [
+              "Append selected section IDs after a preview flow without replacing the caller's whole subscription set.",
+              "Used by dashboard and welcome bulk-import confirmation after users deselect unwanted matched sections.",
+              "Unknown positive section IDs are ignored; malformed or non-positive IDs return 400.",
+              "Already-subscribed selected sections are counted but not duplicated."
+            ]
+          },
+          {
             "path": "/api/calendar-subscriptions/import-codes",
             "method": "POST",
             "returns": "{ success: Boolean, semester, matchedCodes, unmatchedCodes, ambiguousCodes, sections, addedCount, addedSections, alreadySubscribedCount, alreadySubscribedSections, subscription }",
@@ -97,7 +108,8 @@
             "rest_equivalent": "POST /api/sections/match-codes",
             "notes": [
               "Returns suggestions for unmatched inputs when close section codes in the selected semester share a strong code-prefix or edit-distance match; unrelated section codes should be filtered out.",
-              "Prefer this read-only preview before subscribe_my_sections_by_codes when the caller needs confirmation or typo recovery."
+              "Prefer this read-only preview before subscribe_my_sections_by_codes when the caller needs confirmation or typo recovery.",
+              "MCP callers that need per-section selection can subscribe selected preview results by calling subscribe_section_by_jw_id with each section.jwId."
             ]
           },
           {

--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -134,7 +134,7 @@
       "cancel": "Cancel",
       "subscribeSelected": "Follow {count} sections",
       "success": "Added successfully",
-      "successDescription": "Now following {count} sections in Life@USTC",
+      "successDescription": "Added {count} new section{plural} to Life@USTC",
       "importFailed": "Add failed"
     }
   },
@@ -1800,7 +1800,7 @@
     "selectSection": "Select {code}",
     "importing": "Importing...",
     "subscribeSelected": "Subscribe selected ({count})",
-    "importedSummary": "Imported {count} section{plural}."
+    "importedSummary": "Added {count} new section{plural}."
   },
   "oauth": {
     "authorize": "Authorize Application",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -134,7 +134,7 @@
       "cancel": "取消",
       "subscribeSelected": "关注已选的 {count} 个班级",
       "success": "已加入",
-      "successDescription": "已成功关注 {count} 个班级",
+      "successDescription": "已新增关注 {count} 个班级",
       "importFailed": "关注失败"
     }
   },
@@ -1766,7 +1766,7 @@
     "selectSection": "选择 {code}",
     "importing": "导入中...",
     "subscribeSelected": "关注已选（{count}）",
-    "importedSummary": "已导入 {count} 个班级。"
+    "importedSummary": "已新增关注 {count} 个班级。"
   },
   "oauth": {
     "authorize": "授权应用",

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -1419,6 +1419,65 @@
             }
           }
         }
+      },
+      "patch": {
+        "operationId": "appendCalendarSubscriptionSections",
+        "summary": "Append section subscriptions",
+        "tags": [
+          "Calendar"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/calendarSubscriptionAppendRequestSchema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/calendarSubscriptionAppendResponseSchema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/calendar-subscriptions/current": {
@@ -6156,6 +6215,22 @@
           }
         }
       },
+      "calendarSubscriptionAppendRequestSchema": {
+        "type": "object",
+        "properties": {
+          "sectionIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "exclusiveMinimum": true,
+              "maximum": 9007199254740991
+            }
+          }
+        },
+        "required": [
+          "sectionIds"
+        ]
+      },
       "matchSectionCodesRequestSchema": {
         "type": "object",
         "properties": {
@@ -10123,6 +10198,740 @@
         },
         "required": [
           "subscription"
+        ],
+        "additionalProperties": false
+      },
+      "calendarSubscriptionAppendResponseSchema": {
+        "type": "object",
+        "properties": {
+          "subscription": {
+            "nullable": true,
+            "type": "object",
+            "properties": {
+              "userId": {
+                "type": "string"
+              },
+              "sections": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "jwId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "bizTypeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "credits": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "period": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "periodsPerWeek": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "timesPerWeek": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "stdCount": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "limitCount": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "graduateAndPostgraduate": {
+                      "nullable": true,
+                      "type": "boolean"
+                    },
+                    "dateTimePlaceText": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "dateTimePlacePersonText": {
+                      "nullable": true
+                    },
+                    "actualPeriods": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "theoryPeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "practicePeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "experimentPeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "machinePeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "designPeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "testPeriods": {
+                      "nullable": true,
+                      "type": "number"
+                    },
+                    "scheduleState": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "suggestScheduleWeeks": {
+                      "nullable": true
+                    },
+                    "suggestScheduleWeekInfo": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "scheduleJsonParams": {
+                      "nullable": true
+                    },
+                    "selectedStdCount": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "remark": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "scheduleRemark": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "courseId": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "semesterId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "campusId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "examModeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "openDepartmentId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "teachLanguageId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "roomTypeId": {
+                      "nullable": true,
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "course": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "categoryId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "classTypeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "classifyId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "educationLevelId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "gradationId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "typeId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "category": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "nameCn",
+                            "nameEn"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "classType": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "nameCn",
+                            "nameEn"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "classify": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "nameCn",
+                            "nameEn"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "educationLevel": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "nameCn",
+                            "nameEn"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "gradation": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "nameCn",
+                            "nameEn"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "type": {
+                          "nullable": true,
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "nameCn": {
+                              "type": "string"
+                            },
+                            "nameEn": {
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "nameCn",
+                            "nameEn"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "namePrimary": {
+                          "type": "string"
+                        },
+                        "nameSecondary": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "code",
+                        "nameCn",
+                        "nameEn",
+                        "categoryId",
+                        "classTypeId",
+                        "classifyId",
+                        "educationLevelId",
+                        "gradationId",
+                        "typeId",
+                        "category",
+                        "classType",
+                        "classify",
+                        "educationLevel",
+                        "gradation",
+                        "type",
+                        "namePrimary",
+                        "nameSecondary"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "semester": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "startDate": {
+                          "nullable": true,
+                          "type": "string",
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                        },
+                        "endDate": {
+                          "nullable": true,
+                          "type": "string",
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "nameCn",
+                        "code",
+                        "startDate",
+                        "endDate"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "campus": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "jwId": {
+                          "nullable": true,
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "code": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "namePrimary": {
+                          "type": "string"
+                        },
+                        "nameSecondary": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "jwId",
+                        "nameCn",
+                        "nameEn",
+                        "code",
+                        "namePrimary",
+                        "nameSecondary"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "openDepartment": {
+                      "nullable": true,
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "nameCn": {
+                          "type": "string"
+                        },
+                        "nameEn": {
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "isCollege": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
+                        "namePrimary": {
+                          "type": "string"
+                        },
+                        "nameSecondary": {
+                          "nullable": true,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "code",
+                        "nameCn",
+                        "nameEn",
+                        "isCollege",
+                        "namePrimary",
+                        "nameSecondary"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "teachers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "personId": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "teacherId": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "code": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "nameCn": {
+                            "type": "string"
+                          },
+                          "nameEn": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "age": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "email": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "telephone": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "mobile": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "address": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "postcode": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "qq": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "wechat": {
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "departmentId": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "teacherTitleId": {
+                            "nullable": true,
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "namePrimary": {
+                            "type": "string"
+                          },
+                          "nameSecondary": {
+                            "nullable": true,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "personId",
+                          "teacherId",
+                          "code",
+                          "nameCn",
+                          "nameEn",
+                          "age",
+                          "email",
+                          "telephone",
+                          "mobile",
+                          "address",
+                          "postcode",
+                          "qq",
+                          "wechat",
+                          "departmentId",
+                          "teacherTitleId",
+                          "namePrimary",
+                          "nameSecondary"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "jwId",
+                    "code",
+                    "bizTypeId",
+                    "credits",
+                    "period",
+                    "periodsPerWeek",
+                    "timesPerWeek",
+                    "stdCount",
+                    "limitCount",
+                    "graduateAndPostgraduate",
+                    "dateTimePlaceText",
+                    "dateTimePlacePersonText",
+                    "actualPeriods",
+                    "theoryPeriods",
+                    "practicePeriods",
+                    "experimentPeriods",
+                    "machinePeriods",
+                    "designPeriods",
+                    "testPeriods",
+                    "scheduleState",
+                    "suggestScheduleWeeks",
+                    "suggestScheduleWeekInfo",
+                    "scheduleJsonParams",
+                    "selectedStdCount",
+                    "remark",
+                    "scheduleRemark",
+                    "courseId",
+                    "semesterId",
+                    "campusId",
+                    "examModeId",
+                    "openDepartmentId",
+                    "teachLanguageId",
+                    "roomTypeId",
+                    "course",
+                    "semester",
+                    "campus",
+                    "openDepartment",
+                    "teachers"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "calendarPath": {
+                "type": "string"
+              },
+              "calendarUrl": {
+                "type": "string"
+              },
+              "note": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "userId",
+              "sections",
+              "calendarPath",
+              "calendarUrl",
+              "note"
+            ],
+            "additionalProperties": false
+          },
+          "addedCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "alreadySubscribedCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": [
+          "subscription",
+          "addedCount",
+          "alreadySubscribedCount"
         ],
         "additionalProperties": false
       },

--- a/src/features/dashboard/lib/dashboard-controller-mount.ts
+++ b/src/features/dashboard/lib/dashboard-controller-mount.ts
@@ -39,6 +39,7 @@ export function mountDashboardController(input: {
     input.setBulkImportMessage(
       formatMessage(input.copy.subscriptions.bulkImport.successDescription, {
         count: importedCount,
+        plural: importedCount === "1" ? "" : "s",
       }),
     );
   }

--- a/src/features/dashboard/lib/dashboard-controller-subscriptions.ts
+++ b/src/features/dashboard/lib/dashboard-controller-subscriptions.ts
@@ -80,6 +80,7 @@ export async function confirmDashboardImportSections(input: {
 
     return formatMessage(input.copy.bulkImport.successDescription, {
       count: importedCount,
+      plural: importedCount === 1 ? "" : "s",
     });
   } catch (error) {
     throw new Error(

--- a/src/features/dashboard/lib/subscription-client-actions.ts
+++ b/src/features/dashboard/lib/subscription-client-actions.ts
@@ -42,11 +42,10 @@ export async function matchSubscriptionSections(input: {
 }
 
 export async function importSubscriptionSections(input: {
-  copy: Pick<BulkImportCopy, "fetchFailed" | "importFailed">;
+  copy: Pick<BulkImportCopy, "importFailed">;
   selectedSectionIds: number[];
 }) {
   return appendSubscribedSectionIds({
-    fetchFailedMessage: input.copy.fetchFailed,
     importFailedMessage: input.copy.importFailed,
     selectedSectionIds: input.selectedSectionIds,
   });

--- a/src/features/home/lib/subscription-import-client.ts
+++ b/src/features/home/lib/subscription-import-client.ts
@@ -1,6 +1,7 @@
 import type * as z from "zod";
 import { extractApiErrorMessage } from "@/lib/api/client";
 import {
+  calendarSubscriptionAppendResponseSchema,
   calendarSubscriptionCreateResponseSchema,
   currentCalendarSubscriptionResponseSchema,
   matchSectionCodesResponseSchema,
@@ -103,21 +104,28 @@ export async function updateSubscribedSectionIds(
 }
 
 export async function appendSubscribedSectionIds({
-  fetchFailedMessage,
   importFailedMessage,
   selectedSectionIds,
 }: {
-  fetchFailedMessage: string;
   importFailedMessage: string;
   selectedSectionIds: number[];
 }) {
-  const currentSectionIds =
-    await fetchCurrentSubscribedSectionIds(fetchFailedMessage);
-  const nextSectionIds = Array.from(
-    new Set([...currentSectionIds, ...selectedSectionIds]),
+  if (selectedSectionIds.length === 0) {
+    return 0;
+  }
+
+  const response = await fetch("/api/calendar-subscriptions", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ sectionIds: selectedSectionIds }),
+  });
+  const payload = await readJsonPayload(response);
+  assertOkResponse(response, payload, importFailedMessage);
+  const data = validatedPayload(
+    calendarSubscriptionAppendResponseSchema,
+    payload,
+    importFailedMessage,
   );
 
-  await updateSubscribedSectionIds(nextSectionIds, importFailedMessage);
-
-  return selectedSectionIds.length;
+  return data.addedCount;
 }

--- a/src/features/home/server/subscription-write-model.ts
+++ b/src/features/home/server/subscription-write-model.ts
@@ -26,6 +26,18 @@ async function replaceUserSectionIds(
   });
 }
 
+async function getExistingSectionIds(sectionIds: readonly number[]) {
+  if (sectionIds.length === 0) {
+    return [];
+  }
+
+  const sections = await prisma.section.findMany({
+    where: { id: { in: uniqueSectionIds(sectionIds) } },
+    select: { id: true },
+  });
+  return sections.map((section) => section.id);
+}
+
 async function getMutableUserSubscriptions(userId: string) {
   return prisma.user.findUnique({
     where: { id: userId },
@@ -77,15 +89,41 @@ export async function replaceUserSectionSubscriptions(
   sectionIds: number[],
   locale = DEFAULT_LOCALE,
 ) {
-  const existingSections = await prisma.section.findMany({
-    where: { id: { in: sectionIds } },
-    select: { id: true },
-  });
-  const validSectionIds = existingSections.map((section) => section.id);
+  const validSectionIds = await getExistingSectionIds(sectionIds);
 
   await replaceUserSectionIds(userId, validSectionIds);
 
   return getUserCalendarSubscription(userId, locale);
+}
+
+export async function appendUserSectionSubscriptions({
+  locale = DEFAULT_LOCALE,
+  sectionIds,
+  userId,
+}: {
+  locale?: AppLocale;
+  sectionIds: readonly number[];
+  userId: string;
+}) {
+  const user = await getMutableUserSubscriptions(userId);
+  if (!user) {
+    return null;
+  }
+
+  const currentIdSet = new Set(
+    user.subscribedSections.map((section) => section.id),
+  );
+  const validSectionIds = await getExistingSectionIds(sectionIds);
+  const addedSectionIds = validSectionIds.filter((id) => !currentIdSet.has(id));
+
+  await connectUserSectionIds(userId, addedSectionIds);
+
+  return {
+    addedCount: addedSectionIds.length,
+    alreadySubscribedCount: validSectionIds.filter((id) => currentIdSet.has(id))
+      .length,
+    subscription: await getUserCalendarSubscription(userId, locale),
+  };
 }
 
 export async function addUserSectionSubscriptions(

--- a/src/features/home/server/subscriptions.ts
+++ b/src/features/home/server/subscriptions.ts
@@ -4,6 +4,7 @@ export {
 } from "./subscription-read-model";
 export {
   addUserSectionSubscriptions,
+  appendUserSectionSubscriptions,
   hasUserSubscribedSectionByJwId,
   importUserSectionSubscriptionsByCodes,
   removeUserSectionSubscriptions,

--- a/src/features/welcome/lib/welcome-bulk-import-confirm-action.ts
+++ b/src/features/welcome/lib/welcome-bulk-import-confirm-action.ts
@@ -13,7 +13,6 @@ export async function confirmWelcomeBulkImport(
   try {
     const selectedSectionIds = input.getSelectedSectionIds();
     const importedCount = await appendSubscribedSectionIds({
-      fetchFailedMessage: bulkCopy.fetchFailed,
       importFailedMessage: bulkCopy.importFailed,
       selectedSectionIds,
     });

--- a/src/lib/api/routes/calendar-subscriptions.ts
+++ b/src/lib/api/routes/calendar-subscriptions.ts
@@ -6,7 +6,10 @@ import {
 } from "@/lib/api/helpers";
 import { parseSectionMatchCodesRequest } from "@/lib/api/routes/academic-section-route-request";
 import { getRequestLocale } from "@/lib/api/routes/request-locale";
-import { calendarSubscriptionCreateRequestSchema } from "@/lib/api/schemas/request-schemas";
+import {
+  calendarSubscriptionAppendRequestSchema,
+  calendarSubscriptionCreateRequestSchema,
+} from "@/lib/api/schemas/request-schemas";
 import { requireAuth } from "@/lib/auth/api-auth";
 
 export async function getCurrentCalendarSubscriptionRoute(request: Request) {
@@ -108,5 +111,38 @@ export async function postCalendarSubscriptionImportCodesRoute(
     });
   } catch (error) {
     return handleRouteError("Failed to import section subscriptions", error);
+  }
+}
+
+export async function patchCalendarSubscriptionsRoute(request: Request) {
+  try {
+    const auth = await requireAuth(request);
+    if (auth instanceof Response) return auth;
+    const { userId } = auth;
+
+    const parsedBody = await parseRouteJsonBody(
+      request,
+      calendarSubscriptionAppendRequestSchema,
+      "Invalid subscription append request",
+    );
+    if (parsedBody instanceof Response) {
+      return parsedBody;
+    }
+
+    const { appendUserSectionSubscriptions } = await import(
+      "@/features/home/server/subscriptions"
+    );
+    const result = await appendUserSectionSubscriptions({
+      locale: getRequestLocale(request),
+      sectionIds: parsedBody.sectionIds,
+      userId,
+    });
+    if (!result) {
+      return notFound();
+    }
+
+    return jsonResponse(result);
+  } catch (error) {
+    return handleRouteError("Failed to append section subscriptions", error);
   }
 }

--- a/src/lib/api/schemas/misc-response-schema-core.ts
+++ b/src/lib/api/schemas/misc-response-schema-core.ts
@@ -33,6 +33,12 @@ export const calendarSubscriptionCreateResponseSchema = z.object({
   subscription: calendarSubscriptionSchema.nullable(),
 });
 
+export const calendarSubscriptionAppendResponseSchema =
+  calendarSubscriptionCreateResponseSchema.extend({
+    addedCount: z.number().int().nonnegative(),
+    alreadySubscribedCount: z.number().int().nonnegative(),
+  });
+
 export const calendarSubscriptionImportResponseSchema = z.object({
   success: z.boolean(),
   semester: z.object({

--- a/src/lib/api/schemas/request-mutation-schemas.ts
+++ b/src/lib/api/schemas/request-mutation-schemas.ts
@@ -31,6 +31,7 @@ export {
   uploadRenameRequestSchema,
 } from "@/lib/api/schemas/request-upload-mutation-schemas";
 export {
+  calendarSubscriptionAppendRequestSchema,
   calendarSubscriptionCreateRequestSchema,
   dashboardLinkPinRequestSchema,
   dashboardLinkVisitRequestSchema,

--- a/src/lib/api/schemas/request-user-mutation-schemas.ts
+++ b/src/lib/api/schemas/request-user-mutation-schemas.ts
@@ -9,6 +9,10 @@ export const calendarSubscriptionCreateRequestSchema = z.object({
   sectionIds: z.array(z.number().int().positive()).optional(),
 });
 
+export const calendarSubscriptionAppendRequestSchema = z.object({
+  sectionIds: z.array(z.number().int().positive()),
+});
+
 export const localeUpdateRequestSchema = z.object({
   locale: z.enum(APP_LOCALES),
 });

--- a/src/routes/api/calendar-subscriptions/+server.ts
+++ b/src/routes/api/calendar-subscriptions/+server.ts
@@ -1,4 +1,7 @@
-import { postCalendarSubscriptionsRoute } from "@/lib/api/routes/calendar-subscriptions";
+import {
+  patchCalendarSubscriptionsRoute,
+  postCalendarSubscriptionsRoute,
+} from "@/lib/api/routes/calendar-subscriptions";
 import { svelteRequestHandler } from "@/lib/api/svelte-route";
 import { observedApiRoute } from "@/lib/log/api-observability";
 
@@ -11,4 +14,16 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  */
 export const POST = svelteRequestHandler(
   observedApiRoute(postCalendarSubscriptionsRoute),
+);
+
+/**
+ * Append section subscriptions.
+ * @body calendarSubscriptionAppendRequestSchema
+ * @response calendarSubscriptionAppendResponseSchema
+ * @response 400:openApiErrorSchema
+ * @response 401:openApiErrorSchema
+ * @response 404:openApiErrorSchema
+ */
+export const PATCH = svelteRequestHandler(
+  observedApiRoute(patchCalendarSubscriptionsRoute),
 );

--- a/tests/e2e/src/app/api/calendar-subscriptions/test.ts
+++ b/tests/e2e/src/app/api/calendar-subscriptions/test.ts
@@ -1,11 +1,13 @@
 /**
- * E2E tests for POST /api/calendar-subscriptions
+ * E2E tests for the calendar subscription API
  *
- * ## Endpoint
+ * ## Endpoints
  * - `POST /api/calendar-subscriptions` — Replace the current user's subscribed sections
+ * - `PATCH /api/calendar-subscriptions` — Append selected section IDs
  *
  * ## Request
- * - Body: `{ sectionIds?: number[] }` (optional; omitting clears subscriptions)
+ * - POST Body: `{ sectionIds?: number[] }` (optional; omitting clears subscriptions)
+ * - PATCH Body: `{ sectionIds: number[] }`
  *
  * ## Response
  * - 200: `{ subscription: { userId: string, sections: { id: number }[] } }`
@@ -16,19 +18,20 @@
  * - Requires session authentication
  *
  * ## Edge Cases
- * - `sectionIds` is optional — omitting it clears all subscriptions
- * - Non-existent section IDs are silently dropped
+ * - POST `sectionIds` is optional — omitting it clears all subscriptions
+ * - Unknown positive section IDs are silently dropped
  * - Invalid body types (e.g. string instead of array) return 400
  */
 import { expect, test } from "@playwright/test";
 import { signInAsDebugUser } from "../../../../utils/auth";
 import { DEV_SEED } from "../../../../utils/dev-seed";
+import { resolveSeedSectionMatches } from "../../../../utils/seed-lookups";
 import { assertApiContract } from "../../_shared/api-contract";
 
 const BASE = "/api/calendar-subscriptions";
 const IMPORT_BASE = "/api/calendar-subscriptions/import-codes";
 
-test.describe("POST /api/calendar-subscriptions", () => {
+test.describe("calendar subscription API", () => {
   test.describe.configure({ mode: "serial" });
 
   test("contract", async ({ request }) => {
@@ -53,6 +56,27 @@ test.describe("POST /api/calendar-subscriptions", () => {
       data: { codes: [DEV_SEED.section.code] },
     });
     expect(response.status()).toBe(401);
+  });
+
+  test("append sections returns 401 when not authenticated", async ({
+    request,
+  }) => {
+    const response = await request.patch(BASE, {
+      data: { sectionIds: [1] },
+    });
+    expect(response.status()).toBe(401);
+  });
+
+  test("append sections returns 400 for malformed section ids", async ({
+    page,
+  }) => {
+    await signInAsDebugUser(page, "/");
+
+    const response = await page.request.patch(BASE, {
+      data: { sectionIds: [0] },
+    });
+
+    expect(response.status()).toBe(400);
   });
 
   test("import-codes appends matched section codes and reports repeats", async ({
@@ -112,6 +136,63 @@ test.describe("POST /api/calendar-subscriptions", () => {
       expect(secondBody.alreadySubscribedSections?.[0]?.code).toBe(
         DEV_SEED.section.code,
       );
+    } finally {
+      await page.request.post(BASE, {
+        data: { sectionIds: originalIds },
+      });
+    }
+  });
+
+  test("append sections adds selected ids without replacing existing subscriptions", async ({
+    page,
+  }) => {
+    await signInAsDebugUser(page, "/");
+    const [firstSection, secondSection] = await resolveSeedSectionMatches(page);
+    expect(firstSection?.id).toBeDefined();
+    expect(secondSection?.id).toBeDefined();
+
+    const currentRes = await page.request.get(
+      "/api/calendar-subscriptions/current",
+    );
+    const currentBody = (await currentRes.json()) as {
+      subscription?: { sections?: Array<{ id?: number }> } | null;
+    };
+    const originalIds =
+      currentBody.subscription?.sections?.map((s) => s.id as number) ?? [];
+
+    try {
+      await page.request.post(BASE, {
+        data: { sectionIds: [firstSection.id] },
+      });
+
+      const unknownPositiveSectionId = 999_999_999;
+      const response = await page.request.patch(BASE, {
+        data: { sectionIds: [secondSection.id, unknownPositiveSectionId] },
+      });
+      expect(response.status()).toBe(200);
+      const body = (await response.json()) as {
+        addedCount?: number;
+        alreadySubscribedCount?: number;
+        subscription?: { sections?: Array<{ id?: number }> };
+      };
+
+      expect(body.addedCount).toBe(1);
+      expect(body.alreadySubscribedCount).toBe(0);
+      const sectionIds = body.subscription?.sections?.map((s) => s.id) ?? [];
+      expect(sectionIds).toContain(firstSection.id);
+      expect(sectionIds).toContain(secondSection.id);
+      expect(sectionIds).not.toContain(unknownPositiveSectionId);
+
+      const repeatResponse = await page.request.patch(BASE, {
+        data: { sectionIds: [secondSection.id] },
+      });
+      expect(repeatResponse.status()).toBe(200);
+      const repeatBody = (await repeatResponse.json()) as {
+        addedCount?: number;
+        alreadySubscribedCount?: number;
+      };
+      expect(repeatBody.addedCount).toBe(0);
+      expect(repeatBody.alreadySubscribedCount).toBe(1);
     } finally {
       await page.request.post(BASE, {
         data: { sectionIds: originalIds },

--- a/tests/e2e/src/app/dashboard/exams/test.ts
+++ b/tests/e2e/src/app/dashboard/exams/test.ts
@@ -199,7 +199,26 @@ test.describe("dashboard exams", () => {
     });
     await completedTab.click();
     await expect(completedTab).toHaveAttribute("aria-pressed", "true");
-    await expect(page.getByText(DEV_SEED.previousSemesterNameCn)).toBeVisible();
+    const endedExamCards = page.locator('[data-slot="card"]').filter({
+      has: page.locator('a[href^="/sections/"]'),
+    });
+    await expect(endedExamCards.first()).toBeVisible({ timeout: 15_000 });
+    await expect(
+      endedExamCards
+        .first()
+        .getByText(/Ended|已结束|已完成/i)
+        .first(),
+    ).toBeVisible();
+    await expect(
+      endedExamCards
+        .first()
+        .getByText(
+          new RegExp(
+            `${DEV_SEED.semesterNameCn}|${DEV_SEED.previousSemesterNameCn}`,
+          ),
+        )
+        .first(),
+    ).toBeVisible();
     await captureStepScreenshot(page, testInfo, "exams/filter-completed");
 
     // Switch back to incomplete/upcoming

--- a/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
+++ b/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
@@ -116,11 +116,6 @@ test.describe("dashboard subscriptions", () => {
           timeout: 3_000,
         },
       );
-      await expect(
-        page.getByText(DEV_SEED.previousSemesterNameCn).first(),
-      ).toBeVisible({
-        timeout: 3_000,
-      });
     }).toPass({
       timeout: 20_000,
       intervals: [500, 1_000, 2_000],
@@ -355,7 +350,9 @@ test.describe("dashboard subscriptions", () => {
 
     await expect(
       page
-        .getByText(/已成功关注 \d+ 个班级|Now following \d+ sections/i)
+        .getByText(
+          /已新增关注 \d+ 个班级|Added \d+ new sections? to Life@USTC/i,
+        )
         .first(),
     ).toBeVisible({ timeout: 15_000 });
     await page.waitForLoadState("networkidle");

--- a/tests/e2e/src/app/dashboard/test.ts
+++ b/tests/e2e/src/app/dashboard/test.ts
@@ -146,9 +146,6 @@ test.describe("dashboard", () => {
       }),
     ).toBeVisible();
     await expect(page.getByText(DEV_SEED.semesterNameCn).first()).toBeVisible();
-    await expect(
-      page.getByText(DEV_SEED.previousSemesterNameCn).first(),
-    ).toBeVisible();
     await captureStepScreenshot(page, testInfo, "dashboard-subscriptions-path");
   });
 });

--- a/tests/unit/api-schemas.test.ts
+++ b/tests/unit/api-schemas.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { HOMEWORK_DESCRIPTION_MAX_LENGTH } from "@/features/homeworks/lib/homework-limits";
 import { TODO_CONTENT_MAX_LENGTH } from "@/features/todos/lib/todo-limits";
 import {
+  calendarSubscriptionAppendRequestSchema,
   calendarSubscriptionCreateRequestSchema,
   commentReactionRequestSchema,
   coursesQuerySchema,
@@ -161,6 +162,16 @@ describe("other request schemas", () => {
       sectionIds: [1, 2, 3],
     });
     expect(valid.success).toBe(true);
+  });
+
+  it("validates calendar subscription append payload", () => {
+    const valid = calendarSubscriptionAppendRequestSchema.safeParse({
+      sectionIds: [1, 2, 3],
+    });
+    const missingIds = calendarSubscriptionAppendRequestSchema.safeParse({});
+
+    expect(valid.success).toBe(true);
+    expect(missingIds.success).toBe(false);
   });
 
   it("rejects invalid reaction type", () => {

--- a/tests/unit/subscription-import-client.test.ts
+++ b/tests/unit/subscription-import-client.test.ts
@@ -119,6 +119,14 @@ function subscriptionPayload(sectionIds: number[]) {
   };
 }
 
+function appendPayload(sectionIds: number[], addedCount = sectionIds.length) {
+  return {
+    ...subscriptionPayload(sectionIds),
+    addedCount,
+    alreadySubscribedCount: sectionIds.length - addedCount,
+  };
+}
+
 describe("subscription import client", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -216,25 +224,38 @@ describe("subscription import client", () => {
     });
   });
 
-  it("appends selected section ids without duplicating existing ids", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(jsonResponse(subscriptionPayload([1, 2])))
-      .mockResolvedValueOnce(jsonResponse(subscriptionPayload([1, 2, 3])));
+  it("appends selected section ids through the server-owned append route", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(appendPayload([1, 2, 3], 2)),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
       appendSubscribedSectionIds({
-        fetchFailedMessage: "fetch failed",
         importFailedMessage: "import failed",
         selectedSectionIds: [2, 3],
       }),
     ).resolves.toBe(2);
 
-    expect(fetchMock).toHaveBeenLastCalledWith("/api/calendar-subscriptions", {
-      method: "POST",
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith("/api/calendar-subscriptions", {
+      method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ sectionIds: [1, 2, 3] }),
+      body: JSON.stringify({ sectionIds: [2, 3] }),
     });
+  });
+
+  it("does not call the append route when no section ids are selected", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      appendSubscribedSectionIds({
+        importFailedMessage: "import failed",
+        selectedSectionIds: [],
+      }),
+    ).resolves.toBe(0);
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/tools/build/openapi/generate-spec.ts
+++ b/tools/build/openapi/generate-spec.ts
@@ -745,6 +745,14 @@ function rewriteOperationId(
   }
 
   if (
+    resource === "calendar-subscriptions" &&
+    resourceSegments.length === 1 &&
+    method === "patch"
+  ) {
+    return "appendCalendarSubscriptionSections";
+  }
+
+  if (
     resource === "users" &&
     segments.at(-1) === "calendar.ics" &&
     method === "get"


### PR DESCRIPTION
## Goal

Make dashboard and welcome bulk-import confirmation append the user-selected sections server-side instead of client-reading the current subscription set and replacing the whole set. This preserves concurrent additions and keeps the preview/deselect flow scoped to the selected matches.

## Changed Surfaces

- Added `PATCH /api/calendar-subscriptions` for append-only selected section IDs, with shared request/response schemas and OpenAPI operation generation.
- Moved append semantics into `src/features/home/server/subscription-write-model.ts`; replacement `POST /api/calendar-subscriptions` remains unchanged.
- Updated dashboard and welcome bulk-import clients to call the append route directly and report `addedCount` as newly-added sections.
- Updated subscription contract JSON, generated OpenAPI, i18n success copy, and unit/E2E coverage for append, malformed IDs, unauthenticated access, unknown positive IDs, and already-subscribed IDs.
- Kept MCP behavior unchanged; contract now documents using `match_section_codes` preview plus `subscribe_section_by_jw_id` for selected MCP preview results.

## Evidence

- `bun run test -- tests/unit/subscription-import-client.test.ts tests/unit/api-schemas.test.ts`
- `bun run openapi:generate && bun run openapi:check && bun run check:contracts`
- `bun run tsc --noEmit -p tsconfig.typecheck.json`
- `bun run tsc --noEmit -p tsconfig.typecheck.tests.json`
- Focused Biome over touched files; `bun run check:routes`; `git diff --check`
- `bun run e2e:db:prepare`; `bun run e2e:build-artifacts`; `bun run seed`
- `PLAYWRIGHT_PORT=4173 bun run e2e:test -- tests/e2e/src/app/api/calendar-subscriptions/test.ts`
- `bun run verify`
- `bun run seed && PLAYWRIGHT_PORT=4173 bun run e2e:test -- tests/e2e/src/app/dashboard/exams/test.ts tests/e2e/src/app/dashboard/subscriptions/sections/test.ts tests/e2e/src/app/dashboard/test.ts`
- `PLAYWRIGHT_PORT=4173 bun run verify:full`
- Two subagent review passes found no blockers; their low-severity findings around contract wording, PATCH edge coverage, stale copy shape, success-count copy, and MCP parity notes were folded into this PR.

## Docs / Contracts

- Updated `docs/contracts/subscription.json` for the new REST append endpoint and MCP preview-selection guidance.
- Regenerated `public/openapi.generated.json` from route annotations.
- Updated `messages/en-us.json` and `messages/zh-cn.json` so import success copy describes newly-added sections.

## Risk Areas

- Auth: PATCH uses the same `requireAuth` path as subscription replacement; E2E covers 401.
- Data shape: malformed/non-positive IDs return 400, unknown positive IDs are ignored, and repeated IDs already in the subscription are counted without duplication.
- Concurrency: the mutation is append-only and no longer overwrites concurrent additions. Exact `addedCount` under duplicate simultaneous PATCHes is still read-before-connect, so counts are best-effort under that race while the stored subscription remains safe.
- E2E port: the first full-gate attempt hit a local occupied `127.0.0.1:3000` listener with no visible process owner, so the final passing full gate used the repo-supported `PLAYWRIGHT_PORT=4173` override.

## Cleanup

- `git status` was clean before push.
- Local Docker Compose development database was stopped after verification.
- No scratch artifacts, one-time probes, unrelated rewrites, or manual generated-file edits remain; OpenAPI was regenerated through the repo script.