### PR TITLE
fix(profile): profile callback and username flow

### DIFF
--- a/docs/contracts/user.json
+++ b/docs/contracts/user.json
@@ -10,8 +10,9 @@
     "sign-in-providers": "Sign-in supports USTC, GitHub, and Google OAuth; custom username/password login is not considered due to security and maintenance cost.",
     "oauth-callback-integrity": "On a canonical same-origin deployment, OAuth login callbacks must complete state validation and session creation directly, without losing state due to proxy wrapping or container-internal host differences.",
     "welcome-flow-required": "New users who have not set a name or username on first login must complete the welcome flow before proceeding.",
+    "welcome-completion-resume": "If the welcome flow was reached from an app-relative callbackUrl, successful completion returns to that page; otherwise completion returns home.",
     "auth-callback-not-intercepted": "Authorization callback continuation requests carrying OAuth code/error and state must be allowed to complete the protocol redirect; the welcome page interceptor must not break the authorization result redirect.",
-    "post-login-redirect": "After successful login, the user should be redirected back to the originally requested page whenever possible; if no origin page exists, redirect to the home page.",
+    "post-login-redirect": "After successful login, the user should be redirected back to the originally requested app-relative page whenever possible; unsafe external callbacks fall back to the home page.",
     "oauth-login-resume": "If an OAuth authorization request lands on /signin with raw authorization query parameters instead of callbackUrl, the sign-in flow should resume that exact authorization request after login rather than falling back to /.",
     "oauth-consent-loopback-continuation": "The OAuth consent step must continue working for loopback public clients even when the client uses 127.0.0.1 and the app itself is being browsed via localhost; consent submission should preserve the original authorization query and complete the redirect back to the registered loopback callback.",
     "public-identity-display": "Public identity defaults to displaying name or username, not internal identifiers."
@@ -63,6 +64,7 @@
       "display": {
         "fields": [
           "callbackUrl query parameter (origin page)",
+          "External or protocol-relative callbackUrl values are rejected",
           "Sign-in action links include the current path and query as callbackUrl",
           "Fallback to home page if no origin"
         ]

--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -1160,7 +1160,7 @@
     "publicProfileHint": "Public profile link",
     "publicProfileMissing": "Set a username to enable your public profile.",
     "publicProfileIdHint": "Public profile by ID",
-    "usernameValidation": "Lowercase letters and numbers only, max 20 chars",
+    "usernameValidation": "Lowercase letters, numbers, and hyphens only, max 20 chars",
     "usernameInvalid": "Username must be 1-20 lowercase letters, numbers, or hyphens.",
     "usernameTaken": "Username is already taken.",
     "avatarInvalid": "Select one of your uploaded avatars.",

--- a/src/features/admin/server/admin-api-service.ts
+++ b/src/features/admin/server/admin-api-service.ts
@@ -1,4 +1,5 @@
 import { getAdminUserListItem } from "@/features/admin/server/admin-user-read-model";
+import { isValidProfileUsername } from "@/features/profile/lib/profile-username";
 import type { CommentStatus } from "@/generated/prisma/client";
 import { fireAuditLog } from "@/lib/audit/write-audit-log";
 import { prisma } from "@/lib/db/prisma";
@@ -50,7 +51,7 @@ async function buildAdminUserUpdateData(
   if ("username" in parsedBody) {
     const username = normalizeAdminUsername(parsedBody.username);
     if (username) {
-      if (!/^[a-z0-9-]{1,20}$/.test(username)) {
+      if (!isValidProfileUsername(username)) {
         return { ok: false as const, reason: "invalid_username" as const };
       }
       const existing = await prisma.user.findUnique({

--- a/src/features/auth/server/signin-page-server.ts
+++ b/src/features/auth/server/signin-page-server.ts
@@ -1,6 +1,9 @@
 import { type Cookies, fail, redirect } from "@sveltejs/kit";
 import { allowDebugAuth } from "@/lib/auth/auth-config";
-import { resolveSignInCallbackUrl } from "@/lib/auth/auth-routing";
+import {
+  resolveSignInCallbackUrl,
+  sanitizeAuthCallbackUrl,
+} from "@/lib/auth/auth-routing";
 import {
   DEV_ADMIN_PROVIDER_ID,
   DEV_DEBUG_PROVIDER_ID,
@@ -72,7 +75,7 @@ export async function signInPageDefaultAction({
 }) {
   const form = await request.formData();
   const providerId = String(form.get("providerId") ?? "");
-  const callbackUrl = String(form.get("callbackUrl") ?? "/") || "/";
+  const callbackUrl = sanitizeAuthCallbackUrl(form.get("callbackUrl"));
   try {
     const result = await signInFromSvelteAction({
       providerId,

--- a/src/features/profile/lib/profile-username.ts
+++ b/src/features/profile/lib/profile-username.ts
@@ -1,0 +1,16 @@
+const PROFILE_USERNAME_CHAR_CLASS = "[a-z0-9-]";
+
+export const PROFILE_USERNAME_PATTERN = `${PROFILE_USERNAME_CHAR_CLASS}+`;
+export const PROFILE_USERNAME_MAX_LENGTH = 20;
+
+const PROFILE_USERNAME_REGEXP = new RegExp(
+  `^${PROFILE_USERNAME_CHAR_CLASS}{1,${PROFILE_USERNAME_MAX_LENGTH}}$`,
+);
+const RESERVED_PROFILE_USERNAMES = new Set(["id"]);
+
+export function isValidProfileUsername(username: string) {
+  return (
+    PROFILE_USERNAME_REGEXP.test(username) &&
+    !RESERVED_PROFILE_USERNAMES.has(username)
+  );
+}

--- a/src/features/profile/server/profile-update-service.ts
+++ b/src/features/profile/server/profile-update-service.ts
@@ -1,0 +1,69 @@
+import { authApi } from "@/lib/auth/core";
+import { prisma } from "@/lib/db/prisma";
+import { isValidProfileUsername } from "../lib/profile-username";
+
+type ProfileUpdateInput = {
+  headers: Headers;
+  image: string | null;
+  name: string;
+  userId: string;
+  username: string;
+};
+
+export type ProfileUpdateFailureReason =
+  | "avatar_invalid"
+  | "invalid_username"
+  | "name_required"
+  | "user_not_found"
+  | "username_taken";
+
+export type ProfileUpdateResult =
+  | { headers: Headers; ok: true }
+  | { ok: false; reason: ProfileUpdateFailureReason };
+
+export async function updateOwnProfile(
+  input: ProfileUpdateInput,
+): Promise<ProfileUpdateResult> {
+  if (!input.name) return { ok: false, reason: "name_required" };
+  if (!isValidProfileUsername(input.username)) {
+    return { ok: false, reason: "invalid_username" };
+  }
+
+  const current = await prisma.user.findUnique({
+    where: { id: input.userId },
+    select: { id: true, image: true, profilePictures: true },
+  });
+  if (!current) return { ok: false, reason: "user_not_found" };
+  if (
+    input.image &&
+    input.image !== current.image &&
+    !current.profilePictures.includes(input.image)
+  ) {
+    return { ok: false, reason: "avatar_invalid" };
+  }
+
+  const existing = await prisma.user.findUnique({
+    where: { username: input.username },
+    select: { id: true },
+  });
+  if (existing && existing.id !== input.userId) {
+    return { ok: false, reason: "username_taken" };
+  }
+
+  const updateBody: {
+    image?: string | null;
+    name: string;
+    username: string;
+  } = { name: input.name, username: input.username };
+  if (input.image !== null && input.image !== current.image) {
+    updateBody.image = input.image;
+  }
+
+  const response = await authApi.updateUser({
+    body: updateBody,
+    headers: input.headers,
+    returnHeaders: true,
+  });
+
+  return { headers: response.headers, ok: true };
+}

--- a/src/features/settings/components/SettingsProfileTab.svelte
+++ b/src/features/settings/components/SettingsProfileTab.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+import {
+  PROFILE_USERNAME_MAX_LENGTH,
+  PROFILE_USERNAME_PATTERN,
+} from "@/features/profile/lib/profile-username";
 import { Button } from "$lib/components/ui/button/index.js";
 import * as Card from "$lib/components/ui/card/index.js";
 import { Input } from "$lib/components/ui/input/index.js";
@@ -59,10 +63,11 @@ export let user: SettingsUser;
             name="username"
             value={user.username ?? ""}
             placeholder={copy.profile.usernamePlaceholder}
-            pattern="[a-z0-9-]+"
-            maxlength="20"
+            pattern={PROFILE_USERNAME_PATTERN}
+            maxlength={PROFILE_USERNAME_MAX_LENGTH}
             autocomplete="username"
             title={copy.profile.usernameValidation}
+            required
             disabled={!isMounted}
           />
           <span class="text-base-content/60 text-xs">

--- a/src/features/settings/lib/settings-profile-form.ts
+++ b/src/features/settings/lib/settings-profile-form.ts
@@ -1,16 +1,9 @@
-const USERNAME_PATTERN = /^[a-z0-9-]{1,20}$/;
-
-export function isValidSettingsUsername(username: string) {
-  return USERNAME_PATTERN.test(username) && username !== "id";
-}
-
 export function parseSettingsProfileForm(form: FormData) {
-  const rawUsername = String(form.get("username") ?? "").trim();
   const submittedImage = form.get("image");
 
   return {
     name: String(form.get("name") ?? "").trim(),
-    username: rawUsername.length > 0 ? rawUsername : null,
+    username: String(form.get("username") ?? "").trim(),
     image:
       typeof submittedImage === "string" ? submittedImage.trim() || null : null,
   };

--- a/src/features/settings/server/settings-profile-action.ts
+++ b/src/features/settings/server/settings-profile-action.ts
@@ -1,12 +1,9 @@
 import { type Cookies, fail, redirect } from "@sveltejs/kit";
+import { updateOwnProfile } from "@/features/profile/server/profile-update-service";
 import { getSettingsCopy } from "@/features/settings/lib/settings-copy";
-import {
-  isValidSettingsUsername,
-  parseSettingsProfileForm,
-} from "@/features/settings/lib/settings-profile-form";
+import { parseSettingsProfileForm } from "@/features/settings/lib/settings-profile-form";
 import type { SettingsActionInput } from "@/features/settings/server/settings-page-common";
 import { requireSettingsUser } from "@/features/settings/server/settings-page-data";
-import { authApi } from "@/lib/auth/core";
 import { applyAuthResponseCookies } from "@/lib/auth/svelte-auth-actions";
 
 export async function updateSettingsProfileAction({
@@ -19,64 +16,44 @@ export async function updateSettingsProfileAction({
   const user = await requireSettingsUser(request, url);
   const form = await request.formData();
   const { image, name, username } = parseSettingsProfileForm(form);
-  if (!name) {
-    return fail(400, {
-      kind: "profile",
-      message: copy.profile.nameRequired,
-    });
-  }
-  if (username && !isValidSettingsUsername(username)) {
-    return fail(400, {
-      kind: "profile",
-      message: copy.profile.usernameInvalid,
-    });
-  }
-
-  const { prisma } = await import("@/lib/db/prisma");
-  const current = await prisma.user.findUnique({
-    where: { id: user.id },
-    select: { id: true, image: true, profilePictures: true },
+  const result = await updateOwnProfile({
+    headers: request.headers,
+    image,
+    name,
+    userId: user.id,
+    username,
   });
-  if (!current)
-    return fail(404, { kind: "profile", message: copy.common.userNotFound });
-  if (
-    image &&
-    image !== current.image &&
-    !current.profilePictures.includes(image)
-  ) {
-    return fail(400, {
-      kind: "profile",
-      message: copy.profile.avatarInvalid,
-    });
-  }
-
-  if (username) {
-    const existing = await prisma.user.findUnique({
-      where: { username },
-      select: { id: true },
-    });
-    if (existing && existing.id !== user.id) {
+  if (!result.ok) {
+    if (result.reason === "name_required") {
       return fail(400, {
         kind: "profile",
-        message: copy.profile.usernameTaken,
+        message: copy.profile.nameRequired,
       });
     }
+    if (result.reason === "invalid_username") {
+      return fail(400, {
+        kind: "profile",
+        message: copy.profile.usernameInvalid,
+      });
+    }
+    if (result.reason === "user_not_found") {
+      return fail(404, {
+        kind: "profile",
+        message: copy.common.userNotFound,
+      });
+    }
+    if (result.reason === "avatar_invalid") {
+      return fail(400, {
+        kind: "profile",
+        message: copy.profile.avatarInvalid,
+      });
+    }
+    return fail(400, {
+      kind: "profile",
+      message: copy.profile.usernameTaken,
+    });
   }
 
-  const updateBody: {
-    image?: string | null;
-    name: string;
-    username: string | null;
-  } = { name, username };
-  if (image !== null && image !== current.image) {
-    updateBody.image = image;
-  }
-
-  const response = await authApi.updateUser({
-    body: updateBody,
-    headers: request.headers,
-    returnHeaders: true,
-  });
-  applyAuthResponseCookies(response.headers, cookies);
+  applyAuthResponseCookies(result.headers, cookies);
   throw redirect(303, "/settings/profile?message=Success");
 }

--- a/src/features/welcome/components/WelcomePageController.svelte
+++ b/src/features/welcome/components/WelcomePageController.svelte
@@ -119,6 +119,7 @@ const completeProfileAction = createCompleteProfileAction({
 <section class="mx-auto grid min-h-[calc(100vh-14rem)] w-full max-w-5xl content-center gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(18rem,0.8fr)]">
   <WelcomeProfileForm
     {avatarOptions}
+    callbackUrl={data.callbackUrl}
     {completeProfileAction}
     {copy}
     {currentImage}

--- a/src/features/welcome/components/WelcomeProfileForm.svelte
+++ b/src/features/welcome/components/WelcomeProfileForm.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+import {
+  PROFILE_USERNAME_MAX_LENGTH,
+  PROFILE_USERNAME_PATTERN,
+} from "@/features/profile/lib/profile-username";
 import { enhance } from "$app/forms";
 import { Alert } from "$lib/components/ui/alert/index.js";
 import * as Avatar from "$lib/components/ui/avatar/index.js";
@@ -16,6 +20,7 @@ import type {
 } from "./welcome-component-types";
 
 export let avatarOptions: string[];
+export let callbackUrl: string;
 export let completeProfileAction: CompleteProfileAction;
 export let copy: WelcomeRootCopy;
 export let currentImage: string;
@@ -29,6 +34,7 @@ export let welcomeCopy: WelcomeCopy;
 </script>
 
 <form method="POST" action="?/complete" use:enhance={completeProfileAction}>
+  <input type="hidden" name="callbackUrl" value={callbackUrl} />
   <Card.Root class="border-base-300 bg-base-100">
     <Card.Header class="items-center text-center">
       <Badge class="w-fit" variant="secondary">{welcomeCopy.firstSignIn}</Badge>
@@ -85,7 +91,7 @@ export let welcomeCopy: WelcomeCopy;
 
       <label class="grid gap-2">
         <span class="font-medium text-sm">{profileCopy.username} <span class="text-error">*</span></span>
-        <Input id="username" name="username" value={user.username ?? ""} placeholder={profileCopy.usernamePlaceholder} pattern="[a-z0-9-]+" maxlength="20" required autocomplete="username" title={profileCopy.usernameValidation} />
+        <Input id="username" name="username" value={user.username ?? ""} placeholder={profileCopy.usernamePlaceholder} pattern={PROFILE_USERNAME_PATTERN} maxlength={PROFILE_USERNAME_MAX_LENGTH} required autocomplete="username" title={profileCopy.usernameValidation} />
         <span class="text-base-content/60 text-xs">{profileCopy.usernameValidation}</span>
       </label>
 

--- a/src/features/welcome/components/welcome-component-types.ts
+++ b/src/features/welcome/components/welcome-component-types.ts
@@ -83,6 +83,7 @@ export type WelcomePageUser = WelcomeProfileUser & {
 };
 
 export type WelcomePageData = {
+  callbackUrl: string;
   copy: WelcomePageCopy;
   defaultSemesterId?: number | string | null;
   locale: string;

--- a/src/features/welcome/server/welcome-callback-url.ts
+++ b/src/features/welcome/server/welcome-callback-url.ts
@@ -1,0 +1,9 @@
+import { sanitizeAuthCallbackUrl } from "@/lib/auth/auth-routing";
+
+const WELCOME_CALLBACK_ORIGIN = "https://life-ustc.local";
+
+export function resolveWelcomeCallbackUrl(value: unknown) {
+  const callbackUrl = sanitizeAuthCallbackUrl(value);
+  const callbackPath = new URL(callbackUrl, WELCOME_CALLBACK_ORIGIN).pathname;
+  return callbackPath === "/welcome" ? "/" : callbackUrl;
+}

--- a/src/features/welcome/server/welcome-complete-action.ts
+++ b/src/features/welcome/server/welcome-complete-action.ts
@@ -1,13 +1,12 @@
 import type { Cookies } from "@sveltejs/kit";
 import { fail, redirect } from "@sveltejs/kit";
+import { updateOwnProfile } from "@/features/profile/server/profile-update-service";
 import { buildSignInPageUrl } from "@/lib/auth/auth-routing";
-import { authApi, getSessionFromHeaders } from "@/lib/auth/core";
+import { getSessionFromHeaders } from "@/lib/auth/core";
 import { applyAuthResponseCookies } from "@/lib/auth/svelte-auth-actions";
+import { resolveWelcomeCallbackUrl } from "./welcome-callback-url";
 import { getWelcomeCopy } from "./welcome-page-copy";
-import {
-  isValidWelcomeUsername,
-  parseWelcomeProfileForm,
-} from "./welcome-profile-form";
+import { parseWelcomeProfileForm } from "./welcome-profile-form";
 
 export async function completeWelcomeProfile({
   locals,
@@ -19,61 +18,42 @@ export async function completeWelcomeProfile({
   request: Request;
 }) {
   const copy = getWelcomeCopy(locals.locale);
+  const form = await request.formData();
+  const { callbackUrl, image, name, username } = parseWelcomeProfileForm(form);
+  const redirectTo = resolveWelcomeCallbackUrl(callbackUrl);
   const session = await getSessionFromHeaders(request.headers);
   if (!session?.user?.id) {
-    throw redirect(303, buildSignInPageUrl("/welcome"));
+    throw redirect(
+      303,
+      buildSignInPageUrl(
+        `/welcome?callbackUrl=${encodeURIComponent(redirectTo)}`,
+      ),
+    );
   }
 
-  const form = await request.formData();
-  const { image, name, username } = parseWelcomeProfileForm(form);
-
-  if (!name) {
-    return fail(400, { message: copy.profile.nameRequired });
-  }
-  if (!isValidWelcomeUsername(username)) {
-    return fail(400, {
-      message: copy.profile.usernameInvalid,
-    });
-  }
-
-  const { prisma } = await import("@/lib/db/prisma");
-  const current = await prisma.user.findUnique({
-    where: { id: session.user.id },
-    select: { id: true, image: true, profilePictures: true },
+  const result = await updateOwnProfile({
+    headers: request.headers,
+    image,
+    name,
+    userId: session.user.id,
+    username,
   });
-  if (!current) {
-    return fail(404, { message: copy.profile.userNotFound });
-  }
-  if (
-    image &&
-    image !== current.image &&
-    !current.profilePictures.includes(image)
-  ) {
-    return fail(400, { message: copy.profile.avatarInvalid });
-  }
-
-  const existing = await prisma.user.findUnique({
-    where: { username },
-    select: { id: true },
-  });
-  if (existing && existing.id !== session.user.id) {
+  if (!result.ok) {
+    if (result.reason === "name_required") {
+      return fail(400, { message: copy.profile.nameRequired });
+    }
+    if (result.reason === "invalid_username") {
+      return fail(400, { message: copy.profile.usernameInvalid });
+    }
+    if (result.reason === "user_not_found") {
+      return fail(404, { message: copy.profile.userNotFound });
+    }
+    if (result.reason === "avatar_invalid") {
+      return fail(400, { message: copy.profile.avatarInvalid });
+    }
     return fail(400, { message: copy.profile.usernameTaken });
   }
 
-  const updateBody: {
-    name: string;
-    username: string;
-    image?: string | null;
-  } = { name, username };
-  if (image !== null && image !== current.image) {
-    updateBody.image = image;
-  }
-
-  const response = await authApi.updateUser({
-    body: updateBody,
-    headers: request.headers,
-    returnHeaders: true,
-  });
-  applyAuthResponseCookies(response.headers, cookies);
-  throw redirect(303, "/");
+  applyAuthResponseCookies(result.headers, cookies);
+  throw redirect(303, redirectTo);
 }

--- a/src/features/welcome/server/welcome-page-server.ts
+++ b/src/features/welcome/server/welcome-page-server.ts
@@ -2,6 +2,7 @@ import { redirect, type ServerLoadEvent } from "@sveltejs/kit";
 import { getCurrentSemester } from "@/features/catalog/server/academic-metadata-read-model";
 import { buildSignInPageUrl } from "@/lib/auth/auth-routing";
 import { getSessionFromHeaders } from "@/lib/auth/core";
+import { resolveWelcomeCallbackUrl } from "./welcome-callback-url";
 import { completeWelcomeProfile } from "./welcome-complete-action";
 import { getWelcomeCopy } from "./welcome-page-copy";
 
@@ -10,9 +11,17 @@ export const loadWelcomePage = async ({
   request,
   url,
 }: ServerLoadEvent) => {
+  const callbackUrl = resolveWelcomeCallbackUrl(
+    url.searchParams.get("callbackUrl"),
+  );
   const session = await getSessionFromHeaders(request.headers);
   if (!session?.user?.id) {
-    throw redirect(303, buildSignInPageUrl(`${url.pathname}${url.search}`));
+    throw redirect(
+      303,
+      buildSignInPageUrl(
+        `${url.pathname}?callbackUrl=${encodeURIComponent(callbackUrl)}`,
+      ),
+    );
   }
 
   const { prisma } = await import("@/lib/db/prisma");
@@ -36,17 +45,23 @@ export const loadWelcomePage = async ({
   ]);
 
   if (!user) {
-    throw redirect(303, buildSignInPageUrl(`${url.pathname}${url.search}`));
+    throw redirect(
+      303,
+      buildSignInPageUrl(
+        `${url.pathname}?callbackUrl=${encodeURIComponent(callbackUrl)}`,
+      ),
+    );
   }
 
   if (user.name && user.username) {
-    throw redirect(303, "/");
+    throw redirect(303, callbackUrl);
   }
 
   return {
     user,
     semesters,
     defaultSemesterId: currentSemester?.id ?? null,
+    callbackUrl,
     locale: locals.locale,
     copy: getWelcomeCopy(locals.locale),
   };

--- a/src/features/welcome/server/welcome-profile-form.ts
+++ b/src/features/welcome/server/welcome-profile-form.ts
@@ -1,13 +1,8 @@
-const USERNAME_PATTERN = /^[a-z0-9-]{1,20}$/;
-
-export function isValidWelcomeUsername(username: string) {
-  return USERNAME_PATTERN.test(username) && username !== "id";
-}
-
 export function parseWelcomeProfileForm(form: FormData) {
   const submittedImage = form.get("image");
 
   return {
+    callbackUrl: String(form.get("callbackUrl") ?? "").trim(),
     name: String(form.get("name") ?? "").trim(),
     username: String(form.get("username") ?? "").trim(),
     image:

--- a/src/lib/auth/auth-routing.ts
+++ b/src/lib/auth/auth-routing.ts
@@ -11,15 +11,54 @@ type AuthRedirectOptions = {
   callbackUrl?: string;
 };
 
+const AUTH_CALLBACK_ORIGIN = "https://life-ustc.local";
+
+function hasUnsafeCallbackCharacter(value: string) {
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code <= 31 || code === 127 || character === "\\") return true;
+  }
+  return false;
+}
+
+function parseAppRelativeCallbackUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+
+  const candidate = value.trim();
+  if (!candidate.startsWith("/") || candidate.startsWith("//")) return null;
+  if (/^\/%(?:2f|5c)/i.test(candidate)) return null;
+  if (hasUnsafeCallbackCharacter(candidate)) return null;
+
+  try {
+    const parsed = new URL(candidate, AUTH_CALLBACK_ORIGIN);
+    if (parsed.origin !== AUTH_CALLBACK_ORIGIN) return null;
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return null;
+  }
+}
+
+export function sanitizeAuthCallbackUrl(value: unknown, fallbackUrl = "/") {
+  return (
+    parseAppRelativeCallbackUrl(value) ??
+    parseAppRelativeCallbackUrl(fallbackUrl) ??
+    "/"
+  );
+}
+
 export function resolveAuthRedirectTarget(
   options: AuthRedirectOptions,
   fallbackUrl = "/",
 ): string {
-  return options.redirectTo ?? options.callbackUrl ?? fallbackUrl;
+  return (
+    parseAppRelativeCallbackUrl(options.redirectTo) ??
+    parseAppRelativeCallbackUrl(options.callbackUrl) ??
+    sanitizeAuthCallbackUrl(fallbackUrl)
+  );
 }
 
 export function buildSignInPageUrl(callbackUrl: string) {
-  return `/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+  return `/signin?callbackUrl=${encodeURIComponent(sanitizeAuthCallbackUrl(callbackUrl))}`;
 }
 
 export function buildCurrentPathCallbackUrl(
@@ -38,9 +77,8 @@ export function buildSignInRedirectUrl(
 }
 
 export function resolveSignInCallbackUrl(params: SignInSearchParams): string {
-  if (typeof params.callbackUrl === "string" && params.callbackUrl.length > 0) {
-    return params.callbackUrl;
-  }
+  const explicitCallbackUrl = parseAppRelativeCallbackUrl(params.callbackUrl);
+  if (explicitCallbackUrl) return explicitCallbackUrl;
 
   const {
     callbackUrl: _callbackUrl,

--- a/tests/e2e/src/app/settings/profile/test.ts
+++ b/tests/e2e/src/app/settings/profile/test.ts
@@ -15,6 +15,7 @@
  * ## Edge Cases
  * - Unauthenticated → redirects to /signin
  * - Invalid username pattern → browser validation prevents submission
+ * - Empty username → browser validation prevents submission
  * - Save success → toast with "Success" heading
  * - Name change persists across page reload
  */
@@ -101,5 +102,28 @@ test.describe("/settings?tab=profile", () => {
     await expect(page.locator("input#name")).toHaveValue(originalName, {
       timeout: 10_000,
     });
+  });
+
+  test("requires username before saving", async ({ page }, testInfo) => {
+    test.setTimeout(300_000);
+    await signInAsDebugUser(page, "/settings?tab=profile");
+
+    const usernameInput = page.locator("input#username");
+    await usernameInput.fill("");
+    await page.getByRole("button", { name: /保存|Save/i }).click();
+
+    await expect(usernameInput).toBeFocused();
+    await expect
+      .poll(() =>
+        usernameInput.evaluate(
+          (input) => (input as HTMLInputElement).validationMessage.length,
+        ),
+      )
+      .toBeGreaterThan(0);
+    await captureStepScreenshot(
+      page,
+      testInfo,
+      "settings/profile-username-required",
+    );
   });
 });

--- a/tests/e2e/src/app/welcome/test.ts
+++ b/tests/e2e/src/app/welcome/test.ts
@@ -129,6 +129,48 @@ test("incomplete signed-in users are redirected to /welcome from normal pages", 
   }
 });
 
+test("/welcome completion returns to the original callback page", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(300_000);
+  await signInAsDebugUser(page, "/");
+  const sessionUser = await getCurrentSessionUser(page);
+  const originalUser = await getUserProfileById(sessionUser.id);
+
+  await updateUserProfileById(sessionUser.id, {
+    name: null,
+    username: null,
+  });
+
+  try {
+    await gotoAndWaitForReady(page, "/settings", {
+      expectMainContent: false,
+    });
+
+    await expect(page).toHaveURL(/\/welcome\?callbackUrl=%2Fsettings$/);
+    await page
+      .getByRole("textbox", { name: /^(姓名|Name)\b/i })
+      .fill(DEV_SEED.debugName);
+    await page
+      .getByRole("textbox", { name: /^(用户名|Username)\b/i })
+      .fill(DEV_SEED.debugUsername);
+
+    await page.getByRole("button", { name: /继续|Continue/i }).click();
+
+    await expect(page).toHaveURL(/\/settings(?:\?.*)?$/, {
+      timeout: 15_000,
+    });
+    await expect(page.locator("#main-content")).toBeVisible();
+    await captureStepScreenshot(page, testInfo, "welcome/completed-callback");
+  } finally {
+    await updateUserProfileById(sessionUser.id, {
+      name: originalUser.name ?? DEV_SEED.debugName,
+      username: originalUser.username ?? DEV_SEED.debugUsername,
+      image: originalUser.image ?? null,
+    });
+  }
+});
+
 test("/welcome 未完善资料的用户可完成资料并返回首页", async ({
   page,
 }, testInfo) => {

--- a/tests/unit/auth-provider-routing.test.ts
+++ b/tests/unit/auth-provider-routing.test.ts
@@ -20,6 +20,18 @@ describe("auth provider routing", () => {
     ).toBe("/dashboard");
   });
 
+  it("falls back when redirect targets are external", () => {
+    expect(
+      resolveAuthRedirectTarget(
+        {
+          redirectTo: "https://attacker.example",
+          callbackUrl: "//attacker.example",
+        },
+        "/settings",
+      ),
+    ).toBe("/settings");
+  });
+
   it("builds the sign-in page callback URL once", () => {
     expect(buildSignInPageUrl("/oauth/authorize?client_id=test")).toBe(
       "/signin?callbackUrl=%2Foauth%2Fauthorize%3Fclient_id%3Dtest",

--- a/tests/unit/profile-username.test.ts
+++ b/tests/unit/profile-username.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  isValidProfileUsername,
+  PROFILE_USERNAME_MAX_LENGTH,
+  PROFILE_USERNAME_PATTERN,
+} from "@/features/profile/lib/profile-username";
+
+describe("profile username rules", () => {
+  it("exposes the same pattern and limit used by form inputs", () => {
+    expect(PROFILE_USERNAME_PATTERN).toBe("[a-z0-9-]+");
+    expect(PROFILE_USERNAME_MAX_LENGTH).toBe(20);
+  });
+
+  it("allows lowercase letters, numbers, and hyphens", () => {
+    expect(isValidProfileUsername("student-2026")).toBe(true);
+  });
+
+  it("rejects empty, overlong, uppercase, and reserved names", () => {
+    expect(isValidProfileUsername("")).toBe(false);
+    expect(isValidProfileUsername("a".repeat(21))).toBe(false);
+    expect(isValidProfileUsername("Student")).toBe(false);
+    expect(isValidProfileUsername("id")).toBe(false);
+  });
+});

--- a/tests/unit/signin-callback-url.test.ts
+++ b/tests/unit/signin-callback-url.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveSignInCallbackUrl } from "@/lib/auth/auth-routing";
+import {
+  resolveSignInCallbackUrl,
+  sanitizeAuthCallbackUrl,
+} from "@/lib/auth/auth-routing";
 import {
   MCP_TOOLS_SCOPE,
   OAUTH_CODE_RESPONSE_TYPE,
@@ -15,6 +18,27 @@ describe("resolveSignInCallbackUrl", () => {
         client_id: "ignored",
       }),
     ).toBe("/settings?tab=accounts");
+  });
+
+  it("rejects external callbackUrl values", () => {
+    expect(
+      resolveSignInCallbackUrl({ callbackUrl: "https://attacker.example" }),
+    ).toBe("/");
+    expect(
+      resolveSignInCallbackUrl({ callbackUrl: "//attacker.example" }),
+    ).toBe("/");
+    expect(
+      resolveSignInCallbackUrl({ callbackUrl: "javascript:alert(1)" }),
+    ).toBe("/");
+  });
+
+  it("sanitizes app-relative callback URLs", () => {
+    expect(sanitizeAuthCallbackUrl("/settings?tab=profile#accounts")).toBe(
+      "/settings?tab=profile#accounts",
+    );
+    expect(sanitizeAuthCallbackUrl("/\\attacker.example")).toBe("/");
+    expect(sanitizeAuthCallbackUrl("/%2f%2fattacker.example")).toBe("/");
+    expect(sanitizeAuthCallbackUrl("/%5cattacker.example")).toBe("/");
   });
 
   it("reconstructs oauth authorize continuation from raw sign-in params", () => {


### PR DESCRIPTION
## Goal

Fix profile/auth flow drift found during structural review:
- reject unsafe sign-in callback redirects
- preserve the original app-relative destination through required welcome profile completion
- centralize profile username validation and own-profile update rules across welcome/settings

## Changed Surfaces

- Auth routing: shared app-relative callback sanitizer used by sign-in load/action and sign-in URL construction.
- Welcome flow: `callbackUrl` is sanitized, carried through the completion form, and used after successful profile completion.
- Profile/settings/admin username rules: one shared username helper covers format, length, and reserved `id`; settings now requires username instead of saving an immediately-incomplete profile.
- Profile mutation structure: welcome and settings now call a shared profile update service for name/username/avatar/uniqueness/Better Auth updates.
- UI/copy/contracts/tests: settings and welcome username inputs share constants; English helper copy and user contract wording now match behavior.

## Evidence

- `bun run vitest run tests/unit/signin-callback-url.test.ts tests/unit/auth-provider-routing.test.ts tests/unit/profile-username.test.ts`
- `bun run verify`
- `PLAYWRIGHT_PORT=3002 bun run e2e:test -- tests/e2e/src/app/welcome/test.ts tests/e2e/src/app/settings/profile/test.ts`
- `PLAYWRIGHT_PORT=3002 bun run verify:full`
- Browser evidence inspected manually at desktop and mobile widths for `/settings?tab=profile` and `/welcome?callbackUrl=%2Fsettings`; temporary screenshots were removed.

`PLAYWRIGHT_PORT=3002` was used because an unrelated local Docker container (`napcat`) owns `127.0.0.1:3000-3001` on this machine.

## Docs / Contracts

- Updated `docs/contracts/user.json` for app-relative callback behavior and welcome completion resume behavior.
- Updated `messages/en-us.json` so username helper text mentions hyphens, matching the shared rule.
- No OpenAPI change: no public REST route shape changed.

## Risk Areas

- Auth/OAuth: callback sanitizer only accepts app-relative paths; raw OAuth authorize continuation reconstruction remains covered by unit/E2E tests.
- Profile updates: shared service changes welcome/settings behavior and preserves Better Auth cookie propagation.
- Admin users: admin username updates now reject the same reserved names as self-service profile flows when a username is present.

## Cleanup

- Removed temporary screenshots and local E2E artifacts before commit.
- No generated files, scratch reports, or unrelated rewrites are included.
