### PR TITLE
fix: comment attachment and subscription surface drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,7 @@ buildPaginatedResponse(items, page, pageSize, total)
 - Never log tokens, secrets, session cookies, OAuth codes, upload URLs, or personal data beyond what a test explicitly requires.
 - Preserve auth surface differences: pages redirect, REST returns status responses, MCP is bearer-only with `/api/mcp` audience.
 - Check permissions before mutations; suspended users are blocked from collaborative writes.
-- Upload downloads are owner-scoped unless a feature change explicitly updates the permission model and docs.
+- Upload downloads require a shared permission gate: owners may download their files, and signed-in viewers may download files attached to comments they are allowed to read.
 
 **Documentation Changes**:
 - Ask before broad documentation rewrites or restructures when the user did not explicitly request doc edits.

--- a/docs/contracts/admin.json
+++ b/docs/contracts/admin.json
@@ -38,7 +38,10 @@
         "routes": [
           {
             "path": "/api/admin/comments",
-            "returns": "{ comments: Comment[] }"
+            "returns": "{ comments: Comment[] }",
+            "notes": [
+              "Omitted status defaults to the active moderation queue, matching /admin/moderation."
+            ]
           },
           {
             "path": "/api/admin/comments/[id]",

--- a/docs/contracts/comment.json
+++ b/docs/contracts/comment.json
@@ -88,7 +88,10 @@
         "routes": [
           {
             "path": "/api/admin/comments",
-            "returns": "{ comments: Comment[] }"
+            "returns": "{ comments: Comment[] }",
+            "notes": [
+              "Omitted status defaults to the active moderation queue, matching /admin/moderation."
+            ]
           },
           {
             "path": "/api/admin/comments/[id]",

--- a/docs/contracts/subscription.json
+++ b/docs/contracts/subscription.json
@@ -28,6 +28,7 @@
             "name": "subscribe_section_by_jw_id",
             "returns": "{ success: Boolean, action: String, sectionJwId: Int, subscription }",
             "notes": [
+              "Missing section jwId returns { success: false, action: \"not_found\", subscription: null }.",
               "Default/summary responses return a compact subscription update result instead of the full subscribed section list.",
               "Request full mode only when the caller explicitly needs the full CalendarSubscription with sections[]."
             ]
@@ -36,6 +37,7 @@
             "name": "unsubscribe_section_by_jw_id",
             "returns": "{ success: Boolean, action: String, sectionJwId: Int, subscription }",
             "notes": [
+              "Missing section jwId returns { success: false, action: \"not_found\", subscription: null }.",
               "Default/summary responses return a compact subscription update result instead of the full subscribed section list.",
               "Request full mode only when the caller explicitly needs the full CalendarSubscription with sections[]."
             ]

--- a/docs/contracts/upload.json
+++ b/docs/contracts/upload.json
@@ -14,7 +14,7 @@
     "storage-observability": "Shared storage helpers record production-safe bounded metrics for storage operation status and duration; metrics identify operation type but do not include bucket names, object keys, signed URLs, filenames, or user IDs.",
     "e2e-r2": "E2E upload coverage should exercise the same Workers upload object route used in production.",
     "download-auth-required": "Downloads must not bypass authorization by obtaining a direct link.",
-    "download-delivery": "/api/uploads/[id]/download validates access permissions before streaming the object from the R2 binding."
+    "download-delivery": "/api/uploads/[id]/download validates owner access or visible comment-attachment access before streaming the object from the R2 binding."
   },
   "capabilities": {
     "upload-list": {
@@ -93,7 +93,7 @@
             "path": "/api/uploads/[id]/download",
             "returns": "download response streamed from R2",
             "notes": [
-              "Validates access permissions before serving the object from R2."
+              "Validates owner access or access through a visible attached comment before serving the object from R2."
             ]
           }
         ]

--- a/src/features/home/server/subscription-write-model.ts
+++ b/src/features/home/server/subscription-write-model.ts
@@ -38,6 +38,14 @@ async function getExistingSectionIds(sectionIds: readonly number[]) {
   return sections.map((section) => section.id);
 }
 
+async function getSectionIdByJwId(jwId: number) {
+  const section = await prisma.section.findUnique({
+    where: { jwId },
+    select: { id: true },
+  });
+  return section?.id ?? null;
+}
+
 async function getMutableUserSubscriptions(userId: string) {
   return prisma.user.findUnique({
     where: { id: userId },
@@ -208,15 +216,12 @@ export async function subscribeUserToSectionByJwId(
   sectionJwId: number,
   locale = DEFAULT_LOCALE,
 ) {
-  const section = await prisma.section.findUnique({
-    where: { jwId: sectionJwId },
-    select: { id: true },
-  });
-  if (!section) {
+  const sectionId = await getSectionIdByJwId(sectionJwId);
+  if (sectionId === null) {
     return null;
   }
 
-  const state = await addUserSectionSubscriptions(userId, [section.id]);
+  const state = await addUserSectionSubscriptions(userId, [sectionId]);
   if (!state) {
     return null;
   }
@@ -229,6 +234,11 @@ export async function unsubscribeUserFromSectionByJwId(
   sectionJwId: number,
   locale = DEFAULT_LOCALE,
 ) {
+  const sectionId = await getSectionIdByJwId(sectionJwId);
+  if (sectionId === null) {
+    return null;
+  }
+
   const user = await getMutableUserSubscriptions(userId);
   if (!user) {
     return null;
@@ -237,7 +247,7 @@ export async function unsubscribeUserFromSectionByJwId(
   await replaceUserSectionIds(
     userId,
     user.subscribedSections
-      .filter((section) => section.jwId !== sectionJwId)
+      .filter((section) => section.id !== sectionId)
       .map((section) => section.id),
   );
 

--- a/src/features/section-detail/server/section-detail-subscription-actions.ts
+++ b/src/features/section-detail/server/section-detail-subscription-actions.ts
@@ -1,4 +1,5 @@
 import { fail, redirect } from "@sveltejs/kit";
+import type { AppLocale } from "@/i18n/config";
 import { getSectionDetailPageCopy } from "./section-detail-page-copy";
 import { parseSectionJwId } from "./section-detail-params";
 import { getSectionDetailUserId } from "./section-detail-session";
@@ -10,7 +11,7 @@ async function updateSectionSubscription({
   request,
 }: {
   action: "subscribe" | "unsubscribe";
-  locals: App.Locals;
+  locals: { locale: AppLocale };
   params: { jwId: string };
   request: Request;
 }) {
@@ -20,16 +21,16 @@ async function updateSectionSubscription({
   const jwId = parseSectionJwId(params.jwId);
   if (jwId === null) return fail(400, { error: copy.operationFailed });
   const subscriptions = await import("@/features/home/server/subscriptions");
-  if (action === "subscribe") {
-    await subscriptions.subscribeUserToSectionByJwId(userId, jwId);
-  } else {
-    await subscriptions.unsubscribeUserFromSectionByJwId(userId, jwId);
-  }
+  const result =
+    action === "subscribe"
+      ? await subscriptions.subscribeUserToSectionByJwId(userId, jwId)
+      : await subscriptions.unsubscribeUserFromSectionByJwId(userId, jwId);
+  if (!result) return fail(404, { error: copy.operationFailed });
   throw redirect(303, `/sections/${jwId}`);
 }
 
 export function subscribeSectionAction(input: {
-  locals: App.Locals;
+  locals: { locale: AppLocale };
   params: { jwId: string };
   request: Request;
 }) {
@@ -37,7 +38,7 @@ export function subscribeSectionAction(input: {
 }
 
 export function unsubscribeSectionAction(input: {
-  locals: App.Locals;
+  locals: { locale: AppLocale };
   params: { jwId: string };
   request: Request;
 }) {

--- a/src/features/uploads/server/upload-service.ts
+++ b/src/features/uploads/server/upload-service.ts
@@ -4,6 +4,11 @@ import {
   runUploadSerializableTransaction,
   UploadError,
 } from "@/features/uploads/server/upload-quota";
+import type {
+  CommentStatus,
+  CommentVisibility,
+} from "@/generated/prisma/client";
+import { getViewerContext } from "@/lib/auth/viewer-context";
 import { prisma } from "@/lib/db/prisma";
 import {
   deleteStorageObject,
@@ -258,10 +263,61 @@ export async function deleteUploadRecord(input: {
   return upload;
 }
 
-export async function findOwnedUpload(id: string, userId: string) {
-  return prisma.upload.findFirst({
-    where: { id, userId },
-  });
+export async function findDownloadableUpload(id: string, userId: string) {
+  const [viewer, upload] = await Promise.all([
+    getViewerContext({ includeAdmin: true, userId }),
+    prisma.upload.findUnique({
+      where: { id },
+      select: {
+        contentType: true,
+        filename: true,
+        key: true,
+        userId: true,
+        commentAttachments: {
+          select: {
+            comment: {
+              select: {
+                status: true,
+                userId: true,
+                visibility: true,
+              },
+            },
+          },
+        },
+      },
+    }),
+  ]);
+  if (!upload || !viewer.isAuthenticated) return null;
+  if (upload.userId === userId) return upload;
+
+  const canDownloadAttachedUpload = upload.commentAttachments.some(
+    ({ comment }) => canViewerDownloadCommentAttachment(comment, viewer),
+  );
+  return canDownloadAttachedUpload ? upload : null;
+}
+
+function canViewerDownloadCommentAttachment(
+  comment: {
+    status: CommentStatus;
+    userId: string | null;
+    visibility: CommentVisibility;
+  },
+  viewer: {
+    isAdmin: boolean;
+    isAuthenticated: boolean;
+    userId: string | null;
+  },
+) {
+  if (!viewer.isAuthenticated) return false;
+  if (comment.status === "deleted") return false;
+  if (comment.status === "softbanned") {
+    return viewer.isAdmin || comment.userId === viewer.userId;
+  }
+  return (
+    comment.visibility === "public" ||
+    comment.visibility === "logged_in_only" ||
+    comment.visibility === "anonymous"
+  );
 }
 
 export async function validatePendingUploadObject(input: {

--- a/src/lib/api/routes/admin-comments-list-route.ts
+++ b/src/lib/api/routes/admin-comments-list-route.ts
@@ -1,3 +1,4 @@
+import { normalizeAdminCommentStatusFilter } from "@/features/admin/lib/admin-moderation-filters";
 import { listAdminModerationComments } from "@/features/admin/server/admin-moderation-api-lists";
 import {
   getRequestSearchParams,
@@ -24,7 +25,7 @@ export async function getAdminCommentsRoute(request: Request) {
       if (parsed instanceof Response) return parsed;
 
       const { query: parsedQuery, pagination } = parsed;
-      const status = parsedQuery.status ?? "all";
+      const status = normalizeAdminCommentStatusFilter(parsedQuery.status);
       const { pageSize: limit } = pagination;
       const comments = await listAdminModerationComments({ limit, status });
 

--- a/src/lib/api/routes/upload-download-route.ts
+++ b/src/lib/api/routes/upload-download-route.ts
@@ -1,5 +1,5 @@
 import { buildContentDisposition } from "@/features/uploads/lib/upload-utils";
-import { findOwnedUpload } from "@/features/uploads/server/upload-service";
+import { findDownloadableUpload } from "@/features/uploads/server/upload-service";
 import { handleRouteError, notFound } from "@/lib/api/helpers";
 import {
   parseUploadId,
@@ -25,7 +25,7 @@ export async function getUploadDownloadRoute(
   const id = parsed.id;
 
   try {
-    const upload = await findOwnedUpload(id, userId);
+    const upload = await findDownloadableUpload(id, userId);
     if (!upload) {
       return notFound();
     }

--- a/tests/e2e/src/app/api/admin/comments/test.ts
+++ b/tests/e2e/src/app/api/admin/comments/test.ts
@@ -45,7 +45,9 @@ test.describe("GET /api/admin/comments", () => {
     );
   });
 
-  test("admin can list comments without status filter", async ({ page }) => {
+  test("admin can list active comments without status filter", async ({
+    page,
+  }) => {
     await signInAsDevAdmin(page, "/admin");
     const response = await page.request.get(`${BASE}?limit=5`);
     expect(response.status()).toBe(200);
@@ -54,5 +56,6 @@ test.describe("GET /api/admin/comments", () => {
     };
     expect((body.comments?.length ?? 0) > 0).toBe(true);
     expect(body.comments?.length).toBeLessThanOrEqual(5);
+    expect(body.comments?.every((item) => item.status === "active")).toBe(true);
   });
 });

--- a/tests/e2e/src/app/api/uploads/[id]/download/test.ts
+++ b/tests/e2e/src/app/api/uploads/[id]/download/test.ts
@@ -17,6 +17,7 @@ import {
   signInAsDebugUser,
   signInAsDevAdmin,
 } from "../../../../../../utils/auth";
+import { resolveSeedSectionId } from "../../../../../../utils/seed-lookups";
 import { createUploadedFileViaApi } from "../../../../../../utils/uploads";
 import { assertApiContract } from "../../../../_shared/api-contract";
 
@@ -70,6 +71,112 @@ test("/api/uploads/[id]/download GET 非本人返回 404", async ({ browser }) =
 
     try {
       // Try to download as admin user
+      const adminContext = await browser.newContext();
+      const adminPage = await adminContext.newPage();
+
+      try {
+        await signInAsDevAdmin(adminPage, "/");
+        const downloadResponse = await adminPage.request.get(
+          `/api/uploads/${uploaded.uploadId}/download`,
+          { maxRedirects: 0 },
+        );
+        expect(downloadResponse.status()).toBe(404);
+      } finally {
+        await adminContext.close();
+      }
+    } finally {
+      await userPage.request.delete(`/api/uploads/${uploaded.uploadId}`);
+    }
+  } finally {
+    await userContext.close();
+  }
+});
+
+test("/api/uploads/[id]/download GET allows visible comment attachments", async ({
+  browser,
+}) => {
+  const userContext = await browser.newContext();
+  const userPage = await userContext.newPage();
+
+  try {
+    await signInAsDebugUser(userPage, "/");
+    const sectionId = await resolveSeedSectionId(userPage);
+    const uploaded = await createUploadedFileViaApi(userPage.request, {
+      filename: `e2e-comment-attachment-${Date.now()}.txt`,
+      contents: "visible comment attachment",
+    });
+
+    const createCommentResponse = await userPage.request.post("/api/comments", {
+      data: {
+        attachmentIds: [uploaded.uploadId],
+        body: `e2e comment attachment ${Date.now()}`,
+        targetId: String(sectionId),
+        targetType: "section",
+        visibility: "public",
+      },
+    });
+    expect(createCommentResponse.status()).toBe(200);
+    const commentId = ((await createCommentResponse.json()) as { id?: string })
+      .id;
+    expect(commentId).toBeTruthy();
+
+    try {
+      const adminContext = await browser.newContext();
+      const adminPage = await adminContext.newPage();
+
+      try {
+        await signInAsDevAdmin(adminPage, "/");
+        const downloadResponse = await adminPage.request.get(
+          `/api/uploads/${uploaded.uploadId}/download`,
+        );
+        expect(downloadResponse.status()).toBe(200);
+        await expect(downloadResponse.text()).resolves.toBe(
+          "visible comment attachment",
+        );
+      } finally {
+        await adminContext.close();
+      }
+    } finally {
+      if (commentId) {
+        await userPage.request.delete(`/api/comments/${commentId}`);
+      }
+      await userPage.request.delete(`/api/uploads/${uploaded.uploadId}`);
+    }
+  } finally {
+    await userContext.close();
+  }
+});
+
+test("/api/uploads/[id]/download GET denies deleted comment attachments", async ({
+  browser,
+}) => {
+  const userContext = await browser.newContext();
+  const userPage = await userContext.newPage();
+
+  try {
+    await signInAsDebugUser(userPage, "/");
+    const sectionId = await resolveSeedSectionId(userPage);
+    const uploaded = await createUploadedFileViaApi(userPage.request, {
+      filename: `e2e-deleted-comment-attachment-${Date.now()}.txt`,
+      contents: "deleted comment attachment",
+    });
+
+    const createCommentResponse = await userPage.request.post("/api/comments", {
+      data: {
+        attachmentIds: [uploaded.uploadId],
+        body: `e2e deleted comment attachment ${Date.now()}`,
+        targetId: String(sectionId),
+        targetType: "section",
+        visibility: "public",
+      },
+    });
+    expect(createCommentResponse.status()).toBe(200);
+    const commentId = ((await createCommentResponse.json()) as { id?: string })
+      .id;
+    expect(commentId).toBeTruthy();
+
+    try {
+      await userPage.request.delete(`/api/comments/${commentId}`);
       const adminContext = await browser.newContext();
       const adminPage = await adminContext.newPage();
 

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -1115,4 +1115,39 @@ describe("subscribe_section_by_jw_id — returns action + compact subscription",
     expect(result.subscription?.currentSemesterSections).toBeUndefined();
     expect(typeof result.subscription?.sectionCount).toBe("number");
   });
+
+  it("returns not_found for missing subscribe and unsubscribe targets", async () => {
+    const missingJwId = 2_147_483_647;
+    const subscribeResult = await mcp.call<{
+      success?: boolean;
+      action?: string;
+      sectionJwId?: number;
+      subscription?: unknown;
+    }>("subscribe_section_by_jw_id", {
+      jwId: missingJwId,
+      locale: "zh-cn",
+    });
+    const unsubscribeResult = await mcp.call<{
+      success?: boolean;
+      action?: string;
+      sectionJwId?: number;
+      subscription?: unknown;
+    }>("unsubscribe_section_by_jw_id", {
+      jwId: missingJwId,
+      locale: "zh-cn",
+    });
+
+    expect(subscribeResult).toMatchObject({
+      action: "not_found",
+      sectionJwId: missingJwId,
+      success: false,
+      subscription: null,
+    });
+    expect(unsubscribeResult).toMatchObject({
+      action: "not_found",
+      sectionJwId: missingJwId,
+      success: false,
+      subscription: null,
+    });
+  });
 });

--- a/tests/unit/section-detail-subscription-actions.test.ts
+++ b/tests/unit/section-detail-subscription-actions.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSessionFromHeadersMock = vi.fn();
+const subscribeUserToSectionByJwIdMock = vi.fn();
+const unsubscribeUserFromSectionByJwIdMock = vi.fn();
+
+vi.mock("@/lib/auth/core", () => ({
+  getSessionFromHeaders: getSessionFromHeadersMock,
+}));
+
+vi.mock("@/features/home/server/subscriptions", () => ({
+  subscribeUserToSectionByJwId: subscribeUserToSectionByJwIdMock,
+  unsubscribeUserFromSectionByJwId: unsubscribeUserFromSectionByJwIdMock,
+}));
+
+function actionInput(jwId = "99999999") {
+  return {
+    locals: { locale: "en-us" as const },
+    params: { jwId },
+    request: new Request("http://localhost/sections/99999999"),
+  };
+}
+
+describe("section detail subscription actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionFromHeadersMock.mockResolvedValue({ user: { id: "user-1" } });
+  });
+
+  it("returns 404 when subscribe target is missing", async () => {
+    subscribeUserToSectionByJwIdMock.mockResolvedValue(null);
+    const { subscribeSectionAction } = await import(
+      "@/features/section-detail/server/section-detail-subscription-actions"
+    );
+
+    const result = await subscribeSectionAction(actionInput());
+
+    expect(result).toMatchObject({ status: 404 });
+    expect(subscribeUserToSectionByJwIdMock).toHaveBeenCalledWith(
+      "user-1",
+      99999999,
+    );
+  });
+
+  it("returns 404 when unsubscribe target is missing", async () => {
+    unsubscribeUserFromSectionByJwIdMock.mockResolvedValue(null);
+    const { unsubscribeSectionAction } = await import(
+      "@/features/section-detail/server/section-detail-subscription-actions"
+    );
+
+    const result = await unsubscribeSectionAction(actionInput());
+
+    expect(result).toMatchObject({ status: 404 });
+    expect(unsubscribeUserFromSectionByJwIdMock).toHaveBeenCalledWith(
+      "user-1",
+      99999999,
+    );
+  });
+});

--- a/tests/unit/upload-download-permissions.test.ts
+++ b/tests/unit/upload-download-permissions.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { findDownloadableUpload } from "@/features/uploads/server/upload-service";
+import { getViewerContext } from "@/lib/auth/viewer-context";
+import { prisma } from "@/lib/db/prisma";
+
+vi.mock("@/lib/auth/viewer-context", () => ({
+  getViewerContext: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    upload: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+const findUniqueMock = vi.mocked(prisma.upload.findUnique);
+const getViewerContextMock = vi.mocked(getViewerContext);
+
+function upload(overrides: Record<string, unknown> = {}) {
+  return {
+    contentType: "text/plain",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    filename: "note.txt",
+    id: "upload-1",
+    key: "uploads/owner/upload.txt",
+    size: 123,
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    userId: "owner",
+    commentAttachments: [],
+    ...overrides,
+  };
+}
+
+function viewer(overrides: Record<string, unknown> = {}) {
+  return {
+    image: null,
+    isAdmin: false,
+    isAuthenticated: true,
+    isSuspended: false,
+    name: "Viewer",
+    suspensionExpiresAt: null,
+    suspensionReason: null,
+    userId: "viewer",
+    ...overrides,
+  };
+}
+
+function attachmentComment(overrides: Record<string, unknown> = {}) {
+  return {
+    comment: {
+      status: "active",
+      userId: "owner",
+      visibility: "public",
+      ...overrides,
+    },
+  };
+}
+
+describe("upload download permissions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getViewerContextMock.mockResolvedValue(viewer());
+  });
+
+  it("allows owners to download unattached uploads", async () => {
+    findUniqueMock.mockResolvedValue(upload({ userId: "viewer" }));
+
+    await expect(findDownloadableUpload("upload-1", "viewer")).resolves.toEqual(
+      expect.objectContaining({ filename: "note.txt" }),
+    );
+  });
+
+  it("allows signed-in non-owners through visible comment attachments", async () => {
+    findUniqueMock.mockResolvedValue(
+      upload({ commentAttachments: [attachmentComment()] }),
+    );
+
+    await expect(findDownloadableUpload("upload-1", "viewer")).resolves.toEqual(
+      expect.objectContaining({ key: "uploads/owner/upload.txt" }),
+    );
+  });
+
+  it("does not expose unattached non-owner uploads", async () => {
+    findUniqueMock.mockResolvedValue(upload());
+
+    await expect(
+      findDownloadableUpload("upload-1", "viewer"),
+    ).resolves.toBeNull();
+  });
+
+  it("does not expose uploads through hidden comments", async () => {
+    findUniqueMock.mockResolvedValue(
+      upload({
+        commentAttachments: [
+          attachmentComment({ status: "deleted" }),
+          attachmentComment({ status: "softbanned" }),
+        ],
+      }),
+    );
+
+    await expect(
+      findDownloadableUpload("upload-1", "viewer"),
+    ).resolves.toBeNull();
+  });
+
+  it("allows admins to download softbanned comment attachments", async () => {
+    getViewerContextMock.mockResolvedValue(viewer({ isAdmin: true }));
+    findUniqueMock.mockResolvedValue(
+      upload({
+        commentAttachments: [attachmentComment({ status: "softbanned" })],
+      }),
+    );
+
+    await expect(findDownloadableUpload("upload-1", "viewer")).resolves.toEqual(
+      expect.objectContaining({ filename: "note.txt" }),
+    );
+  });
+});


### PR DESCRIPTION
## Goal

Align shared access behavior across the upload, subscription, and admin comment surfaces where code and contracts had drifted.

## Changed Surfaces

- `src/features/uploads/server/upload-service.ts` and `/api/uploads/[id]/download`: owners can still download uploads, and signed-in viewers can now download uploads attached to comments they are allowed to read.
- `src/features/home/server/subscription-write-model.ts`, section page actions, and MCP section subscription tools: missing section `jwId` now returns a not-found result instead of silently succeeding on unsubscribe.
- `/api/admin/comments`: omitted `status` now defaults to the active moderation queue, matching the admin moderation page.
- Tests added or updated for upload download permissions, section subscription actions, MCP missing-section output, admin comment defaults, and focused E2E download cases.

## Evidence

- Focused unit coverage: `bun run vitest run tests/unit/upload-download-permissions.test.ts tests/unit/section-detail-subscription-actions.test.ts tests/unit/comment-serialization-permissions.test.ts`
- Local gates: `bun run verify:conventions`, `bun run verify:types`, `bun run test`, `bun run verify:integration`
- Focused browser/API loop: `PLAYWRIGHT_PORT=3002 bun run e2e:test -- 'tests/e2e/src/app/api/uploads/\[id\]/download/test.ts' 'tests/e2e/src/app/sections/\[jwId\]/test.ts'`
- Full local gate after rebasing on `origin/main`: `PLAYWRIGHT_PORT=3002 bun run verify:full`
- Review pass: subagent reviewed the changed upload, subscription, admin comment, contract, and test surfaces and reported no blocking findings.

## Docs / Contracts

- Updated `AGENTS.md` upload permission guidance.
- Updated `docs/contracts/upload.json`, `docs/contracts/subscription.json`, `docs/contracts/admin.json`, and `docs/contracts/comment.json` to match the implemented behavior.
- No OpenAPI annotation change was needed because the affected response envelope/status semantics did not add new REST fields.

## Risk Areas

- Upload privacy: the new shared gate only allows non-owner downloads through readable, non-deleted comment attachments; soft-banned comments remain restricted to admins or the author.
- REST/MCP parity: subscription missing-target behavior is covered in page-action unit tests and MCP integration output tests.
- Admin queue behavior: omitted API status now matches the moderation UI default.

## Cleanup

- Removed local E2E artifacts before publishing.
- Stopped local Docker Compose services started for verification.
- `git diff --check origin/main...HEAD` passed.
- `git status --short --branch` was clean before push.
