### PR TITLE
feat(mcp): comment read tools through MCP

### DIFF
--- a/docs/contracts/comment.json
+++ b/docs/contracts/comment.json
@@ -4,13 +4,14 @@
     "anon": "Can read public comments but cannot create sign-in-required comments.",
     "user": "Can post, reply, react, edit, and delete their own comments; suspended users can read permitted comments but cannot use comment write actions or upload comment attachments.",
     "admin": "Can hide, delete, and moderate comments, and handle suspensions.",
-    "agent": "No comment read/write capability is currently provided."
+    "agent": "Can read visible comment lists and focused threads through MCP with authenticated viewer context; no comment write or moderation capability is currently provided."
   },
   "rules": {
     "attached-to-object": "Comments must be attached to a specific object; no decontextualized public feed entry is provided.",
     "attached-object-types": "Attached objects include courses, sections, teachers, homework, and section-teacher relationships.",
     "rich-content": "Supports Markdown, math formulas, emoji, tables, replies, and reactions.",
-    "visibility-modes": "Supports public, signed-in-only, and anonymous posting; anonymous comments hide identity from regular users but are traceable by admins in governance scenarios."
+    "visibility-modes": "Supports public, signed-in-only, and anonymous posting; anonymous comments hide identity from regular users but are traceable by admins in governance scenarios.",
+    "shared-read-policy": "Web, REST, and MCP comment reads share the same target resolution, thread serialization, visibility filtering, author masking, reaction, attachment, and viewer action-flag logic."
   },
   "capabilities": {
     "object-comment-section": {
@@ -21,7 +22,10 @@
         "routes": [
           {
             "path": "/api/comments",
-            "returns": "{ comments: Comment[], hiddenCount: Int, viewer, target }"
+            "returns": "{ comments: Comment[], hiddenCount: Int, viewer, target }",
+            "notes": [
+              "Returns 404 when the attached target entity does not exist."
+            ]
           },
           {
             "path": "/api/comments",
@@ -59,7 +63,22 @@
           }
         ]
       },
-      "mcp": "unavailable",
+      "mcp": {
+        "tools": [
+          {
+            "name": "list_comments",
+            "returns": "{ found: Boolean, comments: Comment[], hiddenCount: Int, viewer, target }",
+            "auth": "user",
+            "rest_equivalent": "GET /api/comments"
+          },
+          {
+            "name": "get_comment_thread",
+            "returns": "{ found: Boolean, thread: Comment[], focusId: String, hiddenCount: Int, viewer, target }",
+            "auth": "user",
+            "rest_equivalent": "GET /api/comments/[id]"
+          }
+        ]
+      },
       "display": {
         "fields": [
           "comment.id",

--- a/docs/contracts/comment.json
+++ b/docs/contracts/comment.json
@@ -11,7 +11,7 @@
     "attached-object-types": "Attached objects include courses, sections, teachers, homework, and section-teacher relationships.",
     "rich-content": "Supports Markdown, math formulas, emoji, tables, replies, and reactions.",
     "visibility-modes": "Supports public, signed-in-only, and anonymous posting; anonymous comments hide identity from regular users but are traceable by admins in governance scenarios.",
-    "shared-read-policy": "Web, REST, and MCP comment reads share the same target resolution, thread serialization, visibility filtering, author masking, reaction, attachment, and viewer action-flag logic; read-only paths must not create durable comment targets."
+    "shared-read-policy": "Web, REST, and MCP comment reads share the same target resolution, thread serialization, visibility filtering, author masking, reaction, attachment, and viewer action-flag logic; read-only paths must not create durable comment targets and valid empty section-teacher targets load as empty threads."
   },
   "capabilities": {
     "object-comment-section": {

--- a/docs/contracts/comment.json
+++ b/docs/contracts/comment.json
@@ -11,7 +11,7 @@
     "attached-object-types": "Attached objects include courses, sections, teachers, homework, and section-teacher relationships.",
     "rich-content": "Supports Markdown, math formulas, emoji, tables, replies, and reactions.",
     "visibility-modes": "Supports public, signed-in-only, and anonymous posting; anonymous comments hide identity from regular users but are traceable by admins in governance scenarios.",
-    "shared-read-policy": "Web, REST, and MCP comment reads share the same target resolution, thread serialization, visibility filtering, author masking, reaction, attachment, and viewer action-flag logic."
+    "shared-read-policy": "Web, REST, and MCP comment reads share the same target resolution, thread serialization, visibility filtering, author masking, reaction, attachment, and viewer action-flag logic; read-only paths must not create durable comment targets."
   },
   "capabilities": {
     "object-comment-section": {

--- a/docs/contracts/mcp.json
+++ b/docs/contracts/mcp.json
@@ -95,6 +95,10 @@
             ]
           },
           {
+            "name": "Comments",
+            "tools": ["list_comments", "get_comment_thread"]
+          },
+          {
             "name": "Calendar & Subscription",
             "tools": [
               "list_my_calendar_events",

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -1639,6 +1639,16 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
           }
         }
       },

--- a/src/features/comments/lib/comment-target-types.ts
+++ b/src/features/comments/lib/comment-target-types.ts
@@ -1,0 +1,9 @@
+export const COMMENT_TARGET_TYPES = [
+  "section",
+  "course",
+  "teacher",
+  "section-teacher",
+  "homework",
+] as const;
+
+export type CommentTargetType = (typeof COMMENT_TARGET_TYPES)[number];

--- a/src/features/comments/server/comment-mutations.ts
+++ b/src/features/comments/server/comment-mutations.ts
@@ -51,6 +51,7 @@ export async function createComment(input: {
   if (!actor.ok) return actor;
 
   const target = await resolveCommentTarget({
+    createSectionTeacherTarget: true,
     rawTargetId: input.rawTargetId,
     sectionId: input.sectionId,
     targetType: input.targetType,

--- a/src/features/comments/server/comment-read-model.ts
+++ b/src/features/comments/server/comment-read-model.ts
@@ -94,6 +94,16 @@ export async function loadCommentThread(input: {
   viewer?: ViewerContext;
   viewerUserId: string | null;
 }) {
+  if (input.target.empty) {
+    const viewer =
+      input.viewer ??
+      (await getViewerContext({
+        includeAdmin: false,
+        userId: input.viewerUserId,
+      }));
+    return { comments: [], hiddenCount: 0, viewer };
+  }
+
   const [viewer, comments] = await Promise.all([
     input.viewer
       ? Promise.resolve(input.viewer)

--- a/src/features/comments/server/comment-section-teacher.ts
+++ b/src/features/comments/server/comment-section-teacher.ts
@@ -46,3 +46,30 @@ export async function findSectionTeacherId(
 
   return sectionTeacher?.id ?? null;
 }
+
+export async function findSectionTeacherTarget(
+  sectionId: number,
+  teacherId: number,
+) {
+  const { prisma } = await import("@/lib/db/prisma");
+  const sectionTeacherId = await findSectionTeacherId(sectionId, teacherId);
+  if (sectionTeacherId) {
+    return { exists: true, id: sectionTeacherId } as const;
+  }
+
+  const section = await prisma.section.findFirst({
+    where: {
+      id: sectionId,
+      teachers: {
+        some: { id: teacherId },
+      },
+    },
+    select: { id: true },
+  });
+
+  if (!section) {
+    return { exists: false, id: null } as const;
+  }
+
+  return { exists: true, id: null } as const;
+}

--- a/src/features/comments/server/comment-section-teacher.ts
+++ b/src/features/comments/server/comment-section-teacher.ts
@@ -28,3 +28,21 @@ export async function resolveSectionTeacherId(
 
   return sectionTeacher.id as number;
 }
+
+export async function findSectionTeacherId(
+  sectionId: number,
+  teacherId: number,
+) {
+  const { prisma } = await import("@/lib/db/prisma");
+  const sectionTeacher = await prisma.sectionTeacher.findUnique({
+    where: {
+      sectionId_teacherId: {
+        sectionId,
+        teacherId,
+      },
+    },
+    select: { id: true },
+  });
+
+  return sectionTeacher?.id ?? null;
+}

--- a/src/features/comments/server/comment-target-payload.ts
+++ b/src/features/comments/server/comment-target-payload.ts
@@ -1,8 +1,5 @@
-import type { CommentTargetLookupRecord } from "@/features/comments/server/comment-read-model";
-import type {
-  CommentTargetType,
-  ResolvedCommentTarget,
-} from "@/features/comments/server/comment-utils";
+import type { CommentTargetLookupRecord } from "./comment-read-model";
+import type { CommentTargetType, ResolvedCommentTarget } from "./comment-utils";
 
 export function commentListTargetPayload(
   targetType: CommentTargetType,
@@ -18,7 +15,7 @@ export function commentListTargetPayload(
   };
 }
 
-export function buildCommentRouteTarget(comment: CommentTargetLookupRecord) {
+export function commentThreadTargetPayload(comment: CommentTargetLookupRecord) {
   return {
     sectionId: comment.sectionId ?? null,
     courseId: comment.courseId ?? null,

--- a/src/features/comments/server/comment-utils.ts
+++ b/src/features/comments/server/comment-utils.ts
@@ -1,6 +1,9 @@
 import { parseInteger } from "@/lib/integers";
 import type { CommentTargetType } from "../lib/comment-target-types";
-import { resolveSectionTeacherId } from "./comment-section-teacher";
+import {
+  findSectionTeacherId,
+  resolveSectionTeacherId,
+} from "./comment-section-teacher";
 import { verifyCommentTargetEntity } from "./comment-target-verification";
 
 export type { CommentTargetType };
@@ -20,6 +23,7 @@ export { resolveSectionTeacherId };
 
 export async function resolveCommentTarget(input: {
   allowDirectSectionTeacherId?: boolean;
+  createSectionTeacherTarget?: boolean;
   /** Whether to verify the target entity exists in the DB before returning. */
   verifyExistence?: boolean;
   rawTargetId: unknown;
@@ -50,7 +54,10 @@ export async function resolveCommentTarget(input: {
     if (input.allowDirectSectionTeacherId && normalizedTargetId) {
       sectionTeacherId = normalizedTargetId;
     } else if (sectionId && teacherId) {
-      sectionTeacherId = await resolveSectionTeacherId(sectionId, teacherId);
+      sectionTeacherId =
+        input.createSectionTeacherTarget === true
+          ? await resolveSectionTeacherId(sectionId, teacherId)
+          : await findSectionTeacherId(sectionId, teacherId);
     }
 
     if (sectionTeacherId) {

--- a/src/features/comments/server/comment-utils.ts
+++ b/src/features/comments/server/comment-utils.ts
@@ -1,13 +1,9 @@
 import { parseInteger } from "@/lib/integers";
+import type { CommentTargetType } from "../lib/comment-target-types";
 import { resolveSectionTeacherId } from "./comment-section-teacher";
 import { verifyCommentTargetEntity } from "./comment-target-verification";
 
-export type CommentTargetType =
-  | "section"
-  | "course"
-  | "teacher"
-  | "section-teacher"
-  | "homework";
+export type { CommentTargetType };
 
 export type ResolvedCommentTarget = {
   homeworkId: string | null;

--- a/src/features/comments/server/comment-utils.ts
+++ b/src/features/comments/server/comment-utils.ts
@@ -46,6 +46,7 @@ export async function resolveCommentTarget(input: {
   let whereTarget: Record<string, number | string> | null = null;
   let sectionTeacherId: number | null = null;
   let empty = false;
+  let missing = false;
 
   if (input.targetType === "section" && normalizedTargetId) {
     whereTarget = { sectionId: normalizedTargetId };
@@ -67,6 +68,9 @@ export async function resolveCommentTarget(input: {
         if (target.exists && target.id === null) {
           whereTarget = EMPTY_SECTION_TEACHER_WHERE_TARGET;
           empty = true;
+        } else if (!target.exists && input.verifyExistence === true) {
+          whereTarget = EMPTY_SECTION_TEACHER_WHERE_TARGET;
+          missing = true;
         }
       }
     }
@@ -80,11 +84,13 @@ export async function resolveCommentTarget(input: {
     return null;
   }
 
-  const verified = empty
-    ? true
-    : input.verifyExistence === true
-      ? await verifyCommentTargetEntity(input.targetType, whereTarget)
-      : true;
+  const verified = missing
+    ? false
+    : empty
+      ? true
+      : input.verifyExistence === true
+        ? await verifyCommentTargetEntity(input.targetType, whereTarget)
+        : true;
 
   return {
     empty,

--- a/src/features/comments/server/comment-utils.ts
+++ b/src/features/comments/server/comment-utils.ts
@@ -1,7 +1,7 @@
 import { parseInteger } from "@/lib/integers";
 import type { CommentTargetType } from "../lib/comment-target-types";
 import {
-  findSectionTeacherId,
+  findSectionTeacherTarget,
   resolveSectionTeacherId,
 } from "./comment-section-teacher";
 import { verifyCommentTargetEntity } from "./comment-target-verification";
@@ -15,11 +15,15 @@ export type ResolvedCommentTarget = {
   targetId: number | string | null;
   teacherId: number | null;
   whereTarget: Record<string, number | string>;
+  /** True when the target is valid but cannot have comments yet. */
+  empty: boolean;
   /** True when the underlying target entity was verified to exist in the DB. */
   verified: boolean;
 };
 
 export { resolveSectionTeacherId };
+
+const EMPTY_SECTION_TEACHER_WHERE_TARGET = { sectionTeacherId: -1 } as const;
 
 export async function resolveCommentTarget(input: {
   allowDirectSectionTeacherId?: boolean;
@@ -41,6 +45,7 @@ export async function resolveCommentTarget(input: {
 
   let whereTarget: Record<string, number | string> | null = null;
   let sectionTeacherId: number | null = null;
+  let empty = false;
 
   if (input.targetType === "section" && normalizedTargetId) {
     whereTarget = { sectionId: normalizedTargetId };
@@ -54,13 +59,19 @@ export async function resolveCommentTarget(input: {
     if (input.allowDirectSectionTeacherId && normalizedTargetId) {
       sectionTeacherId = normalizedTargetId;
     } else if (sectionId && teacherId) {
-      sectionTeacherId =
-        input.createSectionTeacherTarget === true
-          ? await resolveSectionTeacherId(sectionId, teacherId)
-          : await findSectionTeacherId(sectionId, teacherId);
+      if (input.createSectionTeacherTarget === true) {
+        sectionTeacherId = await resolveSectionTeacherId(sectionId, teacherId);
+      } else {
+        const target = await findSectionTeacherTarget(sectionId, teacherId);
+        sectionTeacherId = target.id;
+        if (target.exists && target.id === null) {
+          whereTarget = EMPTY_SECTION_TEACHER_WHERE_TARGET;
+          empty = true;
+        }
+      }
     }
 
-    if (sectionTeacherId) {
+    if (!whereTarget && sectionTeacherId) {
       whereTarget = { sectionTeacherId };
     }
   }
@@ -69,12 +80,14 @@ export async function resolveCommentTarget(input: {
     return null;
   }
 
-  const verified =
-    input.verifyExistence === true
+  const verified = empty
+    ? true
+    : input.verifyExistence === true
       ? await verifyCommentTargetEntity(input.targetType, whereTarget)
       : true;
 
   return {
+    empty,
     homeworkId,
     sectionId,
     sectionTeacherId,

--- a/src/lib/api/routes/comments-list-route.ts
+++ b/src/lib/api/routes/comments-list-route.ts
@@ -1,14 +1,15 @@
 import { loadCommentThread } from "@/features/comments/server/comment-read-model";
+import { commentListTargetPayload } from "@/features/comments/server/comment-target-payload";
 import { resolveCommentTarget } from "@/features/comments/server/comment-utils";
 import {
   badRequest,
   handleRouteError,
   jsonResponse,
+  notFound,
   parseRouteSearchParams,
 } from "@/lib/api/helpers";
 import { commentsQuerySchema } from "@/lib/api/schemas/request-schemas";
 import { resolveApiUserId } from "@/lib/auth/api-auth";
-import { commentListTargetPayload } from "./comment-target-payloads";
 
 export async function getCommentsRoute(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -31,9 +32,13 @@ export async function getCommentsRoute(request: Request) {
       sectionId: parsedQuery.sectionId,
       targetType,
       teacherId: parsedQuery.teacherId,
+      verifyExistence: true,
     });
     if (!target) {
       return badRequest("Invalid target");
+    }
+    if (!target.verified) {
+      return notFound();
     }
 
     const viewerUserId = await resolveApiUserId(request);

--- a/src/lib/api/routes/comments-thread-route.ts
+++ b/src/lib/api/routes/comments-thread-route.ts
@@ -1,4 +1,5 @@
 import { loadFocusedCommentThread } from "@/features/comments/server/comment-read-model";
+import { commentThreadTargetPayload } from "@/features/comments/server/comment-target-payload";
 import {
   forbidden,
   handleRouteError,
@@ -8,7 +9,6 @@ import {
 } from "@/lib/api/helpers";
 import { resourceIdPathParamsSchema } from "@/lib/api/schemas/request-schemas";
 import { resolveApiUserId } from "@/lib/auth/api-auth";
-import { buildCommentRouteTarget } from "./comment-target-payloads";
 
 type IdParams = { id: string };
 
@@ -42,7 +42,7 @@ export async function getCommentRoute(request: Request, params: IdParams) {
       focusId: result.focusId,
       hiddenCount: result.hiddenCount,
       viewer: result.viewer,
-      target: buildCommentRouteTarget(result.target),
+      target: commentThreadTargetPayload(result.target),
     });
   } catch (error) {
     return handleRouteError("Failed to fetch comment", error);

--- a/src/lib/api/schemas/request-schema-primitives.ts
+++ b/src/lib/api/schemas/request-schema-primitives.ts
@@ -1,5 +1,6 @@
 import * as z from "zod";
 import { sectionCodeSchema } from "@/features/catalog/lib/section-code-schema";
+import { COMMENT_TARGET_TYPES } from "@/features/comments/lib/comment-target-types";
 import { todoPrioritySchema } from "@/features/todos/lib/todo-schema";
 import { parseDateInput } from "@/lib/time/parse-date-input";
 import { parseInteger } from "../request-integers";
@@ -61,13 +62,7 @@ export const commentReactionTypeSchema = z.enum([
 
 export { commentVisibilitySchema, sectionCodeSchema };
 
-export const commentTargetTypeSchema = z.enum([
-  "section",
-  "course",
-  "teacher",
-  "section-teacher",
-  "homework",
-]);
+export const commentTargetTypeSchema = z.enum(COMMENT_TARGET_TYPES);
 
 export const descriptionTargetTypeSchema = z.enum([
   "section",

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerBusTools } from "@/lib/mcp/tools/bus-tools";
 import { registerCalendarTools } from "@/lib/mcp/tools/calendar-tools";
+import { registerCommentTools } from "@/lib/mcp/tools/comment-tools";
 import { registerCourseTools } from "@/lib/mcp/tools/course-tools";
 import { registerDashboardTools } from "@/lib/mcp/tools/dashboard-tools";
 import { registerMyDataTools } from "@/lib/mcp/tools/my-data-tools";
@@ -14,6 +15,7 @@ export function createMcpServer() {
   });
 
   registerBusTools(server);
+  registerCommentTools(server);
   registerProfileTools(server);
   registerCourseTools(server);
   registerDashboardTools(server);

--- a/src/lib/mcp/tools/comment-tools.ts
+++ b/src/lib/mcp/tools/comment-tools.ts
@@ -1,0 +1,281 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod";
+import { COMMENT_TARGET_TYPES } from "@/features/comments/lib/comment-target-types";
+import {
+  loadCommentThread,
+  loadFocusedCommentThread,
+} from "@/features/comments/server/comment-read-model";
+import {
+  commentListTargetPayload,
+  commentThreadTargetPayload,
+} from "@/features/comments/server/comment-target-payload";
+import type { ResolvedCommentTarget } from "@/features/comments/server/comment-utils";
+import {
+  type CommentTargetType,
+  resolveCommentTarget,
+} from "@/features/comments/server/comment-utils";
+import { prisma } from "@/lib/db/prisma";
+import {
+  getUserId,
+  jsonToolResult,
+  mcpModeInputSchema,
+  resolveMcpMode,
+} from "@/lib/mcp/tools/_helpers";
+
+const commentTargetIdSchema = z.union([
+  z.number().int().positive(),
+  z.string().trim().min(1),
+]);
+
+const commentsTargetInputSchema = z.object({
+  targetType: z.enum(COMMENT_TARGET_TYPES),
+  targetId: commentTargetIdSchema
+    .optional()
+    .describe(
+      "Internal target id matching REST /api/comments. Prefer public identifiers such as sectionJwId or courseJwId when available.",
+    ),
+  sectionJwId: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Public JW section id for section or section-teacher comments."),
+  courseJwId: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Public JW course id for course comments."),
+  teacherId: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Teacher id for teacher or section-teacher comments."),
+  homeworkId: z.string().trim().min(1).optional(),
+  sectionTeacherId: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Direct section-teacher relationship id."),
+  mode: mcpModeInputSchema,
+});
+
+const commentThreadInputSchema = z.object({
+  commentId: z.string().trim().min(1),
+  mode: mcpModeInputSchema,
+});
+
+type CommentsTargetInput = z.infer<typeof commentsTargetInputSchema>;
+
+type ResolvedMcpCommentTarget =
+  | {
+      ok: true;
+      target: ResolvedCommentTarget;
+      targetType: CommentTargetType;
+    }
+  | {
+      ok: false;
+      error: "invalid_target" | "target_not_found";
+      message: string;
+      hint: string;
+    };
+
+export function registerCommentTools(server: McpServer) {
+  server.registerTool(
+    "list_comments",
+    {
+      description:
+        "List visible comments for one course, section, teacher, homework, or section-teacher target. " +
+        "Returns the same threaded comment nodes, hidden count, viewer state, reactions, attachments, and action flags as the REST comment list.",
+      inputSchema: commentsTargetInputSchema.shape,
+    },
+    async (args, extra) => {
+      const mode = resolveMcpMode(args.mode);
+      const resolved = await resolveMcpCommentTarget(args);
+      if (!resolved.ok) {
+        return jsonToolResult(
+          {
+            success: false,
+            found: false,
+            error: resolved.error,
+            message: resolved.message,
+            hint: resolved.hint,
+          },
+          { mode },
+        );
+      }
+
+      const viewerUserId = getUserId(extra.authInfo);
+      const { comments, hiddenCount, viewer } = await loadCommentThread({
+        target: resolved.target,
+        viewerUserId,
+      });
+
+      return jsonToolResult(
+        {
+          found: true,
+          comments,
+          hiddenCount,
+          viewer,
+          target: commentListTargetPayload(
+            resolved.targetType,
+            resolved.target,
+          ),
+        },
+        { mode },
+      );
+    },
+  );
+
+  server.registerTool(
+    "get_comment_thread",
+    {
+      description:
+        "Fetch the visible thread around one comment id. Returns the same focus id, target payload, viewer state, and threaded comment nodes as REST /api/comments/[id].",
+      inputSchema: commentThreadInputSchema.shape,
+    },
+    async ({ commentId, mode }, extra) => {
+      const resolvedMode = resolveMcpMode(mode);
+      const viewerUserId = getUserId(extra.authInfo);
+      const result = await loadFocusedCommentThread({
+        commentId,
+        viewerUserId,
+      });
+
+      if (!result.ok) {
+        return jsonToolResult(
+          {
+            success: false,
+            found: result.error !== "not_found",
+            error: result.error,
+            message:
+              result.error === "not_found"
+                ? `Comment ${commentId} was not found`
+                : `Comment ${commentId} is not visible to the current viewer`,
+          },
+          { mode: resolvedMode },
+        );
+      }
+
+      return jsonToolResult(
+        {
+          found: true,
+          thread: result.thread,
+          focusId: result.focusId,
+          hiddenCount: result.hiddenCount,
+          viewer: result.viewer,
+          target: commentThreadTargetPayload(result.target),
+        },
+        { mode: resolvedMode },
+      );
+    },
+  );
+}
+
+async function resolveMcpCommentTarget(
+  input: CommentsTargetInput,
+): Promise<ResolvedMcpCommentTarget> {
+  if (input.targetType === "section" && input.sectionJwId) {
+    const section = await prisma.section.findUnique({
+      where: { jwId: input.sectionJwId },
+      select: { id: true },
+    });
+    if (!section) return targetNotFound("section", input.sectionJwId);
+    return resolveVerifiedTarget("section", section.id);
+  }
+
+  if (input.targetType === "course" && input.courseJwId) {
+    const course = await prisma.course.findUnique({
+      where: { jwId: input.courseJwId },
+      select: { id: true },
+    });
+    if (!course) return targetNotFound("course", input.courseJwId);
+    return resolveVerifiedTarget("course", course.id);
+  }
+
+  if (input.targetType === "teacher") {
+    return resolveVerifiedTarget("teacher", input.teacherId ?? input.targetId);
+  }
+
+  if (input.targetType === "homework") {
+    return resolveVerifiedTarget(
+      "homework",
+      input.homeworkId ?? input.targetId,
+    );
+  }
+
+  if (input.targetType === "section-teacher") {
+    const directId = input.sectionTeacherId ?? input.targetId;
+    if (directId) {
+      return resolveVerifiedTarget("section-teacher", directId);
+    }
+
+    if (input.sectionJwId && input.teacherId) {
+      const section = await prisma.section.findUnique({
+        where: { jwId: input.sectionJwId },
+        select: { id: true },
+      });
+      if (!section) return targetNotFound("section", input.sectionJwId);
+
+      const target = await resolveCommentTarget({
+        rawTargetId: undefined,
+        sectionId: section.id,
+        targetType: "section-teacher",
+        teacherId: input.teacherId,
+        verifyExistence: true,
+      });
+      if (!target?.verified) {
+        return targetNotFound("section-teacher", input.sectionJwId);
+      }
+      return { ok: true, target, targetType: "section-teacher" };
+    }
+  }
+
+  return resolveVerifiedTarget(input.targetType, input.targetId);
+}
+
+async function resolveVerifiedTarget(
+  targetType: CommentTargetType,
+  rawTargetId: unknown,
+): Promise<ResolvedMcpCommentTarget> {
+  const target = await resolveCommentTarget({
+    allowDirectSectionTeacherId: true,
+    rawTargetId,
+    targetType,
+    verifyExistence: true,
+  });
+
+  if (!target) {
+    return invalidTarget(targetType);
+  }
+  if (!target.verified) {
+    return targetNotFound(targetType, rawTargetId);
+  }
+
+  return { ok: true, target, targetType };
+}
+
+function invalidTarget(
+  targetType: CommentTargetType,
+): ResolvedMcpCommentTarget {
+  return {
+    ok: false,
+    error: "invalid_target",
+    message: `Missing or invalid ${targetType} comment target`,
+    hint: "Provide targetId for the REST-compatible internal id, or a public identifier such as sectionJwId, courseJwId, teacherId, homeworkId, or sectionTeacherId.",
+  };
+}
+
+function targetNotFound(
+  targetType: string,
+  targetId: unknown,
+): ResolvedMcpCommentTarget {
+  return {
+    ok: false,
+    error: "target_not_found",
+    message: `Comment target ${targetType}:${String(targetId)} was not found`,
+    hint: "Use search_sections, search_courses, search_teachers, or get_section_by_jw_id to find a valid comment target.",
+  };
+}

--- a/src/routes/api/comments/+server.ts
+++ b/src/routes/api/comments/+server.ts
@@ -7,6 +7,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  * @params commentsQuerySchema
  * @response commentsListResponseSchema
  * @response 400:openApiErrorSchema
+ * @response 404:openApiErrorSchema
  */
 export const GET = svelteRequestHandler(observedApiRoute(getCommentsRoute));
 /**

--- a/tests/e2e/src/app/api/comments/test.ts
+++ b/tests/e2e/src/app/api/comments/test.ts
@@ -6,6 +6,7 @@
  * - Response: { comments: CommentNode[], hiddenCount: number, viewer: ViewerContext, target: {...} }
  * - Public endpoint (no auth required)
  * - Returns 400 for missing/invalid target
+ * - Returns 404 for missing target entity
  *
  * ## POST /api/comments
  * - Body: { targetType, targetId, body, visibility?, isAnonymous?, parentId?, attachmentIds?, sectionId?, teacherId? }
@@ -76,6 +77,13 @@ test("/api/comments GET 无效 targetType 返回 400", async ({ request }) => {
     "/api/comments?targetType=invalid&targetId=1",
   );
   expect(response.status()).toBe(400);
+});
+
+test("/api/comments GET 不存在的目标返回 404", async ({ request }) => {
+  const response = await request.get(
+    "/api/comments?targetType=section&targetId=2147483647",
+  );
+  expect(response.status()).toBe(404);
 });
 
 test("/api/comments POST 未登录返回 401", async ({ request }) => {

--- a/tests/e2e/src/app/api/comments/test.ts
+++ b/tests/e2e/src/app/api/comments/test.ts
@@ -154,6 +154,37 @@ test("/api/comments GET section-teacher 空目标不会创建关系行", async (
   }
 });
 
+test("/api/comments GET 未关联的 section-teacher 目标返回 404", async ({
+  request,
+}) => {
+  const marker = `[e2e] section-teacher-missing-${Date.now()}`;
+  const { sectionId, teacherId } = await withE2ePrisma(async (prisma) => {
+    const section = await prisma.section.findUniqueOrThrow({
+      where: { jwId: DEV_SEED.section.jwId },
+      select: { id: true },
+    });
+    const teacher = await prisma.teacher.create({
+      data: {
+        code: marker,
+        nameCn: marker,
+      },
+      select: { id: true },
+    });
+    return { sectionId: section.id, teacherId: teacher.id };
+  });
+
+  try {
+    const response = await request.get(
+      `/api/comments?targetType=section-teacher&sectionId=${sectionId}&teacherId=${teacherId}`,
+    );
+    expect(response.status()).toBe(404);
+  } finally {
+    await withE2ePrisma((prisma) =>
+      prisma.teacher.deleteMany({ where: { id: teacherId } }),
+    );
+  }
+});
+
 test("/api/comments POST 未登录返回 401", async ({ request }) => {
   const response = await request.post("/api/comments", {
     data: {

--- a/tests/e2e/src/app/api/comments/test.ts
+++ b/tests/e2e/src/app/api/comments/test.ts
@@ -24,6 +24,7 @@
 import { expect, test } from "@playwright/test";
 import { signInAsDebugUser } from "../../../../utils/auth";
 import { DEV_SEED } from "../../../../utils/dev-seed";
+import { withE2ePrisma } from "../../../../utils/e2e-db/prisma";
 import { assertApiContract } from "../../_shared/api-contract";
 
 /** Resolve the seed section's internal DB id via match-codes. */
@@ -84,6 +85,73 @@ test("/api/comments GET 不存在的目标返回 404", async ({ request }) => {
     "/api/comments?targetType=section&targetId=2147483647",
   );
   expect(response.status()).toBe(404);
+});
+
+test("/api/comments GET section-teacher 空目标不会创建关系行", async ({
+  request,
+}) => {
+  const marker = `[e2e] section-teacher-read-${Date.now()}`;
+  const { sectionId, teacherId } = await withE2ePrisma(async (prisma) => {
+    const section = await prisma.section.findUniqueOrThrow({
+      where: { jwId: DEV_SEED.section.jwId },
+      select: { id: true },
+    });
+    const teacher = await prisma.teacher.create({
+      data: {
+        code: marker,
+        nameCn: marker,
+      },
+      select: { id: true },
+    });
+    await prisma.section.update({
+      where: { id: section.id },
+      data: { teachers: { connect: { id: teacher.id } } },
+    });
+    return { sectionId: section.id, teacherId: teacher.id };
+  });
+
+  try {
+    const response = await request.get(
+      `/api/comments?targetType=section-teacher&sectionId=${sectionId}&teacherId=${teacherId}`,
+    );
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as {
+      comments?: unknown[];
+      target?: {
+        sectionId?: number | null;
+        sectionTeacherId?: number | null;
+        teacherId?: number | null;
+      };
+    };
+    expect(body.comments).toEqual([]);
+    expect(body.target?.sectionId).toBe(sectionId);
+    expect(body.target?.teacherId).toBe(teacherId);
+    expect(body.target?.sectionTeacherId).toBeNull();
+
+    const created = await withE2ePrisma((prisma) =>
+      prisma.sectionTeacher.findUnique({
+        where: {
+          sectionId_teacherId: {
+            sectionId,
+            teacherId,
+          },
+        },
+        select: { id: true },
+      }),
+    );
+    expect(created).toBeNull();
+  } finally {
+    await withE2ePrisma(async (prisma) => {
+      await prisma.sectionTeacher.deleteMany({
+        where: { sectionId, teacherId },
+      });
+      await prisma.section.update({
+        where: { id: sectionId },
+        data: { teachers: { disconnect: { id: teacherId } } },
+      });
+      await prisma.teacher.deleteMany({ where: { id: teacherId } });
+    });
+  }
 });
 
 test("/api/comments POST 未登录返回 401", async ({ request }) => {

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -227,18 +227,24 @@ describe("comment read tools — MCP exposes the REST comment hierarchy", () => 
       expect(before).toBeNull();
 
       const result = await mcp.call<{
-        success?: boolean;
         found?: boolean;
-        error?: string;
+        comments?: unknown[];
+        target?: {
+          sectionId?: number | null;
+          sectionTeacherId?: number | null;
+          teacherId?: number | null;
+        };
       }>("list_comments", {
         targetType: "section-teacher",
         sectionJwId: DEV_SEED.section.jwId,
         teacherId,
       });
 
-      expect(result.success).toBe(false);
-      expect(result.found).toBe(false);
-      expect(result.error).toBe("target_not_found");
+      expect(result.found).toBe(true);
+      expect(result.comments).toEqual([]);
+      expect(result.target?.sectionId).toBe(section.id);
+      expect(result.target?.teacherId).toBe(teacherId);
+      expect(result.target?.sectionTeacherId).toBeNull();
 
       const after = await prisma.sectionTeacher.findUnique({
         where: {

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -92,6 +92,104 @@ describe("get_my_profile", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Comments
+// ---------------------------------------------------------------------------
+
+describe("comment read tools — MCP exposes the REST comment hierarchy", () => {
+  it("list_comments returns threaded section comments with viewer/action fields", async () => {
+    const result = await mcp.call<{
+      found?: boolean;
+      comments?: Array<{
+        id?: string;
+        body?: string;
+        author?: { name?: string | null } | null;
+        replies?: Array<{ body?: string }>;
+        reactions?: Array<{ type?: string; count?: number }>;
+        canReply?: boolean;
+        canEdit?: boolean;
+        canDelete?: boolean;
+      }>;
+      hiddenCount?: number;
+      target?: { type?: string; targetId?: number | null };
+      viewer?: { userId?: string | null; isAuthenticated?: boolean };
+    }>("list_comments", {
+      targetType: "section",
+      sectionJwId: DEV_SEED.section.jwId,
+      mode: "full",
+    });
+
+    expect(result.found).toBe(true);
+    expect(result.target?.type).toBe("section");
+    expect(typeof result.target?.targetId).toBe("number");
+    expect(result.viewer?.userId).toBe(devUserId);
+    expect(result.viewer?.isAuthenticated).toBe(true);
+    expect(typeof result.hiddenCount).toBe("number");
+
+    const root = result.comments?.find((comment) =>
+      comment.body?.includes(DEV_SEED.comments.sectionRootBody),
+    );
+    expect(root).toBeDefined();
+    expect(root?.author?.name).toBe(DEV_SEED.debugName);
+    expect(root?.canReply).toBe(true);
+    expect(root?.canEdit).toBe(true);
+    expect(root?.canDelete).toBe(true);
+    expect(root?.replies?.length).toBeGreaterThan(0);
+    expect(
+      root?.reactions?.some(
+        (reaction) => reaction.type === "upvote" && reaction.count === 1,
+      ),
+    ).toBe(true);
+  });
+
+  it("get_comment_thread returns the focused thread and target metadata", async () => {
+    const seedComment = await prisma.comment.findFirst({
+      where: { body: DEV_SEED.comments.sectionRootBody },
+      select: { id: true },
+    });
+    expect(seedComment?.id).toBeTruthy();
+
+    const result = await mcp.call<{
+      found?: boolean;
+      focusId?: string;
+      thread?: Array<{
+        id?: string;
+        body?: string;
+        replies?: Array<{ body?: string }>;
+      }>;
+      target?: { sectionJwId?: number | null; sectionCode?: string | null };
+    }>("get_comment_thread", {
+      commentId: seedComment?.id,
+      mode: "full",
+    });
+
+    expect(result.found).toBe(true);
+    expect(result.focusId).toBe(seedComment?.id);
+    expect(result.thread?.[0]?.id).toBe(seedComment?.id);
+    expect(result.thread?.[0]?.body).toContain(
+      DEV_SEED.comments.sectionRootBody,
+    );
+    expect(result.thread?.[0]?.replies?.length).toBeGreaterThan(0);
+    expect(result.target?.sectionJwId).toBe(DEV_SEED.section.jwId);
+    expect(result.target?.sectionCode).toBe(DEV_SEED.section.code);
+  });
+
+  it("list_comments reports missing targets instead of returning an empty success", async () => {
+    const result = await mcp.call<{
+      success?: boolean;
+      found?: boolean;
+      error?: string;
+    }>("list_comments", {
+      targetType: "section",
+      sectionJwId: 2_147_483_647,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.found).toBe(false);
+    expect(result.error).toBe("target_not_found");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Todos
 // ---------------------------------------------------------------------------
 

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -187,6 +187,82 @@ describe("comment read tools — MCP exposes the REST comment hierarchy", () => 
     expect(result.found).toBe(false);
     expect(result.error).toBe("target_not_found");
   });
+
+  it("list_comments does not create section-teacher targets while reading", async () => {
+    const section = await prisma.section.findUnique({
+      where: { jwId: DEV_SEED.section.jwId },
+      select: { id: true },
+    });
+    if (!section) {
+      throw new Error(`Seed section ${DEV_SEED.section.jwId} not found`);
+    }
+
+    const marker = `[integration-test] mcp-section-teacher-read-${Date.now()}`;
+    let teacherId: number | null = null;
+
+    try {
+      const teacher = await prisma.teacher.create({
+        data: {
+          code: marker,
+          nameCn: marker,
+        },
+        select: { id: true },
+      });
+      teacherId = teacher.id;
+
+      await prisma.section.update({
+        where: { id: section.id },
+        data: { teachers: { connect: { id: teacherId } } },
+      });
+
+      const before = await prisma.sectionTeacher.findUnique({
+        where: {
+          sectionId_teacherId: {
+            sectionId: section.id,
+            teacherId,
+          },
+        },
+        select: { id: true },
+      });
+      expect(before).toBeNull();
+
+      const result = await mcp.call<{
+        success?: boolean;
+        found?: boolean;
+        error?: string;
+      }>("list_comments", {
+        targetType: "section-teacher",
+        sectionJwId: DEV_SEED.section.jwId,
+        teacherId,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.found).toBe(false);
+      expect(result.error).toBe("target_not_found");
+
+      const after = await prisma.sectionTeacher.findUnique({
+        where: {
+          sectionId_teacherId: {
+            sectionId: section.id,
+            teacherId,
+          },
+        },
+        select: { id: true },
+      });
+      expect(after).toBeNull();
+    } finally {
+      if (teacherId) {
+        await prisma.sectionTeacher.deleteMany({
+          where: { sectionId: section.id, teacherId },
+        });
+        await prisma.section.update({
+          where: { id: section.id },
+          data: { teachers: { disconnect: { id: teacherId } } },
+        });
+        await prisma.teacher.deleteMany({ where: { id: teacherId } });
+      }
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -188,6 +188,35 @@ describe("comment read tools — MCP exposes the REST comment hierarchy", () => 
     expect(result.error).toBe("target_not_found");
   });
 
+  it("list_comments reports unattached section-teacher pairs as missing targets", async () => {
+    const marker = `[integration-test] mcp-section-teacher-missing-${Date.now()}`;
+    const teacher = await prisma.teacher.create({
+      data: {
+        code: marker,
+        nameCn: marker,
+      },
+      select: { id: true },
+    });
+
+    try {
+      const result = await mcp.call<{
+        success?: boolean;
+        found?: boolean;
+        error?: string;
+      }>("list_comments", {
+        targetType: "section-teacher",
+        sectionJwId: DEV_SEED.section.jwId,
+        teacherId: teacher.id,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.found).toBe(false);
+      expect(result.error).toBe("target_not_found");
+    } finally {
+      await prisma.teacher.deleteMany({ where: { id: teacher.id } });
+    }
+  });
+
   it("list_comments does not create section-teacher targets while reading", async () => {
     const section = await prisma.section.findUnique({
       where: { jwId: DEV_SEED.section.jwId },


### PR DESCRIPTION
## Goal

Expose comment reads through MCP at the same hierarchy level as REST/web comment reads, while keeping comment visibility, masking, reaction, attachment, viewer action, and target-resolution logic shared in the comments feature layer.

## Changed Surfaces

- Added read-only MCP tools: `list_comments` and `get_comment_thread`.
- Moved comment target type and target payload helpers into `src/features/comments` for REST/MCP reuse.
- Updated `GET /api/comments` to return 404 when the attached target entity does not exist.
- Made section-teacher target creation explicit for comment writes; read paths now load valid empty targets without creating rows and report unattached pairs as not found.
- Updated comment and MCP contracts plus generated OpenAPI.
- Added MCP integration coverage and REST E2E coverage for the changed behavior.

## Evidence

Latest local checks on the pushed branch:

- Touched-file Biome check and `git diff --check` passed.
- Focused MCP integration passed: `bun run db:migrate:deploy && bun run seed && bun run vitest run --config vitest.integration.config.ts tests/integration/mcp-tools.test.ts`.
- Focused comments REST E2E passed: `bun run e2e:db:prepare && bun run e2e:build-artifacts && bun run seed && PLAYWRIGHT_PORT=3002 bun run e2e:test -- tests/e2e/src/app/api/comments/test.ts`.
- Default repo gate passed: `bun run verify`.
- Integration gate passed: `bun run verify:integration`.

Complete-loop coverage exercised serialized MCP success, missing-target, valid-empty section-teacher, and unattached-pair shapes. REST E2E covers missing-target 404, valid empty section-teacher reads without creating rows, and unattached section-teacher 404.

## Docs / Contracts

- Updated `docs/contracts/comment.json` with MCP read capability, the shared read policy, and the read-only/valid-empty target invariant.
- Updated `docs/contracts/mcp.json` with the comment tool group.
- Regenerated `public/openapi.generated.json` after adding the 404 response annotation.

## Risk Areas

- Comment privacy and visibility: anonymous author masking, hidden comments, attachments, reactions, and viewer action flags now flow through MCP using the existing shared read model.
- MCP auth remains bearer-only; unlike public REST reads, MCP comment reads run with authenticated viewer context.
- REST behavior change: nonexistent and unattached comment targets now return 404 instead of an empty 200 or invalid-target response.
- Section-teacher writes can still create a durable target, but read-only web/REST/MCP paths now only look up existing targets or return valid empty/not-found results.

## Cleanup

No scratch artifacts or one-time probes remain. Local Docker dev services started for verification will be stopped before handoff.