### PR TITLE
refactor(api): MCP section detail with REST

### DIFF
--- a/src/features/catalog/server/course-section-read-queries.ts
+++ b/src/features/catalog/server/course-section-read-queries.ts
@@ -8,6 +8,7 @@ import { buildCourseListWhere } from "@/features/catalog/server/course-section-q
 import type { AppLocale } from "@/i18n/config";
 import { DEFAULT_LOCALE } from "@/i18n/config";
 import { getPrisma } from "@/lib/db/prisma";
+import { serializeScheduleTimeFields } from "@/lib/schedule-serialization";
 
 export async function listCoursesBySearch(
   search: string,
@@ -48,7 +49,7 @@ export async function findSectionDetailByJwId(
   jwId: number,
   locale: AppLocale = DEFAULT_LOCALE,
 ) {
-  return getPrisma(locale).section.findUnique({
+  const section = await getPrisma(locale).section.findUnique({
     where: { jwId },
     include: {
       ...sectionInclude,
@@ -75,6 +76,13 @@ export async function findSectionDetailByJwId(
       },
     },
   });
+
+  if (!section) return null;
+
+  return {
+    ...section,
+    schedules: section.schedules.map(serializeScheduleTimeFields),
+  };
 }
 
 export async function findSectionCompactByJwId(

--- a/src/lib/mcp/tools/course-search-section-tool-handlers.ts
+++ b/src/lib/mcp/tools/course-search-section-tool-handlers.ts
@@ -1,5 +1,5 @@
 import {
-  findSectionByJwId,
+  findSectionDetailByJwId,
   type listCoursesBySearch,
 } from "@/features/catalog/server/course-section-queries";
 import { DEFAULT_LOCALE } from "@/i18n/config";
@@ -18,7 +18,7 @@ export async function getSectionByJwIdTool({
   locale: CourseSearchLocale;
   mode?: McpModeInput;
 }) {
-  const section = await findSectionByJwId(jwId, locale);
+  const section = await findSectionDetailByJwId(jwId, locale);
 
   if (!section) {
     return jsonToolResult({

--- a/tests/e2e/src/app/api/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/api/sections/[jwId]/test.ts
@@ -27,7 +27,7 @@ test("section detail has all SectionDetail fields", async ({ request }) => {
   const body = (await response.json()) as {
     code?: unknown;
     teachers?: Array<{ id?: unknown; nameCn?: unknown }>;
-    schedules?: unknown[];
+    schedules?: Array<{ endTime?: unknown; startTime?: unknown }>;
     scheduleGroups?: unknown[];
     exams?: unknown[];
     examMode?: unknown;
@@ -41,6 +41,8 @@ test("section detail has all SectionDetail fields", async ({ request }) => {
     expect(typeof firstTeacher.nameCn).toBe("string");
   }
   expect(Array.isArray(body.schedules)).toBe(true);
+  expect(typeof body.schedules?.[0]?.startTime).toBe("string");
+  expect(typeof body.schedules?.[0]?.endTime).toBe("string");
   expect(Array.isArray(body.scheduleGroups)).toBe(true);
   expect(Array.isArray(body.exams)).toBe(true);
   expect(Object.hasOwn(body, "examMode")).toBe(true);

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -1151,6 +1151,10 @@ describe("course and section lookups", () => {
       found?: boolean;
       section?: {
         code?: string;
+        schedules?: Array<{
+          endTime?: unknown;
+          startTime?: unknown;
+        }>;
         teacherAssignments?: unknown[];
         scheduleGroups?: unknown[];
         exams?: unknown[];
@@ -1164,6 +1168,8 @@ describe("course and section lookups", () => {
 
     expect(result.found).toBe(true);
     expect(result.section?.code).toBe(DEV_SEED.section.code);
+    expect(typeof result.section?.schedules?.[0]?.startTime).toBe("string");
+    expect(typeof result.section?.schedules?.[0]?.endTime).toBe("string");
     expect((result.section?.teacherAssignments?.length ?? 0) > 0).toBe(true);
     expect(Array.isArray(result.section?.scheduleGroups)).toBe(true);
     expect((result.section?.exams?.length ?? 0) > 0).toBe(true);

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -1145,7 +1145,31 @@ describe("query_schedules — flexible date filters", () => {
   });
 });
 
-describe("course and section lookup errors", () => {
+describe("course and section lookups", () => {
+  it("get_section_by_jw_id returns the same detail hierarchy as REST section detail", async () => {
+    const result = await mcp.call<{
+      found?: boolean;
+      section?: {
+        code?: string;
+        teacherAssignments?: unknown[];
+        scheduleGroups?: unknown[];
+        exams?: unknown[];
+        roomType?: unknown;
+      };
+    }>("get_section_by_jw_id", {
+      jwId: DEV_SEED.section.jwId,
+      locale: "zh-cn",
+      mode: "full",
+    });
+
+    expect(result.found).toBe(true);
+    expect(result.section?.code).toBe(DEV_SEED.section.code);
+    expect((result.section?.teacherAssignments?.length ?? 0) > 0).toBe(true);
+    expect(Array.isArray(result.section?.scheduleGroups)).toBe(true);
+    expect((result.section?.exams?.length ?? 0) > 0).toBe(true);
+    expect(Object.hasOwn(result.section ?? {}, "roomType")).toBe(true);
+  });
+
   it("get_section_by_jw_id returns a recovery hint when the jwId is missing", async () => {
     const result = await mcp.call<{
       found?: boolean;


### PR DESCRIPTION
## Goal

Make `get_section_by_jw_id` return the same section detail hierarchy documented for `GET /api/sections/[jwId]`, and keep shared section detail schedule times serialized consistently across REST and MCP.

## Changed Surfaces

- MCP: `get_section_by_jw_id` now uses the shared `findSectionDetailByJwId` detail read model instead of the lighter generic section include.
- Shared read model: `findSectionDetailByJwId` serializes nested `schedules[].startTime` and `schedules[].endTime` through the existing schedule serializer before REST or MCP return the payload.
- Tests: MCP integration checks detail-only fields and serialized schedule times; REST E2E section detail checks serialized schedule times.

## Evidence

- `bun run biome check --write src/features/catalog/server/course-section-read-queries.ts src/lib/mcp/tools/course-search-section-tool-handlers.ts tests/integration/mcp-tools.test.ts 'tests/e2e/src/app/api/sections/[jwId]/test.ts'`
- `bun run db:migrate:deploy && bun run seed && bun run vitest run --config vitest.integration.config.ts tests/integration/mcp-tools.test.ts`
- `PLAYWRIGHT_PORT=3002 bun run e2e:test -- 'tests/e2e/src/app/api/sections/\\[jwId\\]/test.ts'`
- `PLAYWRIGHT_PORT=3002 bun run verify:full` (443 unit tests, 47 integration tests, 499 E2E tests)
- `git diff --check`
- Remote checks: CI, E2E shards, CodeQL, Cloudflare Workers build, static loader image, and snapshot artifact checks are green on `9d8da659` after rerunning a transient Playwright dependency setup failure caused by a GitHub runner apt repository returning `403 Forbidden`.

Port note: local port 3000 is occupied by an unrelated `napcat` Docker container publishing `127.0.0.1:3000-3001`, so local Playwright verification used port 3002. Repo-owned Docker Compose services were started for verification and stopped afterward.

## Docs / Contracts

No docs change: `docs/contracts/section.json` already states that `get_section_by_jw_id` is the MCP equivalent of `GET /api/sections/[jwId]`, and the API schedule schema already documents serialized string time fields. This PR makes implementation match those contracts.

## Risk Areas

- MCP payload size increases for `get_section_by_jw_id` when `mode: "full"` is requested because it now returns the REST detail hierarchy.
- Section detail `schedules[].startTime` and `schedules[].endTime` are now serialized strings at the shared read boundary, matching the public API schema and schedule endpoints.
- Prisma schema, OpenAPI annotations, auth, UI, and generated files are unchanged.

## Cleanup

- Removed local E2E scratch output (`test-results`, `.wrangler/e2e`).
- Stopped repo-owned Docker Compose services after verification.
- Final `git status --short --branch` was clean after push.
