### PR TITLE
refactor(api): REST and MCP public surfaces

### DIFF
--- a/docs/contracts/bus.json
+++ b/docs/contracts/bus.json
@@ -129,7 +129,7 @@
     },
     "bus-next-departures": {
       "title": "Bus Next Departures",
-      "auth": "user",
+      "auth": "anon",
       "web": "unavailable",
       "rest": {
         "routes": [

--- a/docs/contracts/comment.json
+++ b/docs/contracts/comment.json
@@ -24,6 +24,7 @@
             "path": "/api/comments",
             "returns": "{ comments: Comment[], hiddenCount: Int, viewer, target }",
             "notes": [
+              "Accepts REST-compatible internal targetId plus public identifiers such as sectionJwId, courseJwId, teacherId, homeworkId, and sectionTeacherId.",
               "Returns 404 when the attached target entity does not exist."
             ]
           },
@@ -91,7 +92,7 @@
           "comment.status (non-active states)",
           "comment.reactions[] (counts per reaction type)",
           "comment.replies[] (threaded)",
-          "comment.attachments[] filename/open action",
+          "comment.attachments[] filename/open action for signed-in viewers with attachment access",
           "canReply/canEdit/canDelete/canModerate actions",
           "Copy link action"
         ]

--- a/docs/contracts/course.json
+++ b/docs/contracts/course.json
@@ -34,7 +34,7 @@
         "tools": [
           {
             "name": "search_courses",
-            "returns": "{ courses: Course[] }",
+            "returns": "PaginatedResponse<Course>",
             "rest_equivalent": "GET /api/courses"
           }
         ]

--- a/docs/contracts/mcp.json
+++ b/docs/contracts/mcp.json
@@ -22,7 +22,7 @@
   "capabilities": {
     "protocol-endpoint": {
       "title": "Protocol Endpoint",
-      "auth": "anon",
+      "auth": "user",
       "web": "unavailable",
       "rest": {
         "routes": [
@@ -58,7 +58,7 @@
     },
     "tool-groups": {
       "title": "Tool Groups",
-      "auth": "anon",
+      "auth": "user",
       "mcp": {
         "groups": [
           {

--- a/docs/contracts/user.json
+++ b/docs/contracts/user.json
@@ -80,7 +80,7 @@
         "routes": [
           {
             "path": "/api/me",
-            "returns": "{ id, email, name, image, username, isAdmin }",
+            "returns": "{ id, email, name, image, username, isAdmin, createdAt, updatedAt }",
             "auth": "user",
             "notes": [
               "Returns the authenticated user's core profile fields only; no separate public profile endpoint for other users is currently exposed."
@@ -93,7 +93,7 @@
           {
             "name": "get_my_profile",
             "auth": "user",
-            "returns": "{ id, username, name, image, isAdmin, createdAt, updatedAt }",
+            "returns": "{ id, email, username, name, image, isAdmin, createdAt, updatedAt }",
             "rest_equivalent": "GET /api/me"
           },
           {

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -1612,7 +1612,39 @@
           },
           {
             "in": "query",
+            "name": "sectionJwId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "courseJwId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
             "name": "teacherId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "homeworkId",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "sectionTeacherId",
             "schema": {
               "type": "integer",
               "format": "int64"
@@ -14601,6 +14633,12 @@
                   }
                 ]
               },
+              "courseId": {
+                "nullable": true,
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
               "sectionId": {
                 "nullable": true,
                 "type": "integer",
@@ -14622,15 +14660,105 @@
               "homeworkId": {
                 "nullable": true,
                 "type": "string"
+              },
+              "sectionTeacherSectionId": {
+                "nullable": true,
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "sectionTeacherTeacherId": {
+                "nullable": true,
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "sectionTeacherSectionJwId": {
+                "nullable": true,
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "sectionTeacherSectionCode": {
+                "nullable": true,
+                "type": "string"
+              },
+              "sectionTeacherTeacherName": {
+                "nullable": true,
+                "type": "string"
+              },
+              "sectionTeacherCourseJwId": {
+                "nullable": true,
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "sectionTeacherCourseName": {
+                "nullable": true,
+                "type": "string"
+              },
+              "homeworkTitle": {
+                "nullable": true,
+                "type": "string"
+              },
+              "homeworkSectionJwId": {
+                "nullable": true,
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "homeworkSectionCode": {
+                "nullable": true,
+                "type": "string"
+              },
+              "sectionJwId": {
+                "nullable": true,
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "sectionCode": {
+                "nullable": true,
+                "type": "string"
+              },
+              "courseJwId": {
+                "nullable": true,
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "courseName": {
+                "nullable": true,
+                "type": "string"
+              },
+              "teacherName": {
+                "nullable": true,
+                "type": "string"
               }
             },
             "required": [
               "type",
               "targetId",
+              "courseId",
               "sectionId",
               "teacherId",
               "sectionTeacherId",
-              "homeworkId"
+              "homeworkId",
+              "sectionTeacherSectionId",
+              "sectionTeacherTeacherId",
+              "sectionTeacherSectionJwId",
+              "sectionTeacherSectionCode",
+              "sectionTeacherTeacherName",
+              "sectionTeacherCourseJwId",
+              "sectionTeacherCourseName",
+              "homeworkTitle",
+              "homeworkSectionJwId",
+              "homeworkSectionCode",
+              "sectionJwId",
+              "sectionCode",
+              "courseJwId",
+              "courseName",
+              "teacherName"
             ],
             "additionalProperties": false
           }
@@ -18070,6 +18198,16 @@
           },
           "isAdmin": {
             "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
           }
         },
         "required": [
@@ -18078,7 +18216,9 @@
           "name",
           "image",
           "username",
-          "isAdmin"
+          "isAdmin",
+          "createdAt",
+          "updatedAt"
         ],
         "additionalProperties": false
       },

--- a/src/features/catalog/server/course-section-queries.ts
+++ b/src/features/catalog/server/course-section-queries.ts
@@ -8,7 +8,6 @@ export {
   findSectionCompactByJwId,
   findSectionDetailByJwId,
   findSectionSummaryByJwId,
-  listCoursesBySearch,
 } from "@/features/catalog/server/course-section-read-queries";
 export { findSectionCodeMatches } from "@/features/catalog/server/section-code-match-query";
 export { listSectionSummaries } from "@/features/catalog/server/section-summary-read-model";

--- a/src/features/catalog/server/course-section-read-queries.ts
+++ b/src/features/catalog/server/course-section-read-queries.ts
@@ -1,29 +1,12 @@
 import {
   courseDetailInclude,
-  courseInclude,
   sectionCompactInclude,
   sectionInclude,
 } from "@/features/catalog/server/academic-query-includes";
-import { buildCourseListWhere } from "@/features/catalog/server/course-section-query-filters";
 import type { AppLocale } from "@/i18n/config";
 import { DEFAULT_LOCALE } from "@/i18n/config";
 import { getPrisma } from "@/lib/db/prisma";
 import { serializeScheduleTimeFields } from "@/lib/schedule-serialization";
-
-export async function listCoursesBySearch(
-  search: string,
-  limit: number,
-  locale: AppLocale = DEFAULT_LOCALE,
-) {
-  const localizedPrisma = getPrisma(locale);
-
-  return localizedPrisma.course.findMany({
-    where: buildCourseListWhere({ search }),
-    include: courseInclude,
-    orderBy: [{ code: "asc" }, { jwId: "asc" }],
-    take: limit,
-  });
-}
 
 export async function findCourseDetailByJwId(
   jwId: number,

--- a/src/features/comments/server/comment-attachment-access.ts
+++ b/src/features/comments/server/comment-attachment-access.ts
@@ -1,0 +1,32 @@
+import type {
+  CommentStatus,
+  CommentVisibility,
+} from "@/generated/prisma/client";
+
+export type CommentAttachmentAccessComment = {
+  status: CommentStatus;
+  userId: string | null;
+  visibility: CommentVisibility;
+};
+
+export type CommentAttachmentAccessViewer = {
+  isAdmin: boolean;
+  isAuthenticated: boolean;
+  userId: string | null;
+};
+
+export function canViewerAccessCommentAttachment(
+  comment: CommentAttachmentAccessComment,
+  viewer: CommentAttachmentAccessViewer,
+) {
+  if (!viewer.isAuthenticated) return false;
+  if (comment.status === "deleted") return false;
+  if (comment.status === "softbanned") {
+    return viewer.isAdmin || comment.userId === viewer.userId;
+  }
+  return (
+    comment.visibility === "public" ||
+    comment.visibility === "logged_in_only" ||
+    comment.visibility === "anonymous"
+  );
+}

--- a/src/features/comments/server/comment-read-model.ts
+++ b/src/features/comments/server/comment-read-model.ts
@@ -75,7 +75,13 @@ export const commentTargetLookupSelect = {
     },
   },
   section: {
-    select: { jwId: true, code: true },
+    select: {
+      jwId: true,
+      code: true,
+      course: {
+        select: { jwId: true, nameCn: true },
+      },
+    },
   },
   course: {
     select: { jwId: true, nameCn: true },

--- a/src/features/comments/server/comment-target-payload.ts
+++ b/src/features/comments/server/comment-target-payload.ts
@@ -1,7 +1,80 @@
+import { prisma } from "@/lib/db/prisma";
 import type { CommentTargetLookupRecord } from "./comment-read-model";
 import type { CommentTargetType, ResolvedCommentTarget } from "./comment-utils";
 
-export function commentListTargetPayload(
+type CommentTargetCourseMetadata = {
+  jwId: number | null;
+  nameCn: string | null;
+};
+
+type CommentTargetSectionMetadata = {
+  code: string | null;
+  course?: CommentTargetCourseMetadata | null;
+  jwId: number | null;
+};
+
+type CommentTargetMetadataSource = {
+  course?: CommentTargetCourseMetadata | null;
+  homework?: {
+    section?: Pick<CommentTargetSectionMetadata, "code" | "jwId"> | null;
+    title: string | null;
+  } | null;
+  section?: CommentTargetSectionMetadata | null;
+  sectionTeacher?: {
+    section?: CommentTargetSectionMetadata | null;
+    sectionId: number | null;
+    teacher?: { nameCn: string | null } | null;
+    teacherId: number | null;
+  } | null;
+  teacher?: { nameCn: string | null } | null;
+};
+
+const emptyPublicCommentTargetMetadataFields = {
+  courseJwId: null,
+  courseName: null,
+  homeworkSectionCode: null,
+  homeworkSectionJwId: null,
+  homeworkTitle: null,
+  sectionCode: null,
+  sectionJwId: null,
+  sectionTeacherCourseJwId: null,
+  sectionTeacherCourseName: null,
+  sectionTeacherSectionCode: null,
+  sectionTeacherSectionId: null,
+  sectionTeacherSectionJwId: null,
+  sectionTeacherTeacherId: null,
+  sectionTeacherTeacherName: null,
+  teacherName: null,
+} as const;
+
+function publicCommentTargetMetadataPayload(
+  source: CommentTargetMetadataSource | null | undefined,
+) {
+  const course = source?.course ?? source?.section?.course ?? null;
+
+  return {
+    ...emptyPublicCommentTargetMetadataFields,
+    courseJwId: course?.jwId ?? null,
+    courseName: course?.nameCn ?? null,
+    homeworkSectionCode: source?.homework?.section?.code ?? null,
+    homeworkSectionJwId: source?.homework?.section?.jwId ?? null,
+    homeworkTitle: source?.homework?.title ?? null,
+    sectionCode: source?.section?.code ?? null,
+    sectionJwId: source?.section?.jwId ?? null,
+    sectionTeacherCourseJwId:
+      source?.sectionTeacher?.section?.course?.jwId ?? null,
+    sectionTeacherCourseName:
+      source?.sectionTeacher?.section?.course?.nameCn ?? null,
+    sectionTeacherSectionCode: source?.sectionTeacher?.section?.code ?? null,
+    sectionTeacherSectionId: source?.sectionTeacher?.sectionId ?? null,
+    sectionTeacherSectionJwId: source?.sectionTeacher?.section?.jwId ?? null,
+    sectionTeacherTeacherId: source?.sectionTeacher?.teacherId ?? null,
+    sectionTeacherTeacherName: source?.sectionTeacher?.teacher?.nameCn ?? null,
+    teacherName: source?.teacher?.nameCn ?? null,
+  };
+}
+
+function baseCommentListTargetPayload(
   targetType: CommentTargetType,
   target: ResolvedCommentTarget,
 ) {
@@ -15,29 +88,143 @@ export function commentListTargetPayload(
   };
 }
 
+export async function commentListTargetPayload(
+  targetType: CommentTargetType,
+  target: ResolvedCommentTarget,
+) {
+  const base = {
+    ...baseCommentListTargetPayload(targetType, target),
+    courseId:
+      typeof target.whereTarget.courseId === "number"
+        ? target.whereTarget.courseId
+        : null,
+  };
+
+  if (
+    targetType === "section" &&
+    typeof target.whereTarget.sectionId === "number"
+  ) {
+    const section = await prisma.section.findUnique({
+      where: { id: target.whereTarget.sectionId },
+      select: {
+        code: true,
+        jwId: true,
+        course: { select: { jwId: true, nameCn: true } },
+      },
+    });
+    return {
+      ...base,
+      ...publicCommentTargetMetadataPayload({ section }),
+    };
+  }
+
+  if (
+    targetType === "course" &&
+    typeof target.whereTarget.courseId === "number"
+  ) {
+    const course = await prisma.course.findUnique({
+      where: { id: target.whereTarget.courseId },
+      select: { jwId: true, nameCn: true },
+    });
+    return {
+      ...base,
+      ...publicCommentTargetMetadataPayload({ course }),
+    };
+  }
+
+  if (
+    targetType === "teacher" &&
+    typeof target.whereTarget.teacherId === "number"
+  ) {
+    const teacher = await prisma.teacher.findUnique({
+      where: { id: target.whereTarget.teacherId },
+      select: { nameCn: true },
+    });
+    return {
+      ...base,
+      ...publicCommentTargetMetadataPayload({ teacher }),
+    };
+  }
+
+  if (targetType === "homework" && target.homeworkId) {
+    const homework = await prisma.homework.findUnique({
+      where: { id: target.homeworkId },
+      select: {
+        title: true,
+        section: { select: { jwId: true, code: true } },
+      },
+    });
+    return {
+      ...base,
+      ...publicCommentTargetMetadataPayload({ homework }),
+    };
+  }
+
+  if (targetType === "section-teacher") {
+    if (target.sectionTeacherId) {
+      const sectionTeacher = await prisma.sectionTeacher.findUnique({
+        where: { id: target.sectionTeacherId },
+        select: {
+          sectionId: true,
+          teacherId: true,
+          section: {
+            select: {
+              jwId: true,
+              code: true,
+              course: { select: { jwId: true, nameCn: true } },
+            },
+          },
+          teacher: { select: { nameCn: true } },
+        },
+      });
+      return {
+        ...base,
+        ...publicCommentTargetMetadataPayload({ sectionTeacher }),
+      };
+    }
+
+    if (target.sectionId && target.teacherId) {
+      const [section, teacher] = await Promise.all([
+        prisma.section.findUnique({
+          where: { id: target.sectionId },
+          select: {
+            jwId: true,
+            code: true,
+            course: { select: { jwId: true, nameCn: true } },
+          },
+        }),
+        prisma.teacher.findUnique({
+          where: { id: target.teacherId },
+          select: { nameCn: true },
+        }),
+      ]);
+      return {
+        ...base,
+        ...publicCommentTargetMetadataPayload({
+          sectionTeacher: {
+            section,
+            sectionId: target.sectionId,
+            teacher,
+            teacherId: target.teacherId,
+          },
+        }),
+      };
+    }
+  }
+
+  return {
+    ...base,
+    ...publicCommentTargetMetadataPayload(null),
+  };
+}
+
 export function commentThreadTargetPayload(comment: CommentTargetLookupRecord) {
   return {
     sectionId: comment.sectionId ?? null,
     courseId: comment.courseId ?? null,
     teacherId: comment.teacherId ?? null,
     sectionTeacherId: comment.sectionTeacherId ?? null,
-    sectionTeacherSectionId: comment.sectionTeacher?.sectionId ?? null,
-    sectionTeacherTeacherId: comment.sectionTeacher?.teacherId ?? null,
-    sectionTeacherSectionJwId: comment.sectionTeacher?.section?.jwId ?? null,
-    sectionTeacherSectionCode: comment.sectionTeacher?.section?.code ?? null,
-    sectionTeacherTeacherName: comment.sectionTeacher?.teacher?.nameCn ?? null,
-    sectionTeacherCourseJwId:
-      comment.sectionTeacher?.section?.course?.jwId ?? null,
-    sectionTeacherCourseName:
-      comment.sectionTeacher?.section?.course?.nameCn ?? null,
     homeworkId: comment.homework?.id ?? null,
-    homeworkTitle: comment.homework?.title ?? null,
-    homeworkSectionJwId: comment.homework?.section?.jwId ?? null,
-    homeworkSectionCode: comment.homework?.section?.code ?? null,
-    sectionJwId: comment.section?.jwId ?? null,
-    sectionCode: comment.section?.code ?? null,
-    courseJwId: comment.course?.jwId ?? null,
-    courseName: comment.course?.nameCn ?? null,
-    teacherName: comment.teacher?.nameCn ?? null,
+    ...publicCommentTargetMetadataPayload(comment),
   };
 }

--- a/src/features/comments/server/comment-target-resolution.ts
+++ b/src/features/comments/server/comment-target-resolution.ts
@@ -1,0 +1,159 @@
+import { prisma } from "@/lib/db/prisma";
+import { parseInteger } from "@/lib/integers";
+import {
+  type CommentTargetType,
+  type ResolvedCommentTarget,
+  resolveCommentTarget,
+} from "./comment-utils";
+
+export type CommentTargetReferenceInput = {
+  allowDirectSectionTeacherId?: boolean;
+  courseJwId?: unknown;
+  homeworkId?: string;
+  rawTargetId?: unknown;
+  sectionId?: unknown;
+  sectionJwId?: unknown;
+  sectionTeacherId?: unknown;
+  targetType: CommentTargetType;
+  teacherId?: unknown;
+  verifyExistence?: boolean;
+};
+
+export type ResolvedCommentTargetReference =
+  | {
+      ok: true;
+      target: ResolvedCommentTarget;
+      targetType: CommentTargetType;
+    }
+  | {
+      ok: false;
+      error: "invalid_target" | "target_not_found";
+      targetId: unknown;
+      targetType: CommentTargetType | string;
+    };
+
+async function findSectionIdByJwId(jwId: number) {
+  const section = await prisma.section.findUnique({
+    where: { jwId },
+    select: { id: true },
+  });
+  return section?.id ?? null;
+}
+
+async function findCourseIdByJwId(jwId: number) {
+  const course = await prisma.course.findUnique({
+    where: { jwId },
+    select: { id: true },
+  });
+  return course?.id ?? null;
+}
+
+function invalidTarget(
+  targetType: CommentTargetType,
+): ResolvedCommentTargetReference {
+  return {
+    ok: false,
+    error: "invalid_target",
+    targetId: undefined,
+    targetType,
+  };
+}
+
+function targetNotFound(
+  targetType: CommentTargetType | string,
+  targetId: unknown,
+): ResolvedCommentTargetReference {
+  return {
+    ok: false,
+    error: "target_not_found",
+    targetId,
+    targetType,
+  };
+}
+
+async function resolveVerifiedTarget(
+  targetType: CommentTargetType,
+  rawTargetId: unknown,
+  input: Pick<
+    CommentTargetReferenceInput,
+    | "allowDirectSectionTeacherId"
+    | "sectionId"
+    | "teacherId"
+    | "verifyExistence"
+  >,
+): Promise<ResolvedCommentTargetReference> {
+  const target = await resolveCommentTarget({
+    allowDirectSectionTeacherId: input.allowDirectSectionTeacherId,
+    rawTargetId,
+    sectionId: input.sectionId,
+    targetType,
+    teacherId: input.teacherId,
+    verifyExistence: input.verifyExistence,
+  });
+
+  if (!target) return invalidTarget(targetType);
+  if (!target.verified) return targetNotFound(targetType, rawTargetId);
+
+  return { ok: true, target, targetType };
+}
+
+export async function resolveCommentTargetReference(
+  input: CommentTargetReferenceInput,
+): Promise<ResolvedCommentTargetReference> {
+  const sectionJwId = parseInteger(input.sectionJwId);
+  const courseJwId = parseInteger(input.courseJwId);
+
+  if (input.targetType === "section" && sectionJwId) {
+    const sectionId = await findSectionIdByJwId(sectionJwId);
+    if (!sectionId) return targetNotFound("section", sectionJwId);
+    return resolveVerifiedTarget("section", sectionId, input);
+  }
+
+  if (input.targetType === "course" && courseJwId) {
+    const courseId = await findCourseIdByJwId(courseJwId);
+    if (!courseId) return targetNotFound("course", courseJwId);
+    return resolveVerifiedTarget("course", courseId, input);
+  }
+
+  if (input.targetType === "teacher") {
+    return resolveVerifiedTarget(
+      "teacher",
+      input.teacherId ?? input.rawTargetId,
+      input,
+    );
+  }
+
+  if (input.targetType === "homework") {
+    return resolveVerifiedTarget(
+      "homework",
+      input.homeworkId ?? input.rawTargetId,
+      input,
+    );
+  }
+
+  if (input.targetType === "section-teacher") {
+    const directId = input.sectionTeacherId ?? input.rawTargetId;
+    if (directId) {
+      return resolveVerifiedTarget("section-teacher", directId, input);
+    }
+
+    if (sectionJwId && input.teacherId) {
+      const sectionId = await findSectionIdByJwId(sectionJwId);
+      if (!sectionId) return targetNotFound("section", sectionJwId);
+
+      const target = await resolveCommentTarget({
+        rawTargetId: undefined,
+        sectionId,
+        targetType: "section-teacher",
+        teacherId: input.teacherId,
+        verifyExistence: input.verifyExistence,
+      });
+      if (!target?.verified) {
+        return targetNotFound("section-teacher", sectionJwId);
+      }
+      return { ok: true, target, targetType: "section-teacher" };
+    }
+  }
+
+  return resolveVerifiedTarget(input.targetType, input.rawTargetId, input);
+}

--- a/src/features/comments/server/serialized-comment-node.ts
+++ b/src/features/comments/server/serialized-comment-node.ts
@@ -1,4 +1,5 @@
 import { toShanghaiIsoString } from "@/lib/time/serialize-date-output";
+import { canViewerAccessCommentAttachment } from "./comment-attachment-access";
 import {
   buildAttachments,
   buildAuthorSummary,
@@ -49,7 +50,16 @@ export function buildVisibleCommentNode({
     parentId: comment.parentId ?? null,
     rootId: comment.rootId ?? null,
     replies: [],
-    attachments: buildAttachments(comment),
+    attachments: canViewerAccessCommentAttachment(
+      {
+        status: rawStatus,
+        userId: comment.userId ?? null,
+        visibility: comment.visibility,
+      },
+      viewer,
+    )
+      ? buildAttachments(comment)
+      : [],
     reactions: buildReactionSummary(comment, viewer),
     canReply: canWrite,
     canEdit: canWrite && isAuthor && rawStatus !== "deleted",

--- a/src/features/oauth/server/device-approval-state.server.ts
+++ b/src/features/oauth/server/device-approval-state.server.ts
@@ -1,4 +1,5 @@
-import { DEVICE_CODE_STATUS, normalizeUserCode } from "@/lib/oauth/device-code";
+import { normalizeUserCode } from "@/lib/oauth/device-code";
+import { getDeviceApprovalFailureReason } from "./device-approval-validation.server";
 import { requireDeviceUserId } from "./device-auth.server";
 import type { DeviceCopy } from "./device-copy.server";
 import { callbackPath } from "./device-url.server";
@@ -26,6 +27,7 @@ export async function loadDeviceApprovalState({
       client: {
         select: {
           clientId: true,
+          disabled: true,
           name: true,
         },
       },
@@ -41,7 +43,17 @@ export async function loadDeviceApprovalState({
     };
   }
 
-  if (record.expiresAt < new Date()) {
+  const failureReason = getDeviceApprovalFailureReason(record);
+  if (failureReason === "disabled") {
+    return {
+      state: "error",
+      title: copy.deviceErrorTitle,
+      reason: "invalid_or_expired",
+      copy,
+    };
+  }
+
+  if (failureReason === "expired") {
     return {
       state: "error",
       title: copy.deviceCodeExpiredTitle,
@@ -50,7 +62,7 @@ export async function loadDeviceApprovalState({
     };
   }
 
-  if (record.status !== DEVICE_CODE_STATUS.PENDING) {
+  if (failureReason === "used") {
     return {
       state: "error",
       title: copy.deviceCodeUsedTitle,

--- a/src/features/oauth/server/device-approval-validation.server.ts
+++ b/src/features/oauth/server/device-approval-validation.server.ts
@@ -1,0 +1,19 @@
+import { DEVICE_CODE_STATUS } from "@/lib/oauth/device-code";
+
+export type DeviceApprovalValidationRecord = {
+  client: { disabled: boolean };
+  expiresAt: Date;
+  status: string;
+};
+
+export type DeviceApprovalFailureReason = "disabled" | "expired" | "used";
+
+export function getDeviceApprovalFailureReason(
+  record: DeviceApprovalValidationRecord,
+  now = new Date(),
+): DeviceApprovalFailureReason | null {
+  if (record.client.disabled) return "disabled";
+  if (record.expiresAt < now) return "expired";
+  if (record.status !== DEVICE_CODE_STATUS.PENDING) return "used";
+  return null;
+}

--- a/src/features/oauth/server/device-decision.server.ts
+++ b/src/features/oauth/server/device-decision.server.ts
@@ -1,5 +1,6 @@
 import { redirect } from "@sveltejs/kit";
 import { DEVICE_CODE_STATUS, normalizeUserCode } from "@/lib/oauth/device-code";
+import { getDeviceApprovalFailureReason } from "./device-approval-validation.server";
 import { requireDeviceUserId } from "./device-auth.server";
 import {
   buildDeviceCallbackUrl,
@@ -31,14 +32,15 @@ export async function completeDeviceCodeDecision(
       id: true,
       status: true,
       expiresAt: true,
+      client: {
+        select: {
+          disabled: true,
+        },
+      },
     },
   });
 
-  if (
-    !record ||
-    record.status !== DEVICE_CODE_STATUS.PENDING ||
-    record.expiresAt < new Date()
-  ) {
+  if (!record || getDeviceApprovalFailureReason(record)) {
     throw redirect(
       303,
       buildDevicePageUrl({ result: "error", reason: "invalid_or_expired" }),

--- a/src/features/profile/server/profile-read-model.ts
+++ b/src/features/profile/server/profile-read-model.ts
@@ -1,22 +1,14 @@
 import { prisma } from "@/lib/db/prisma";
 
-export const userProfileSelect = {
+export const authenticatedUserProfileSelect = {
   id: true,
+  email: true,
   username: true,
   name: true,
   image: true,
   isAdmin: true,
   createdAt: true,
   updatedAt: true,
-} as const;
-
-export const userApiProfileSelect = {
-  id: true,
-  email: true,
-  name: true,
-  image: true,
-  username: true,
-  isAdmin: true,
 } as const;
 
 export const viewerInfoSelect = {
@@ -26,17 +18,10 @@ export const viewerInfoSelect = {
   isAdmin: true,
 } as const;
 
-export function findUserProfileById(userId: string) {
+export function findAuthenticatedUserProfileById(userId: string) {
   return prisma.user.findUnique({
     where: { id: userId },
-    select: userProfileSelect,
-  });
-}
-
-export function findUserApiProfileById(userId: string) {
-  return prisma.user.findUnique({
-    where: { id: userId },
-    select: userApiProfileSelect,
+    select: authenticatedUserProfileSelect,
   });
 }
 

--- a/src/features/uploads/server/upload-service.ts
+++ b/src/features/uploads/server/upload-service.ts
@@ -1,13 +1,10 @@
+import { canViewerAccessCommentAttachment } from "@/features/comments/server/comment-attachment-access";
 import { uploadConfig } from "@/features/uploads/lib/upload-config";
 import { normalizeContentType } from "@/features/uploads/lib/upload-utils";
 import {
   runUploadSerializableTransaction,
   UploadError,
 } from "@/features/uploads/server/upload-quota";
-import type {
-  CommentStatus,
-  CommentVisibility,
-} from "@/generated/prisma/client";
 import { getViewerContext } from "@/lib/auth/viewer-context";
 import { prisma } from "@/lib/db/prisma";
 import {
@@ -291,33 +288,9 @@ export async function findDownloadableUpload(id: string, userId: string) {
   if (upload.userId === userId) return upload;
 
   const canDownloadAttachedUpload = upload.commentAttachments.some(
-    ({ comment }) => canViewerDownloadCommentAttachment(comment, viewer),
+    ({ comment }) => canViewerAccessCommentAttachment(comment, viewer),
   );
   return canDownloadAttachedUpload ? upload : null;
-}
-
-function canViewerDownloadCommentAttachment(
-  comment: {
-    status: CommentStatus;
-    userId: string | null;
-    visibility: CommentVisibility;
-  },
-  viewer: {
-    isAdmin: boolean;
-    isAuthenticated: boolean;
-    userId: string | null;
-  },
-) {
-  if (!viewer.isAuthenticated) return false;
-  if (comment.status === "deleted") return false;
-  if (comment.status === "softbanned") {
-    return viewer.isAdmin || comment.userId === viewer.userId;
-  }
-  return (
-    comment.visibility === "public" ||
-    comment.visibility === "logged_in_only" ||
-    comment.visibility === "anonymous"
-  );
 }
 
 export async function validatePendingUploadObject(input: {

--- a/src/lib/api/routes/comments-list-route.ts
+++ b/src/lib/api/routes/comments-list-route.ts
@@ -1,6 +1,6 @@
 import { loadCommentThread } from "@/features/comments/server/comment-read-model";
 import { commentListTargetPayload } from "@/features/comments/server/comment-target-payload";
-import { resolveCommentTarget } from "@/features/comments/server/comment-utils";
+import { resolveCommentTargetReference } from "@/features/comments/server/comment-target-resolution";
 import {
   badRequest,
   handleRouteError,
@@ -26,24 +26,28 @@ export async function getCommentsRoute(request: Request) {
   const targetIdParam = parsedQuery.targetId ?? null;
 
   try {
-    const target = await resolveCommentTarget({
+    const resolved = await resolveCommentTargetReference({
       allowDirectSectionTeacherId: true,
+      courseJwId: parsedQuery.courseJwId,
+      homeworkId: parsedQuery.homeworkId,
       rawTargetId: targetIdParam,
       sectionId: parsedQuery.sectionId,
+      sectionJwId: parsedQuery.sectionJwId,
+      sectionTeacherId: parsedQuery.sectionTeacherId,
       targetType,
       teacherId: parsedQuery.teacherId,
       verifyExistence: true,
     });
-    if (!target) {
+    if (!resolved.ok && resolved.error === "invalid_target") {
       return badRequest("Invalid target");
     }
-    if (!target.verified) {
+    if (!resolved.ok) {
       return notFound();
     }
 
     const viewerUserId = await resolveApiUserId(request);
     const { comments, hiddenCount, viewer } = await loadCommentThread({
-      target,
+      target: resolved.target,
       viewerUserId,
     });
 
@@ -51,7 +55,7 @@ export async function getCommentsRoute(request: Request) {
       comments,
       hiddenCount,
       viewer,
-      target: commentListTargetPayload(targetType, target),
+      target: await commentListTargetPayload(targetType, resolved.target),
     });
   } catch (error) {
     return handleRouteError("Failed to fetch comments", error);

--- a/src/lib/api/routes/me.ts
+++ b/src/lib/api/routes/me.ts
@@ -1,4 +1,4 @@
-import { findUserApiProfileById } from "@/features/profile/server/profile-read-model";
+import { findAuthenticatedUserProfileById } from "@/features/profile/server/profile-read-model";
 import { handleRouteError, jsonResponse, notFound } from "@/lib/api/helpers";
 import { requireAuth } from "@/lib/auth/api-auth";
 
@@ -8,7 +8,7 @@ export async function getMeRoute(request: Request) {
     if (auth instanceof Response) return auth;
     const { userId } = auth;
 
-    const user = await findUserApiProfileById(userId);
+    const user = await findAuthenticatedUserProfileById(userId);
 
     if (!user) {
       return notFound("User not found");

--- a/src/lib/api/schemas/comment-target-response-schema.ts
+++ b/src/lib/api/schemas/comment-target-response-schema.ts
@@ -3,10 +3,26 @@ import * as z from "zod";
 export const commentListTargetSchema = z.object({
   type: z.string(),
   targetId: z.union([z.number().int(), z.string(), z.null()]),
+  courseId: z.number().int().nullable(),
   sectionId: z.number().int().nullable(),
   teacherId: z.number().int().nullable(),
   sectionTeacherId: z.number().int().nullable(),
   homeworkId: z.string().nullable(),
+  sectionTeacherSectionId: z.number().int().nullable(),
+  sectionTeacherTeacherId: z.number().int().nullable(),
+  sectionTeacherSectionJwId: z.number().int().nullable(),
+  sectionTeacherSectionCode: z.string().nullable(),
+  sectionTeacherTeacherName: z.string().nullable(),
+  sectionTeacherCourseJwId: z.number().int().nullable(),
+  sectionTeacherCourseName: z.string().nullable(),
+  homeworkTitle: z.string().nullable(),
+  homeworkSectionJwId: z.number().int().nullable(),
+  homeworkSectionCode: z.string().nullable(),
+  sectionJwId: z.number().int().nullable(),
+  sectionCode: z.string().nullable(),
+  courseJwId: z.number().int().nullable(),
+  courseName: z.string().nullable(),
+  teacherName: z.string().nullable(),
 });
 
 export const commentThreadTargetSchema = z.object({

--- a/src/lib/api/schemas/content-query-schemas.ts
+++ b/src/lib/api/schemas/content-query-schemas.ts
@@ -9,7 +9,11 @@ export const commentsQuerySchema = z.object({
   targetType: commentTargetTypeSchema,
   targetId: z.string().optional(),
   sectionId: integerStringSchema.optional(),
+  sectionJwId: integerStringSchema.optional(),
+  courseJwId: integerStringSchema.optional(),
   teacherId: integerStringSchema.optional(),
+  homeworkId: z.string().trim().min(1).optional(),
+  sectionTeacherId: integerStringSchema.optional(),
 });
 
 export const descriptionsQuerySchema = z.object({

--- a/src/lib/api/schemas/misc-response-schema-core.ts
+++ b/src/lib/api/schemas/misc-response-schema-core.ts
@@ -117,6 +117,8 @@ export const meResponseSchema = z.object({
   image: z.string().nullable(),
   username: z.string().nullable(),
   isAdmin: z.boolean(),
+  createdAt: dateTimeSchema,
+  updatedAt: dateTimeSchema,
 });
 
 export const todoItemSchema = z.object({

--- a/src/lib/mcp/tools/comment-tools.ts
+++ b/src/lib/mcp/tools/comment-tools.ts
@@ -9,12 +9,10 @@ import {
   commentListTargetPayload,
   commentThreadTargetPayload,
 } from "@/features/comments/server/comment-target-payload";
-import type { ResolvedCommentTarget } from "@/features/comments/server/comment-utils";
 import {
-  type CommentTargetType,
-  resolveCommentTarget,
-} from "@/features/comments/server/comment-utils";
-import { prisma } from "@/lib/db/prisma";
+  type ResolvedCommentTargetReference,
+  resolveCommentTargetReference,
+} from "@/features/comments/server/comment-target-resolution";
 import {
   getUserId,
   jsonToolResult,
@@ -67,21 +65,6 @@ const commentThreadInputSchema = z.object({
   mode: mcpModeInputSchema,
 });
 
-type CommentsTargetInput = z.infer<typeof commentsTargetInputSchema>;
-
-type ResolvedMcpCommentTarget =
-  | {
-      ok: true;
-      target: ResolvedCommentTarget;
-      targetType: CommentTargetType;
-    }
-  | {
-      ok: false;
-      error: "invalid_target" | "target_not_found";
-      message: string;
-      hint: string;
-    };
-
 export function registerCommentTools(server: McpServer) {
   server.registerTool(
     "list_comments",
@@ -93,15 +76,26 @@ export function registerCommentTools(server: McpServer) {
     },
     async (args, extra) => {
       const mode = resolveMcpMode(args.mode);
-      const resolved = await resolveMcpCommentTarget(args);
+      const resolved = await resolveCommentTargetReference({
+        allowDirectSectionTeacherId: true,
+        courseJwId: args.courseJwId,
+        homeworkId: args.homeworkId,
+        rawTargetId: args.targetId,
+        sectionJwId: args.sectionJwId,
+        sectionTeacherId: args.sectionTeacherId,
+        targetType: args.targetType,
+        teacherId: args.teacherId,
+        verifyExistence: true,
+      });
       if (!resolved.ok) {
+        const errorPayload = unresolvedCommentTargetPayload(resolved);
         return jsonToolResult(
           {
             success: false,
             found: false,
-            error: resolved.error,
-            message: resolved.message,
-            hint: resolved.hint,
+            error: errorPayload.error,
+            message: errorPayload.message,
+            hint: errorPayload.hint,
           },
           { mode },
         );
@@ -119,7 +113,7 @@ export function registerCommentTools(server: McpServer) {
           comments,
           hiddenCount,
           viewer,
-          target: commentListTargetPayload(
+          target: await commentListTargetPayload(
             resolved.targetType,
             resolved.target,
           ),
@@ -174,96 +168,15 @@ export function registerCommentTools(server: McpServer) {
   );
 }
 
-async function resolveMcpCommentTarget(
-  input: CommentsTargetInput,
-): Promise<ResolvedMcpCommentTarget> {
-  if (input.targetType === "section" && input.sectionJwId) {
-    const section = await prisma.section.findUnique({
-      where: { jwId: input.sectionJwId },
-      select: { id: true },
-    });
-    if (!section) return targetNotFound("section", input.sectionJwId);
-    return resolveVerifiedTarget("section", section.id);
+function unresolvedCommentTargetPayload(
+  result: Extract<ResolvedCommentTargetReference, { ok: false }>,
+) {
+  if (result.error === "target_not_found") {
+    return targetNotFound(result.targetType, result.targetId);
   }
-
-  if (input.targetType === "course" && input.courseJwId) {
-    const course = await prisma.course.findUnique({
-      where: { jwId: input.courseJwId },
-      select: { id: true },
-    });
-    if (!course) return targetNotFound("course", input.courseJwId);
-    return resolveVerifiedTarget("course", course.id);
-  }
-
-  if (input.targetType === "teacher") {
-    return resolveVerifiedTarget("teacher", input.teacherId ?? input.targetId);
-  }
-
-  if (input.targetType === "homework") {
-    return resolveVerifiedTarget(
-      "homework",
-      input.homeworkId ?? input.targetId,
-    );
-  }
-
-  if (input.targetType === "section-teacher") {
-    const directId = input.sectionTeacherId ?? input.targetId;
-    if (directId) {
-      return resolveVerifiedTarget("section-teacher", directId);
-    }
-
-    if (input.sectionJwId && input.teacherId) {
-      const section = await prisma.section.findUnique({
-        where: { jwId: input.sectionJwId },
-        select: { id: true },
-      });
-      if (!section) return targetNotFound("section", input.sectionJwId);
-
-      const target = await resolveCommentTarget({
-        rawTargetId: undefined,
-        sectionId: section.id,
-        targetType: "section-teacher",
-        teacherId: input.teacherId,
-        verifyExistence: true,
-      });
-      if (!target?.verified) {
-        return targetNotFound("section-teacher", input.sectionJwId);
-      }
-      return { ok: true, target, targetType: "section-teacher" };
-    }
-  }
-
-  return resolveVerifiedTarget(input.targetType, input.targetId);
-}
-
-async function resolveVerifiedTarget(
-  targetType: CommentTargetType,
-  rawTargetId: unknown,
-): Promise<ResolvedMcpCommentTarget> {
-  const target = await resolveCommentTarget({
-    allowDirectSectionTeacherId: true,
-    rawTargetId,
-    targetType,
-    verifyExistence: true,
-  });
-
-  if (!target) {
-    return invalidTarget(targetType);
-  }
-  if (!target.verified) {
-    return targetNotFound(targetType, rawTargetId);
-  }
-
-  return { ok: true, target, targetType };
-}
-
-function invalidTarget(
-  targetType: CommentTargetType,
-): ResolvedMcpCommentTarget {
   return {
-    ok: false,
     error: "invalid_target",
-    message: `Missing or invalid ${targetType} comment target`,
+    message: `Missing or invalid ${result.targetType} comment target`,
     hint: "Provide targetId for the REST-compatible internal id, or a public identifier such as sectionJwId, courseJwId, teacherId, homeworkId, or sectionTeacherId.",
   };
 }
@@ -271,9 +184,12 @@ function invalidTarget(
 function targetNotFound(
   targetType: string,
   targetId: unknown,
-): ResolvedMcpCommentTarget {
+): {
+  error: "target_not_found";
+  message: string;
+  hint: string;
+} {
   return {
-    ok: false,
     error: "target_not_found",
     message: `Comment target ${targetType}:${String(targetId)} was not found`,
     hint: "Use search_sections, search_courses, search_teachers, or get_section_by_jw_id to find a valid comment target.",

--- a/src/lib/mcp/tools/course-search-course-tool-handlers.ts
+++ b/src/lib/mcp/tools/course-search-course-tool-handlers.ts
@@ -1,31 +1,49 @@
 import {
   findCourseDetailByJwId,
-  listCoursesBySearch,
+  listCourseSummaries,
 } from "@/features/catalog/server/course-section-queries";
+import type { AppLocale } from "@/i18n/config";
+import { DEFAULT_LOCALE } from "@/i18n/config";
 import { jsonToolResult, resolveMcpMode } from "@/lib/mcp/tools/_helpers";
 
 type McpModeInput = Parameters<typeof resolveMcpMode>[0];
-type CourseSearchLocale = Parameters<typeof listCoursesBySearch>[2];
 
 export async function searchCoursesTool({
   search,
+  educationLevelId,
+  categoryId,
+  classTypeId,
+  page,
   limit,
   locale,
   mode,
 }: {
-  search: string;
+  search?: string;
+  educationLevelId?: number;
+  categoryId?: number;
+  classTypeId?: number;
+  page: number;
   limit: number;
-  locale: CourseSearchLocale;
+  locale?: AppLocale;
   mode?: McpModeInput;
 }) {
-  const courses = await listCoursesBySearch(search, limit, locale);
-
-  return jsonToolResult(
-    { courses },
-    {
-      mode: resolveMcpMode(mode),
+  const result = await listCourseSummaries({
+    filters: {
+      categoryId,
+      classTypeId,
+      educationLevelId,
+      search,
     },
-  );
+    locale: locale ?? DEFAULT_LOCALE,
+    pagination: {
+      page,
+      pageSize: limit,
+    },
+  });
+
+  return jsonToolResult(result, {
+    mode: resolveMcpMode(mode),
+  });
 }
 
 export async function getCourseByJwIdTool({
@@ -34,10 +52,10 @@ export async function getCourseByJwIdTool({
   mode,
 }: {
   jwId: number;
-  locale: CourseSearchLocale;
+  locale?: AppLocale;
   mode?: McpModeInput;
 }) {
-  const course = await findCourseDetailByJwId(jwId, locale);
+  const course = await findCourseDetailByJwId(jwId, locale ?? DEFAULT_LOCALE);
 
   return jsonToolResult(
     {

--- a/src/lib/mcp/tools/course-search-section-tool-handlers.ts
+++ b/src/lib/mcp/tools/course-search-section-tool-handlers.ts
@@ -1,13 +1,10 @@
-import {
-  findSectionDetailByJwId,
-  type listCoursesBySearch,
-} from "@/features/catalog/server/course-section-queries";
+import { findSectionDetailByJwId } from "@/features/catalog/server/course-section-queries";
+import type { AppLocale } from "@/i18n/config";
 import { DEFAULT_LOCALE } from "@/i18n/config";
 import { jsonToolResult, resolveMcpMode } from "@/lib/mcp/tools/_helpers";
 import { searchSectionsForMcpTool } from "./course-search-section-tool";
 
 type McpModeInput = Parameters<typeof resolveMcpMode>[0];
-type CourseSearchLocale = Parameters<typeof listCoursesBySearch>[2];
 
 export async function getSectionByJwIdTool({
   jwId,
@@ -15,10 +12,10 @@ export async function getSectionByJwIdTool({
   mode,
 }: {
   jwId: number;
-  locale: CourseSearchLocale;
+  locale?: AppLocale;
   mode?: McpModeInput;
 }) {
-  const section = await findSectionDetailByJwId(jwId, locale);
+  const section = await findSectionDetailByJwId(jwId, locale ?? DEFAULT_LOCALE);
 
   if (!section) {
     return jsonToolResult({
@@ -70,7 +67,7 @@ export async function searchSectionsTool({
   search?: string;
   page: number;
   limit: number;
-  locale: CourseSearchLocale;
+  locale?: AppLocale;
   mode?: McpModeInput;
 }) {
   return jsonToolResult(

--- a/src/lib/mcp/tools/course-search-tools.ts
+++ b/src/lib/mcp/tools/course-search-tools.ts
@@ -16,10 +16,14 @@ export function registerCourseSearchTools(server: McpServer) {
     "search_courses",
     {
       description:
-        "Search courses by Chinese/English name or course code. Use this before search_sections when starting from a course name.",
+        "Search public courses by Chinese/English name, course code, education level, category, or class type. Use this before search_sections when starting from a course name.",
       inputSchema: {
-        search: z.string().trim().min(1),
-        limit: z.number().int().min(1).max(25).default(10),
+        search: z.string().trim().optional(),
+        educationLevelId: z.number().int().positive().optional(),
+        categoryId: z.number().int().positive().optional(),
+        classTypeId: z.number().int().positive().optional(),
+        page: z.number().int().min(1).default(1),
+        limit: z.number().int().min(1).max(100).default(20),
         locale: mcpLocaleInputSchema,
         mode: mcpModeInputSchema,
       },

--- a/src/lib/mcp/tools/profile-tool-user-actions.ts
+++ b/src/lib/mcp/tools/profile-tool-user-actions.ts
@@ -1,5 +1,5 @@
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-import { findUserProfileById } from "@/features/profile/server/profile-read-model";
+import { findAuthenticatedUserProfileById } from "@/features/profile/server/profile-read-model";
 import {
   getUserId,
   jsonToolResult,
@@ -14,7 +14,7 @@ export async function getMyProfileAction(
   extra: ToolExtra,
 ) {
   const userId = getUserId(extra.authInfo);
-  const user = await findUserProfileById(userId);
+  const user = await findAuthenticatedUserProfileById(userId);
 
   if (!user) {
     return jsonToolResult({

--- a/src/lib/mcp/tools/profile-tools.ts
+++ b/src/lib/mcp/tools/profile-tools.ts
@@ -19,7 +19,7 @@ export function registerProfileTools(server: McpServer) {
     "get_my_profile",
     {
       description:
-        "Return the authenticated user's Life@USTC profile: id, username, name, image, isAdmin, timestamps.",
+        "Return the authenticated user's Life@USTC profile: id, email, username, name, image, isAdmin, and timestamps.",
       inputSchema: getMyProfileInputSchema,
     },
     getMyProfileAction,

--- a/tests/e2e/src/app/api/comments/[id]/test.ts
+++ b/tests/e2e/src/app/api/comments/[id]/test.ts
@@ -79,7 +79,12 @@ test("/api/comments/[id] GET 返回线程 focus 与 target 元数据", async ({
   expect(threadResponse.status()).toBe(200);
   const body = (await threadResponse.json()) as {
     focusId?: string;
-    target?: { sectionId?: number; sectionJwId?: number };
+    target?: {
+      courseJwId?: number | null;
+      courseName?: string | null;
+      sectionId?: number;
+      sectionJwId?: number;
+    };
     thread?: Array<{ id?: string }>;
     hiddenCount?: number;
     viewer?: object;
@@ -87,6 +92,8 @@ test("/api/comments/[id] GET 返回线程 focus 与 target 元数据", async ({
 
   expect(body.focusId).toBe(commentId);
   expect(body.target?.sectionJwId).toBe(DEV_SEED.section.jwId);
+  expect(body.target?.courseJwId).toBe(DEV_SEED.course.jwId);
+  expect(body.target?.courseName).toBe(DEV_SEED.course.nameCn);
   expect(body.thread?.length ?? 0).toBeGreaterThan(0);
   expect(typeof body.hiddenCount).toBe("number");
   expect(body.viewer).toBeDefined();

--- a/tests/e2e/src/app/api/comments/test.ts
+++ b/tests/e2e/src/app/api/comments/test.ts
@@ -2,7 +2,7 @@
  * E2E tests for GET /api/comments and POST /api/comments.
  *
  * ## GET /api/comments
- * - Query: targetType (section|course|teacher|homework|section-teacher), targetId, sectionId, teacherId
+ * - Query: targetType (section|course|teacher|homework|section-teacher), targetId, sectionId, sectionJwId, courseJwId, teacherId, homeworkId, sectionTeacherId
  * - Response: { comments: CommentNode[], hiddenCount: number, viewer: ViewerContext, target: {...} }
  * - Public endpoint (no auth required)
  * - Returns 400 for missing/invalid target
@@ -69,6 +69,32 @@ test("/api/comments GET 返回 section 目标与 seed 评论", async ({ request 
   expect(
     body.comments?.some((c) =>
       c.body?.includes(DEV_SEED.comments.sectionRootBody),
+    ),
+  ).toBe(true);
+});
+
+test("/api/comments GET accepts public section JW id", async ({ request }) => {
+  const response = await request.get(
+    `/api/comments?targetType=section&sectionJwId=${DEV_SEED.section.jwId}`,
+  );
+  expect(response.status()).toBe(200);
+  const body = (await response.json()) as {
+    target?: {
+      courseJwId?: number | null;
+      courseName?: string | null;
+      type?: string;
+      sectionJwId?: number | null;
+    };
+    comments?: Array<{ body?: string }>;
+  };
+
+  expect(body.target?.type).toBe("section");
+  expect(body.target?.sectionJwId).toBe(DEV_SEED.section.jwId);
+  expect(body.target?.courseJwId).toBe(DEV_SEED.course.jwId);
+  expect(body.target?.courseName).toBe(DEV_SEED.course.nameCn);
+  expect(
+    body.comments?.some((comment) =>
+      comment.body?.includes(DEV_SEED.comments.sectionRootBody),
     ),
   ).toBe(true);
 });

--- a/tests/e2e/src/app/api/mcp/test.ts
+++ b/tests/e2e/src/app/api/mcp/test.ts
@@ -719,13 +719,22 @@ test.describe("/api/mcp – MCP Streamable-HTTP transport", () => {
       });
       const profile = parseTextContent(profileResult) as {
         id?: string;
+        email?: string | null;
+        name?: string | null;
         username?: string | null;
+        isAdmin?: boolean;
         createdAt?: string;
+        updatedAt?: string;
       };
       expect(profile.id).toBe(currentUser.id);
+      expect(typeof profile.email).toBe("string");
+      expect(profile.name).toBe(DEV_SEED.debugName);
       expect(profile.username).toBe(currentUser.username ?? null);
+      expect(profile.isAdmin).toBe(false);
       expect(typeof profile.createdAt).toBe("string");
       expect(profile.createdAt).toMatch(/\+08:00$/);
+      expect(typeof profile.updatedAt).toBe("string");
+      expect(profile.updatedAt).toMatch(/\+08:00$/);
 
       const todosResult = await mcpClient.callTool({
         name: "list_my_todos",
@@ -765,14 +774,16 @@ test.describe("/api/mcp – MCP Streamable-HTTP transport", () => {
         },
       });
       const coursesPayload = parseTextContent(coursesResult) as {
-        courses?: Array<{
+        data?: Array<{
           jwId?: number;
           code?: string | null;
           namePrimary?: string | null;
         }>;
+        pagination?: { pageSize?: number; total?: number };
       };
+      expect(coursesPayload.pagination?.pageSize).toBe(5);
       expect(
-        coursesPayload.courses?.some(
+        coursesPayload.data?.some(
           (course) =>
             course.jwId === DEV_SEED.course.jwId &&
             course.code === DEV_SEED.course.code &&

--- a/tests/e2e/src/app/api/me/test.ts
+++ b/tests/e2e/src/app/api/me/test.ts
@@ -1,0 +1,50 @@
+/**
+ * E2E tests for GET /api/me.
+ *
+ * Authenticated profile endpoint used by lightweight clients and mirrored by
+ * the get_my_profile MCP tool.
+ */
+import { expect, test } from "@playwright/test";
+import { signInAsDebugUser } from "../../../../utils/auth";
+import { DEV_SEED } from "../../../../utils/dev-seed";
+
+const BASE = "/api/me";
+
+test.describe("GET /api/me", () => {
+  test("returns 401 when not authenticated", async ({ request }) => {
+    const response = await request.get(BASE);
+    expect(response.status()).toBe(401);
+  });
+
+  test("returns authenticated profile fields", async ({ page }) => {
+    await signInAsDebugUser(page, "/");
+
+    const sessionResponse = await page.request.get("/api/auth/get-session");
+    expect(sessionResponse.status()).toBe(200);
+    const session = (await sessionResponse.json()) as {
+      user?: { id?: string; username?: string | null };
+    };
+
+    const response = await page.request.get(BASE);
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as {
+      id?: string;
+      email?: string | null;
+      name?: string | null;
+      image?: string | null;
+      username?: string | null;
+      isAdmin?: boolean;
+      createdAt?: string;
+      updatedAt?: string;
+    };
+
+    expect(body.id).toBe(session.user?.id);
+    expect(typeof body.email).toBe("string");
+    expect(body.name).toBe(DEV_SEED.debugName);
+    expect(body.username).toBe(session.user?.username ?? null);
+    expect(body.isAdmin).toBe(false);
+    expect(body.image === null || typeof body.image === "string").toBe(true);
+    expect(body.createdAt).toMatch(/\+08:00$/);
+    expect(body.updatedAt).toMatch(/\+08:00$/);
+  });
+});

--- a/tests/e2e/src/app/oauth/device/test.ts
+++ b/tests/e2e/src/app/oauth/device/test.ts
@@ -25,6 +25,7 @@ import { signInAsDebugUser } from "../../../../utils/auth";
 import {
   createOAuthClientFixture,
   deleteOAuthClientsByName,
+  disableOAuthClientByName,
   PLAYWRIGHT_BASE_URL,
 } from "../../../../utils/e2e-db";
 import { gotoAndWaitForReady } from "../../../../utils/page-ready";
@@ -227,6 +228,35 @@ test("/oauth/device authenticated user sees approval screen", async ({
     ).toBeVisible({ timeout: 15_000 });
 
     await captureStepScreenshot(page, testInfo, "oauth/device/approval-screen");
+  } finally {
+    await deleteOAuthClientsByName(clientName);
+  }
+});
+
+test("/oauth/device disabled client code shows error instead of approval", async ({
+  page,
+  request,
+}, testInfo) => {
+  const clientName = `device-e2e-disabled-${Date.now()}`;
+  try {
+    const result = await requestDeviceCode(request, clientName);
+    const verificationPath = getVerificationPath(
+      result.verificationUriComplete,
+    );
+
+    await disableOAuthClientByName(clientName);
+    await gotoAndWaitForReady(page, verificationPath, {
+      expectMainContent: false,
+    });
+
+    await expect(page).not.toHaveURL(/\/signin(?:\?.*)?$/);
+    await expect(
+      page.getByText(/invalid or has expired|无效|已过期/i).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /允许|Allow|批准|Approve/i }),
+    ).toHaveCount(0);
+    await captureStepScreenshot(page, testInfo, "oauth/device/disabled-client");
   } finally {
     await deleteOAuthClientsByName(clientName);
   }

--- a/tests/e2e/utils/e2e-db.ts
+++ b/tests/e2e/utils/e2e-db.ts
@@ -13,6 +13,7 @@ const operations = {
   createOAuthClientFixture: oauthFixtures.createOAuthClientFixture,
   deleteLinkedAccountFixture: oauthFixtures.deleteLinkedAccountFixture,
   deleteOAuthClientsByName: oauthFixtures.deleteOAuthClientsByName,
+  disableOAuthClientByName: oauthFixtures.disableOAuthClientByName,
   ensureLinkedAccountFixture: oauthFixtures.ensureLinkedAccountFixture,
   getSeedCourseFilterFixture: seedFixtures.getSeedCourseFilterFixture,
   getSeedSectionSemesterFixture: seedFixtures.getSeedSectionSemesterFixture,
@@ -159,6 +160,9 @@ export const createOAuthClientFixture = (options?: OAuthClientFixtureOptions) =>
 
 export const deleteOAuthClientsByName = (name: string) =>
   runDbFixture<null>("deleteOAuthClientsByName", [name]);
+
+export const disableOAuthClientByName = (name: string) =>
+  runDbFixture<null>("disableOAuthClientByName", [name]);
 
 export const ensureLinkedAccountFixture = (
   options: LinkedAccountFixtureOptions,

--- a/tests/e2e/utils/e2e-db/oauth.ts
+++ b/tests/e2e/utils/e2e-db/oauth.ts
@@ -89,6 +89,15 @@ export async function deleteOAuthClientsByName(name: string) {
   );
 }
 
+export async function disableOAuthClientByName(name: string) {
+  await withE2ePrisma((prisma) =>
+    prisma.oAuthClient.updateMany({
+      where: { name },
+      data: { disabled: true },
+    }),
+  );
+}
+
 export async function ensureLinkedAccountFixture(options: {
   userId: string;
   provider: "github" | "google" | "oidc";

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -77,17 +77,25 @@ afterAll(async () => {
 // ---------------------------------------------------------------------------
 
 describe("get_my_profile", () => {
-  it("returns the authenticated user's id and username", async () => {
+  it("returns the authenticated user's REST-equivalent profile fields", async () => {
     const profile = await mcp.call<{
       id?: string;
+      email?: string | null;
+      name?: string | null;
       username?: string | null;
+      isAdmin?: boolean;
       createdAt?: string;
+      updatedAt?: string;
     }>("get_my_profile");
 
     expect(profile.id).toBe(devUserId);
+    expect(typeof profile.email).toBe("string");
+    expect(profile.name).toBe(DEV_SEED.debugName);
     expect(profile.username).toBe(DEV_SEED.debugUsername);
+    expect(profile.isAdmin).toBe(false);
     // Dates are serialized in Asia/Shanghai (+08:00)
     expect(profile.createdAt).toMatch(/\+08:00$/);
+    expect(profile.updatedAt).toMatch(/\+08:00$/);
   });
 });
 
@@ -110,7 +118,14 @@ describe("comment read tools — MCP exposes the REST comment hierarchy", () => 
         canDelete?: boolean;
       }>;
       hiddenCount?: number;
-      target?: { type?: string; targetId?: number | null };
+      target?: {
+        courseJwId?: number | null;
+        courseName?: string | null;
+        type?: string;
+        targetId?: number | null;
+        sectionJwId?: number | null;
+        sectionCode?: string | null;
+      };
       viewer?: { userId?: string | null; isAuthenticated?: boolean };
     }>("list_comments", {
       targetType: "section",
@@ -121,6 +136,10 @@ describe("comment read tools — MCP exposes the REST comment hierarchy", () => 
     expect(result.found).toBe(true);
     expect(result.target?.type).toBe("section");
     expect(typeof result.target?.targetId).toBe("number");
+    expect(result.target?.sectionJwId).toBe(DEV_SEED.section.jwId);
+    expect(result.target?.sectionCode).toBe(DEV_SEED.section.code);
+    expect(result.target?.courseJwId).toBe(DEV_SEED.course.jwId);
+    expect(result.target?.courseName).toBe(DEV_SEED.course.nameCn);
     expect(result.viewer?.userId).toBe(devUserId);
     expect(result.viewer?.isAuthenticated).toBe(true);
     expect(typeof result.hiddenCount).toBe("number");
@@ -156,7 +175,12 @@ describe("comment read tools — MCP exposes the REST comment hierarchy", () => 
         body?: string;
         replies?: Array<{ body?: string }>;
       }>;
-      target?: { sectionJwId?: number | null; sectionCode?: string | null };
+      target?: {
+        courseJwId?: number | null;
+        courseName?: string | null;
+        sectionJwId?: number | null;
+        sectionCode?: string | null;
+      };
     }>("get_comment_thread", {
       commentId: seedComment?.id,
       mode: "full",
@@ -171,6 +195,8 @@ describe("comment read tools — MCP exposes the REST comment hierarchy", () => 
     expect(result.thread?.[0]?.replies?.length).toBeGreaterThan(0);
     expect(result.target?.sectionJwId).toBe(DEV_SEED.section.jwId);
     expect(result.target?.sectionCode).toBe(DEV_SEED.section.code);
+    expect(result.target?.courseJwId).toBe(DEV_SEED.course.jwId);
+    expect(result.target?.courseName).toBe(DEV_SEED.course.nameCn);
   });
 
   it("list_comments reports missing targets instead of returning an empty success", async () => {
@@ -1146,6 +1172,61 @@ describe("query_schedules — flexible date filters", () => {
 });
 
 describe("course and section lookups", () => {
+  it("search_courses returns the REST-equivalent paginated course hierarchy", async () => {
+    const seedCourseFilters = await prisma.course.findUnique({
+      where: { jwId: DEV_SEED.course.jwId },
+      select: {
+        categoryId: true,
+        classTypeId: true,
+        educationLevelId: true,
+      },
+    });
+    expect(seedCourseFilters).toBeTruthy();
+
+    const args: Record<string, unknown> = {
+      limit: 10,
+      locale: "zh-cn",
+      mode: "full",
+      page: 1,
+    };
+    for (const [key, value] of Object.entries(seedCourseFilters ?? {})) {
+      if (value != null) args[key] = value;
+    }
+
+    const result = await mcp.call<{
+      data?: Array<{
+        jwId?: number;
+        code?: string | null;
+        nameCn?: string | null;
+        educationLevel?: { nameCn?: string | null } | null;
+        category?: { nameCn?: string | null } | null;
+        classType?: { nameCn?: string | null } | null;
+      }>;
+      pagination?: {
+        page?: number;
+        pageSize?: number;
+        total?: number;
+        totalPages?: number;
+      };
+    }>("search_courses", args);
+
+    expect(result.pagination?.page).toBe(1);
+    expect(result.pagination?.pageSize).toBe(10);
+    expect(result.pagination?.total).toBeGreaterThan(0);
+    expect(result.pagination?.totalPages).toBeGreaterThanOrEqual(1);
+
+    const course = result.data?.find(
+      (item) => item.jwId === DEV_SEED.course.jwId,
+    );
+    expect(course?.code).toBe(DEV_SEED.course.code);
+    expect(course?.nameCn).toBe(DEV_SEED.course.nameCn);
+    expect(course?.educationLevel?.nameCn).toBe(
+      DEV_SEED.course.educationLevelNameCn,
+    );
+    expect(course?.category?.nameCn).toBe(DEV_SEED.course.categoryNameCn);
+    expect(course?.classType?.nameCn).toBe(DEV_SEED.course.classTypeNameCn);
+  });
+
   it("get_section_by_jw_id returns the same detail hierarchy as REST section detail", async () => {
     const result = await mcp.call<{
       found?: boolean;

--- a/tests/unit/api-schemas.test.ts
+++ b/tests/unit/api-schemas.test.ts
@@ -5,6 +5,7 @@ import {
   calendarSubscriptionAppendRequestSchema,
   calendarSubscriptionCreateRequestSchema,
   commentReactionRequestSchema,
+  commentsQuerySchema,
   coursesQuerySchema,
   descriptionUpsertRequestSchema,
   homeworkCompletionBatchRequestSchema,
@@ -157,6 +158,33 @@ describe("other request schemas", () => {
     expect(valid.success).toBe(true);
   });
 
+  it("validates comment list public target identifiers", () => {
+    expect(
+      commentsQuerySchema.safeParse({
+        targetType: "section",
+        sectionJwId: "9902001",
+      }).success,
+    ).toBe(true);
+    expect(
+      commentsQuerySchema.safeParse({
+        targetType: "course",
+        courseJwId: "9901001",
+      }).success,
+    ).toBe(true);
+    expect(
+      commentsQuerySchema.safeParse({
+        targetType: "section-teacher",
+        sectionTeacherId: "123",
+      }).success,
+    ).toBe(true);
+    expect(
+      commentsQuerySchema.safeParse({
+        targetType: "section",
+        sectionJwId: "abc",
+      }).success,
+    ).toBe(false);
+  });
+
   it("validates calendar subscription payload", () => {
     const valid = calendarSubscriptionCreateRequestSchema.safeParse({
       sectionIds: [1, 2, 3],
@@ -273,6 +301,8 @@ describe("other request schemas", () => {
         image: null,
         username: "user",
         isAdmin: false,
+        createdAt: "2026-01-01T00:00:00+08:00",
+        updatedAt: "2026-01-01T00:00:00+08:00",
       }).success,
     ).toBe(true);
 

--- a/tests/unit/comment-serialization-permissions.test.ts
+++ b/tests/unit/comment-serialization-permissions.test.ts
@@ -31,6 +31,18 @@ function comment(overrides: Partial<RawComment> = {}): RawComment {
   };
 }
 
+function attachment() {
+  return {
+    id: "attachment-1",
+    uploadId: "upload-1",
+    upload: {
+      contentType: "text/plain",
+      filename: "note.txt",
+      size: 123,
+    },
+  };
+}
+
 function viewer(overrides: Partial<ViewerInfo> = {}): ViewerInfo {
   return {
     userId: "user-1",
@@ -91,5 +103,47 @@ describe("comment serialization permissions", () => {
       canReply: false,
       isAuthor: false,
     });
+  });
+
+  it("keeps deleted tombstones for visible replies but omits attachments", () => {
+    const { roots } = buildCommentNodes(
+      [
+        comment({
+          attachments: [attachment()],
+          status: "deleted",
+        }),
+        comment({
+          id: "reply-1",
+          body: "reply",
+          parentId: "comment-1",
+          rootId: "comment-1",
+          userId: "user-2",
+        }),
+      ],
+      viewer(),
+    );
+
+    expect(roots).toHaveLength(1);
+    expect(roots[0]).toMatchObject({
+      status: "deleted",
+      attachments: [],
+    });
+    expect(roots[0].replies).toHaveLength(1);
+  });
+
+  it("exposes attachment actions only to authenticated viewers", () => {
+    const rawComment = comment({ attachments: [attachment()] });
+
+    const anonymous = buildCommentNodes(
+      [rawComment],
+      viewer({
+        isAuthenticated: false,
+        userId: null,
+      }),
+    );
+    const authenticated = buildCommentNodes([rawComment], viewer());
+
+    expect(anonymous.roots[0]?.attachments).toEqual([]);
+    expect(authenticated.roots[0]?.attachments).toHaveLength(1);
   });
 });

--- a/tests/unit/device-approval-validation.test.ts
+++ b/tests/unit/device-approval-validation.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { getDeviceApprovalFailureReason } from "@/features/oauth/server/device-approval-validation.server";
+import { DEVICE_CODE_STATUS } from "@/lib/oauth/device-code";
+
+const now = new Date("2026-01-01T00:00:00.000Z");
+const future = new Date("2026-01-01T00:10:00.000Z");
+const past = new Date("2025-12-31T23:59:00.000Z");
+
+function record(
+  overrides: Partial<Parameters<typeof getDeviceApprovalFailureReason>[0]> = {},
+): Parameters<typeof getDeviceApprovalFailureReason>[0] {
+  return {
+    client: { disabled: false },
+    expiresAt: future,
+    status: DEVICE_CODE_STATUS.PENDING,
+    ...overrides,
+  };
+}
+
+describe("device approval validation", () => {
+  it("allows pending codes for enabled clients before expiry", () => {
+    expect(getDeviceApprovalFailureReason(record(), now)).toBeNull();
+  });
+
+  it("rejects disabled clients before checking expiry or status", () => {
+    expect(
+      getDeviceApprovalFailureReason(
+        record({
+          client: { disabled: true },
+          expiresAt: past,
+          status: DEVICE_CODE_STATUS.APPROVED,
+        }),
+        now,
+      ),
+    ).toBe("disabled");
+  });
+
+  it("rejects expired pending codes", () => {
+    expect(
+      getDeviceApprovalFailureReason(record({ expiresAt: past }), now),
+    ).toBe("expired");
+  });
+
+  it("rejects already-used codes", () => {
+    expect(
+      getDeviceApprovalFailureReason(
+        record({ status: DEVICE_CODE_STATUS.DENIED }),
+        now,
+      ),
+    ).toBe("used");
+  });
+});


### PR DESCRIPTION
## Goal

Align public REST and MCP surfaces so shared feature logic owns common target, permission, and profile/course output behavior instead of duplicating those rules in adapters.

## Changed Surfaces

- Shared comment target resolution for REST and MCP, including public identifiers such as `sectionJwId`, `courseJwId`, `homeworkId`, and `sectionTeacherId`.
- Shared comment attachment visibility for serialized comments and upload downloads.
- REST/MCP profile parity for `/api/me` and `get_my_profile`.
- MCP `search_courses` now uses the REST course summary pagination/filter path.
- OAuth device approval uses one disabled/expired/used validation gate.

## Evidence

- Full local gate on `b1e6fc90`: `PLAYWRIGHT_PORT=3002 bun run verify:full`.
- Covered types, conventions, OpenAPI check, contract check, i18n/routes, 450 unit tests, 48 MCP integration tests, and 503 Playwright tests.
- Complete-loop coverage includes REST comments list/thread, MCP comment/profile/course calls, `/api/me`, upload download permissions, and OAuth device disabled-client behavior.

## Docs / Contracts

- Updated `docs/contracts/{bus,comment,course,mcp,user}.json`.
- Regenerated `public/openapi.generated.json` for the changed REST schemas/query parameters.

## Risk Areas

- Auth and permission gates for MCP, comment attachments, and OAuth device approval.
- Public API/MCP response shapes for comments, profile, and course search.
- Generated OpenAPI is intentionally included because public schemas changed.

## Cleanup

- No scratch reports, temporary probes, Playwright output, or `.wrangler/e2e` runtime artifacts remain.
