### PR TITLE
feat(mcp): description MCP tools

### DIFF
--- a/docs/contracts/_audit.json
+++ b/docs/contracts/_audit.json
@@ -17,7 +17,7 @@
       "description": "User adds or removes a reaction on a comment."
     },
     "description_edit": {
-      "trigger": "POST /api/descriptions",
+      "trigger": "POST /api/descriptions or MCP upsert_description",
       "description": "User updates an object description (content changed)."
     },
     "upload_delete": {

--- a/docs/contracts/description.json
+++ b/docs/contracts/description.json
@@ -4,7 +4,7 @@
     "anon": "Can read public descriptions.",
     "user": "When signed in and not suspended, can maintain descriptions.",
     "admin": "Can review and maintain descriptions in the admin backend.",
-    "agent": "No general description tools are currently provided."
+    "agent": "Can read and maintain object descriptions through MCP tools after authorization."
   },
   "rules": {
     "supplement-not-comment": "Description is a Markdown supplement on an object, not equivalent to comments expressing personal opinions.",
@@ -30,7 +30,25 @@
           }
         ]
       },
-      "mcp": "unavailable",
+      "mcp": {
+        "tools": [
+          {
+            "name": "get_description",
+            "returns": "{ found, target, description, history, viewer }",
+            "notes": [
+              "Inputs accept targetType plus targetId, or public identifiers such as sectionJwId, courseJwId, teacherId, homeworkId."
+            ]
+          },
+          {
+            "name": "upsert_description",
+            "returns": "{ success, id, updated, target, description, history, viewer }",
+            "auth": "user",
+            "notes": [
+              "Inputs accept targetType plus targetId, or public identifiers such as sectionJwId, courseJwId, teacherId, homeworkId."
+            ]
+          }
+        ]
+      },
       "display": {
         "fields": [
           "description.content (markdown-rendered)",

--- a/docs/contracts/mcp.json
+++ b/docs/contracts/mcp.json
@@ -99,6 +99,10 @@
             "tools": ["list_comments", "get_comment_thread"]
           },
           {
+            "name": "Descriptions",
+            "tools": ["get_description", "upsert_description"]
+          },
+          {
             "name": "Calendar & Subscription",
             "tools": [
               "list_my_calendar_events",

--- a/src/features/descriptions/server/description-targets.ts
+++ b/src/features/descriptions/server/description-targets.ts
@@ -1,10 +1,13 @@
 import { parseInteger } from "@/lib/integers";
 
-export type DescriptionTargetType =
-  | "section"
-  | "course"
-  | "teacher"
-  | "homework";
+export const DESCRIPTION_TARGET_TYPES = [
+  "section",
+  "course",
+  "teacher",
+  "homework",
+] as const;
+
+export type DescriptionTargetType = (typeof DESCRIPTION_TARGET_TYPES)[number];
 
 type DescriptionTargetIdMap = {
   section: number;
@@ -109,4 +112,147 @@ export function resolveDescriptionTarget<
     where: config.where(targetId),
     ensureExists: () => config.findTarget(targetId),
   };
+}
+
+export type ResolvedDescriptionTarget = NonNullable<
+  ReturnType<typeof resolveDescriptionTarget>
+>;
+
+export type DescriptionTargetReferenceInput = {
+  courseJwId?: unknown;
+  homeworkId?: string;
+  rawTargetId?: unknown;
+  sectionJwId?: unknown;
+  targetType: DescriptionTargetType;
+  teacherId?: unknown;
+  verifyExistence?: boolean;
+};
+
+export type ResolvedDescriptionTargetReference =
+  | {
+      ok: true;
+      target: ResolvedDescriptionTarget;
+      targetId: number | string;
+      targetType: DescriptionTargetType;
+    }
+  | {
+      ok: false;
+      error: "invalid_target" | "target_not_found";
+      targetId: unknown;
+      targetType: DescriptionTargetType | string;
+    };
+
+async function findSectionIdByJwId(jwId: number) {
+  const { prisma } = await import("@/lib/db/prisma");
+  const section = await prisma.section.findUnique({
+    where: { jwId },
+    select: { id: true },
+  });
+  return section?.id ?? null;
+}
+
+async function findCourseIdByJwId(jwId: number) {
+  const { prisma } = await import("@/lib/db/prisma");
+  const course = await prisma.course.findUnique({
+    where: { jwId },
+    select: { id: true },
+  });
+  return course?.id ?? null;
+}
+
+function invalidTarget(
+  targetType: DescriptionTargetType,
+): ResolvedDescriptionTargetReference {
+  return {
+    ok: false,
+    error: "invalid_target",
+    targetId: undefined,
+    targetType,
+  };
+}
+
+function targetNotFound(
+  targetType: DescriptionTargetType | string,
+  targetId: unknown,
+): ResolvedDescriptionTargetReference {
+  return {
+    ok: false,
+    error: "target_not_found",
+    targetId,
+    targetType,
+  };
+}
+
+async function resolveVerifiedDescriptionTarget(
+  targetType: DescriptionTargetType,
+  rawTargetId: unknown,
+  verifyExistence: boolean | undefined,
+): Promise<ResolvedDescriptionTargetReference> {
+  if (typeof rawTargetId !== "string" && typeof rawTargetId !== "number") {
+    return invalidTarget(targetType);
+  }
+
+  const target = resolveDescriptionTarget(targetType, rawTargetId);
+  if (!target) return invalidTarget(targetType);
+
+  if (verifyExistence) {
+    const existingTarget = await target.ensureExists();
+    if (!existingTarget) return targetNotFound(targetType, target.targetId);
+  }
+
+  return {
+    ok: true,
+    target,
+    targetId: target.targetId,
+    targetType,
+  };
+}
+
+export async function resolveDescriptionTargetReference(
+  input: DescriptionTargetReferenceInput,
+): Promise<ResolvedDescriptionTargetReference> {
+  const sectionJwId = parseInteger(input.sectionJwId);
+  const courseJwId = parseInteger(input.courseJwId);
+
+  if (input.targetType === "section" && sectionJwId) {
+    const sectionId = await findSectionIdByJwId(sectionJwId);
+    if (!sectionId) return targetNotFound("section", sectionJwId);
+    return resolveVerifiedDescriptionTarget(
+      "section",
+      sectionId,
+      input.verifyExistence,
+    );
+  }
+
+  if (input.targetType === "course" && courseJwId) {
+    const courseId = await findCourseIdByJwId(courseJwId);
+    if (!courseId) return targetNotFound("course", courseJwId);
+    return resolveVerifiedDescriptionTarget(
+      "course",
+      courseId,
+      input.verifyExistence,
+    );
+  }
+
+  if (input.targetType === "teacher") {
+    return resolveVerifiedDescriptionTarget(
+      "teacher",
+      input.teacherId ?? input.rawTargetId,
+      input.verifyExistence,
+    );
+  }
+
+  if (input.targetType === "homework") {
+    return resolveVerifiedDescriptionTarget(
+      "homework",
+      input.homeworkId ?? input.rawTargetId,
+      input.verifyExistence,
+    );
+  }
+
+  return resolveVerifiedDescriptionTarget(
+    input.targetType,
+    input.rawTargetId,
+    input.verifyExistence,
+  );
 }

--- a/src/features/descriptions/server/description-upsert.ts
+++ b/src/features/descriptions/server/description-upsert.ts
@@ -1,3 +1,4 @@
+import { fireAuditLog } from "@/lib/audit/write-audit-log";
 import { getViewerContext } from "@/lib/auth/viewer-context";
 import {
   type DescriptionTargetType,
@@ -10,12 +11,20 @@ type DescriptionUpsertError =
   | "not_found"
   | "suspended";
 
+type DescriptionEditAuditMetadata = {
+  ipAddress?: string;
+  source?: string;
+  userAgent?: string;
+};
+
 export async function upsertDescriptionContent({
+  auditMetadata,
   content,
   targetId,
   targetType,
   userId,
 }: {
+  auditMetadata?: DescriptionEditAuditMetadata;
   content: string;
   targetId: number | string;
   targetType: DescriptionTargetType;
@@ -84,5 +93,43 @@ export async function upsertDescriptionContent({
     return { id: description.id, updated: true };
   });
 
+  if (result.updated) {
+    writeDescriptionEditAuditLog({
+      content,
+      descriptionId: result.id,
+      metadata: auditMetadata,
+      targetType,
+      userId,
+    });
+  }
+
   return { ok: true as const, ...result };
+}
+
+function writeDescriptionEditAuditLog({
+  content,
+  descriptionId,
+  metadata,
+  targetType,
+  userId,
+}: {
+  content: string;
+  descriptionId: string;
+  metadata?: DescriptionEditAuditMetadata;
+  targetType: DescriptionTargetType;
+  userId: string;
+}) {
+  const { source, ...requestMetadata } = metadata ?? {};
+  fireAuditLog({
+    action: "description_edit",
+    userId,
+    targetId: descriptionId,
+    targetType: "description",
+    metadata: {
+      targetType,
+      content: content.slice(0, 200),
+      ...(source ? { source } : {}),
+    },
+    ...requestMetadata,
+  });
 }

--- a/src/lib/api/routes/description-upsert-route.ts
+++ b/src/lib/api/routes/description-upsert-route.ts
@@ -9,10 +9,7 @@ import {
   suspensionForbidden,
 } from "@/lib/api/helpers";
 import { descriptionUpsertRequestSchema } from "@/lib/api/schemas/request-schemas";
-import {
-  fireAuditLog,
-  getAuditRequestMetadata,
-} from "@/lib/audit/write-audit-log";
+import { getAuditRequestMetadata } from "@/lib/audit/write-audit-log";
 import { requireAuth } from "@/lib/auth/api-auth";
 
 export async function postDescriptionRoute(request: Request) {
@@ -36,6 +33,7 @@ export async function postDescriptionRoute(request: Request) {
 
   try {
     const result = await upsertDescriptionContent({
+      auditMetadata: getAuditRequestMetadata(request),
       content,
       targetId: parsedBody.targetId,
       targetType,
@@ -48,17 +46,6 @@ export async function postDescriptionRoute(request: Request) {
       if (result.error === "suspended")
         return suspensionForbidden("reason" in result ? result.reason : null);
       return forbidden();
-    }
-
-    if (result.updated) {
-      fireAuditLog({
-        action: "description_edit",
-        userId,
-        targetId: result.id,
-        targetType: "description",
-        metadata: { targetType, content: content.slice(0, 200) },
-        ...getAuditRequestMetadata(request),
-      });
     }
 
     return jsonResponse({ id: result.id, updated: result.updated });

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -4,6 +4,7 @@ import { registerCalendarTools } from "@/lib/mcp/tools/calendar-tools";
 import { registerCommentTools } from "@/lib/mcp/tools/comment-tools";
 import { registerCourseTools } from "@/lib/mcp/tools/course-tools";
 import { registerDashboardTools } from "@/lib/mcp/tools/dashboard-tools";
+import { registerDescriptionTools } from "@/lib/mcp/tools/description-tools";
 import { registerMyDataTools } from "@/lib/mcp/tools/my-data-tools";
 import { registerProfileTools } from "@/lib/mcp/tools/profile-tools";
 import { registerSectionDataTools } from "@/lib/mcp/tools/section-data-tools";
@@ -16,6 +17,7 @@ export function createMcpServer() {
 
   registerBusTools(server);
   registerCommentTools(server);
+  registerDescriptionTools(server);
   registerProfileTools(server);
   registerCourseTools(server);
   registerDashboardTools(server);

--- a/src/lib/mcp/tools/description-tools.ts
+++ b/src/lib/mcp/tools/description-tools.ts
@@ -1,0 +1,250 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod";
+import {
+  DESCRIPTION_TARGET_TYPES,
+  type DescriptionTargetType,
+  type ResolvedDescriptionTargetReference,
+  resolveDescriptionTargetReference,
+} from "@/features/descriptions/server/description-targets";
+import { upsertDescriptionContent } from "@/features/descriptions/server/description-upsert";
+import { getResolvedDescriptionPayload } from "@/features/descriptions/server/descriptions-server";
+import { getViewerContext } from "@/lib/auth/viewer-context";
+import {
+  getUserId,
+  jsonToolResult,
+  mcpModeInputSchema,
+  resolveMcpMode,
+} from "@/lib/mcp/tools/_helpers";
+
+const descriptionTargetIdSchema = z.union([
+  z.number().int().positive(),
+  z.string().trim().min(1),
+]);
+
+const descriptionTargetInputSchema = z.object({
+  targetType: z.enum(DESCRIPTION_TARGET_TYPES),
+  targetId: descriptionTargetIdSchema
+    .optional()
+    .describe(
+      "Internal target id matching REST /api/descriptions. Prefer public identifiers such as sectionJwId or courseJwId when available.",
+    ),
+  sectionJwId: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Public JW section id for section descriptions."),
+  courseJwId: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Public JW course id for course descriptions."),
+  teacherId: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Teacher id for teacher descriptions."),
+  homeworkId: z.string().trim().min(1).optional(),
+  mode: mcpModeInputSchema,
+});
+
+const descriptionUpsertInputSchema = descriptionTargetInputSchema.extend({
+  content: z
+    .string()
+    .max(4000)
+    .describe("Markdown description content. Matches POST /api/descriptions."),
+});
+
+type DescriptionTargetInput = z.infer<typeof descriptionTargetInputSchema>;
+
+export function registerDescriptionTools(server: McpServer) {
+  server.registerTool(
+    "get_description",
+    {
+      description:
+        "Read the Markdown description, edit history, and viewer state for one section, course, teacher, or homework target. " +
+        "Returns the same description/history/viewer payload as REST /api/descriptions.",
+      inputSchema: descriptionTargetInputSchema.shape,
+    },
+    async (args, extra) => {
+      const mode = resolveMcpMode(args.mode);
+      const resolved = await resolveDescriptionTargetForTool(args, true);
+      if (!resolved.ok) {
+        return jsonToolResult(unresolvedDescriptionTargetPayload(resolved), {
+          mode,
+        });
+      }
+
+      const userId = getUserId(extra.authInfo);
+      const viewer = await getViewerContext({ userId });
+      const payload = await getResolvedDescriptionPayload(
+        resolved.target,
+        viewer,
+      );
+
+      return jsonToolResult(
+        {
+          found: true,
+          target: descriptionTargetPayload(resolved),
+          ...payload,
+        },
+        { mode },
+      );
+    },
+  );
+
+  server.registerTool(
+    "upsert_description",
+    {
+      description:
+        "Create or replace the Markdown description for one section, course, teacher, or homework target. " +
+        "Requires an authenticated, unsuspended user and returns the updated description payload.",
+      inputSchema: descriptionUpsertInputSchema.shape,
+    },
+    async (args, extra) => {
+      const mode = resolveMcpMode(args.mode);
+      const resolved = await resolveDescriptionTargetForTool(args, true);
+      if (!resolved.ok) {
+        return jsonToolResult(unresolvedDescriptionTargetPayload(resolved), {
+          mode,
+        });
+      }
+
+      const userId = getUserId(extra.authInfo);
+      const targetType = resolved.targetType;
+      const content = args.content.trim();
+      const result = await upsertDescriptionContent({
+        auditMetadata: { source: "mcp" },
+        content,
+        targetId: resolved.targetId,
+        targetType,
+        userId,
+      });
+
+      if (!result.ok) {
+        return jsonToolResult(descriptionUpsertErrorPayload(result), { mode });
+      }
+
+      const viewer = await getViewerContext({ userId });
+      const payload = await getResolvedDescriptionPayload(
+        resolved.target,
+        viewer,
+      );
+
+      return jsonToolResult(
+        {
+          success: true,
+          id: result.id,
+          updated: result.updated,
+          target: descriptionTargetPayload(resolved),
+          ...payload,
+        },
+        { mode },
+      );
+    },
+  );
+}
+
+async function resolveDescriptionTargetForTool(
+  input: DescriptionTargetInput,
+  verifyExistence: boolean,
+) {
+  return resolveDescriptionTargetReference({
+    courseJwId: input.courseJwId,
+    homeworkId: input.homeworkId,
+    rawTargetId: input.targetId,
+    sectionJwId: input.sectionJwId,
+    targetType: input.targetType,
+    teacherId: input.teacherId,
+    verifyExistence,
+  });
+}
+
+function descriptionTargetPayload(
+  resolved: Extract<ResolvedDescriptionTargetReference, { ok: true }>,
+) {
+  return {
+    type: resolved.targetType,
+    targetId: resolved.targetId,
+  };
+}
+
+function unresolvedDescriptionTargetPayload(
+  result: Extract<ResolvedDescriptionTargetReference, { ok: false }>,
+) {
+  if (result.error === "target_not_found") {
+    return {
+      success: false,
+      found: false,
+      error: "target_not_found",
+      message: `Description target ${result.targetType}:${String(result.targetId)} was not found`,
+      hint: descriptionTargetHint(result.targetType),
+    };
+  }
+
+  return {
+    success: false,
+    found: false,
+    error: "invalid_target",
+    message: `Missing or invalid ${result.targetType} description target`,
+    hint: descriptionTargetHint(result.targetType),
+  };
+}
+
+function descriptionTargetHint(targetType: DescriptionTargetType | string) {
+  if (targetType === "section") {
+    return "Provide sectionJwId, or use search_sections/get_section_by_jw_id to find a valid section.";
+  }
+  if (targetType === "course") {
+    return "Provide courseJwId, or use search_courses/get_course_by_jw_id to find a valid course.";
+  }
+  if (targetType === "teacher") {
+    return "Provide teacherId, or use search_teachers/get_teacher_by_id to find a valid teacher.";
+  }
+  if (targetType === "homework") {
+    return "Provide homeworkId, or use list_homeworks_by_section/list_my_homeworks to find a valid homework.";
+  }
+  return "Provide targetId for the REST-compatible internal id, or a public identifier such as sectionJwId, courseJwId, teacherId, or homeworkId.";
+}
+
+function descriptionUpsertErrorPayload(
+  result: Exclude<
+    Awaited<ReturnType<typeof upsertDescriptionContent>>,
+    { ok: true }
+  >,
+) {
+  if (result.error === "suspended") {
+    return {
+      success: false,
+      error: "suspended",
+      message: "Suspended",
+      reason: "reason" in result ? (result.reason ?? null) : null,
+    };
+  }
+
+  if (result.error === "not_found") {
+    return {
+      success: false,
+      found: false,
+      error: "target_not_found",
+      message: "Description target was not found",
+    };
+  }
+
+  if (result.error === "invalid_target") {
+    return {
+      success: false,
+      found: false,
+      error: "invalid_target",
+      message: "Missing or invalid description target",
+    };
+  }
+
+  return {
+    success: false,
+    error: "forbidden",
+    message: "Forbidden",
+  };
+}

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -24,6 +24,28 @@ function seedDatePlusDays(days: number) {
   return date.toISOString().slice(0, 10);
 }
 
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function findDescriptionEditAuditLog(descriptionId: string) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const log = await prisma.auditLog.findFirst({
+      where: {
+        action: "description_edit",
+        targetId: descriptionId,
+        targetType: "description",
+        userId: devUserId,
+      },
+      select: { id: true, metadata: true },
+    });
+    if (log) return log;
+    await sleep(25);
+  }
+
+  return null;
+}
+
 const SEED_PLUS_THREE_DAYS = seedDatePlusDays(3);
 const SEED_PLUS_SIX_DAYS = seedDatePlusDays(6);
 const SEED_PLUS_SEVEN_DAYS = seedDatePlusDays(7);
@@ -322,6 +344,143 @@ describe("comment read tools — MCP exposes the REST comment hierarchy", () => 
         });
         await prisma.teacher.deleteMany({ where: { id: teacherId } });
       }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Descriptions
+// ---------------------------------------------------------------------------
+
+describe("description tools — MCP exposes the REST description payload", () => {
+  it("get_description returns seeded section description by public JW id", async () => {
+    const section = await prisma.section.findUnique({
+      where: { jwId: DEV_SEED.section.jwId },
+      select: { id: true },
+    });
+    expect(section?.id).toBeTruthy();
+
+    const result = await mcp.call<{
+      found?: boolean;
+      description?: { content?: string; id?: string | null };
+      history?: Array<{ id?: string; nextContent?: string }>;
+      target?: { targetId?: number; type?: string };
+      viewer?: { isAuthenticated?: boolean; userId?: string | null };
+    }>("get_description", {
+      targetType: "section",
+      sectionJwId: DEV_SEED.section.jwId,
+      mode: "full",
+    });
+
+    expect(result.found).toBe(true);
+    expect(result.target).toMatchObject({
+      targetId: section?.id,
+      type: "section",
+    });
+    expect(result.description?.id).toBeTruthy();
+    expect(result.description?.content).toContain("课程建议");
+    expect(result.history?.length).toBeGreaterThan(0);
+    expect(result.viewer).toMatchObject({
+      isAuthenticated: true,
+      userId: devUserId,
+    });
+  });
+
+  it("get_description reports missing public section targets", async () => {
+    const result = await mcp.call<{
+      success?: boolean;
+      found?: boolean;
+      error?: string;
+      hint?: string;
+    }>("get_description", {
+      targetType: "section",
+      sectionJwId: 2_147_483_647,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.found).toBe(false);
+    expect(result.error).toBe("target_not_found");
+    expect(result.hint).toContain("search_sections");
+  });
+
+  it("upsert_description creates, idempotently rereads, audits, and cleans up", async () => {
+    const marker = `[integration-test] mcp-description-${Date.now()}`;
+    const teacher = await prisma.teacher.create({
+      data: {
+        code: marker,
+        nameCn: marker,
+      },
+      select: { id: true },
+    });
+    let descriptionId: string | undefined;
+
+    try {
+      const created = await mcp.call<{
+        success?: boolean;
+        id?: string;
+        updated?: boolean;
+        description?: { content?: string; id?: string | null };
+        target?: { targetId?: number; type?: string };
+      }>("upsert_description", {
+        targetType: "teacher",
+        teacherId: teacher.id,
+        content: ` ${marker} `,
+        mode: "full",
+      });
+      descriptionId = created.id;
+
+      expect(created.success).toBe(true);
+      expect(created.updated).toBe(true);
+      expect(created.target).toMatchObject({
+        targetId: teacher.id,
+        type: "teacher",
+      });
+      expect(created.description?.id).toBe(descriptionId);
+      expect(created.description?.content).toBe(marker);
+
+      const auditLog = descriptionId
+        ? await findDescriptionEditAuditLog(descriptionId)
+        : null;
+      expect(auditLog?.metadata).toMatchObject({
+        source: "mcp",
+        targetType: "teacher",
+      });
+
+      const idempotent = await mcp.call<{
+        success?: boolean;
+        id?: string;
+        updated?: boolean;
+        description?: { content?: string };
+      }>("upsert_description", {
+        targetType: "teacher",
+        teacherId: teacher.id,
+        content: marker,
+        mode: "full",
+      });
+
+      expect(idempotent.success).toBe(true);
+      expect(idempotent.id).toBe(descriptionId);
+      expect(idempotent.updated).toBe(false);
+      expect(idempotent.description?.content).toBe(marker);
+    } finally {
+      if (descriptionId) {
+        await findDescriptionEditAuditLog(descriptionId);
+        await prisma.auditLog.deleteMany({
+          where: {
+            action: "description_edit",
+            targetId: descriptionId,
+            targetType: "description",
+            userId: devUserId,
+          },
+        });
+      }
+      await prisma.descriptionEdit.deleteMany({
+        where: { description: { teacherId: teacher.id } },
+      });
+      await prisma.description.deleteMany({
+        where: { teacherId: teacher.id },
+      });
+      await prisma.teacher.deleteMany({ where: { id: teacher.id } });
     }
   });
 });


### PR DESCRIPTION
## Goal

Close the description surface gap: descriptions were available in web and REST, but MCP had no general description tools.

## Changed Surfaces

- Added MCP `get_description` and `upsert_description` tools backed by `src/features/descriptions/server` read/write services.
- Added shared description target reference resolution for REST-compatible `targetId` and public identifiers such as `sectionJwId`, `courseJwId`, `teacherId`, and `homeworkId`.
- Moved description edit audit emission into the shared description write service so REST and MCP writes use the same audit path.
- Updated description, MCP, and audit contracts.
- Added MCP integration coverage for section description reads, missing public targets, write/idempotency, audit metadata, and cleanup.

## Evidence

- Focused MCP behavior: `bun run db:migrate:deploy && bun run seed && bun run vitest run --config vitest.integration.config.ts tests/integration/mcp-tools.test.ts -t "description tools"`
- Default gate: `bun run verify`
- Full local gate: `PLAYWRIGHT_PORT=3002 bun run verify:full`

The focused MCP test inspects serialized `get_description` and `upsert_description` tool results through the in-process MCP harness, including the seeded section description payload and the MCP audit source metadata for a temporary teacher description.

## Docs / Contracts

- Updated `docs/contracts/description.json` to document `get_description` and `upsert_description`.
- Updated `docs/contracts/mcp.json` tool groups.
- Updated `docs/contracts/_audit.json` so `description_edit` is no longer REST-only.
- No OpenAPI change: this PR adds MCP tools and keeps the existing REST route shape.

## Risk Areas

- MCP auth remains bearer-only via existing transport auth; tool handlers use `getUserId(extra.authInfo)`.
- Description writes still enforce existing signed-in and suspension gates through `upsertDescriptionContent`.
- Target resolution now adds public identifier lookup for MCP but keeps REST-compatible internal IDs.
- Audit logging remains fire-and-forget, matching the existing audit contract.

## Cleanup

- No scratch artifacts or generated-file edits are included.
- `git diff --check` passed before commit.
