### PR TITLE
feat(api): public profile REST and MCP parity

### DIFF
--- a/docs/contracts/mcp.json
+++ b/docs/contracts/mcp.json
@@ -65,6 +65,7 @@
             "name": "Profile & Todo",
             "tools": [
               "get_my_profile",
+              "get_public_user_profile",
               "list_my_todos",
               "create_my_todo",
               "update_my_todo",

--- a/docs/contracts/user.json
+++ b/docs/contracts/user.json
@@ -82,8 +82,13 @@
             "path": "/api/me",
             "returns": "{ id, email, name, image, username, isAdmin, createdAt, updatedAt }",
             "auth": "user",
+            "notes": ["Returns the authenticated user's core profile fields."]
+          },
+          {
+            "path": "/api/users/profile",
+            "returns": "{ user, sectionCount, weeks, totalContributions }",
             "notes": [
-              "Returns the authenticated user's core profile fields only; no separate public profile endpoint for other users is currently exposed."
+              "Accepts exactly one lookup key: username or userId. Returns the same public profile hierarchy as /u/$username and /u/id/$uid."
             ]
           }
         ]
@@ -98,7 +103,9 @@
           },
           {
             "name": "get_public_user_profile",
-            "status": "unavailable"
+            "returns": "{ found, user, sectionCount, weeks, totalContributions }",
+            "rest_equivalent": "GET /api/users/profile",
+            "notes": ["Accepts exactly one lookup key: username or userId."]
           }
         ]
       },

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -6064,6 +6064,65 @@
           }
         }
       }
+    },
+    "/api/users/profile": {
+      "get": {
+        "operationId": "get-api-users-profile",
+        "summary": "Get public user profile",
+        "tags": [
+          "Api"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "username",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "userId",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publicUserProfileResponseSchema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -27263,6 +27322,119 @@
           "upload",
           "usedBytes",
           "quotaBytes"
+        ],
+        "additionalProperties": false
+      },
+      "publicUserProfileResponseSchema": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "username": {
+                "nullable": true,
+                "type": "string"
+              },
+              "name": {
+                "nullable": true,
+                "type": "string"
+              },
+              "image": {
+                "nullable": true,
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "_count": {
+                "type": "object",
+                "properties": {
+                  "comments": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "uploads": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "homeworksCreated": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "subscribedSections": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "comments",
+                  "uploads",
+                  "homeworksCreated",
+                  "subscribedSections"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "id",
+              "username",
+              "name",
+              "image",
+              "createdAt",
+              "_count"
+            ],
+            "additionalProperties": false
+          },
+          "sectionCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "weeks": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "date": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                  },
+                  "count": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "date",
+                  "count"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "totalContributions": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": [
+          "user",
+          "sectionCount",
+          "weeks",
+          "totalContributions"
         ],
         "additionalProperties": false
       },

--- a/src/lib/api/routes/public-user-profile.ts
+++ b/src/lib/api/routes/public-user-profile.ts
@@ -1,0 +1,35 @@
+import {
+  getUserProfileById,
+  getUserProfileByUsername,
+} from "@/features/profile/server/user-profile-page-data";
+import {
+  handleRouteError,
+  jsonResponse,
+  notFound,
+  parseRouteSearchParams,
+} from "@/lib/api/helpers";
+import { publicUserProfileQuerySchema } from "@/lib/api/schemas/request-schemas";
+
+export async function getPublicUserProfileRoute(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const query = parseRouteSearchParams(
+    searchParams,
+    publicUserProfileQuerySchema,
+    "Invalid public profile query",
+  );
+  if (query instanceof Response) return query;
+
+  try {
+    const profile = query.username
+      ? await getUserProfileByUsername(query.username)
+      : query.userId
+        ? await getUserProfileById(query.userId)
+        : null;
+
+    if (!profile) return notFound("User not found");
+
+    return jsonResponse(profile);
+  } catch (error) {
+    return handleRouteError("Failed to fetch public user profile", error);
+  }
+}

--- a/src/lib/api/schemas/misc-query-schemas.ts
+++ b/src/lib/api/schemas/misc-query-schemas.ts
@@ -63,6 +63,30 @@ export const compactOverviewQuerySchema = z.object({
   locale: z.enum(APP_LOCALES).optional(),
 });
 
+export const publicUserProfileQuerySchema = z
+  .object({
+    username: z.string().trim().min(1).optional(),
+    userId: z.string().trim().min(1).optional(),
+  })
+  .superRefine((input, ctx) => {
+    if (input.username && input.userId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Provide either username or userId, not both",
+        path: ["username"],
+      });
+      return;
+    }
+
+    if (!input.username && !input.userId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Provide username or userId",
+        path: ["username"],
+      });
+    }
+  });
+
 export const todosQuerySchema = z.object({
   completed: z.enum(["true", "false"]).optional(),
   priority: todoPrioritySchema.optional(),

--- a/src/lib/api/schemas/misc-response-schema-core.ts
+++ b/src/lib/api/schemas/misc-response-schema-core.ts
@@ -121,6 +121,32 @@ export const meResponseSchema = z.object({
   updatedAt: dateTimeSchema,
 });
 
+export const publicUserProfileResponseSchema = z.object({
+  user: z.object({
+    id: z.string(),
+    username: z.string().nullable(),
+    name: z.string().nullable(),
+    image: z.string().nullable(),
+    createdAt: dateTimeSchema,
+    _count: z.object({
+      comments: z.number().int().nonnegative(),
+      uploads: z.number().int().nonnegative(),
+      homeworksCreated: z.number().int().nonnegative(),
+      subscribedSections: z.number().int().nonnegative(),
+    }),
+  }),
+  sectionCount: z.number().int().nonnegative(),
+  weeks: z.array(
+    z.array(
+      z.object({
+        date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+        count: z.number().int().nonnegative(),
+      }),
+    ),
+  ),
+  totalContributions: z.number().int().nonnegative(),
+});
+
 export const todoItemSchema = z.object({
   id: z.string(),
   title: z.string(),

--- a/src/lib/api/schemas/request-query-schemas.ts
+++ b/src/lib/api/schemas/request-query-schemas.ts
@@ -24,6 +24,7 @@ export {
   busRouteSearchQuerySchema,
   compactOverviewQuerySchema,
   dashboardLinkVisitQuerySchema,
+  publicUserProfileQuerySchema,
   semestersQuerySchema,
   subscribedSchedulesQuerySchema,
   todosQuerySchema,

--- a/src/lib/mcp/tools/profile-tool-actions.ts
+++ b/src/lib/mcp/tools/profile-tool-actions.ts
@@ -4,4 +4,7 @@ export {
   listMyTodosAction,
   updateMyTodoAction,
 } from "./profile-tool-todo-actions";
-export { getMyProfileAction } from "./profile-tool-user-actions";
+export {
+  getMyProfileAction,
+  getPublicUserProfileAction,
+} from "./profile-tool-user-actions";

--- a/src/lib/mcp/tools/profile-tool-helpers.ts
+++ b/src/lib/mcp/tools/profile-tool-helpers.ts
@@ -11,6 +11,12 @@ export const getMyProfileInputSchema = {
   mode: mcpModeInputSchema,
 };
 
+export const getPublicUserProfileInputSchema = {
+  username: z.string().trim().min(1).optional(),
+  userId: z.string().trim().min(1).optional(),
+  mode: mcpModeInputSchema,
+};
+
 export const listMyTodosInputSchema = {
   includeCompleted: z.boolean().default(false),
   limit: z.number().int().min(1).max(200).default(50),

--- a/src/lib/mcp/tools/profile-tool-user-actions.ts
+++ b/src/lib/mcp/tools/profile-tool-user-actions.ts
@@ -1,6 +1,10 @@
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { findAuthenticatedUserProfileById } from "@/features/profile/server/profile-read-model";
 import {
+  getUserProfileById,
+  getUserProfileByUsername,
+} from "@/features/profile/server/user-profile-page-data";
+import {
   getUserId,
   jsonToolResult,
   type McpModeInput,
@@ -26,4 +30,63 @@ export async function getMyProfileAction(
   return jsonToolResult(user, {
     mode: resolveMcpMode(mode),
   });
+}
+
+export async function getPublicUserProfileAction({
+  username,
+  userId,
+  mode,
+}: {
+  username?: string;
+  userId?: string;
+  mode?: McpModeInput;
+}) {
+  const resolvedMode = resolveMcpMode(mode);
+  if (username && userId) {
+    return jsonToolResult(
+      {
+        success: false,
+        error: "invalid_request",
+        message: "Provide either username or userId, not both",
+      },
+      { mode: resolvedMode },
+    );
+  }
+
+  if (!username && !userId) {
+    return jsonToolResult(
+      {
+        success: false,
+        error: "invalid_request",
+        message: "Provide username or userId",
+      },
+      { mode: resolvedMode },
+    );
+  }
+
+  const profile = username
+    ? await getUserProfileByUsername(username)
+    : userId
+      ? await getUserProfileById(userId)
+      : null;
+
+  if (!profile) {
+    return jsonToolResult(
+      {
+        success: false,
+        found: false,
+        error: "not_found",
+        message: "User not found",
+      },
+      { mode: resolvedMode },
+    );
+  }
+
+  return jsonToolResult(
+    {
+      found: true,
+      ...profile,
+    },
+    { mode: resolvedMode },
+  );
 }

--- a/src/lib/mcp/tools/profile-tools.ts
+++ b/src/lib/mcp/tools/profile-tools.ts
@@ -3,6 +3,7 @@ import {
   createMyTodoAction,
   deleteMyTodoAction,
   getMyProfileAction,
+  getPublicUserProfileAction,
   listMyTodosAction,
   updateMyTodoAction,
 } from "@/lib/mcp/tools/profile-tool-actions";
@@ -10,6 +11,7 @@ import {
   createMyTodoInputSchema,
   deleteMyTodoInputSchema,
   getMyProfileInputSchema,
+  getPublicUserProfileInputSchema,
   listMyTodosInputSchema,
   updateMyTodoInputSchema,
 } from "@/lib/mcp/tools/profile-tool-helpers";
@@ -23,6 +25,16 @@ export function registerProfileTools(server: McpServer) {
       inputSchema: getMyProfileInputSchema,
     },
     getMyProfileAction,
+  );
+
+  server.registerTool(
+    "get_public_user_profile",
+    {
+      description:
+        "Return a public Life@USTC user profile by username or userId, including visible stats and contribution heatmap data from the web profile page.",
+      inputSchema: getPublicUserProfileInputSchema,
+    },
+    getPublicUserProfileAction,
   );
 
   server.registerTool(

--- a/src/routes/api/users/profile/+server.ts
+++ b/src/routes/api/users/profile/+server.ts
@@ -1,0 +1,14 @@
+import { getPublicUserProfileRoute } from "@/lib/api/routes/public-user-profile";
+import { svelteRequestHandler } from "@/lib/api/svelte-route";
+import { observedApiRoute } from "@/lib/log/api-observability";
+
+/**
+ * Get public user profile.
+ * @params publicUserProfileQuerySchema
+ * @response publicUserProfileResponseSchema
+ * @response 400:openApiErrorSchema
+ * @response 404:openApiErrorSchema
+ */
+export const GET = svelteRequestHandler(
+  observedApiRoute(getPublicUserProfileRoute),
+);

--- a/tests/e2e/src/app/_shared/api-contract.ts
+++ b/tests/e2e/src/app/_shared/api-contract.ts
@@ -163,6 +163,40 @@ export async function assertApiContract(
       return;
     }
 
+    case "/api/users/profile": {
+      const response = await request.get(
+        `/api/users/profile?username=${DEV_SEED.debugUsername}`,
+      );
+      expect(response.status()).toBe(200);
+      const body = (await response.json()) as {
+        user?: {
+          id?: string;
+          name?: string | null;
+          username?: string | null;
+          _count?: {
+            comments?: number;
+            homeworksCreated?: number;
+            subscribedSections?: number;
+            uploads?: number;
+          };
+        };
+        sectionCount?: number;
+        totalContributions?: number;
+        weeks?: unknown[];
+      };
+      expect(body.user?.id).toBeTruthy();
+      expect(body.user?.name).toBe(DEV_SEED.debugName);
+      expect(body.user?.username).toBe(DEV_SEED.debugUsername);
+      expect(typeof body.sectionCount).toBe("number");
+      expect(typeof body.totalContributions).toBe("number");
+      expect(Array.isArray(body.weeks)).toBe(true);
+      expect(typeof body.user?._count?.comments).toBe("number");
+      expect(typeof body.user?._count?.uploads).toBe("number");
+      expect(typeof body.user?._count?.homeworksCreated).toBe("number");
+      expect(typeof body.user?._count?.subscribedSections).toBe("number");
+      return;
+    }
+
     case "/api/teachers": {
       const response = await request.get(
         `/api/teachers?search=${encodeURIComponent(DEV_SEED.teacher.nameCn)}`,

--- a/tests/e2e/src/app/api/mcp/test.ts
+++ b/tests/e2e/src/app/api/mcp/test.ts
@@ -677,6 +677,7 @@ test.describe("/api/mcp – MCP Streamable-HTTP transport", () => {
       expect(tools.tools.map((tool) => tool.name)).toEqual(
         expect.arrayContaining([
           "get_my_profile",
+          "get_public_user_profile",
           "list_my_todos",
           "create_my_todo",
           "update_my_todo",
@@ -735,6 +736,32 @@ test.describe("/api/mcp – MCP Streamable-HTTP transport", () => {
       expect(profile.createdAt).toMatch(/\+08:00$/);
       expect(typeof profile.updatedAt).toBe("string");
       expect(profile.updatedAt).toMatch(/\+08:00$/);
+
+      const publicProfileResult = await mcpClient.callTool({
+        name: "get_public_user_profile",
+        arguments: { username: DEV_SEED.debugUsername, mode: "full" },
+      });
+      const publicProfile = parseTextContent(publicProfileResult) as {
+        found?: boolean;
+        user?: {
+          id?: string;
+          name?: string | null;
+          username?: string | null;
+          _count?: { comments?: number; uploads?: number };
+        };
+        sectionCount?: number;
+        weeks?: unknown[];
+        totalContributions?: number;
+      };
+      expect(publicProfile.found).toBe(true);
+      expect(publicProfile.user?.id).toBe(currentUser.id);
+      expect(publicProfile.user?.name).toBe(DEV_SEED.debugName);
+      expect(publicProfile.user?.username).toBe(DEV_SEED.debugUsername);
+      expect(typeof publicProfile.sectionCount).toBe("number");
+      expect(typeof publicProfile.totalContributions).toBe("number");
+      expect(Array.isArray(publicProfile.weeks)).toBe(true);
+      expect(typeof publicProfile.user?._count?.comments).toBe("number");
+      expect(typeof publicProfile.user?._count?.uploads).toBe("number");
 
       const todosResult = await mcpClient.callTool({
         name: "list_my_todos",

--- a/tests/e2e/src/app/api/users/profile/test.ts
+++ b/tests/e2e/src/app/api/users/profile/test.ts
@@ -1,0 +1,78 @@
+/**
+ * E2E tests for GET /api/users/profile.
+ *
+ * Public profile endpoint mirroring /u/[username] and /u/id/[uid].
+ */
+import { expect, test } from "@playwright/test";
+import { DEV_SEED } from "../../../../../utils/dev-seed";
+import { assertApiContract } from "../../../_shared/api-contract";
+
+const BASE = "/api/users/profile";
+
+test.describe("GET /api/users/profile", () => {
+  test("contract", async ({ request }) => {
+    await assertApiContract(request, { routePath: BASE });
+  });
+
+  test("returns public profile by username", async ({ request }) => {
+    const response = await request.get(
+      `${BASE}?username=${DEV_SEED.debugUsername}`,
+    );
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as {
+      user?: {
+        id?: string;
+        name?: string | null;
+        username?: string | null;
+        _count?: { comments?: number; uploads?: number };
+      };
+      sectionCount?: number;
+      weeks?: Array<Array<{ date?: string; count?: number }>>;
+      totalContributions?: number;
+    };
+
+    expect(body.user?.name).toBe(DEV_SEED.debugName);
+    expect(body.user?.username).toBe(DEV_SEED.debugUsername);
+    expect(typeof body.sectionCount).toBe("number");
+    expect(typeof body.user?._count?.comments).toBe("number");
+    expect(typeof body.user?._count?.uploads).toBe("number");
+    expect((body.weeks?.length ?? 0) > 0).toBe(true);
+    expect(body.weeks?.[0]?.[0]?.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(typeof body.totalContributions).toBe("number");
+  });
+
+  test("returns the same user by userId", async ({ request }) => {
+    const byUsername = await request.get(
+      `${BASE}?username=${DEV_SEED.debugUsername}`,
+    );
+    expect(byUsername.status()).toBe(200);
+    const usernameBody = (await byUsername.json()) as {
+      user?: { id?: string; username?: string | null };
+    };
+    expect(usernameBody.user?.id).toBeTruthy();
+
+    const byId = await request.get(`${BASE}?userId=${usernameBody.user?.id}`);
+    expect(byId.status()).toBe(200);
+    const idBody = (await byId.json()) as {
+      user?: { id?: string; username?: string | null };
+    };
+
+    expect(idBody.user?.id).toBe(usernameBody.user?.id);
+    expect(idBody.user?.username).toBe(DEV_SEED.debugUsername);
+  });
+
+  test("requires exactly one lookup key", async ({ request }) => {
+    const missing = await request.get(BASE);
+    expect(missing.status()).toBe(400);
+
+    const duplicate = await request.get(
+      `${BASE}?username=${DEV_SEED.debugUsername}&userId=duplicate`,
+    );
+    expect(duplicate.status()).toBe(400);
+  });
+
+  test("returns 404 for missing users", async ({ request }) => {
+    const response = await request.get(`${BASE}?username=missing-e2e-user`);
+    expect(response.status()).toBe(404);
+  });
+});

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -121,6 +121,58 @@ describe("get_my_profile", () => {
   });
 });
 
+describe("get_public_user_profile", () => {
+  it("returns public profile hierarchy by username", async () => {
+    const profile = await mcp.call<{
+      found?: boolean;
+      user?: {
+        id?: string;
+        name?: string | null;
+        username?: string | null;
+        _count?: {
+          comments?: number;
+          homeworksCreated?: number;
+          subscribedSections?: number;
+          uploads?: number;
+        };
+      };
+      sectionCount?: number;
+      totalContributions?: number;
+      weeks?: Array<Array<{ date?: string; count?: number }>>;
+    }>("get_public_user_profile", {
+      username: DEV_SEED.debugUsername,
+      mode: "full",
+    });
+
+    expect(profile.found).toBe(true);
+    expect(profile.user?.id).toBe(devUserId);
+    expect(profile.user?.name).toBe(DEV_SEED.debugName);
+    expect(profile.user?.username).toBe(DEV_SEED.debugUsername);
+    expect(typeof profile.sectionCount).toBe("number");
+    expect(typeof profile.totalContributions).toBe("number");
+    expect((profile.weeks?.length ?? 0) > 0).toBe(true);
+    expect(profile.weeks?.[0]?.[0]?.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(typeof profile.user?._count?.comments).toBe("number");
+    expect(typeof profile.user?._count?.uploads).toBe("number");
+    expect(typeof profile.user?._count?.homeworksCreated).toBe("number");
+    expect(typeof profile.user?._count?.subscribedSections).toBe("number");
+  });
+
+  it("returns not_found for missing users", async () => {
+    const result = await mcp.call<{
+      success?: boolean;
+      found?: boolean;
+      error?: string;
+    }>("get_public_user_profile", {
+      username: "missing-integration-user",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.found).toBe(false);
+    expect(result.error).toBe("not_found");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Comments
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Goal

Expose the public profile page read model through REST and MCP so `/u/$username` and `/u/id/$uid` data is available at the same hierarchy outside the web UI.

## Changed Surfaces

- Added `GET /api/users/profile` with `username` or `userId` lookup, response schema, route adapter, and generated OpenAPI entry.
- Added MCP tool `get_public_user_profile` using the same profile page read model.
- Updated user/MCP contract JSON and API/MCP E2E + integration coverage.

## Evidence

- `bun run check:contracts`
- `bun run verify:types`
- `bun run db:migrate:deploy && bun run seed && bun run vitest run --config vitest.integration.config.ts tests/integration/mcp-tools.test.ts -t "get_public_user_profile"`
- `PLAYWRIGHT_PORT=3002 bun run e2e:db:prepare && PLAYWRIGHT_PORT=3002 bun run e2e:build-artifacts && bun run seed && PLAYWRIGHT_PORT=3002 bun run e2e:test -- tests/e2e/src/app/api/users/profile/test.ts`
- `bun run seed && PLAYWRIGHT_PORT=3002 bun run e2e:test -- tests/e2e/src/app/api/mcp/test.ts`
- `bun run verify`
- `PLAYWRIGHT_PORT=3002 bun run verify:full`

Complete-loop checks inspected the serialized REST body for success, userId lookup, validation, and 404, plus MCP tool output for success and not_found. The full E2E gate passed 508 Playwright tests; local workerd warning logs appeared during existing invalid-request/MCP cases but the test process exited 0.

## Docs / Contracts

Updated `docs/contracts/user.json`, `docs/contracts/mcp.json`, and `public/openapi.generated.json`. No message/i18n changes were needed because this adds public API/MCP access to existing profile data without UI copy changes.

## Risk Areas

- Public data exposure: the endpoint/tool reuse `getUserProfileByUsername` / `getUserProfileById`, the same shared read model behind the public profile pages.
- API/MCP query validation: both surfaces enforce exactly one lookup key and return documented error shapes.
- No Prisma schema, migration, auth, upload, or seed fixture changes.

## Cleanup

Working tree was clean before push. No scratch reports, ad hoc probes, or unrelated rewrites remain. Generated OpenAPI was produced with `bun run openapi:generate` / build rather than manually edited.
