### PR TITLE
fix(openapi): document protected route security

### DIFF
--- a/docs/contracts/openapi.json
+++ b/docs/contracts/openapi.json
@@ -11,6 +11,7 @@
     "no-developer-model": "Public documentation helps callers understand the existing product capability boundaries, not to introduce a separate developer-specific business model.",
     "session-and-bearer": "Current user-side business REST endpoints support both in-site session from the request cookie and OAuth bearer tokens; bearer-token access is no longer limited to MCP.",
     "rest-mcp-consistent": "The same abstract endpoint currently maintains the same core fields, state information, and action results in both REST and MCP; differences mainly appear in interaction form and serialization level.",
+    "security-schemes": "Generated OpenAPI marks protected REST operations with bearer/session alternatives and MCP operations with bearer-only auth.",
     "rest-observability": "REST API handling records production-safe structured request-start/request-finish logs and bounded in-memory metrics with request ID, method, status, auth mode, duration, and normalized route template; it does not log request bodies, credentials, raw query strings, or high-cardinality resource IDs."
   },
   "capabilities": {
@@ -27,6 +28,7 @@
           "Route-scoped tag and operation pages",
           "Endpoint path, method, parameters",
           "Request/response schemas where annotated",
+          "Auth/security schemes for protected operations",
           "Try-it-out interface"
         ]
       }
@@ -47,6 +49,7 @@
         "fields": [
           "OpenAPI 3.x JSON",
           "Annotated routes with schemas",
+          "Security schemes and operation security",
           "Some protocol routes without detailed schemas"
         ]
       }

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -362,7 +362,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/admin/comments/{id}": {
@@ -424,7 +432,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/admin/descriptions": {
@@ -508,7 +524,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/admin/homeworks": {
@@ -578,7 +602,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/admin/homeworks/{id}": {
@@ -640,7 +672,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/admin/suspensions": {
@@ -671,7 +711,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       },
       "post": {
         "operationId": "createAdminSuspension",
@@ -720,7 +768,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/admin/suspensions/{id}": {
@@ -772,7 +828,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/admin/users": {
@@ -838,7 +902,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/admin/users/{id}": {
@@ -900,7 +972,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/auth/.well-known/openid-configuration": {
@@ -1240,7 +1320,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       },
       "post": {
         "operationId": "setBusPreferences",
@@ -1289,7 +1377,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/bus/routes": {
@@ -1418,7 +1514,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       },
       "patch": {
         "operationId": "appendCalendarSubscriptionSections",
@@ -1477,7 +1581,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/calendar-subscriptions/current": {
@@ -1508,7 +1620,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/calendar-subscriptions/import-codes": {
@@ -1569,7 +1689,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/comments": {
@@ -1751,7 +1879,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/comments/{id}": {
@@ -1873,7 +2009,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       },
       "delete": {
         "operationId": "deleteComment",
@@ -1933,7 +2077,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/comments/{id}/reactions": {
@@ -2015,7 +2167,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       },
       "delete": {
         "operationId": "removeCommentReaction",
@@ -2093,7 +2253,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/courses": {
@@ -2481,7 +2649,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/dashboard-links/visit": {
@@ -2669,7 +2845,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/homeworks": {
@@ -2816,7 +3000,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/homeworks/{id}": {
@@ -2898,7 +3090,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       },
       "delete": {
         "operationId": "deleteHomework",
@@ -2958,7 +3158,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/homeworks/{id}/completion": {
@@ -3030,7 +3238,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/homeworks/completions": {
@@ -3081,7 +3297,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/locale": {
@@ -3156,7 +3380,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "mcpBearerAuth": []
+          }
+        ]
       },
       "post": {
         "operationId": "createMcp",
@@ -3188,7 +3417,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "mcpBearerAuth": []
+          }
+        ]
       },
       "delete": {
         "operationId": "delete-api-mcp",
@@ -3220,7 +3454,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "mcpBearerAuth": []
+          }
+        ]
       },
       "options": {
         "operationId": "options-api-mcp",
@@ -3357,7 +3596,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/me/overview": {
@@ -3435,7 +3682,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/me/subscriptions/homeworks": {
@@ -3466,7 +3721,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/me/subscriptions/schedules": {
@@ -3554,7 +3817,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/metadata": {
@@ -5409,7 +5680,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       },
       "post": {
         "operationId": "createTodo",
@@ -5458,7 +5737,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/todos/{id}": {
@@ -5540,7 +5827,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       },
       "delete": {
         "operationId": "deleteTodo",
@@ -5600,7 +5895,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/uploads": {
@@ -5680,7 +5983,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/uploads/{id}": {
@@ -5752,7 +6063,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       },
       "delete": {
         "operationId": "deleteUpload",
@@ -5802,7 +6121,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/uploads/{id}/download": {
@@ -5855,7 +6182,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/uploads/complete": {
@@ -5916,7 +6251,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/uploads/object": {
@@ -5999,7 +6342,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/users/{userId}/calendar.ics": {
@@ -6062,7 +6413,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/users/profile": {
@@ -27617,6 +27976,26 @@
           "canModerate"
         ],
         "additionalProperties": false
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "OAuth access token accepted by protected REST endpoints. These endpoints also accept an in-site Better Auth session cookie."
+      },
+      "sessionCookie": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "better-auth.session_token",
+        "description": "Better Auth session cookie used by the web UI. Production cookies may use the __Secure- prefix."
+      },
+      "mcpBearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "OAuth bearer token for /api/mcp. MCP requires a bearer token with the MCP resource audience and does not accept session cookies."
       }
     }
   },

--- a/tests/e2e/src/app/api/openapi/test.ts
+++ b/tests/e2e/src/app/api/openapi/test.ts
@@ -154,6 +154,38 @@ test.describe("GET /api/openapi", () => {
     ).toBeTruthy();
   });
 
+  test("spec exposes auth security metadata", async ({ request }) => {
+    const response = await request.get("/api/openapi");
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as {
+      components?: { securitySchemes?: Record<string, unknown> };
+      paths?: Record<
+        string,
+        {
+          get?: { security?: unknown[] };
+          options?: { security?: unknown[] };
+          post?: { security?: unknown[] };
+        }
+      >;
+    };
+
+    expect(Object.keys(body.components?.securitySchemes ?? {})).toEqual(
+      expect.arrayContaining(["bearerAuth", "sessionCookie", "mcpBearerAuth"]),
+    );
+    expect(body.paths?.["/api/todos"]?.get?.security).toEqual([
+      { bearerAuth: [] },
+      { sessionCookie: [] },
+    ]);
+    expect(body.paths?.["/api/mcp"]?.get?.security).toEqual([
+      { mcpBearerAuth: [] },
+    ]);
+    expect(body.paths?.["/api/mcp"]?.options?.security).toBeUndefined();
+    expect(body.paths?.["/api/users/profile"]?.get?.security).toBeUndefined();
+    expect(
+      body.paths?.["/api/auth/oauth2/token"]?.post?.security,
+    ).toBeUndefined();
+  });
+
   test("static openapi.generated.json is accessible", async ({ request }) => {
     const response = await request.get("/openapi.generated.json");
     expect(response.status()).toBe(200);

--- a/tests/unit/openapi-scenario-examples.test.ts
+++ b/tests/unit/openapi-scenario-examples.test.ts
@@ -43,6 +43,7 @@ type GeneratedOperation = {
       content?: Record<string, GeneratedMediaType>;
     }
   >;
+  security?: unknown[];
   summary?: string;
 };
 
@@ -62,6 +63,7 @@ type GeneratedSchema = {
 type GeneratedOpenApiDocument = {
   components?: {
     schemas?: Record<string, GeneratedSchema>;
+    securitySchemes?: Record<string, unknown>;
   };
   paths: Record<
     string,
@@ -228,6 +230,35 @@ describe("buildScenarioOpenApiExamples", () => {
       "Return OAuth device authorization CORS preflight headers",
     );
     expect(deviceAuthorizationOptions?.responses?.["204"]).toBeTruthy();
+  });
+
+  it("documents auth security for protected REST and MCP operations", () => {
+    const spec = generatedOpenApiDocument as GeneratedOpenApiDocument;
+
+    expect(Object.keys(spec.components?.securitySchemes ?? {})).toEqual(
+      expect.arrayContaining(["bearerAuth", "sessionCookie", "mcpBearerAuth"]),
+    );
+
+    expect(spec.paths["/api/todos"]?.get?.security).toEqual([
+      { bearerAuth: [] },
+      { sessionCookie: [] },
+    ]);
+    expect(spec.paths["/api/admin/users"]?.get?.security).toEqual([
+      { bearerAuth: [] },
+      { sessionCookie: [] },
+    ]);
+    expect(spec.paths["/api/dashboard-links/pin"]?.post?.security).toEqual([
+      { bearerAuth: [] },
+      { sessionCookie: [] },
+    ]);
+    expect(spec.paths["/api/mcp"]?.get?.security).toEqual([
+      { mcpBearerAuth: [] },
+    ]);
+    expect(spec.paths["/api/mcp"]?.options?.security).toBeUndefined();
+    expect(spec.paths["/api/users/profile"]?.get?.security).toBeUndefined();
+    expect(
+      spec.paths["/api/auth/oauth2/token"]?.post?.security,
+    ).toBeUndefined();
   });
 
   it("documents OAuth success response bodies", () => {

--- a/tools/build/openapi/generate-spec.ts
+++ b/tools/build/openapi/generate-spec.ts
@@ -473,7 +473,11 @@ type MutableOpenApiDocument = {
   info?: unknown;
   servers?: unknown;
   paths?: Record<string, Record<string, Record<string, unknown>>>;
-  components?: unknown;
+  components?: {
+    schemas?: Record<string, JsonSchema>;
+    securitySchemes?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
   tags?: Array<{
     name: string;
     description?: string;
@@ -486,6 +490,31 @@ type MutableOpenApiOperation = Record<string, unknown>;
 type MutableOpenApiMediaType = Record<string, unknown>;
 
 const SCENARIO_OPENAPI_EXAMPLES = buildScenarioOpenApiExamples();
+const REST_AUTH_SECURITY = [{ bearerAuth: [] }, { sessionCookie: [] }];
+const MCP_AUTH_SECURITY = [{ mcpBearerAuth: [] }];
+const SECURITY_SCHEMES = {
+  bearerAuth: {
+    type: "http",
+    scheme: "bearer",
+    bearerFormat: "JWT",
+    description:
+      "OAuth access token accepted by protected REST endpoints. These endpoints also accept an in-site Better Auth session cookie.",
+  },
+  sessionCookie: {
+    type: "apiKey",
+    in: "cookie",
+    name: "better-auth.session_token",
+    description:
+      "Better Auth session cookie used by the web UI. Production cookies may use the __Secure- prefix.",
+  },
+  mcpBearerAuth: {
+    type: "http",
+    scheme: "bearer",
+    bearerFormat: "JWT",
+    description:
+      "OAuth bearer token for /api/mcp. MCP requires a bearer token with the MCP resource audience and does not accept session cookies.",
+  },
+};
 
 const TAG_DESCRIPTIONS: Record<string, string> = {
   Admin: "Admin and moderation endpoints",
@@ -1097,6 +1126,59 @@ function applyScenarioExamples(
   }
 }
 
+function operationHasResponse(
+  operation: MutableOpenApiOperation,
+  statusCode: string,
+) {
+  return Boolean(
+    operation.responses &&
+      typeof operation.responses === "object" &&
+      statusCode in operation.responses,
+  );
+}
+
+function isOAuthProtocolPath(path: string) {
+  return path.startsWith("/api/auth/oauth2/");
+}
+
+function isProtectedRedirectOperation(path: string, method: string) {
+  return path === "/api/dashboard-links/pin" && method === "post";
+}
+
+function applySecurityMetadata(doc: MutableOpenApiDocument) {
+  if (!doc.paths) return;
+
+  doc.components = {
+    ...(doc.components ?? {}),
+    securitySchemes: SECURITY_SCHEMES,
+  };
+
+  for (const [path, pathItem] of Object.entries(doc.paths)) {
+    for (const [method, operation] of Object.entries(pathItem)) {
+      if (
+        !isOperationKey(method) ||
+        !operation ||
+        typeof operation !== "object"
+      ) {
+        continue;
+      }
+
+      if (path === "/api/mcp" && operationHasResponse(operation, "401")) {
+        operation.security = MCP_AUTH_SECURITY;
+        continue;
+      }
+
+      if (
+        !isOAuthProtocolPath(path) &&
+        (operationHasResponse(operation, "401") ||
+          isProtectedRedirectOperation(path, method))
+      ) {
+        operation.security = REST_AUTH_SECURITY;
+      }
+    }
+  }
+}
+
 async function postprocessOpenApiSpec(filePath: string) {
   const raw = await readFile(filePath, "utf8");
   const doc = JSON.parse(raw) as MutableOpenApiDocument;
@@ -1145,6 +1227,7 @@ async function postprocessOpenApiSpec(filePath: string) {
   doc.paths = sortedPaths;
   patchRedirectOperations(sortedPaths);
   applyScenarioExamples(sortedPaths);
+  applySecurityMetadata(doc);
 
   doc.tags = buildTopLevelTags(sortedPaths);
   doc["x-tagGroups"] = buildTagGroups(doc.tags);


### PR DESCRIPTION
## Goal

Document the auth boundary already enforced by the public API surfaces: protected REST operations accept OAuth bearer tokens or Better Auth session cookies, while MCP remains bearer-only.

## Changed Surfaces

- `tools/build/openapi/generate-spec.ts` adds generated OpenAPI security schemes and operation security metadata during postprocess.
- `public/openapi.generated.json` is regenerated with REST bearer/session alternatives and MCP bearer-only security.
- `docs/contracts/openapi.json` records security metadata as part of the OpenAPI contract surface.
- OpenAPI unit and served-spec E2E tests cover protected REST, protected MCP, public profile, OAuth protocol, and redirect-auth exceptions.

## Evidence

- OpenAPI/contract focused checks: `bun run openapi:check`, `bun run check:contracts`, `bun run vitest run tests/unit/openapi-scenario-examples.test.ts`.
- Complete local gate: `PLAYWRIGHT_PORT=3002 bun run verify:full` passed, including 451 unit tests, 53 integration tests, production build, and 509 Playwright tests.
- Serialized spec inspection confirmed `bearerAuth`, `sessionCookie`, and `mcpBearerAuth`; `/api/todos`, `/api/admin/users`, and `/api/dashboard-links/pin` use REST alternatives; `/api/mcp` uses MCP bearer only; `/api/users/profile` and `/api/auth/oauth2/token` remain public/protocol-specific with no app auth security.

## Docs / Contracts

- Updated `docs/contracts/openapi.json` and regenerated `public/openapi.generated.json`.
- No runtime route, MCP tool, Prisma, or UI behavior changed.

## Risk Areas

- Auth documentation only. Runtime auth remains unchanged.
- Security inference is based on documented `401` responses, with explicit exceptions for OAuth protocol endpoints and the redirect-form dashboard pin route.

## Cleanup

- `git diff --check` passed.
- Worktree was clean before pushing the branch; no scratch artifacts or manual-only generated edits remain.
