### PR TITLE
docs(api): calendar feed token auth in OpenAPI

### DIFF
--- a/docs/contracts/ical.json
+++ b/docs/contracts/ical.json
@@ -1,7 +1,7 @@
 {
   "name": "Personal Calendar Subscription iCal",
   "access": {
-    "anon": "Can copy a single-section iCal link from the public section detail page.",
+    "anon": "Can copy a single-section iCal link from the public section detail page and can retrieve a personal feed only when holding its token-bearing URL.",
     "user": "Can copy their own personal subscription iCal link.",
     "admin": "No additional exclusive iCal capabilities.",
     "agent": "After authorization, can read the current user's personal calendar subscription information; REST and MCP should both return the same subscription feed information and description."
@@ -55,7 +55,11 @@
         "routes": [
           {
             "path": "/api/users/[userId]/calendar.ics",
-            "returns": "text/calendar"
+            "returns": "text/calendar",
+            "notes": [
+              "Same-user session or bearer access is accepted.",
+              "Anonymous feed access is accepted with either ?token=... or the userId:token path segment form."
+            ]
           },
           {
             "path": "/api/calendar-subscriptions/current",

--- a/docs/contracts/openapi.json
+++ b/docs/contracts/openapi.json
@@ -11,7 +11,7 @@
     "no-developer-model": "Public documentation helps callers understand the existing product capability boundaries, not to introduce a separate developer-specific business model.",
     "session-and-bearer": "Current user-side business REST endpoints support both in-site session from the request cookie and OAuth bearer tokens; bearer-token access is no longer limited to MCP.",
     "rest-mcp-consistent": "The same abstract endpoint currently maintains the same core fields, state information, and action results in both REST and MCP; differences mainly appear in interaction form and serialization level.",
-    "security-schemes": "Generated OpenAPI marks protected REST operations with bearer/session alternatives and MCP operations with bearer-only auth.",
+    "security-schemes": "Generated OpenAPI marks protected REST operations with bearer/session alternatives, MCP operations with bearer-only auth, and personal calendar feed export with bearer/session/token alternatives.",
     "rest-observability": "REST API handling records production-safe structured request-start/request-finish logs and bounded in-memory metrics with request ID, method, status, auth mode, duration, and normalized route template; it does not log request bodies, credentials, raw query strings, or high-cardinality resource IDs."
   },
   "capabilities": {
@@ -28,7 +28,7 @@
           "Route-scoped tag and operation pages",
           "Endpoint path, method, parameters",
           "Request/response schemas where annotated",
-          "Auth/security schemes for protected operations",
+          "Auth/security schemes for protected operations and token-backed calendar feeds",
           "Try-it-out interface"
         ]
       }
@@ -49,7 +49,7 @@
         "fields": [
           "OpenAPI 3.x JSON",
           "Annotated routes with schemas",
-          "Security schemes and operation security",
+          "Security schemes and operation security, including calendar feed token access",
           "Some protocol routes without detailed schemas"
         ]
       }

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -6366,9 +6366,21 @@
             "name": "userId",
             "schema": {
               "type": "string",
+              "minLength": 1,
+              "description": "User ID. Token-bearing feed URLs may also use the userId:token path segment form."
+            },
+            "required": true,
+            "description": "User ID. Token-bearing feed URLs may also use the userId:token path segment form."
+          },
+          {
+            "in": "query",
+            "name": "token",
+            "schema": {
+              "description": "Calendar feed token for anonymous personal iCal access.",
+              "type": "string",
               "minLength": 1
             },
-            "required": true
+            "description": "Calendar feed token for anonymous personal iCal access."
           }
         ],
         "responses": {
@@ -6420,6 +6432,9 @@
           },
           {
             "sessionCookie": []
+          },
+          {
+            "calendarFeedToken": []
           }
         ]
       }
@@ -27996,6 +28011,12 @@
         "scheme": "bearer",
         "bearerFormat": "JWT",
         "description": "OAuth bearer token for /api/mcp. MCP requires a bearer token with the MCP resource audience and does not accept session cookies."
+      },
+      "calendarFeedToken": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "token",
+        "description": "Calendar feed token accepted by the personal iCal endpoint. Token-bearing feed URLs may also embed the token in the userId:token path segment."
       }
     }
   },

--- a/src/lib/api/schemas/content-query-schemas.ts
+++ b/src/lib/api/schemas/content-query-schemas.ts
@@ -31,3 +31,12 @@ export const homeworksQuerySchema = z.object({
 export const sectionsCalendarQuerySchema = z.object({
   sectionIds: z.string().trim().min(1),
 });
+
+export const userCalendarQuerySchema = z.object({
+  token: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe("Calendar feed token for anonymous personal iCal access."),
+});

--- a/src/lib/api/schemas/request-path-schemas.ts
+++ b/src/lib/api/schemas/request-path-schemas.ts
@@ -10,5 +10,11 @@ export const jwIdPathParamsSchema = z.object({
 });
 
 export const userCalendarPathParamsSchema = z.object({
-  userId: z.string().trim().min(1),
+  userId: z
+    .string()
+    .trim()
+    .min(1)
+    .describe(
+      "User ID. Token-bearing feed URLs may also use the userId:token path segment form.",
+    ),
 });

--- a/src/lib/api/schemas/request-query-schemas.ts
+++ b/src/lib/api/schemas/request-query-schemas.ts
@@ -16,6 +16,7 @@ export {
   descriptionsQuerySchema,
   homeworksQuerySchema,
   sectionsCalendarQuerySchema,
+  userCalendarQuerySchema,
 } from "./content-query-schemas";
 export {
   busNextDeparturesQuerySchema,

--- a/src/routes/api/users/[userId]/calendar.ics/+server.ts
+++ b/src/routes/api/users/[userId]/calendar.ics/+server.ts
@@ -5,6 +5,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
 /**
  * Generate user calendar.
  * @pathParams userCalendarPathParamsSchema
+ * @params userCalendarQuerySchema
  * @response 200:binary
  * @response 401:openApiErrorSchema
  * @response 403:openApiErrorSchema

--- a/tests/e2e/src/app/api/openapi/test.ts
+++ b/tests/e2e/src/app/api/openapi/test.ts
@@ -162,7 +162,7 @@ test.describe("GET /api/openapi", () => {
       paths?: Record<
         string,
         {
-          get?: { security?: unknown[] };
+          get?: { parameters?: unknown[]; security?: unknown[] };
           options?: { security?: unknown[] };
           post?: { security?: unknown[] };
         }
@@ -170,7 +170,12 @@ test.describe("GET /api/openapi", () => {
     };
 
     expect(Object.keys(body.components?.securitySchemes ?? {})).toEqual(
-      expect.arrayContaining(["bearerAuth", "sessionCookie", "mcpBearerAuth"]),
+      expect.arrayContaining([
+        "bearerAuth",
+        "sessionCookie",
+        "mcpBearerAuth",
+        "calendarFeedToken",
+      ]),
     );
     expect(body.paths?.["/api/todos"]?.get?.security).toEqual([
       { bearerAuth: [] },
@@ -179,11 +184,25 @@ test.describe("GET /api/openapi", () => {
     expect(body.paths?.["/api/mcp"]?.get?.security).toEqual([
       { mcpBearerAuth: [] },
     ]);
+    expect(
+      body.paths?.["/api/users/{userId}/calendar.ics"]?.get?.security,
+    ).toEqual([
+      { bearerAuth: [] },
+      { sessionCookie: [] },
+      { calendarFeedToken: [] },
+    ]);
     expect(body.paths?.["/api/mcp"]?.options?.security).toBeUndefined();
     expect(body.paths?.["/api/users/profile"]?.get?.security).toBeUndefined();
     expect(
       body.paths?.["/api/auth/oauth2/token"]?.post?.security,
     ).toBeUndefined();
+    expect(
+      body.paths?.["/api/users/{userId}/calendar.ics"]?.get?.parameters,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ in: "query", name: "token" }),
+      ]),
+    );
   });
 
   test("static openapi.generated.json is accessible", async ({ request }) => {

--- a/tests/unit/openapi-scenario-examples.test.ts
+++ b/tests/unit/openapi-scenario-examples.test.ts
@@ -236,7 +236,12 @@ describe("buildScenarioOpenApiExamples", () => {
     const spec = generatedOpenApiDocument as GeneratedOpenApiDocument;
 
     expect(Object.keys(spec.components?.securitySchemes ?? {})).toEqual(
-      expect.arrayContaining(["bearerAuth", "sessionCookie", "mcpBearerAuth"]),
+      expect.arrayContaining([
+        "bearerAuth",
+        "sessionCookie",
+        "mcpBearerAuth",
+        "calendarFeedToken",
+      ]),
     );
 
     expect(spec.paths["/api/todos"]?.get?.security).toEqual([
@@ -251,6 +256,13 @@ describe("buildScenarioOpenApiExamples", () => {
       { bearerAuth: [] },
       { sessionCookie: [] },
     ]);
+    expect(
+      spec.paths["/api/users/{userId}/calendar.ics"]?.get?.security,
+    ).toEqual([
+      { bearerAuth: [] },
+      { sessionCookie: [] },
+      { calendarFeedToken: [] },
+    ]);
     expect(spec.paths["/api/mcp"]?.get?.security).toEqual([
       { mcpBearerAuth: [] },
     ]);
@@ -259,6 +271,13 @@ describe("buildScenarioOpenApiExamples", () => {
     expect(
       spec.paths["/api/auth/oauth2/token"]?.post?.security,
     ).toBeUndefined();
+    expect(
+      spec.paths["/api/users/{userId}/calendar.ics"]?.get?.parameters,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ in: "query", name: "token" }),
+      ]),
+    );
   });
 
   it("documents OAuth success response bodies", () => {

--- a/tools/build/openapi/generate-spec.ts
+++ b/tools/build/openapi/generate-spec.ts
@@ -492,6 +492,10 @@ type MutableOpenApiMediaType = Record<string, unknown>;
 const SCENARIO_OPENAPI_EXAMPLES = buildScenarioOpenApiExamples();
 const REST_AUTH_SECURITY = [{ bearerAuth: [] }, { sessionCookie: [] }];
 const MCP_AUTH_SECURITY = [{ mcpBearerAuth: [] }];
+const CALENDAR_FEED_AUTH_SECURITY = [
+  ...REST_AUTH_SECURITY,
+  { calendarFeedToken: [] },
+];
 const SECURITY_SCHEMES = {
   bearerAuth: {
     type: "http",
@@ -513,6 +517,13 @@ const SECURITY_SCHEMES = {
     bearerFormat: "JWT",
     description:
       "OAuth bearer token for /api/mcp. MCP requires a bearer token with the MCP resource audience and does not accept session cookies.",
+  },
+  calendarFeedToken: {
+    type: "apiKey",
+    in: "query",
+    name: "token",
+    description:
+      "Calendar feed token accepted by the personal iCal endpoint. Token-bearing feed URLs may also embed the token in the userId:token path segment.",
   },
 };
 
@@ -1145,6 +1156,10 @@ function isProtectedRedirectOperation(path: string, method: string) {
   return path === "/api/dashboard-links/pin" && method === "post";
 }
 
+function isPersonalCalendarFeedOperation(path: string, method: string) {
+  return path === "/api/users/{userId}/calendar.ics" && method === "get";
+}
+
 function applySecurityMetadata(doc: MutableOpenApiDocument) {
   if (!doc.paths) return;
 
@@ -1165,6 +1180,11 @@ function applySecurityMetadata(doc: MutableOpenApiDocument) {
 
       if (path === "/api/mcp" && operationHasResponse(operation, "401")) {
         operation.security = MCP_AUTH_SECURITY;
+        continue;
+      }
+
+      if (isPersonalCalendarFeedOperation(path, method)) {
+        operation.security = CALENDAR_FEED_AUTH_SECURITY;
         continue;
       }
 


### PR DESCRIPTION
## Goal

Document the existing personal iCal feed auth behavior accurately in generated OpenAPI and contracts: same-user bearer/session access plus anonymous token-bearing feed URLs.

## Changed Surfaces

- Added the personal calendar `token` query schema and path-parameter description for the `userId:token` URL form.
- Updated OpenAPI security generation so `GET /api/users/{userId}/calendar.ics` advertises bearer, session, and calendar-feed-token alternatives.
- Regenerated `public/openapi.generated.json`.
- Updated OpenAPI and iCal contract docs.
- Added unit and E2E assertions for the generated and served OpenAPI auth metadata.

## Evidence

- OpenAPI/contracts: `bun run openapi:check`, `bun run check:contracts`.
- OpenAPI unit coverage: `bun run vitest run tests/unit/openapi-scenario-examples.test.ts`.
- Focused browser/API coverage: `PLAYWRIGHT_PORT=3002 bun run e2e:db:prepare`, `PLAYWRIGHT_PORT=3002 bun run e2e:build-artifacts`, `bun run seed`, `PLAYWRIGHT_PORT=3002 bun run e2e:test -- tests/e2e/src/app/api/openapi/test.ts 'tests/e2e/src/app/api/users/\[userId\]/calendar.ics/test.ts'`.
- Full gate: `PLAYWRIGHT_PORT=3002 bun run verify:full`.

## Docs / Contracts

Updated `docs/contracts/openapi.json`, `docs/contracts/ical.json`, and `public/openapi.generated.json`.

## Risk Areas

- Auth documentation only: this does not change runtime calendar access checks.
- OpenAPI cannot model the path-token form as an apiKey security scheme directly, so the path-token form is documented in the security-scheme and path-parameter descriptions while `?token=...` is represented structurally.

## Cleanup

`git diff --check` passed before commit. The branch only contains durable source, contract, generated OpenAPI, and test updates; no scratch artifacts are included.
