### PR TITLE
fix(bus): harden bus imports and preferences

### DIFF
--- a/docs/contracts/bus.json
+++ b/docs/contracts/bus.json
@@ -37,7 +37,10 @@
             "path": "/api/bus/preferences",
             "method": "POST",
             "returns": "{ preference: BusPreferences }",
-            "auth": "user"
+            "auth": "user",
+            "notes": [
+              "Unknown non-null preferred origin or destination campus IDs return 400 with { error } and do not write preferences."
+            ]
           },
           {
             "path": "/api/bus/preferences",

--- a/src/features/bus/server/bus-import-prisma.ts
+++ b/src/features/bus/server/bus-import-prisma.ts
@@ -1,4 +1,4 @@
-export type BusImportPrisma = {
+export type BusImportWritePrisma = {
   busCampus: {
     upsert(args: unknown): Promise<unknown>;
   };
@@ -19,4 +19,10 @@ export type BusImportPrisma = {
     create(args: unknown): Promise<unknown>;
     deleteMany(args: unknown): Promise<unknown>;
   };
+};
+
+export type BusImportPrisma = BusImportWritePrisma & {
+  $transaction<Result>(
+    callback: (tx: BusImportWritePrisma) => Promise<Result>,
+  ): Promise<Result>;
 };

--- a/src/features/bus/server/bus-import-version-upsert.ts
+++ b/src/features/bus/server/bus-import-version-upsert.ts
@@ -1,9 +1,9 @@
 import { buildBusScheduleVersionData } from "../lib/bus-import-version-data";
 import type { BusStaticPayload } from "../lib/bus-types";
-import type { BusImportPrisma } from "./bus-import-prisma";
+import type { BusImportWritePrisma } from "./bus-import-prisma";
 
 export async function findExistingBusScheduleVersion(
-  prisma: BusImportPrisma,
+  prisma: BusImportWritePrisma,
   {
     checksum,
     versionKey,
@@ -21,7 +21,7 @@ export async function findExistingBusScheduleVersion(
 }
 
 export async function refreshExistingBusScheduleVersion(
-  prisma: BusImportPrisma,
+  prisma: BusImportWritePrisma,
   {
     checksum,
     effectiveFrom,
@@ -55,7 +55,7 @@ export async function refreshExistingBusScheduleVersion(
 }
 
 export async function disablePreviousBusScheduleVersions(
-  prisma: BusImportPrisma,
+  prisma: BusImportWritePrisma,
   {
     existingId,
     versionKey,
@@ -73,7 +73,7 @@ export async function disablePreviousBusScheduleVersions(
 }
 
 export function upsertImportedBusScheduleVersion(
-  prisma: BusImportPrisma,
+  prisma: BusImportWritePrisma,
   {
     checksum,
     effectiveFrom,

--- a/src/features/bus/server/bus-import-writes.ts
+++ b/src/features/bus/server/bus-import-writes.ts
@@ -6,7 +6,7 @@ import type {
   BusStaticPayload,
   BusStaticRouteSchedule,
 } from "../lib/bus-types";
-import type { BusImportPrisma } from "./bus-import-prisma";
+import type { BusImportWritePrisma } from "./bus-import-prisma";
 
 export function assertBusRouteConsistency(payload: BusStaticPayload) {
   const routeIds = new Set(payload.routes.map((route) => route.id));
@@ -23,7 +23,7 @@ export function assertBusRouteConsistency(payload: BusStaticPayload) {
 }
 
 export async function upsertBusCampuses(
-  prisma: BusImportPrisma,
+  prisma: BusImportWritePrisma,
   payload: BusStaticPayload,
 ) {
   for (const campus of payload.campuses) {
@@ -45,7 +45,7 @@ export async function upsertBusCampuses(
 }
 
 export async function upsertBusRoutes(
-  prisma: BusImportPrisma,
+  prisma: BusImportWritePrisma,
   payload: BusStaticPayload,
 ) {
   for (const route of payload.routes) {
@@ -74,7 +74,7 @@ export async function upsertBusRoutes(
 }
 
 export async function createBusTripsForDayType(
-  prisma: BusImportPrisma,
+  prisma: BusImportWritePrisma,
   versionId: number,
   dayType: "weekday" | "weekend",
   schedules: BusStaticRouteSchedule[],

--- a/src/features/bus/server/bus-import.ts
+++ b/src/features/bus/server/bus-import.ts
@@ -33,63 +33,63 @@ export async function importBusStaticPayload(
   const effectiveFrom = inferBusEffectiveFrom(payload, options?.effectiveFrom);
   const effectiveUntil = options?.effectiveUntil ?? null;
 
-  const existing = await findExistingBusScheduleVersion(prisma, {
-    checksum,
-    versionKey,
-  });
+  return prisma.$transaction(async (tx) => {
+    const existing = await findExistingBusScheduleVersion(tx, {
+      checksum,
+      versionKey,
+    });
 
-  if (existing) {
-    await refreshExistingBusScheduleVersion(prisma, {
+    if (existing) {
+      await refreshExistingBusScheduleVersion(tx, {
+        checksum,
+        effectiveFrom,
+        effectiveUntil,
+        existingId: existing.id,
+        payload,
+        versionKey,
+        versionTitle,
+      });
+    }
+
+    if (options?.disablePreviousVersions !== false) {
+      await disablePreviousBusScheduleVersions(tx, {
+        existingId: existing?.id,
+        versionKey,
+      });
+    }
+
+    await upsertBusCampuses(tx, payload);
+    await upsertBusRoutes(tx, payload);
+
+    const version = await upsertImportedBusScheduleVersion(tx, {
       checksum,
       effectiveFrom,
       effectiveUntil,
-      existingId: existing.id,
+      existingId: existing?.id,
       payload,
       versionKey,
       versionTitle,
     });
-  }
 
-  if (options?.disablePreviousVersions !== false) {
-    await disablePreviousBusScheduleVersions(prisma, {
-      existingId: existing?.id,
-      versionKey,
-    });
-  }
-
-  await upsertBusCampuses(prisma, payload);
-  await upsertBusRoutes(prisma, payload);
-
-  const version = await upsertImportedBusScheduleVersion(prisma, {
-    checksum,
-    effectiveFrom,
-    effectiveUntil,
-    existingId: existing?.id,
-    payload,
-    versionKey,
-    versionTitle,
-  });
-
-  const [weekdayTrips, weekendTrips] = await Promise.all([
-    createBusTripsForDayType(
-      prisma,
+    const weekdayTrips = await createBusTripsForDayType(
+      tx,
       version.id,
       "weekday",
       payload.weekday_routes,
-    ),
-    createBusTripsForDayType(
-      prisma,
+    );
+    const weekendTrips = await createBusTripsForDayType(
+      tx,
       version.id,
       "weekend",
       payload.weekend_routes,
-    ),
-  ]);
+    );
 
-  return {
-    versionId: version.id,
-    versionKey: version.key,
-    campuses: payload.campuses.length,
-    routes: payload.routes.length,
-    trips: weekdayTrips + weekendTrips,
-  };
+    return {
+      versionId: version.id,
+      versionKey: version.key,
+      campuses: payload.campuses.length,
+      routes: payload.routes.length,
+      trips: weekdayTrips + weekendTrips,
+    };
+  });
 }

--- a/src/features/bus/server/bus-preferences.ts
+++ b/src/features/bus/server/bus-preferences.ts
@@ -4,6 +4,10 @@ import type {
   BusUserPreferenceSummary,
 } from "../lib/bus-types";
 
+type SaveBusPreferenceResult =
+  | { ok: true; preference: BusUserPreferenceSummary }
+  | { ok: false; error: string };
+
 export async function getBusPreference(
   userId: string | null,
 ): Promise<BusUserPreferenceSummary | null> {
@@ -31,7 +35,12 @@ export async function getBusPreference(
 export async function saveBusPreference(
   userId: string,
   payload: BusPreferencePayload,
-) {
+): Promise<SaveBusPreferenceResult> {
+  const validationError = await validatePreferredBusCampuses(payload);
+  if (validationError) {
+    return { ok: false, error: validationError };
+  }
+
   const data = {
     preferredOriginCampusId: payload.preferredOriginCampusId,
     preferredDestinationCampusId: payload.preferredDestinationCampusId,
@@ -46,5 +55,43 @@ export async function saveBusPreference(
     update: data,
   });
 
-  return { ...data } satisfies BusUserPreferenceSummary;
+  return {
+    ok: true,
+    preference: { ...data } satisfies BusUserPreferenceSummary,
+  };
+}
+
+async function validatePreferredBusCampuses(payload: BusPreferencePayload) {
+  const campusIds = Array.from(
+    new Set(
+      [
+        payload.preferredOriginCampusId,
+        payload.preferredDestinationCampusId,
+      ].filter((id): id is number => id !== null),
+    ),
+  );
+
+  if (campusIds.length === 0) return null;
+
+  const campuses = await prisma.busCampus.findMany({
+    where: { id: { in: campusIds } },
+    select: { id: true },
+  });
+  const knownCampusIds = new Set(campuses.map((campus) => campus.id));
+
+  if (
+    payload.preferredOriginCampusId !== null &&
+    !knownCampusIds.has(payload.preferredOriginCampusId)
+  ) {
+    return "Unknown preferred origin campus";
+  }
+
+  if (
+    payload.preferredDestinationCampusId !== null &&
+    !knownCampusIds.has(payload.preferredDestinationCampusId)
+  ) {
+    return "Unknown preferred destination campus";
+  }
+
+  return null;
 }

--- a/src/lib/api/routes/bus.ts
+++ b/src/lib/api/routes/bus.ts
@@ -1,4 +1,5 @@
 import {
+  badRequest,
   handleRouteError,
   jsonResponse,
   notFound,
@@ -199,8 +200,11 @@ export async function postBusPreferencesRoute(request: Request) {
     const { saveBusPreference } = await import(
       "@/features/bus/server/bus-service"
     );
-    const preference = await saveBusPreference(userId, parsedBody);
-    return jsonResponse({ preference });
+    const result = await saveBusPreference(userId, parsedBody);
+    if (!result.ok) {
+      return badRequest(result.error);
+    }
+    return jsonResponse({ preference: result.preference });
   } catch (error) {
     return handleRouteError("Failed to save bus preferences", error);
   }

--- a/tests/unit/bus-import.test.ts
+++ b/tests/unit/bus-import.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import type { BusStaticPayload } from "@/features/bus/lib/bus-types";
+import { importBusStaticPayload } from "@/features/bus/server/bus-import";
+import type {
+  BusImportPrisma,
+  BusImportWritePrisma,
+} from "@/features/bus/server/bus-import-prisma";
+
+type VersionRow = {
+  id: number;
+  key: string;
+  title: string;
+  checksum: string;
+  rawJson: unknown;
+  isEnabled: boolean;
+};
+
+type TripRow = {
+  versionId: number;
+  routeId: number;
+  dayType: "weekday" | "weekend";
+  position: number;
+  stopTimes: Array<string | null>;
+};
+
+type ImportState = {
+  nextVersionId: number;
+  versions: VersionRow[];
+  trips: TripRow[];
+};
+
+type ImportPrismaMock = BusImportPrisma & {
+  getState(): ImportState;
+};
+
+function cloneState(state: ImportState): ImportState {
+  return structuredClone(state);
+}
+
+function createImportPrismaMock(
+  initialState: ImportState,
+  options: { failTripCreate?: boolean } = {},
+): ImportPrismaMock {
+  let state = cloneState(initialState);
+
+  const createDelegates = (target: ImportState): BusImportWritePrisma => ({
+    busCampus: {
+      async upsert() {
+        return {};
+      },
+    },
+    busRoute: {
+      async upsert() {
+        return {};
+      },
+    },
+    busRouteStop: {
+      async createMany() {
+        return {};
+      },
+      async deleteMany() {
+        return {};
+      },
+    },
+    busScheduleVersion: {
+      async create(args) {
+        const data = (args as { data: Omit<VersionRow, "id"> }).data;
+        const version = { id: target.nextVersionId, ...data };
+        target.nextVersionId += 1;
+        target.versions.push(version);
+        return { id: version.id, key: version.key };
+      },
+      async findFirst(args) {
+        const filters = (
+          args as { where: { OR: Array<{ checksum?: string; key?: string }> } }
+        ).where.OR;
+        const version =
+          target.versions.find((candidate) =>
+            filters.some(
+              (filter) =>
+                filter.key === candidate.key ||
+                filter.checksum === candidate.checksum,
+            ),
+          ) ?? null;
+        return version ? { id: version.id } : null;
+      },
+      async update(args) {
+        const input = args as {
+          where: { id: number };
+          data: Partial<VersionRow>;
+        };
+        const version = target.versions.find(
+          (candidate) => candidate.id === input.where.id,
+        );
+        if (!version) throw new Error("version not found");
+        Object.assign(version, input.data);
+        return { id: version.id, key: version.key };
+      },
+      async updateMany(args) {
+        const input = args as {
+          where: { id: { not: number } } | { key: { not: string } };
+          data: Partial<VersionRow>;
+        };
+        for (const version of target.versions) {
+          if ("id" in input.where && version.id === input.where.id.not) {
+            continue;
+          }
+          if ("key" in input.where && version.key === input.where.key.not) {
+            continue;
+          }
+          Object.assign(version, input.data);
+        }
+        return {};
+      },
+    },
+    busTrip: {
+      async create(args) {
+        if (options.failTripCreate) {
+          throw new Error("injected trip write failure");
+        }
+        const data = (args as { data: TripRow }).data;
+        target.trips.push(data);
+        return {};
+      },
+      async deleteMany(args) {
+        const versionId = (args as { where: { versionId: number } }).where
+          .versionId;
+        target.trips = target.trips.filter(
+          (trip) => trip.versionId !== versionId,
+        );
+        return {};
+      },
+    },
+  });
+
+  const root = {
+    ...createDelegates(state),
+    async $transaction<Result>(
+      callback: (tx: BusImportWritePrisma) => Promise<Result>,
+    ) {
+      const transactionState = cloneState(state);
+      const result = await callback(createDelegates(transactionState));
+      state = transactionState;
+      return result;
+    },
+    getState() {
+      return state;
+    },
+  };
+
+  return root;
+}
+
+function createPayload(): BusStaticPayload {
+  const east = { id: 1, name: "东区", latitude: 31.1, longitude: 117.1 };
+  const west = { id: 2, name: "西区", latitude: 31.2, longitude: 117.2 };
+  const route = { id: 8, campuses: [east, west] };
+
+  return {
+    campuses: [east, west],
+    routes: [route],
+    weekday_routes: [{ id: 1, route, time: [["08:00", "08:20"]] }],
+    weekend_routes: [],
+    message: { message: "2026 春校车时刻表", url: "https://example.test" },
+  };
+}
+
+describe("bus schedule imports", () => {
+  it("keeps the active timetable intact when replacement trip writes fail", async () => {
+    const initialState: ImportState = {
+      nextVersionId: 2,
+      versions: [
+        {
+          id: 1,
+          key: "current-bus",
+          title: "Current bus schedule",
+          checksum: "old-checksum",
+          rawJson: { old: true },
+          isEnabled: true,
+        },
+      ],
+      trips: [
+        {
+          versionId: 1,
+          routeId: 8,
+          dayType: "weekday",
+          position: 0,
+          stopTimes: ["07:30", "07:50"],
+        },
+      ],
+    };
+    const prisma = createImportPrismaMock(initialState, {
+      failTripCreate: true,
+    });
+
+    await expect(
+      importBusStaticPayload(prisma, createPayload(), {
+        versionKey: "current-bus",
+      }),
+    ).rejects.toThrow("injected trip write failure");
+
+    expect(prisma.getState()).toEqual(initialState);
+  });
+});

--- a/tests/unit/bus-preferences-route.test.ts
+++ b/tests/unit/bus-preferences-route.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { prismaMock, requireAuthMock, resolveApiUserIdMock } = vi.hoisted(
+  () => ({
+    prismaMock: {
+      busCampus: {
+        findMany: vi.fn(),
+      },
+      busUserPreference: {
+        findUnique: vi.fn(),
+        upsert: vi.fn(),
+      },
+    },
+    requireAuthMock: vi.fn(),
+    resolveApiUserIdMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/auth/api-auth", () => ({
+  requireAuth: requireAuthMock,
+  resolveApiUserId: resolveApiUserIdMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+function preferenceRequest(body: unknown) {
+  return new Request("https://example.test/api/bus/preferences", {
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+  });
+}
+
+describe("POST /api/bus/preferences", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    requireAuthMock.mockReset();
+    resolveApiUserIdMock.mockReset();
+    prismaMock.busCampus.findMany.mockReset();
+    prismaMock.busUserPreference.findUnique.mockReset();
+    prismaMock.busUserPreference.upsert.mockReset();
+    requireAuthMock.mockResolvedValue({ userId: "user-1" });
+  });
+
+  it("returns 400 for an unknown preferred origin campus", async () => {
+    prismaMock.busCampus.findMany.mockResolvedValue([]);
+    const { postBusPreferencesRoute } = await import("@/lib/api/routes/bus");
+
+    const response = await postBusPreferencesRoute(
+      preferenceRequest({
+        preferredOriginCampusId: 999,
+        preferredDestinationCampusId: null,
+        showDepartedTrips: false,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Unknown preferred origin campus",
+    });
+    expect(prismaMock.busUserPreference.upsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an unknown preferred destination campus", async () => {
+    prismaMock.busCampus.findMany.mockResolvedValue([{ id: 1 }]);
+    const { postBusPreferencesRoute } = await import("@/lib/api/routes/bus");
+
+    const response = await postBusPreferencesRoute(
+      preferenceRequest({
+        preferredOriginCampusId: 1,
+        preferredDestinationCampusId: 999,
+        showDepartedTrips: true,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Unknown preferred destination campus",
+    });
+    expect(prismaMock.busUserPreference.upsert).not.toHaveBeenCalled();
+  });
+
+  it("keeps null campus reset behavior", async () => {
+    prismaMock.busUserPreference.upsert.mockResolvedValue({});
+    const { postBusPreferencesRoute } = await import("@/lib/api/routes/bus");
+
+    const response = await postBusPreferencesRoute(
+      preferenceRequest({
+        preferredOriginCampusId: null,
+        preferredDestinationCampusId: null,
+        showDepartedTrips: false,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      preference: {
+        preferredOriginCampusId: null,
+        preferredDestinationCampusId: null,
+        showDepartedTrips: false,
+      },
+    });
+    expect(prismaMock.busCampus.findMany).not.toHaveBeenCalled();
+    expect(prismaMock.busUserPreference.upsert).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Goal

Fixes #98.
Fixes #103.

Make bus timetable import publication atomic and return controlled client errors for unknown bus preference campus IDs.

## Changed Surfaces

- Bus static imports now run version refresh, previous-version disable, campus/route/stop writes, and trip creation inside one Prisma transaction.
- Bus preference saves validate non-null preferred origin/destination campus IDs against `BusCampus` before upsert.
- `POST /api/bus/preferences` returns the existing `{ error }` client-error shape with status 400 for unknown preference campus IDs.
- Added focused unit coverage for import failure rollback and bus preference route validation.

## Evidence

- `bun run test -- tests/unit/bus-import.test.ts tests/unit/bus-preferences-route.test.ts tests/unit/bus-service.test.ts tests/unit/bus-client.test.ts tests/unit/bus-static-source.test.ts` passed: 5 files, 13 tests.
- `bun run check:contracts` passed.
- `DATABASE_URL=postgresql://life_ustc:life_ustc@127.0.0.1:5432/life_ustc bun run verify` passed on the clean PR worktree: 99 files, 470 tests.
- REST evidence from `tests/unit/bus-preferences-route.test.ts`: unknown origin campus `999` returns `400` with `{ "error": "Unknown preferred origin campus" }`; unknown destination campus `999` returns `400` with `{ "error": "Unknown preferred destination campus" }`; null campus reset returns `200` with null origin/destination IDs.

## Docs / Contracts

- Updated `docs/contracts/bus.json` to document the unknown preferred-campus 400 behavior.
- OpenAPI route annotation already documented `400:openApiErrorSchema` for `POST /api/bus/preferences`, so no annotation/generated OpenAPI change was needed.

## Risk Areas

- Prisma transaction behavior for the bus import path.
- Preference validation is REST-only; there is no MCP preference-write surface to update.
- Bus preference success response shape is preserved, including existing extra favorite arrays.

## Cleanup

- PR branch diff is limited to bus server code, one bus contract note, the bus REST route adapter, and focused unit tests.
- No scratch artifacts or generated files are included.
