### PR TITLE
fix: comment upload and dashboard pin state races

### DIFF
--- a/src/features/comments/components/CommentComposerActions.svelte
+++ b/src/features/comments/components/CommentComposerActions.svelte
@@ -32,7 +32,7 @@ export let viewer: ViewerContext;
   />
   <Button
     class="ml-auto"
-    disabled={!body.trim() || !viewer.isAuthenticated || viewer.isSuspended || submitting}
+    disabled={!body.trim() || !viewer.isAuthenticated || viewer.isSuspended || submitting || uploading}
     size="sm"
     type="button"
     onclick={submitComment}

--- a/src/features/comments/components/CommentReplyEditor.svelte
+++ b/src/features/comments/components/CommentReplyEditor.svelte
@@ -86,7 +86,7 @@ $: replyDisabled = !viewer.isAuthenticated || viewer.isSuspended;
     />
     <Button size="sm" type="button" variant="ghost" onclick={cancelReply}>{commentCopy.cancelAction}</Button>
     <Button
-      disabled={!replyDraft.trim() || replyDisabled || submitting}
+      disabled={!replyDraft.trim() || replyDisabled || submitting || uploading}
       size="sm"
       type="button"
       onclick={() => {

--- a/src/features/comments/components/CommentThreadEditForm.svelte
+++ b/src/features/comments/components/CommentThreadEditForm.svelte
@@ -73,7 +73,12 @@ export let visibilityOptions: CommentSelectOption[];
     <Button size="sm" type="button" variant="ghost" onclick={cancelEdit}>
       {commentCopy.cancelAction}
     </Button>
-    <Button size="sm" type="button" onclick={() => saveEdit(comment)}>
+    <Button
+      disabled={!editDraft.trim() || uploading}
+      size="sm"
+      type="button"
+      onclick={() => saveEdit(comment)}
+    >
       {commentCopy.saveAction}
     </Button>
   </div>

--- a/src/features/comments/components/CommentThreadItem.svelte
+++ b/src/features/comments/components/CommentThreadItem.svelte
@@ -33,6 +33,7 @@ export let editAttachmentOptions: (
   comment: CommentNode,
 ) => CommentUploadOption[];
 export let editDraft: string;
+export let editUploading: boolean;
 export let editingId: string | null;
 export let editIsAnonymous: boolean;
 export let editVisibility: string;
@@ -58,6 +59,7 @@ export let reactionName: (type: string) => string;
 export let reactionOptions: ReactionOption[];
 export let removeReplyAttachment: (uploadId: string) => void;
 export let replyDraft: string;
+export let replyUploading: boolean;
 export let replyingId: string | null;
 export let replyIsAnonymous: boolean;
 export let replyUploadedFiles: CommentUploadOption[];
@@ -69,7 +71,6 @@ export let submitting: boolean;
 export let submitComment: CommentThreadProps["submitComment"];
 export let toggleReply: (comment: CommentNode) => void;
 export let uploadCopy: UploadsCopy;
-export let uploading: boolean;
 export let uploadFile: (file: File, mode?: "edit" | "new" | "reply") => void;
 export let visibilityOptions: CommentSelectOption[];
 export let viewer: ViewerContext;
@@ -111,7 +112,7 @@ export let viewer: ViewerContext;
         {formatSize}
         {saveEdit}
         {uploadCopy}
-        {uploading}
+        uploading={editUploading}
         {uploadFile}
         {visibilityOptions}
       />
@@ -144,7 +145,7 @@ export let viewer: ViewerContext;
           {submitting}
           {submitComment}
           {uploadCopy}
-          {uploading}
+          uploading={replyUploading}
           {uploadFile}
           {visibilityOptions}
           {viewer}

--- a/src/features/comments/components/CommentsPanel.svelte
+++ b/src/features/comments/components/CommentsPanel.svelte
@@ -27,6 +27,10 @@ import {
 import { createCommentPanelTargetActions } from "@/features/comments/lib/comment-panel-target-actions";
 import { createCommentPanelUploadActions } from "@/features/comments/lib/comment-panel-upload-actions";
 import {
+  commentUploadPendingForMode,
+  commentUploadPendingStateWithDelta,
+} from "@/features/comments/lib/comment-panel-upload-state";
+import {
   COMMENT_REACTION_OPTIONS,
   type CommentTargetOption,
   type CommentTargetType as TargetType,
@@ -82,7 +86,7 @@ let {
   _selectedAttachments,
   _submitting,
   _uploadedFiles,
-  _uploading,
+  _uploadPending,
   _viewer,
   _visibility,
 } = createCommentPanelDefaultState();
@@ -248,6 +252,8 @@ const { loadComments: _loadComments, submitComment: _submitComment } =
     getTargetType: () => targetType,
     getTargets: () => _resolvedTargets,
     getVisibility: () => _visibility,
+    hasPendingUploads: (mode) =>
+      commentUploadPendingForMode(_uploadPending, mode),
     scrollToHashComment: _scrollToHashComment,
     selectedPostTarget: _selectedPostTarget,
     setBody: (value) => {
@@ -310,8 +316,12 @@ const { uploadFile: _uploadFile } = createCommentPanelUploadActions({
   setUploadedFiles: (value) => {
     _uploadedFiles = value;
   },
-  setUploading: (value) => {
-    _uploading = value;
+  updatePendingUploads: (mode, delta) => {
+    _uploadPending = commentUploadPendingStateWithDelta({
+      delta,
+      mode,
+      state: _uploadPending,
+    });
   },
 });
 
@@ -355,6 +365,8 @@ const {
   getEditDraft: () => _editDraft,
   getEditIsAnonymous: () => _editIsAnonymous,
   getEditVisibility: () => _editVisibility,
+  hasPendingUploads: (mode) =>
+    commentUploadPendingForMode(_uploadPending, mode),
   loadComments: _loadComments,
   setActionMenuId: (value) => {
     _actionMenuId = value;
@@ -394,6 +406,10 @@ const {
     _reactionMenuId = value;
   },
 });
+
+$: _newUploading = commentUploadPendingForMode(_uploadPending, "new");
+$: _replyUploading = commentUploadPendingForMode(_uploadPending, "reply");
+$: _editUploading = commentUploadPendingForMode(_uploadPending, "edit");
 </script>
 
 <section class="grid gap-4">
@@ -424,7 +440,7 @@ const {
     uploadCopy={_uploadCopy}
     uploadedFiles={_uploadedFiles}
     uploadFile={_uploadFile}
-    uploading={_uploading}
+    uploading={_newUploading}
     viewer={_viewer}
     bind:visibility={_visibility}
     visibilityOptions={_visibilityOptions}
@@ -473,7 +489,8 @@ const {
     toggleReply={_toggleReply}
     uploadCopy={_uploadCopy}
     uploadFile={_uploadFile}
-    uploading={_uploading}
+    editUploading={_editUploading}
+    replyUploading={_replyUploading}
     viewer={_viewer}
     visibilityOptions={_visibilityOptions}
   />

--- a/src/features/comments/components/CommentsThreadList.svelte
+++ b/src/features/comments/components/CommentsThreadList.svelte
@@ -19,6 +19,7 @@ export let copyCommentLink: CommentThreadProps["copyCommentLink"];
 export let editAttachmentIds: string[];
 export let editAttachmentOptions: CommentThreadProps["editAttachmentOptions"];
 export let editDraft: string;
+export let editUploading: boolean;
 export let editingId: string | null;
 export let editIsAnonymous: boolean;
 export let editVisibility: string;
@@ -36,6 +37,7 @@ export let reactionName: CommentThreadProps["reactionName"];
 export let reactionOptions: CommentThreadProps["reactionOptions"];
 export let removeReplyAttachment: CommentThreadProps["removeReplyAttachment"];
 export let replyDraft: string;
+export let replyUploading: boolean;
 export let replyingId: string | null;
 export let replyIsAnonymous: boolean;
 export let replyUploadedFiles: CommentUploadOption[];
@@ -47,7 +49,6 @@ export let submitting: boolean;
 export let submitComment: CommentThreadProps["submitComment"];
 export let toggleReply: CommentThreadProps["toggleReply"];
 export let uploadCopy: CommentThreadProps["uploadCopy"];
-export let uploading: boolean;
 export let uploadFile: CommentThreadProps["uploadFile"];
 export let viewer: ViewerContext;
 export let visibilityOptions: CommentThreadProps["visibilityOptions"];
@@ -67,6 +68,7 @@ export let visibilityOptions: CommentThreadProps["visibilityOptions"];
     bind:editAttachmentIds
     {editAttachmentOptions}
     bind:editDraft
+    {editUploading}
     bind:editingId
     bind:editIsAnonymous
     bind:editVisibility
@@ -84,6 +86,7 @@ export let visibilityOptions: CommentThreadProps["visibilityOptions"];
     {reactionOptions}
     {removeReplyAttachment}
     bind:replyDraft
+    {replyUploading}
     {replyingId}
     bind:replyIsAnonymous
     {replyUploadedFiles}
@@ -95,7 +98,6 @@ export let visibilityOptions: CommentThreadProps["visibilityOptions"];
     {submitComment}
     {toggleReply}
     {uploadCopy}
-    {uploading}
     {uploadFile}
     {visibilityOptions}
     {viewer}

--- a/src/features/comments/components/CommentsThreadSection.svelte
+++ b/src/features/comments/components/CommentsThreadSection.svelte
@@ -21,6 +21,7 @@ export let copyCommentLink: CommentThreadProps["copyCommentLink"];
 export let editAttachmentIds: string[];
 export let editAttachmentOptions: CommentThreadProps["editAttachmentOptions"];
 export let editDraft: string;
+export let editUploading: boolean;
 export let editingId: string | null;
 export let editIsAnonymous: boolean;
 export let editVisibility: string;
@@ -39,6 +40,7 @@ export let reactionName: CommentThreadProps["reactionName"];
 export let reactionOptions: CommentThreadProps["reactionOptions"];
 export let removeReplyAttachment: CommentThreadProps["removeReplyAttachment"];
 export let replyDraft: string;
+export let replyUploading: boolean;
 export let replyingId: string | null;
 export let replyIsAnonymous: boolean;
 export let replyUploadedFiles: CommentUploadOption[];
@@ -51,7 +53,6 @@ export let submitComment: CommentThreadProps["submitComment"];
 export let toggleReply: CommentThreadProps["toggleReply"];
 export let uploadCopy: CommentThreadProps["uploadCopy"];
 export let uploadFile: CommentThreadProps["uploadFile"];
-export let uploading: boolean;
 export let viewer: ViewerContext;
 export let visibilityOptions: CommentThreadProps["visibilityOptions"];
 </script>
@@ -77,6 +78,7 @@ export let visibilityOptions: CommentThreadProps["visibilityOptions"];
     bind:editAttachmentIds
     {editAttachmentOptions}
     bind:editDraft
+    {editUploading}
     bind:editingId
     bind:editIsAnonymous
     bind:editVisibility
@@ -94,6 +96,7 @@ export let visibilityOptions: CommentThreadProps["visibilityOptions"];
     {reactionOptions}
     {removeReplyAttachment}
     bind:replyDraft
+    {replyUploading}
     {replyingId}
     bind:replyIsAnonymous
     {replyUploadedFiles}
@@ -105,7 +108,6 @@ export let visibilityOptions: CommentThreadProps["visibilityOptions"];
     {submitComment}
     {toggleReply}
     {uploadCopy}
-    {uploading}
     {uploadFile}
     {viewer}
     {visibilityOptions}

--- a/src/features/comments/lib/comment-panel-default-state.ts
+++ b/src/features/comments/lib/comment-panel-default-state.ts
@@ -3,6 +3,7 @@ import type { CommentNodeWithContext } from "@/features/comments/lib/comment-ui"
 import type { CommentUploadOption as UploadOption } from "@/features/comments/lib/comment-upload-client";
 import type { CommentNode } from "@/features/comments/server/comment-types";
 import type { ViewerContext } from "@/lib/auth/viewer-context";
+import { createCommentUploadPendingState } from "./comment-panel-upload-state";
 
 export function createCommentPanelDefaultState() {
   return {
@@ -35,7 +36,7 @@ export function createCommentPanelDefaultState() {
     _selectedAttachments: [] as string[],
     _submitting: false,
     _uploadedFiles: [] as UploadOption[],
-    _uploading: false,
+    _uploadPending: createCommentUploadPendingState(),
     _viewer: createDefaultCommentViewer() as ViewerContext,
     _visibility: "public",
   };

--- a/src/features/comments/lib/comment-panel-edit-actions.ts
+++ b/src/features/comments/lib/comment-panel-edit-actions.ts
@@ -1,5 +1,6 @@
 import type { CommentNode } from "@/features/comments/server/comment-types";
 import { saveCommentEditRequest } from "./comment-panel-actions";
+import type { CommentEditorMode } from "./comment-panel-draft-state";
 import {
   type CommentEditDraftState,
   commentEditDraftFromComment,
@@ -17,6 +18,7 @@ export function createCommentPanelEditActions(input: {
   getEditDraft: () => string;
   getEditIsAnonymous: () => boolean;
   getEditVisibility: () => string;
+  hasPendingUploads: (mode: CommentEditorMode) => boolean;
   loadComments: () => Promise<void>;
   setActionMenuId: (value: string | null) => void;
   setMessage: (value: string) => void;
@@ -32,7 +34,7 @@ export function createCommentPanelEditActions(input: {
 
   async function saveEdit(comment: CommentNode) {
     const body = input.getEditDraft().trim();
-    if (!body) return;
+    if (!body || input.hasPendingUploads("edit")) return;
     const copy = input.getCommentCopy();
     try {
       await saveCommentEditRequest({

--- a/src/features/comments/lib/comment-panel-load-submit-actions.ts
+++ b/src/features/comments/lib/comment-panel-load-submit-actions.ts
@@ -1,6 +1,7 @@
 import type { ViewerContext } from "@/lib/auth/viewer-context";
 import { submitCommentRequest } from "./comment-panel-actions";
 import { loadCommentsForTargets } from "./comment-panel-data";
+import type { CommentEditorMode } from "./comment-panel-draft-state";
 import { buildCommentSubmitPayload } from "./comment-panel-submit-payload";
 import type {
   CommentNodeWithContext,
@@ -28,6 +29,7 @@ export function createCommentPanelLoadSubmitActions(input: {
   getTargetType: () => CommentTargetType;
   getTargets: () => CommentTargetOption[];
   getVisibility: () => string;
+  hasPendingUploads: (mode: CommentEditorMode) => boolean;
   scrollToHashComment: () => Promise<void>;
   selectedPostTarget: () => CommentTargetOption | null;
   setBody: (value: string) => void;
@@ -69,7 +71,8 @@ export function createCommentPanelLoadSubmitActions(input: {
     target: CommentTargetOption | null = input.selectedPostTarget(),
   ) {
     const body = (replyBody ?? input.getBody()).trim();
-    if (!body || input.getSubmitting()) return;
+    const mode = parentId ? "reply" : "new";
+    if (!body || input.getSubmitting() || input.hasPendingUploads(mode)) return;
     input.setSubmitting(true);
     input.setMessage("");
     const copy = input.getCommentCopy();

--- a/src/features/comments/lib/comment-panel-upload-actions.ts
+++ b/src/features/comments/lib/comment-panel-upload-actions.ts
@@ -39,7 +39,7 @@ export function createCommentPanelUploadActions(input: {
   setReplyAttachmentIds: (value: string[]) => void;
   setReplyUploadedFiles: (value: CommentUploadOption[]) => void;
   setSelectedAttachments: (value: string[]) => void;
-  setUploading: (value: boolean) => void;
+  updatePendingUploads: (mode: CommentEditorMode, delta: number) => void;
   setUploadedFiles: (value: CommentUploadOption[]) => void;
 }) {
   let uploadSummary: CommentUploadSummary | null = null;
@@ -53,7 +53,7 @@ export function createCommentPanelUploadActions(input: {
   }
 
   async function uploadFile(file: File, mode: CommentEditorMode = "new") {
-    input.setUploading(true);
+    input.updatePendingUploads(mode, 1);
     input.setMessage("");
     const uploadCopy = input.getUploadCopy();
     const token = `![${uploadCopy.uploading} ${file.name}](upload-${Date.now()}-${Math.random().toString(36).slice(2, 8)})`;
@@ -94,7 +94,7 @@ export function createCommentPanelUploadActions(input: {
           : uploadCopy.toastUploadErrorDescription,
       );
     } finally {
-      input.setUploading(false);
+      input.updatePendingUploads(mode, -1);
     }
   }
 

--- a/src/features/comments/lib/comment-panel-upload-state.ts
+++ b/src/features/comments/lib/comment-panel-upload-state.ts
@@ -1,3 +1,4 @@
+import type { CommentEditorMode } from "./comment-panel-draft-state";
 import type { CommentUploadOption } from "./comment-upload-client";
 
 export type CommentUploadState = {
@@ -8,6 +9,38 @@ export type CommentUploadState = {
   selectedAttachments: string[];
   uploadedFiles: CommentUploadOption[];
 };
+
+export type CommentUploadPendingState = Record<CommentEditorMode, number>;
+
+export function createCommentUploadPendingState(): CommentUploadPendingState {
+  return {
+    edit: 0,
+    new: 0,
+    reply: 0,
+  };
+}
+
+export function commentUploadPendingForMode(
+  state: CommentUploadPendingState,
+  mode: CommentEditorMode,
+) {
+  return state[mode] > 0;
+}
+
+export function commentUploadPendingStateWithDelta({
+  delta,
+  mode,
+  state,
+}: {
+  delta: number;
+  mode: CommentEditorMode;
+  state: CommentUploadPendingState;
+}): CommentUploadPendingState {
+  return {
+    ...state,
+    [mode]: Math.max(0, state[mode] + delta),
+  };
+}
 
 export function applyCommentUploadState(
   state: CommentUploadState,

--- a/src/features/dashboard/components/DashboardPageController.svelte
+++ b/src/features/dashboard/components/DashboardPageController.svelte
@@ -29,8 +29,10 @@ import {
   buildCalendarWeekdayLabels,
   buildSignedTabs,
   type DashboardActionData,
+  type DashboardLinkItem,
   type DashboardPageData,
   type DashboardViewState,
+  isSignedDashboardData,
   type TodoItem,
   todoPriorityOrder,
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
@@ -146,8 +148,9 @@ let {
   unmatchedSectionCodes,
   updatingDashboardLinkSlug,
 } = createDashboardControllerDefaultState();
-const fallbackDashboardLinkItems = dashboardLinkItems;
-const fallbackOverviewLinkItems = overviewLinkItems;
+let dashboardLinkSourceItems: DashboardLinkItem[] = [];
+let overviewLinkSourceItems: DashboardLinkItem[] = [];
+let linkSourceData: PageData | null = null;
 $: copy = data.copy;
 $: actionError = form?.error ?? "";
 $: commonCopy = copy.common;
@@ -164,6 +167,13 @@ $: todoPriorityOptions = buildTodoPriorityOptions(todoPriorityOrder, todosCopy);
 $: calendarWeekdayLabels = buildCalendarWeekdayLabels(sectionCopy);
 $: signedTabs = buildSignedTabs(signedTabIds, dashboardCopy);
 $: dashboardLinkGroupLabels = dashboardCopy.linkHub.groups;
+$: if (data !== linkSourceData) {
+  const signedPageData = isSignedDashboardData(data) ? data : null;
+  dashboardLinkSourceItems = signedPageData?.links?.dashboardLinks ?? [];
+  overviewLinkSourceItems =
+    signedPageData?.overview?.overviewLinks.slice(0, 4) ?? [];
+  linkSourceData = data;
+}
 
 function openTodoEditor(todo: TodoItem) {
   selectedTodo = null;
@@ -371,15 +381,15 @@ const { setLinkView, submitDashboardLinkPin } = createDashboardLinkStateActions(
   {
     applyDashboardViewState,
     getDashboardCopy: () => dashboardCopy,
-    getDashboardLinkItems: () => dashboardLinkItems,
+    getDashboardLinkItems: () => dashboardLinkSourceItems,
     getLinkReturnTo: () => linkReturnTo,
-    getOverviewLinkItems: () => overviewLinkItems,
+    getOverviewLinkItems: () => overviewLinkSourceItems,
     getUpdatingDashboardLinkSlug: () => updatingDashboardLinkSlug,
     replaceState: (href) => {
       replaceState(href, {});
     },
     setDashboardLinkItems: (value) => {
-      dashboardLinkItems = value;
+      dashboardLinkSourceItems = value;
     },
     setLinkActionError: (value) => {
       linkActionError = value;
@@ -388,7 +398,7 @@ const { setLinkView, submitDashboardLinkPin } = createDashboardLinkStateActions(
       linkReturnTo = value;
     },
     setOverviewLinkItems: (value) => {
-      overviewLinkItems = value;
+      overviewLinkSourceItems = value;
     },
     setUpdatingDashboardLinkSlug: (value) => {
       updatingDashboardLinkSlug = value;
@@ -452,8 +462,8 @@ $: derivedState = buildDashboardControllerDerivedState({
   examFilter,
   linkSearchQuery,
   notAvailable: dashboardCopy.notAvailable,
-  previousDashboardLinkItems: fallbackDashboardLinkItems,
-  previousOverviewLinkItems: fallbackOverviewLinkItems,
+  currentDashboardLinkItems: dashboardLinkSourceItems,
+  currentOverviewLinkItems: overviewLinkSourceItems,
   todoFilter,
 });
 $: signedData = derivedState.signedData;

--- a/src/features/dashboard/lib/dashboard-controller-derived-state.ts
+++ b/src/features/dashboard/lib/dashboard-controller-derived-state.ts
@@ -22,8 +22,8 @@ export function buildDashboardControllerDerivedState(input: {
   examFilter: ExamFilter;
   linkSearchQuery: string;
   notAvailable: string;
-  previousDashboardLinkItems: DashboardLinkItem[];
-  previousOverviewLinkItems: DashboardLinkItem[];
+  currentDashboardLinkItems: DashboardLinkItem[];
+  currentOverviewLinkItems: DashboardLinkItem[];
   todoFilter: TodoFilter;
 }) {
   const signedData = isSignedDashboardData(input.data) ? input.data : null;
@@ -41,11 +41,11 @@ export function buildDashboardControllerDerivedState(input: {
       })
     : [];
   const dashboardLinkItems = signedData?.links
-    ? signedData.links.dashboardLinks
-    : input.previousDashboardLinkItems;
-  const overviewLinkItems = signedData?.overview?.overviewLinks
-    ? signedData.overview.overviewLinks.slice(0, 4)
-    : input.previousOverviewLinkItems;
+    ? input.currentDashboardLinkItems
+    : [];
+  const overviewLinkItems = signedData?.overview
+    ? input.currentOverviewLinkItems
+    : [];
 
   return {
     anonymousData,

--- a/tests/e2e/src/app/dashboard/links/test.ts
+++ b/tests/e2e/src/app/dashboard/links/test.ts
@@ -204,4 +204,81 @@ test.describe("dashboard links", () => {
       });
     }
   });
+
+  test("keeps pin state when search recomputes links", async ({
+    page,
+  }, testInfo) => {
+    await signInAsDebugUser(page, "/dashboard/links");
+    await page.request.post("/api/dashboard-links/pin", {
+      form: { slug: "jw", action: "unpin", returnTo: "/dashboard/links" },
+      headers: JSON_HEADERS,
+    });
+    await gotoAndWaitForReady(page, "/dashboard/links");
+
+    const searchInput = page.getByRole("searchbox", {
+      name: /搜索网站名称或描述|Search by name or description/i,
+    });
+
+    const locateJwPinButton = async () => {
+      const linkButton = page
+        .getByRole("button", { name: /教务系统/i })
+        .first();
+      await expect(linkButton).toBeVisible();
+
+      const card = linkButton.locator(
+        "xpath=ancestor::div[contains(@class, 'group')][1]",
+      );
+      await card.hover();
+
+      return page
+        .locator('form[action="/api/dashboard-links/pin"]')
+        .filter({
+          has: page.locator('input[name="slug"][value="jw"]'),
+        })
+        .first()
+        .getByRole("button", { name: /置顶|Pin|取消置顶|Unpin/i })
+        .first();
+    };
+
+    async function submitPinChange(actionLabel: RegExp) {
+      const button = await locateJwPinButton();
+      await expect(button).toHaveAttribute("aria-label", actionLabel);
+      const [response] = await Promise.all([
+        page.waitForResponse(
+          (res) =>
+            res.url().includes("/api/dashboard-links/pin") &&
+            res.request().method() === "POST",
+        ),
+        button.click({ force: true }),
+      ]);
+      expect(response.ok()).toBe(true);
+    }
+
+    try {
+      await submitPinChange(PIN_LABEL);
+      await searchInput.fill("教务");
+      await expect(await locateJwPinButton()).toHaveAttribute(
+        "aria-label",
+        UNPIN_LABEL,
+      );
+
+      await submitPinChange(UNPIN_LABEL);
+      await searchInput.fill("教务系统");
+      await expect(await locateJwPinButton()).toHaveAttribute(
+        "aria-label",
+        PIN_LABEL,
+      );
+
+      await captureStepScreenshot(
+        page,
+        testInfo,
+        "dashboard-links-pin-search-stable",
+      );
+    } finally {
+      await page.request.post("/api/dashboard-links/pin", {
+        form: { slug: "jw", action: "pin", returnTo: "/dashboard/links" },
+        headers: JSON_HEADERS,
+      });
+    }
+  });
 });

--- a/tests/unit/comment-panel-upload-pending.test.ts
+++ b/tests/unit/comment-panel-upload-pending.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommentEditorMode } from "@/features/comments/lib/comment-panel-draft-state";
+import { createCommentPanelEditActions } from "@/features/comments/lib/comment-panel-edit-actions";
+import { createCommentPanelLoadSubmitActions } from "@/features/comments/lib/comment-panel-load-submit-actions";
+import {
+  commentUploadPendingForMode,
+  commentUploadPendingStateWithDelta,
+  createCommentUploadPendingState,
+} from "@/features/comments/lib/comment-panel-upload-state";
+import type { CommentTargetOption } from "@/features/comments/lib/comment-ui";
+import type { CommentNode } from "@/features/comments/server/comment-types";
+import type { ViewerContext } from "@/lib/auth/viewer-context";
+
+const apiClientMock = vi.hoisted(() => ({
+  GET: vi.fn(),
+  PATCH: vi.fn(),
+  POST: vi.fn(),
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  apiClient: apiClientMock,
+}));
+
+const target: CommentTargetOption = {
+  key: "section",
+  label: "Section",
+  sectionId: 1,
+  targetId: 1,
+  type: "section",
+};
+
+function viewer(): ViewerContext {
+  return {
+    image: null,
+    isAdmin: false,
+    isAuthenticated: true,
+    isSuspended: false,
+    name: "Viewer",
+    suspensionExpiresAt: null,
+    suspensionReason: null,
+    userId: "user-1",
+  };
+}
+
+function commentsListResponse() {
+  return {
+    comments: [],
+    hiddenCount: 0,
+    target: {
+      courseId: null,
+      courseJwId: null,
+      courseName: null,
+      homeworkId: null,
+      homeworkSectionCode: null,
+      homeworkSectionJwId: null,
+      homeworkTitle: null,
+      sectionCode: null,
+      sectionId: 1,
+      sectionJwId: 1,
+      sectionTeacherCourseJwId: null,
+      sectionTeacherCourseName: null,
+      sectionTeacherId: null,
+      sectionTeacherSectionCode: null,
+      sectionTeacherSectionId: null,
+      sectionTeacherSectionJwId: null,
+      sectionTeacherTeacherId: null,
+      sectionTeacherTeacherName: null,
+      targetId: 1,
+      teacherId: null,
+      teacherName: null,
+      type: "section",
+    },
+    viewer: viewer(),
+  };
+}
+
+function comment(overrides: Partial<CommentNode> = {}): CommentNode {
+  return {
+    attachments: [],
+    author: null,
+    authorHidden: false,
+    body: "existing body",
+    canDelete: false,
+    canEdit: true,
+    canModerate: false,
+    canReact: false,
+    canReply: false,
+    createdAt: "2026-01-01T00:00:00+08:00",
+    id: "comment-1",
+    isAnonymous: false,
+    isAuthor: true,
+    parentId: null,
+    reactions: [],
+    replies: [],
+    rootId: "comment-1",
+    status: "active",
+    updatedAt: "2026-01-01T00:00:00+08:00",
+    visibility: "public",
+    ...overrides,
+  };
+}
+
+function createSubmitActions({
+  body = "new body",
+  pendingModes = [],
+}: {
+  body?: string;
+  pendingModes?: CommentEditorMode[];
+} = {}) {
+  let currentBody = body;
+  let submitting = false;
+  const pending = new Set(pendingModes);
+
+  return createCommentPanelLoadSubmitActions({
+    cancelReply: vi.fn(),
+    getBody: () => currentBody,
+    getCommentCopy: () => ({
+      loadFailed: "load failed",
+      submitFailed: "submit failed",
+    }),
+    getIsAnonymous: () => false,
+    getReplyAttachmentIds: () => ["reply-upload"],
+    getReplyIsAnonymous: () => false,
+    getReplyVisibility: () => "public",
+    getSelectedAttachments: () => ["new-upload"],
+    getShowAllTargets: () => false,
+    getSubmitting: () => submitting,
+    getTargetType: () => "section",
+    getTargets: () => [target],
+    getVisibility: () => "public",
+    hasPendingUploads: (mode) => pending.has(mode),
+    scrollToHashComment: vi.fn(),
+    selectedPostTarget: () => target,
+    setBody: (value) => {
+      currentBody = value;
+    },
+    setComments: vi.fn(),
+    setHiddenCount: vi.fn(),
+    setLoading: vi.fn(),
+    setMessage: vi.fn(),
+    setSelectedAttachments: vi.fn(),
+    setSubmitting: (value) => {
+      submitting = value;
+    },
+    setUploadedFiles: vi.fn(),
+    setViewer: vi.fn(),
+  });
+}
+
+describe("comment panel upload pending state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiClientMock.GET.mockResolvedValue({
+      data: commentsListResponse(),
+      response: new Response(null, { status: 200 }),
+    });
+    apiClientMock.PATCH.mockResolvedValue({
+      response: new Response(null, { status: 200 }),
+    });
+    apiClientMock.POST.mockResolvedValue({
+      response: new Response(null, { status: 200 }),
+    });
+  });
+
+  it("keeps pending state true until all uploads in that editor finish", () => {
+    let state = createCommentUploadPendingState();
+
+    state = commentUploadPendingStateWithDelta({
+      delta: 1,
+      mode: "new",
+      state,
+    });
+    state = commentUploadPendingStateWithDelta({
+      delta: 1,
+      mode: "new",
+      state,
+    });
+    state = commentUploadPendingStateWithDelta({
+      delta: -1,
+      mode: "new",
+      state,
+    });
+
+    expect(commentUploadPendingForMode(state, "new")).toBe(true);
+
+    state = commentUploadPendingStateWithDelta({
+      delta: -1,
+      mode: "new",
+      state,
+    });
+    state = commentUploadPendingStateWithDelta({
+      delta: -1,
+      mode: "new",
+      state,
+    });
+
+    expect(commentUploadPendingForMode(state, "new")).toBe(false);
+  });
+
+  it("blocks new comment submission while the new-comment editor uploads", async () => {
+    const actions = createSubmitActions({ pendingModes: ["new"] });
+
+    await actions.submitComment();
+
+    expect(apiClientMock.POST).not.toHaveBeenCalled();
+  });
+
+  it("blocks reply submission while the reply editor uploads", async () => {
+    const actions = createSubmitActions({ pendingModes: ["reply"] });
+
+    await actions.submitComment("comment-1", "reply body", target);
+
+    expect(apiClientMock.POST).not.toHaveBeenCalled();
+  });
+
+  it("blocks edit save while the edit editor uploads", async () => {
+    const loadComments = vi.fn();
+    const actions = createCommentPanelEditActions({
+      applyEditDraftState: vi.fn(),
+      getCommentCopy: () => ({ submitFailed: "submit failed" }),
+      getEditAttachmentIds: () => ["edit-upload"],
+      getEditDraft: () => "edited body",
+      getEditIsAnonymous: () => false,
+      getEditVisibility: () => "public",
+      hasPendingUploads: (mode) => mode === "edit",
+      loadComments,
+      setActionMenuId: vi.fn(),
+      setMessage: vi.fn(),
+    });
+
+    await actions.saveEdit(comment());
+
+    expect(apiClientMock.PATCH).not.toHaveBeenCalled();
+    expect(loadComments).not.toHaveBeenCalled();
+  });
+
+  it("does not let a reply upload block a new comment submission", async () => {
+    const actions = createSubmitActions({ pendingModes: ["reply"] });
+
+    await actions.submitComment();
+
+    expect(apiClientMock.POST).toHaveBeenCalledWith("/api/comments", {
+      body: {
+        attachmentIds: ["new-upload"],
+        body: "new body",
+        isAnonymous: false,
+        parentId: null,
+        sectionId: 1,
+        targetId: 1,
+        targetType: "section",
+        visibility: "public",
+      },
+    });
+  });
+});

--- a/tests/unit/dashboard-controller-derived-state.test.ts
+++ b/tests/unit/dashboard-controller-derived-state.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { buildDashboardControllerDerivedState } from "@/features/dashboard/lib/dashboard-controller-derived-state";
+import type {
+  DashboardLinkItem,
+  DashboardPageData,
+} from "@/features/dashboard/lib/dashboard-controller-helpers";
+import {
+  DASHBOARD_LINK_GROUP_ORDER,
+  type DashboardLinkGroup,
+} from "@/features/dashboard-links/lib/dashboard-links";
+
+const dashboardLinkGroupLabels = Object.fromEntries(
+  DASHBOARD_LINK_GROUP_ORDER.map((group) => [group, group]),
+) as Record<DashboardLinkGroup, string>;
+
+function link(slug: string, isPinned: boolean): DashboardLinkItem {
+  return {
+    clickCount: 0,
+    description: `${slug} description`,
+    descriptionPinyin: `${slug}description`,
+    group: "study",
+    icon: "school",
+    isPinned,
+    slug,
+    title: `${slug} portal`,
+    titlePinyin: `${slug}portal`,
+    url: `https://example.test/${slug}`,
+  };
+}
+
+function signedDashboardData(
+  dashboardLinks: DashboardLinkItem[],
+): DashboardPageData {
+  return {
+    bus: null,
+    copy: {} as DashboardPageData["copy"],
+    homeworks: null,
+    links: { dashboardLinks },
+    locale: "zh-cn",
+    navStats: {
+      calendarItemsCount: 0,
+      examsCount: 0,
+      pendingHomeworksCount: 0,
+      pendingTodosCount: 0,
+    },
+    overview: {
+      calendar: null,
+      dueToday: [],
+      hasCurrentTermSelection: false,
+      overviewLinks: dashboardLinks.slice(0, 1),
+      pendingHomeworks: [],
+      todaySessions: [],
+    },
+    signedIn: true,
+    subscriptions: null,
+    todos: [],
+  };
+}
+
+describe("dashboard controller derived state", () => {
+  it.each([
+    { currentPinned: true, loadedPinned: false, name: "pin" },
+    { currentPinned: false, loadedPinned: true, name: "unpin" },
+  ])("keeps local link $name state when search recomputes derived groups", ({
+    currentPinned,
+    loadedPinned,
+  }) => {
+    const loadedLinks = [link("jw", loadedPinned), link("mail", false)];
+    const currentLinks = [link("jw", currentPinned), link("mail", false)];
+
+    const result = buildDashboardControllerDerivedState({
+      currentDashboardLinkItems: currentLinks,
+      currentOverviewLinkItems: currentLinks.slice(0, 1),
+      dashboardLinkGroupLabels,
+      data: signedDashboardData(loadedLinks),
+      dateFallback: "TBD",
+      examFilter: "incomplete",
+      linkSearchQuery: "jw",
+      notAvailable: "N/A",
+      todoFilter: "incomplete",
+    });
+
+    expect(
+      result.dashboardLinkItems.find((item) => item.slug === "jw")?.isPinned,
+    ).toBe(currentPinned);
+    expect(result.signedLinkGroups.flatMap((group) => group.links)).toEqual([
+      expect.objectContaining({
+        isPinned: currentPinned,
+        slug: "jw",
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Goal

Fix comment and dashboard UI state races.

Fixes #88.
Fixes #89.

## Changed Surfaces

- Comment panel upload state is now tracked per editor mode (`new`, `reply`, `edit`) with pending counts, so one editor's upload does not block unrelated editors and multiple uploads in one editor keep submit/save blocked until all finish.
- New comment, reply, and edit save helpers now guard against submitting while their relevant editor has pending uploads; matching UI buttons are disabled during that state.
- Dashboard link state now has a local link-source owner refreshed from page data and patched by pin/unpin responses, so search recomputation keeps the current pin state.
- Added focused unit regressions for comment pending-upload submission guards and dashboard derived link pin state.
- Added Playwright coverage for pin/unpin followed by link search recomputation.

## Evidence

- `bun run test -- tests/unit/comment-panel-upload-pending.test.ts tests/unit/dashboard-controller-derived-state.test.ts`
- `bun run verify`
- `bun run e2e:build-artifacts && bun run seed && PLAYWRIGHT_PORT=3002 bun run e2e:test -- tests/e2e/src/app/dashboard/links/test.ts`

Browser evidence: Chromium exercised `/dashboard/links`; the new `keeps pin state when search recomputes links` test pinned, searched, verified Unpin remained, unpinned, searched again, and verified Pin remained.

Comment upload browser race evidence: covered with deterministic unit tests at the action/helper boundary. The existing browser upload flow completes through Worker/R2; reliably holding an upload mid-flight across new/reply/edit editors would require route-stalling infrastructure beyond the current focused spec.

## Docs / Contracts

No docs/contracts/OpenAPI/message changes. The REST/API shapes are unchanged, and existing contracts already cover comment attachment upload and dashboard link pin/search behavior.

## Risk Areas

- Upload UI state: scoped to comment panel client state and action guards; no server mutation behavior changed.
- Dashboard links: local source arrays are refreshed when page data changes and patched after pin/unpin responses.
- E2E used `PLAYWRIGHT_PORT=3002` because `127.0.0.1:3000` was already occupied locally.

## Cleanup

No tracked generated files, scratch reports, or unrelated rewrites are included. Local Playwright output was removed before commit.
