### PR TITLE
fix(api): API contract metadata drift

### DIFF
--- a/docs/contracts.schema.json
+++ b/docs/contracts.schema.json
@@ -255,7 +255,7 @@
     },
     "authLevel": {
       "type": "string",
-      "enum": ["anon", "user", "admin"]
+      "enum": ["anon", "user", "admin", "internal"]
     },
     "surfaceStatus": {
       "type": "string",
@@ -297,8 +297,44 @@
         "auth": {
           "$ref": "#/$defs/authLevel"
         },
+        "reference_only": {
+          "type": "boolean",
+          "const": true
+        },
         "notes": {
           "$ref": "#/$defs/notes"
+        }
+      },
+      "if": {
+        "properties": {
+          "reference_only": {
+            "const": true
+          }
+        },
+        "required": ["reference_only"]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            {
+              "required": ["description"]
+            },
+            {
+              "required": ["returns"]
+            },
+            {
+              "required": ["content_type"]
+            },
+            {
+              "required": ["status"]
+            },
+            {
+              "required": ["auth"]
+            },
+            {
+              "required": ["notes"]
+            }
+          ]
         }
       }
     },

--- a/docs/contracts/admin.json
+++ b/docs/contracts/admin.json
@@ -39,24 +39,21 @@
         "routes": [
           {
             "path": "/api/admin/comments",
-            "returns": "{ comments: Comment[] }",
-            "notes": [
-              "Omitted status defaults to the active moderation queue, matching /admin/moderation."
-            ]
+            "reference_only": true
           },
           {
             "path": "/api/admin/comments/[id]",
             "method": "PATCH",
-            "returns": "{ comment: Comment }"
+            "reference_only": true
           },
           {
             "path": "/api/admin/descriptions",
-            "returns": "{ descriptions: Description[] }"
+            "reference_only": true
           },
           {
             "path": "/api/admin/descriptions/[id]",
             "method": "PATCH",
-            "returns": "{ description: Description }"
+            "reference_only": true
           },
           {
             "path": "/api/admin/suspensions",
@@ -65,21 +62,21 @@
           {
             "path": "/api/admin/suspensions",
             "method": "POST",
-            "returns": "{ suspension: Suspension }"
+            "reference_only": true
           },
           {
             "path": "/api/admin/suspensions/[id]",
             "method": "PATCH",
-            "returns": "{ suspension: Suspension }"
+            "reference_only": true
           },
           {
             "path": "/api/admin/homeworks",
-            "returns": "{ homeworks: HomeworkItem[] }"
+            "reference_only": true
           },
           {
             "path": "/api/admin/homeworks/[id]",
             "method": "DELETE",
-            "returns": "{ success: Boolean }"
+            "reference_only": true
           }
         ]
       },

--- a/docs/contracts/ical.json
+++ b/docs/contracts/ical.json
@@ -63,10 +63,7 @@
           },
           {
             "path": "/api/calendar-subscriptions/current",
-            "returns": "{ subscription: CalendarSubscription | null }",
-            "notes": [
-              "Returns subscribed section details, personal calendar feed path, full feed URL, and descriptive text."
-            ]
+            "reference_only": true
           }
         ]
       },

--- a/docs/contracts/openapi.json
+++ b/docs/contracts/openapi.json
@@ -11,7 +11,7 @@
     "no-developer-model": "Public documentation helps callers understand the existing product capability boundaries, not to introduce a separate developer-specific business model.",
     "session-and-bearer": "Current user-side business REST endpoints support both in-site session from the request cookie and OAuth bearer tokens; bearer-token access is no longer limited to MCP.",
     "rest-mcp-consistent": "The same abstract endpoint currently maintains the same core fields, state information, and action results in both REST and MCP; differences mainly appear in interaction form and serialization level.",
-    "security-schemes": "Generated OpenAPI marks protected REST operations with bearer/session alternatives, MCP operations with bearer-only auth, and personal calendar feed export with bearer/session/token alternatives.",
+    "security-schemes": "Generated OpenAPI derives operation security from contract route auth: user/admin REST operations use bearer/session alternatives, MCP uses bearer-only auth, internal operational endpoints use internal bearer auth, and personal calendar feed export also allows feed tokens.",
     "rest-observability": "REST API handling records production-safe structured request-start/request-finish logs and bounded in-memory metrics with request ID, method, status, auth mode, duration, and normalized route template; it does not log request bodies, credentials, raw query strings, or high-cardinality resource IDs."
   },
   "capabilities": {
@@ -85,11 +85,30 @@
             "notes": ["Sets the user language preference cookie."]
           },
           {
+            "path": "/api/health",
+            "method": "GET",
+            "returns": "text/plain ok",
+            "content_type": "text/plain; charset=utf-8",
+            "notes": ["Plain liveness endpoint with no dependency checks."]
+          },
+          {
             "path": "/api/readiness",
             "method": "GET",
+            "auth": "internal",
             "returns": "{ status, checks, uptimeSeconds }",
+            "content_type": "application/json",
             "notes": [
               "Internal readiness endpoint for dependency checks; readable only from localhost or with the configured readiness/metrics bearer token."
+            ]
+          },
+          {
+            "path": "/api/metrics",
+            "method": "GET",
+            "auth": "internal",
+            "returns": "Prometheus text exposition",
+            "content_type": "text/plain; version=0.0.4; charset=utf-8",
+            "notes": [
+              "Internal runtime metrics endpoint; readable only from localhost or with the configured metrics bearer token."
             ]
           }
         ]
@@ -98,7 +117,9 @@
         "fields": [
           "Metadata endpoint",
           "Locale endpoint",
+          "Health endpoint",
           "Readiness endpoint",
+          "Metrics endpoint",
           "OAuth/provider catch-all endpoints",
           "Webhook endpoint via Better Auth catch-all"
         ]

--- a/docs/contracts/section.json
+++ b/docs/contracts/section.json
@@ -150,10 +150,7 @@
         "routes": [
           {
             "path": "/api/sections/[jwId]/calendar.ics",
-            "returns": "text/calendar",
-            "notes": [
-              "Returns text/calendar; content is derived from the section's schedule and exams."
-            ]
+            "reference_only": true
           }
         ]
       },

--- a/docs/contracts/webhook-login.json
+++ b/docs/contracts/webhook-login.json
@@ -21,11 +21,7 @@
           {
             "path": "/api/auth/{auth}",
             "method": "POST",
-            "returns": "{ ok, userId, email, sessionToken, expires } | { error }",
-            "notes": [
-              "Request body is JSON.",
-              "Also sets the better-auth.session_token cookie."
-            ]
+            "reference_only": true
           }
         ]
       },

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -2847,7 +2847,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       },
       "post": {
         "operationId": "recordDashboardLinkVisit",
@@ -2877,7 +2885,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       }
     },
     "/api/descriptions": {
@@ -3052,6 +3068,27 @@
             "sessionCookie": []
           }
         ]
+      }
+    },
+    "/api/health": {
+      "get": {
+        "operationId": "listHealth",
+        "summary": "Check process liveness",
+        "tags": [
+          "Api"
+        ],
+        "responses": {
+          "200": {
+            "description": "Text response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/homeworks": {
@@ -4128,6 +4165,35 @@
         }
       }
     },
+    "/api/metrics": {
+      "get": {
+        "operationId": "listMetrics",
+        "summary": "Export internal runtime metrics",
+        "tags": [
+          "Api"
+        ],
+        "responses": {
+          "200": {
+            "description": "Text response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Response 404"
+          }
+        },
+        "security": [
+          {
+            "internalBearerAuth": []
+          }
+        ]
+      }
+    },
     "/api/openapi": {
       "get": {
         "operationId": "getOpenApiSpec",
@@ -4180,7 +4246,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "internalBearerAuth": []
+          }
+        ]
       }
     },
     "/api/schedules": {
@@ -6125,8 +6196,26 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "sessionCookie": []
+          }
+        ]
       },
       "post": {
         "operationId": "createUpload",
@@ -29321,6 +29410,11 @@
         "scheme": "bearer",
         "bearerFormat": "JWT",
         "description": "OAuth bearer token for /api/mcp. MCP requires a bearer token with the MCP resource audience and does not accept session cookies."
+      },
+      "internalBearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Configured internal bearer token for operational endpoints. Localhost requests may also be accepted by the server-side access policy."
       },
       "calendarFeedToken": {
         "type": "apiKey",

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,3 +1,7 @@
+/**
+ * Check process liveness.
+ * @response 200:text
+ */
 export function GET() {
   return new Response("ok\n", {
     headers: {

--- a/src/routes/api/metrics/+server.ts
+++ b/src/routes/api/metrics/+server.ts
@@ -2,6 +2,11 @@ import { notFoundText } from "@/lib/api/helpers";
 import { canReadInternalEndpoint } from "@/lib/http/access-control";
 import { renderPrometheusMetrics } from "@/lib/metrics/runtime-metrics";
 
+/**
+ * Export internal runtime metrics.
+ * @response 200:text
+ * @response 404
+ */
 export function GET({ request }: { request: Request }) {
   if (!canReadInternalEndpoint(request, ["METRICS_BEARER_TOKEN"])) {
     return notFoundText();

--- a/src/routes/api/uploads/+server.ts
+++ b/src/routes/api/uploads/+server.ts
@@ -5,6 +5,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
 /**
  * List uploads.
  * @response uploadsListResponseSchema
+ * @response 401:openApiErrorSchema
  */
 export const GET = svelteRequestHandler(observedApiRoute(getUploadsRoute));
 /**

--- a/tests/e2e/src/app/api/openapi/test.ts
+++ b/tests/e2e/src/app/api/openapi/test.ts
@@ -174,9 +174,14 @@ test.describe("GET /api/openapi", () => {
         "bearerAuth",
         "sessionCookie",
         "mcpBearerAuth",
+        "internalBearerAuth",
         "calendarFeedToken",
       ]),
     );
+    expect(body.paths?.["/api/uploads"]?.get?.security).toEqual([
+      { bearerAuth: [] },
+      { sessionCookie: [] },
+    ]);
     expect(body.paths?.["/api/todos"]?.get?.security).toEqual([
       { bearerAuth: [] },
       { sessionCookie: [] },
@@ -184,6 +189,13 @@ test.describe("GET /api/openapi", () => {
     expect(body.paths?.["/api/mcp"]?.get?.security).toEqual([
       { mcpBearerAuth: [] },
     ]);
+    expect(body.paths?.["/api/readiness"]?.get?.security).toEqual([
+      { internalBearerAuth: [] },
+    ]);
+    expect(body.paths?.["/api/metrics"]?.get?.security).toEqual([
+      { internalBearerAuth: [] },
+    ]);
+    expect(body.paths?.["/api/health"]?.get?.security).toBeUndefined();
     expect(
       body.paths?.["/api/users/{userId}/calendar.ics"]?.get?.security,
     ).toEqual([

--- a/tests/unit/openapi-scenario-examples.test.ts
+++ b/tests/unit/openapi-scenario-examples.test.ts
@@ -240,10 +240,15 @@ describe("buildScenarioOpenApiExamples", () => {
         "bearerAuth",
         "sessionCookie",
         "mcpBearerAuth",
+        "internalBearerAuth",
         "calendarFeedToken",
       ]),
     );
 
+    expect(spec.paths["/api/uploads"]?.get?.security).toEqual([
+      { bearerAuth: [] },
+      { sessionCookie: [] },
+    ]);
     expect(spec.paths["/api/todos"]?.get?.security).toEqual([
       { bearerAuth: [] },
       { sessionCookie: [] },
@@ -266,6 +271,13 @@ describe("buildScenarioOpenApiExamples", () => {
     expect(spec.paths["/api/mcp"]?.get?.security).toEqual([
       { mcpBearerAuth: [] },
     ]);
+    expect(spec.paths["/api/readiness"]?.get?.security).toEqual([
+      { internalBearerAuth: [] },
+    ]);
+    expect(spec.paths["/api/metrics"]?.get?.security).toEqual([
+      { internalBearerAuth: [] },
+    ]);
+    expect(spec.paths["/api/health"]?.get?.security).toBeUndefined();
     expect(spec.paths["/api/mcp"]?.options?.security).toBeUndefined();
     expect(spec.paths["/api/users/profile"]?.get?.security).toBeUndefined();
     expect(
@@ -278,6 +290,26 @@ describe("buildScenarioOpenApiExamples", () => {
         expect.objectContaining({ in: "query", name: "token" }),
       ]),
     );
+  });
+
+  it("documents operational endpoint response shapes", () => {
+    const spec = generatedOpenApiDocument as GeneratedOpenApiDocument;
+
+    expect(
+      spec.paths["/api/health"]?.get?.responses?.["200"]?.content?.[
+        "text/plain"
+      ]?.schema,
+    ).toEqual({ type: "string" });
+    expect(
+      spec.paths["/api/metrics"]?.get?.responses?.["200"]?.content?.[
+        "text/plain"
+      ]?.schema,
+    ).toEqual({ type: "string" });
+    expect(
+      spec.paths["/api/readiness"]?.get?.responses?.["200"]?.content?.[
+        "application/json"
+      ]?.schema?.$ref,
+    ).toBe("#/components/schemas/readinessResponseSchema");
   });
 
   it("documents OAuth success response bodies", () => {

--- a/tools/build/openapi/generate-spec.ts
+++ b/tools/build/openapi/generate-spec.ts
@@ -124,6 +124,29 @@ type HandlerAnnotations = {
   responses: Array<{ status: number | null; schemaName: string | null }>;
 };
 
+type ContractAuthLevel = "anon" | "user" | "admin" | "internal";
+
+type ContractRoute = {
+  path?: unknown;
+  method?: unknown;
+  auth?: unknown;
+  reference_only?: unknown;
+};
+
+type ContractDoc = {
+  capabilities?: Record<
+    string,
+    {
+      auth?: unknown;
+      rest?:
+        | string
+        | {
+            routes?: ContractRoute[];
+          };
+    }
+  >;
+};
+
 function extractJsDocAnnotations(
   source: string,
   httpMethod: string,
@@ -284,6 +307,16 @@ function buildResponses(
       continue;
     }
 
+    if (schemaName === "text") {
+      responses[String(code)] = {
+        description: "Text response",
+        content: {
+          "text/plain": { schema: { type: "string" } },
+        },
+      };
+      continue;
+    }
+
     // schemaName is always a non-null string here; null case was handled above
     usedSchemas.add(schemaName as string);
     responses[String(code)] = {
@@ -341,8 +374,6 @@ function buildRequestBody(
 
 const OPENAPI_EXCLUDED_ROUTES = new Set([
   "src/routes/api/auth/[...auth]/+server.ts",
-  "src/routes/api/health/+server.ts",
-  "src/routes/api/metrics/+server.ts",
 ]);
 const OPENAPI_ROUTE_ROOTS = ["src/routes/api", "src/routes/.well-known"];
 
@@ -492,6 +523,7 @@ type MutableOpenApiMediaType = Record<string, unknown>;
 const SCENARIO_OPENAPI_EXAMPLES = buildScenarioOpenApiExamples();
 const REST_AUTH_SECURITY = [{ bearerAuth: [] }, { sessionCookie: [] }];
 const MCP_AUTH_SECURITY = [{ mcpBearerAuth: [] }];
+const INTERNAL_AUTH_SECURITY = [{ internalBearerAuth: [] }];
 const CALENDAR_FEED_AUTH_SECURITY = [
   ...REST_AUTH_SECURITY,
   { calendarFeedToken: [] },
@@ -517,6 +549,12 @@ const SECURITY_SCHEMES = {
     bearerFormat: "JWT",
     description:
       "OAuth bearer token for /api/mcp. MCP requires a bearer token with the MCP resource audience and does not accept session cookies.",
+  },
+  internalBearerAuth: {
+    type: "http",
+    scheme: "bearer",
+    description:
+      "Configured internal bearer token for operational endpoints. Localhost requests may also be accepted by the server-side access policy.",
   },
   calendarFeedToken: {
     type: "apiKey",
@@ -1137,30 +1175,80 @@ function applyScenarioExamples(
   }
 }
 
-function operationHasResponse(
-  operation: MutableOpenApiOperation,
-  statusCode: string,
-) {
-  return Boolean(
-    operation.responses &&
-      typeof operation.responses === "object" &&
-      statusCode in operation.responses,
-  );
-}
-
-function isOAuthProtocolPath(path: string) {
-  return path.startsWith("/api/auth/oauth2/");
-}
-
-function isProtectedRedirectOperation(path: string, method: string) {
-  return path === "/api/dashboard-links/pin" && method === "post";
-}
-
 function isPersonalCalendarFeedOperation(path: string, method: string) {
   return path === "/api/users/{userId}/calendar.ics" && method === "get";
 }
 
-function applySecurityMetadata(doc: MutableOpenApiDocument) {
+function isContractAuthLevel(value: unknown): value is ContractAuthLevel {
+  return (
+    value === "anon" ||
+    value === "user" ||
+    value === "admin" ||
+    value === "internal"
+  );
+}
+
+function contractRouteToOpenApiPath(routePath: string) {
+  return routePath
+    .replace(/\[\.\.\.([^\]]+)\]/g, "{$1}")
+    .replace(/\[([^\]]+)\]/g, "{$1}");
+}
+
+function contractRouteKey(method: string, routePath: string) {
+  return `${method.toLowerCase()} ${contractRouteToOpenApiPath(routePath)}`;
+}
+
+async function collectContractRestAuth(): Promise<
+  Map<string, ContractAuthLevel>
+> {
+  const contractsDir = path.join(ROOT, "docs/contracts");
+  const files = (await readdir(contractsDir))
+    .filter((file) => file.endsWith(".json") && !file.startsWith("_"))
+    .sort();
+  const authByRoute = new Map<string, ContractAuthLevel>();
+
+  for (const file of files) {
+    const moduleDoc = JSON.parse(
+      await readFile(path.join(contractsDir, file), "utf8"),
+    ) as ContractDoc;
+
+    for (const capability of Object.values(moduleDoc.capabilities ?? {})) {
+      if (!capability || typeof capability !== "object") continue;
+      if (!capability.rest || typeof capability.rest !== "object") continue;
+      const capabilityAuth = isContractAuthLevel(capability.auth)
+        ? capability.auth
+        : "anon";
+
+      for (const route of capability.rest.routes ?? []) {
+        if (!route || typeof route !== "object") continue;
+        if (route.reference_only === true) continue;
+        if (typeof route.path !== "string") continue;
+
+        const method = typeof route.method === "string" ? route.method : "GET";
+        const routeAuth = isContractAuthLevel(route.auth)
+          ? route.auth
+          : capabilityAuth;
+        const key = contractRouteKey(method, route.path);
+        const existingAuth = authByRoute.get(key);
+
+        if (existingAuth && existingAuth !== routeAuth) {
+          throw new Error(
+            `Conflicting contract auth for ${method} ${route.path}: ${existingAuth} vs ${routeAuth}`,
+          );
+        }
+
+        authByRoute.set(key, routeAuth);
+      }
+    }
+  }
+
+  return authByRoute;
+}
+
+function applySecurityMetadata(
+  doc: MutableOpenApiDocument,
+  contractAuthByRoute: Map<string, ContractAuthLevel>,
+) {
   if (!doc.paths) return;
 
   doc.components = {
@@ -1178,21 +1266,27 @@ function applySecurityMetadata(doc: MutableOpenApiDocument) {
         continue;
       }
 
-      if (path === "/api/mcp" && operationHasResponse(operation, "401")) {
+      const contractAuth = contractAuthByRoute.get(`${method} ${path}`);
+
+      if (path === "/api/mcp" && contractAuth === "user") {
         operation.security = MCP_AUTH_SECURITY;
         continue;
       }
 
-      if (isPersonalCalendarFeedOperation(path, method)) {
+      if (
+        isPersonalCalendarFeedOperation(path, method) &&
+        contractAuth === "user"
+      ) {
         operation.security = CALENDAR_FEED_AUTH_SECURITY;
         continue;
       }
 
-      if (
-        !isOAuthProtocolPath(path) &&
-        (operationHasResponse(operation, "401") ||
-          isProtectedRedirectOperation(path, method))
-      ) {
+      if (contractAuth === "internal") {
+        operation.security = INTERNAL_AUTH_SECURITY;
+        continue;
+      }
+
+      if (contractAuth === "user" || contractAuth === "admin") {
         operation.security = REST_AUTH_SECURITY;
       }
     }
@@ -1247,7 +1341,7 @@ async function postprocessOpenApiSpec(filePath: string) {
   doc.paths = sortedPaths;
   patchRedirectOperations(sortedPaths);
   applyScenarioExamples(sortedPaths);
-  applySecurityMetadata(doc);
+  applySecurityMetadata(doc, await collectContractRestAuth());
 
   doc.tags = buildTopLevelTags(sortedPaths);
   doc["x-tagGroups"] = buildTagGroups(doc.tags);

--- a/tools/dev/check/contracts.ts
+++ b/tools/dev/check/contracts.ts
@@ -26,13 +26,14 @@ function checkContractsDoc() {
     capabilities?: Record<
       string,
       {
+        auth?: ContractAuthLevel;
         rest?:
           | "stable"
           | "planned"
           | "unavailable"
           | {
               status?: string;
-              routes?: Array<{ path: string; method?: string }>;
+              routes?: ContractRouteEntry[];
             };
         mcp?:
           | "stable"
@@ -45,6 +46,35 @@ function checkContractsDoc() {
             };
       }
     >;
+  };
+
+  type ContractAuthLevel = "anon" | "user" | "admin" | "internal";
+
+  type ContractRouteEntry = {
+    path: string;
+    method?: string;
+    auth?: ContractAuthLevel;
+    returns?: string;
+    notes?: string[];
+    reference_only?: boolean;
+  };
+
+  type DocumentedRestRoute = {
+    key: string;
+    method: string;
+    path: string;
+    auth: ContractAuthLevel;
+    moduleName: string;
+    capabilityName: string;
+    route: ContractRouteEntry;
+  };
+
+  type OpenApiOperation = {
+    security?: unknown;
+  };
+
+  type OpenApiDocument = {
+    paths?: Record<string, Record<string, OpenApiOperation | undefined>>;
   };
 
   function parsePrismaSchema(source: string): PrismaDocs {
@@ -105,20 +135,12 @@ function checkContractsDoc() {
       "PATCH",
       "DELETE",
     ] as const satisfies readonly HttpMethod[];
-    const contractExcludedRoutes = new Set([
-      "src/routes/api/health/+server.ts",
-      "src/routes/api/metrics/+server.ts",
-    ]);
     const routes = new Set<string>();
 
     for (const routeRoot of restRouteRoots) {
       for (const file of walkFiles(routeRoot).filter((item) =>
         item.endsWith("/+server.ts"),
       )) {
-        const relativeFile = file.replace(/\\/g, "/");
-        if (contractExcludedRoutes.has(relativeFile)) {
-          continue;
-        }
         const source = readFileSync(file, "utf8");
         const routePath = parseImplementedRoutePath(file);
         for (const method of getExportedRouteMethods(source, contractMethods)) {
@@ -132,20 +154,174 @@ function checkContractsDoc() {
 
   function collectDocumentedRestRoutes(
     modules: Record<string, unknown>,
-  ): Set<string> {
-    const routes = new Set<string>();
+  ): DocumentedRestRoute[] {
+    const routes: DocumentedRestRoute[] = [];
 
-    for (const moduleDoc of Object.values(modules) as ContractDoc[]) {
-      for (const capability of Object.values(moduleDoc.capabilities ?? {})) {
+    for (const [moduleName, moduleDoc] of Object.entries(modules) as Array<
+      [string, ContractDoc]
+    >) {
+      for (const [capabilityName, capability] of Object.entries(
+        moduleDoc.capabilities ?? {},
+      )) {
         if (!capability || typeof capability !== "object") continue;
         if (!capability.rest || typeof capability.rest !== "object") continue;
+        const capabilityAuth = capability.auth ?? "anon";
         for (const route of capability.rest.routes ?? []) {
-          routes.add(`${route.method ?? "GET"} ${route.path}`);
+          const method = route.method ?? "GET";
+          const key = `${method} ${route.path}`;
+          routes.push({
+            key,
+            method,
+            path: route.path,
+            auth: route.auth ?? capabilityAuth,
+            moduleName,
+            capabilityName,
+            route,
+          });
         }
       }
     }
 
     return routes;
+  }
+
+  function formatRestOwner(route: DocumentedRestRoute): string {
+    return `${route.moduleName}.${route.capabilityName}`;
+  }
+
+  function checkDuplicateRestRouteOwnership(routes: DocumentedRestRoute[]) {
+    const routeGroups = new Map<string, DocumentedRestRoute[]>();
+    const duplicateErrors: string[] = [];
+    const referenceOnlyShapeErrors: string[] = [];
+
+    for (const route of routes) {
+      const group = routeGroups.get(route.key) ?? [];
+      group.push(route);
+      routeGroups.set(route.key, group);
+
+      if (route.route.reference_only !== true) continue;
+      const disallowedReferenceFields = [
+        "auth",
+        "description",
+        "returns",
+        "content_type",
+        "status",
+        "notes",
+      ];
+      const disallowedFields = disallowedReferenceFields.filter(
+        (field) => field in route.route,
+      );
+      if (disallowedFields.length > 0) {
+        referenceOnlyShapeErrors.push(
+          `${route.key} in ${formatRestOwner(route)} has reference_only with ${disallowedFields.join(", ")}`,
+        );
+      }
+    }
+
+    for (const [routeKey, group] of routeGroups) {
+      const canonicalOwners = group.filter(
+        (route) => route.route.reference_only !== true,
+      );
+      const hasReferenceOnly = group.some(
+        (route) => route.route.reference_only === true,
+      );
+
+      if (hasReferenceOnly && canonicalOwners.length === 0) {
+        duplicateErrors.push(
+          `${routeKey} has only reference-only contract entries: ${group.map(formatRestOwner).join(", ")}`,
+        );
+        continue;
+      }
+
+      if (group.length > 1 && canonicalOwners.length !== 1) {
+        duplicateErrors.push(
+          `${routeKey} has ${canonicalOwners.length} canonical owners: ${canonicalOwners.map(formatRestOwner).join(", ")}`,
+        );
+      }
+    }
+
+    if (referenceOnlyShapeErrors.length > 0 || duplicateErrors.length > 0) {
+      console.error("Contract REST duplicate ownership check failed:");
+      for (const error of referenceOnlyShapeErrors) {
+        console.error(`- ${error}`);
+      }
+      for (const error of duplicateErrors) {
+        console.error(`- ${error}`);
+      }
+      process.exit(1);
+    }
+  }
+
+  function contractPathToOpenApiPath(routePath: string) {
+    return routePath
+      .replace(/\[\.\.\.([^\]]+)\]/g, "{$1}")
+      .replace(/\[([^\]]+)\]/g, "{$1}");
+  }
+
+  function expectedOpenApiSecurity(route: DocumentedRestRoute) {
+    const openApiPath = contractPathToOpenApiPath(route.path);
+    const method = route.method.toLowerCase();
+
+    if (openApiPath === "/api/mcp" && route.auth === "user") {
+      return [{ mcpBearerAuth: [] }];
+    }
+
+    if (
+      openApiPath === "/api/users/{userId}/calendar.ics" &&
+      method === "get" &&
+      route.auth === "user"
+    ) {
+      return [
+        { bearerAuth: [] },
+        { sessionCookie: [] },
+        { calendarFeedToken: [] },
+      ];
+    }
+
+    if (route.auth === "internal") {
+      return [{ internalBearerAuth: [] }];
+    }
+
+    if (route.auth === "user" || route.auth === "admin") {
+      return [{ bearerAuth: [] }, { sessionCookie: [] }];
+    }
+
+    return undefined;
+  }
+
+  function readGeneratedOpenApiSpec(): OpenApiDocument {
+    return JSON.parse(
+      readFileSync("public/openapi.generated.json", "utf8"),
+    ) as OpenApiDocument;
+  }
+
+  function checkOpenApiSecurityParity(routes: DocumentedRestRoute[]) {
+    const spec = readGeneratedOpenApiSpec();
+    const errors: string[] = [];
+
+    for (const route of routes) {
+      if (route.route.reference_only === true) continue;
+      const openApiPath = contractPathToOpenApiPath(route.path);
+      const method = route.method.toLowerCase();
+      const operation = spec.paths?.[openApiPath]?.[method];
+      if (!operation) continue;
+
+      const expectedSecurity = expectedOpenApiSecurity(route);
+      const actualSecurity = operation.security;
+      if (JSON.stringify(actualSecurity) !== JSON.stringify(expectedSecurity)) {
+        errors.push(
+          `${route.method} ${route.path} (${formatRestOwner(route)}) expected OpenAPI security ${JSON.stringify(expectedSecurity ?? null)}, got ${JSON.stringify(actualSecurity ?? null)}`,
+        );
+      }
+    }
+
+    if (errors.length > 0) {
+      console.error("Contract/OpenAPI auth security parity check failed:");
+      for (const error of errors) {
+        console.error(`- ${error}`);
+      }
+      process.exit(1);
+    }
   }
 
   function collectImplementedMcpTools(): Set<string> {
@@ -350,15 +526,21 @@ function checkContractsDoc() {
   }
 
   const documentedRestRoutes = collectDocumentedRestRoutes(merged.modules);
+  checkDuplicateRestRouteOwnership(documentedRestRoutes);
+  checkOpenApiSecurityParity(documentedRestRoutes);
+
+  const documentedRestRouteKeys = new Set(
+    documentedRestRoutes.map((route) => route.key),
+  );
   const implementedRestRoutes = collectImplementedRestRoutes();
 
-  const missingRestRoutes = [...documentedRestRoutes]
+  const missingRestRoutes = [...documentedRestRouteKeys]
     .filter(isDocumentedRestRouteChecked)
     .filter((route) => !implementedRestRoutes.has(route))
     .sort();
 
   const undocumentedRestRoutes = [...implementedRestRoutes]
-    .filter((route) => !documentedRestRoutes.has(route))
+    .filter((route) => !documentedRestRouteKeys.has(route))
     .filter((route) => !isImplementedRestRouteIgnored(route))
     .sort();
 


### PR DESCRIPTION
## What changed
- Derives protected REST OpenAPI security from checked route contract auth metadata instead of relying on `401` annotations alone.
- Makes duplicate REST contract ownership explicit and checked.
- Adds checked operational contract/OpenAPI coverage for health, readiness, and metrics endpoints.
- Updates generated OpenAPI and focused tests for protected uploads and operational endpoints.

Fixes #92.
Fixes #93.
Fixes #94.

## Docs/contracts impact
- Updated contract schema and affected contract modules for canonical route ownership/reference entries.
- Added health/metrics/readiness operational endpoint contract coverage.
- Regenerated `public/openapi.generated.json` through the OpenAPI generator.

## Verification
- Contract checks: `bun run check:contracts`
- OpenAPI generation check: `bun run openapi:check`
- Focused unit coverage: `bun test tests/unit/openapi-scenario-examples.test.ts`

## Complete-loop evidence
- Inspected generated OpenAPI coverage through focused test assertions for protected REST security and operational endpoint response shapes.

## Skipped checks
- Full `bun run verify` not run before draft publication; PR CI will run the full gate and I will address failures before marking ready/merging.

## Residual risks
- The route-contract ownership model is stricter; stale duplicate modules may need explicit reference entries in future feature work.
