### PR TITLE
fix(data): campus date helper drift

### DIFF
--- a/src/features/dashboard/components/overview-tab-week-days.ts
+++ b/src/features/dashboard/components/overview-tab-week-days.ts
@@ -1,17 +1,15 @@
 import {
   calendarEventsForDay,
-  parseDateKey,
   weekDaysFor,
 } from "@/features/dashboard/lib/calendar";
 import { overviewDayLabel } from "@/features/dashboard/lib/calendar-display";
 import { fmtTime } from "@/features/dashboard/lib/overview";
+import { formatCampusDate } from "@/lib/time/campus-date";
 import type { DashboardCalendarData } from "./dashboard-calendar-component-types";
 import type {
   OverviewCalendarTimelineItemsForDay,
   OverviewWeekDay,
 } from "./overview-tab-types";
-
-const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 export function overviewCalendarWeekDays(
   overviewCalendar: DashboardCalendarData,
@@ -24,7 +22,9 @@ export function overviewCalendarWeekDays(
     return {
       key: dayKey,
       label: overviewDayLabel(dayKey),
-      sublabel: WEEKDAY_LABELS[parseDateKey(dayKey).getDay()],
+      sublabel: formatCampusDate(dayKey, dayKey, undefined, {
+        weekday: "short",
+      }),
       isToday: dayKey === overviewCalendar.todayDate,
       events: timelineItems.map((item) => ({
         href: item.href,

--- a/src/features/dashboard/lib/calendar-date-keys.ts
+++ b/src/features/dashboard/lib/calendar-date-keys.ts
@@ -1,25 +1,31 @@
+import {
+  addCampusDays,
+  addCampusMonths,
+  campusDateKeyToLocalDate,
+  campusMonthGridKeys,
+  campusWeekKeys,
+  campusWeekStartKey,
+  isCampusDateKey,
+  isCampusMonthKey,
+  toCampusDateKey,
+} from "@/lib/time/campus-date";
 import type { CalendarView } from "./calendar-types";
 
 export function parseDateKey(key: string) {
-  const [year, month, day] = key.split("-").map(Number);
-  return new Date(year, (month ?? 1) - 1, day ?? 1);
+  // Display-only adapter for Svelte components that still read local Date fields.
+  return campusDateKeyToLocalDate(key) ?? new Date(Number.NaN);
 }
 
 export function toDateKey(date: Date) {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
+  return toCampusDateKey(date) ?? "";
 }
 
 export function isDateKey(value: string | null | undefined): value is string {
-  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
-  return toDateKey(parseDateKey(value)) === value;
+  return isCampusDateKey(value);
 }
 
 export function isMonthKey(value: string | null | undefined): value is string {
-  if (!value || !/^\d{4}-\d{2}$/.test(value)) return false;
-  return isDateKey(`${value}-01`);
+  return isCampusMonthKey(value);
 }
 
 export function isCalendarView(value: string | null): value is CalendarView {
@@ -27,36 +33,21 @@ export function isCalendarView(value: string | null): value is CalendarView {
 }
 
 export function addDays(key: string, days: number) {
-  const date = parseDateKey(key);
-  date.setDate(date.getDate() + days);
-  return toDateKey(date);
+  return addCampusDays(key, days);
 }
 
 export function addMonths(monthKey: string, months: number) {
-  const date = parseDateKey(`${monthKey}-01`);
-  date.setMonth(date.getMonth() + months);
-  return toDateKey(date).slice(0, 7);
+  return addCampusMonths(monthKey, months);
 }
 
 export function weekStartFor(key: string) {
-  const date = parseDateKey(key);
-  const diff = date.getDay();
-  date.setDate(date.getDate() - diff);
-  return toDateKey(date);
+  return campusWeekStartKey(key);
 }
 
 export function monthWeeks(monthKey: string) {
-  const first = parseDateKey(`${monthKey}-01`);
-  const start = parseDateKey(weekStartFor(toDateKey(first)));
-  return Array.from({ length: 6 }, (_, weekIndex) =>
-    Array.from({ length: 7 }, (_, dayIndex) => {
-      const day = new Date(start);
-      day.setDate(start.getDate() + weekIndex * 7 + dayIndex);
-      return toDateKey(day);
-    }),
-  );
+  return campusMonthGridKeys(monthKey);
 }
 
 export function weekDaysFor(startKey: string) {
-  return Array.from({ length: 7 }, (_, index) => addDays(startKey, index));
+  return campusWeekKeys(startKey);
 }

--- a/src/features/dashboard/lib/calendar-display-overview.ts
+++ b/src/features/dashboard/lib/calendar-display-overview.ts
@@ -1,10 +1,7 @@
-import {
-  parseDateKey,
-  toDateKey,
-  weekStartFor,
-} from "@/features/dashboard/lib/calendar";
+import { toDateKey, weekStartFor } from "@/features/dashboard/lib/calendar";
 import type { CalendarExamEvent } from "@/features/dashboard/lib/calendar-display-types";
 import { dayStart } from "@/features/dashboard/lib/overview";
+import { formatCampusDate, toCampusDateKey } from "@/lib/time/campus-date";
 
 export function dashboardOverviewWeekStart(
   overviewWeek: string | null | undefined,
@@ -12,15 +9,13 @@ export function dashboardOverviewWeekStart(
 ) {
   return weekStartFor(
     overviewWeek ??
-      (calendarReferenceDate
-        ? toDateKey(new Date(calendarReferenceDate))
-        : null) ??
+      (calendarReferenceDate ? toCampusDateKey(calendarReferenceDate) : null) ??
       toDateKey(new Date()),
   );
 }
 
 export function overviewDayLabel(dayKey: string) {
-  return parseDateKey(dayKey).toLocaleDateString(undefined, {
+  return formatCampusDate(dayKey, dayKey, undefined, {
     month: "short",
     day: "numeric",
   });

--- a/src/features/dashboard/lib/calendar-navigation.ts
+++ b/src/features/dashboard/lib/calendar-navigation.ts
@@ -6,6 +6,7 @@ import {
   toDateKey,
   weekStartFor,
 } from "@/features/dashboard/lib/calendar";
+import { toCampusDateKey } from "@/lib/time/campus-date";
 
 export type DashboardCalendarNavData = {
   activeCalendarSemesterId?: number | null;
@@ -33,7 +34,8 @@ export function dashboardCalendarStateFromUrl(
   const requestedView = url.searchParams.get("calendarView");
   const view = isCalendarView(requestedView) ? requestedView : "semester";
 
-  const referenceDate = calendar?.referenceDate ?? toDateKey(new Date());
+  const referenceDate =
+    toCampusDateKey(calendar?.referenceDate) ?? toDateKey(new Date());
   const requestedMonth = url.searchParams.get("calendarMonth");
   const month = isMonthKey(requestedMonth)
     ? requestedMonth
@@ -78,7 +80,8 @@ export function dashboardCalendarViewPatch(
   nextView: CalendarView,
   calendar: DashboardCalendarNavData | null,
 ): DashboardCalendarStatePatch {
-  const referenceKey = calendar?.referenceDate ?? toDateKey(new Date());
+  const referenceKey =
+    toCampusDateKey(calendar?.referenceDate) ?? toDateKey(new Date());
   if (nextView === "month") {
     return {
       month: referenceKey.slice(0, 7),

--- a/src/features/profile/server/user-profile-contributions.ts
+++ b/src/features/profile/server/user-profile-contributions.ts
@@ -1,4 +1,11 @@
-import dayjs from "dayjs";
+import {
+  addCampusDays,
+  campusDateKeyRange,
+  campusWeekStartKey,
+  requireCampusDateKeyForValue,
+  toCampusDateKey,
+} from "@/lib/time/campus-date";
+import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
 
 export type ContributionCell = {
   date: string;
@@ -31,8 +38,9 @@ type ContributionPrisma = {
 export async function buildUserProfileContributions(
   prisma: ContributionPrisma,
   userId: string,
+  referenceNow: Date = new Date(),
 ) {
-  const today = dayjs().startOf("day");
+  const today = shanghaiDayjs(referenceNow).startOf("day");
   const startDate = today.subtract(364, "day").startOf("day");
   const [commentEvents, uploadEvents, completionEvents, homeworkEvents] =
     await Promise.all([
@@ -64,7 +72,8 @@ export async function buildUserProfileContributions(
 
   const contributionMap = new Map<string, number>();
   const addContribution = (date: Date) => {
-    const key = dayjs(date).format("YYYY-MM-DD");
+    const key = toCampusDateKey(date);
+    if (!key) return;
     contributionMap.set(key, (contributionMap.get(key) ?? 0) + 1);
   };
 
@@ -73,16 +82,14 @@ export async function buildUserProfileContributions(
   for (const item of completionEvents) addContribution(item.completedAt);
   for (const item of homeworkEvents) addContribution(item.createdAt);
 
-  const gridStart = startDate.startOf("week");
-  const gridEnd = today.endOf("week");
-  const days: ContributionCell[] = Array.from(
-    { length: gridEnd.diff(gridStart, "day") + 1 },
-    (_, index) => {
-      const date = gridStart.add(index, "day");
-      const key = date.format("YYYY-MM-DD");
-      return { date: key, count: contributionMap.get(key) ?? 0 };
-    },
-  );
+  const startDateKey = requireCampusDateKeyForValue(startDate.toDate());
+  const todayKey = requireCampusDateKeyForValue(today.toDate());
+  const gridStartKey = campusWeekStartKey(startDateKey);
+  const gridEndKey = addCampusDays(campusWeekStartKey(todayKey), 6);
+  const days: ContributionCell[] = campusDateKeyRange(
+    gridStartKey,
+    gridEndKey,
+  ).map((key) => ({ date: key, count: contributionMap.get(key) ?? 0 }));
   const weeks: ContributionCell[][] = [];
   for (let index = 0; index < days.length; index += 7) {
     weeks.push(days.slice(index, index + 7));

--- a/src/features/section-detail/components/SectionDetailPageController.svelte
+++ b/src/features/section-detail/components/SectionDetailPageController.svelte
@@ -93,6 +93,7 @@ const {
   dateKey: _dateKey,
   fmtDate: _fmtDate,
   fmtDateTime: _fmtDateTime,
+  fmtMonth: _fmtMonth,
   isSameMonth: _isSameMonth,
   sectionCalendarGridWeeks: _sectionCalendarGridWeeks,
 } = createSectionDetailCalendarDisplayActions({
@@ -136,10 +137,7 @@ $: calendarBaseMonth = findCalendarBaseMonth(sectionCalendarEvents);
 $: visibleCalendarMonth = _addMonths(calendarBaseMonth, _calendarMonthOffset);
 $: calendarMonthDays = _calendarMonthDays(visibleCalendarMonth);
 $: calendarMonthWeeks = _calendarWeeks(calendarMonthDays);
-$: calendarMonthLabel = visibleCalendarMonth.toLocaleDateString(undefined, {
-  month: "long",
-  year: "numeric",
-});
+$: calendarMonthLabel = _fmtMonth(visibleCalendarMonth);
 $: unscheduledCalendarEvents = sectionCalendarEvents.filter(
   (event) => !event.dateKey,
 );

--- a/src/features/section-detail/lib/calendar.ts
+++ b/src/features/section-detail/lib/calendar.ts
@@ -1,3 +1,9 @@
+import {
+  campusDateKeyToLocalDate,
+  requireCampusDateKeyForValue,
+  toCampusDateKey,
+} from "@/lib/time/campus-date";
+
 export type SectionCalendarEvent = {
   id: string;
   kind: "class" | "exam";
@@ -21,8 +27,12 @@ type CalendarGridEvent = {
 
 export function findCalendarBaseMonth(events: SectionCalendarEvent[]) {
   const firstDated = events.find((event) => event.date);
-  const base = firstDated?.date ? new Date(firstDated.date) : new Date();
-  return new Date(base.getFullYear(), base.getMonth(), 1);
+  const baseKey = toCampusDateKey(firstDated?.date ?? new Date());
+  const monthKey = (baseKey ?? requireCampusDateKeyForValue(new Date())).slice(
+    0,
+    7,
+  );
+  return campusDateKeyToLocalDate(`${monthKey}-01`) ?? new Date();
 }
 
 export function calendarEventsForDay(
@@ -34,8 +44,8 @@ export function calendarEventsForDay(
 
 export function isSameMonth(day: Date, monthStart: Date) {
   return (
-    day.getFullYear() === monthStart.getFullYear() &&
-    day.getMonth() === monthStart.getMonth()
+    toCampusDateKey(day)?.slice(0, 7) ===
+    toCampusDateKey(monthStart)?.slice(0, 7)
   );
 }
 
@@ -80,11 +90,12 @@ export function buildSectionCalendarGridWeeks(input: {
   return input.monthWeeks.map((week) => ({
     label: input.semesterWeekLabel(week[0]),
     days: week.map((day) => {
-      const events = calendarEventsForDay(input.events, input.dateKey(day));
+      const dayKey = input.dateKey(day);
+      const events = calendarEventsForDay(input.events, dayKey);
       return {
-        key: day.toISOString(),
+        key: dayKey ?? day.toISOString(),
         label: String(day.getDate()),
-        isToday: input.dateKey(day) === input.todayKey,
+        isToday: dayKey === input.todayKey,
         isMuted: !isSameMonth(day, input.visibleMonth),
         events: events.map((event) =>
           buildCalendarGridEvent({

--- a/src/features/section-detail/lib/date-display.ts
+++ b/src/features/section-detail/lib/date-display.ts
@@ -1,17 +1,35 @@
+import {
+  addCampusMonths,
+  campusDateKeyToLocalDate,
+  campusMonthGridKeys,
+  formatCampusDate,
+  formatCampusDateTime,
+  requireCampusDateKeyForValue,
+  toCampusDateKey,
+} from "@/lib/time/campus-date";
+
 export function formatDate(
   value: string | Date | null | undefined,
   fallback: string,
 ) {
-  if (!value) return fallback;
-  return new Date(value).toLocaleDateString();
+  return formatCampusDate(value, fallback);
 }
 
 export function formatDateTime(
   value: string | Date | null | undefined,
   fallback: string,
 ) {
-  if (!value) return fallback;
-  return new Date(value).toLocaleString();
+  return formatCampusDateTime(value, fallback);
+}
+
+export function formatMonth(
+  value: string | Date | null | undefined,
+  fallback: string,
+) {
+  return formatCampusDate(value, fallback, undefined, {
+    month: "long",
+    year: "numeric",
+  });
 }
 
 export function formatTime(value: number | null | undefined, fallback: string) {
@@ -25,30 +43,31 @@ export function timeSort(value: number | null | undefined) {
 }
 
 export function dateKey(value: string | Date | null | undefined) {
-  if (!value) return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${date.getFullYear()}-${month}-${day}`;
+  return toCampusDateKey(value);
 }
 
 export function addMonths(value: Date, offset: number) {
-  return new Date(value.getFullYear(), value.getMonth() + offset, 1);
+  const key = dateKey(value);
+  const fallbackKey = requireCampusDateKeyForValue(new Date());
+  const month = addCampusMonths((key ?? fallbackKey).slice(0, 7), offset);
+  return campusDateKeyToLocalDate(`${month}-01`) ?? value;
 }
 
 export function calendarMonthDays(monthStart: Date) {
-  const gridStart = new Date(monthStart);
-  gridStart.setDate(gridStart.getDate() - gridStart.getDay());
-  return Array.from({ length: 42 }, (_, index) => {
-    const date = new Date(gridStart);
-    date.setDate(gridStart.getDate() + index);
-    return date;
-  });
+  const fallbackKey = requireCampusDateKeyForValue(new Date());
+  const monthKey = (dateKey(monthStart) ?? fallbackKey).slice(0, 7);
+  return campusMonthGridKeys(monthKey)
+    .flat()
+    .map((key) => campusDateKeyToLocalDate(key))
+    .filter((date): date is Date => Boolean(date));
 }
 
 export function calendarWeeks(days: Date[]) {
   return Array.from({ length: Math.ceil(days.length / 7) }, (_, index) =>
     days.slice(index * 7, index * 7 + 7),
   );
+}
+
+export function isSameMonth(day: Date, monthStart: Date) {
+  return dateKey(day)?.slice(0, 7) === dateKey(monthStart)?.slice(0, 7);
 }

--- a/src/features/section-detail/lib/section-detail-calendar-display-actions.ts
+++ b/src/features/section-detail/lib/section-detail-calendar-display-actions.ts
@@ -10,6 +10,8 @@ import {
   dateKey,
   formatDate,
   formatDateTime,
+  formatMonth,
+  isSameMonth,
 } from "./date-display";
 
 export function createSectionDetailCalendarDisplayActions(input: {
@@ -26,6 +28,10 @@ export function createSectionDetailCalendarDisplayActions(input: {
 
   function fmtDateTime(value: string | Date | null | undefined) {
     return formatDateTime(value, input.getNotAvailable());
+  }
+
+  function fmtMonth(value: string | Date | null | undefined) {
+    return formatMonth(value, input.getNotAvailable());
   }
 
   function dateKeyValue(value: string | Date | null | undefined) {
@@ -45,12 +51,8 @@ export function createSectionDetailCalendarDisplayActions(input: {
     dateKey: dateKeyValue,
     fmtDate,
     fmtDateTime,
-    isSameMonth(day: Date, month: Date) {
-      return (
-        day.getFullYear() === month.getFullYear() &&
-        day.getMonth() === month.getMonth()
-      );
-    },
+    fmtMonth,
+    isSameMonth,
     sectionCalendarGridWeeks() {
       return buildSectionCalendarGridWeeks({
         dateKey: dateKeyValue,

--- a/src/lib/time/campus-date.ts
+++ b/src/lib/time/campus-date.ts
@@ -1,0 +1,154 @@
+import type { ConfigType, Dayjs } from "dayjs";
+import { APP_TIME_ZONE, parseDateInput } from "@/lib/time/parse-date-input";
+import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
+import {
+  APP_DATE_ONLY_FORMAT,
+  formatShanghaiDate,
+} from "@/lib/time/shanghai-format";
+
+export const CAMPUS_WEEK_STARTS_ON = 0;
+
+const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MONTH_KEY_PATTERN = /^\d{4}-\d{2}$/;
+
+type CampusDateValue = ConfigType | null | undefined;
+
+function dateKeyParts(key: string) {
+  if (!DATE_KEY_PATTERN.test(key)) return null;
+  const [year, month, day] = key.split("-").map(Number);
+  if (!year || !month || !day) return null;
+  return { day, month, year };
+}
+
+function resolveCampusDate(value: CampusDateValue) {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === "string") {
+    const parsed = parseDateInput(value);
+    return parsed instanceof Date ? parsed : null;
+  }
+  const parsed = shanghaiDayjs(value);
+  return parsed.isValid() ? parsed.toDate() : null;
+}
+
+function requireCampusDateKey(key: string): Dayjs {
+  const parsed = parseCampusDateKey(key);
+  if (!parsed) throw new Error(`Invalid campus date key: ${key}`);
+  return parsed;
+}
+
+export function toCampusDateKey(value: CampusDateValue) {
+  const date = resolveCampusDate(value);
+  return date ? formatShanghaiDate(date) : null;
+}
+
+export function requireCampusDateKeyForValue(value: CampusDateValue) {
+  const key = toCampusDateKey(value);
+  if (!key) throw new Error("Invalid campus date value");
+  return key;
+}
+
+export function parseCampusDateKey(key: string) {
+  if (!DATE_KEY_PATTERN.test(key)) return null;
+  const parsed = parseDateInput(key);
+  if (!(parsed instanceof Date)) return null;
+  if (formatShanghaiDate(parsed) !== key) return null;
+  return shanghaiDayjs(parsed).startOf("day");
+}
+
+export function isCampusDateKey(
+  value: string | null | undefined,
+): value is string {
+  return Boolean(value && parseCampusDateKey(value));
+}
+
+export function isCampusMonthKey(
+  value: string | null | undefined,
+): value is string {
+  return Boolean(
+    value && MONTH_KEY_PATTERN.test(value) && isCampusDateKey(`${value}-01`),
+  );
+}
+
+export function addCampusDays(key: string, days: number) {
+  return requireCampusDateKey(key)
+    .add(days, "day")
+    .format(APP_DATE_ONLY_FORMAT);
+}
+
+export function addCampusMonths(monthKey: string, months: number) {
+  const start = requireCampusDateKey(`${monthKey}-01`);
+  return start.add(months, "month").format(APP_DATE_ONLY_FORMAT).slice(0, 7);
+}
+
+export function campusWeekStartKey(
+  key: string,
+  weekStartsOn = CAMPUS_WEEK_STARTS_ON,
+) {
+  const date = requireCampusDateKey(key);
+  const diff = (date.day() - weekStartsOn + 7) % 7;
+  return date.subtract(diff, "day").format(APP_DATE_ONLY_FORMAT);
+}
+
+export function campusDateKeyRange(startKey: string, endKey: string) {
+  const start = requireCampusDateKey(startKey);
+  const end = requireCampusDateKey(endKey);
+  const length = end.diff(start, "day") + 1;
+  return Array.from({ length: Math.max(length, 0) }, (_, index) =>
+    start.add(index, "day").format(APP_DATE_ONLY_FORMAT),
+  );
+}
+
+export function campusWeekKeys(startKey: string) {
+  return campusDateKeyRange(startKey, addCampusDays(startKey, 6));
+}
+
+export function campusMonthGridKeys(monthKey: string) {
+  const first = `${monthKey}-01`;
+  const start = campusWeekStartKey(first);
+  return Array.from({ length: 6 }, (_, weekIndex) =>
+    Array.from({ length: 7 }, (_, dayIndex) =>
+      addCampusDays(start, weekIndex * 7 + dayIndex),
+    ),
+  );
+}
+
+export function campusDateKeyToLocalDate(key: string) {
+  const parts = dateKeyParts(key);
+  if (!parts || !isCampusDateKey(key)) return null;
+  // Deliberate display-only adapter: legacy Svelte calendar components read
+  // local Date fields such as getDate(), while date keys remain campus-owned.
+  return new Date(parts.year, parts.month - 1, parts.day);
+}
+
+export function formatCampusDate(
+  value: CampusDateValue,
+  fallback: string,
+  locale?: string | string[],
+  options?: Intl.DateTimeFormatOptions,
+) {
+  const date = resolveCampusDate(value);
+  if (!date) return fallback;
+  return new Intl.DateTimeFormat(locale, {
+    timeZone: APP_TIME_ZONE,
+    ...options,
+  }).format(date);
+}
+
+export function formatCampusDateTime(
+  value: CampusDateValue,
+  fallback: string,
+  locale?: string | string[],
+  options?: Intl.DateTimeFormatOptions,
+) {
+  const date = resolveCampusDate(value);
+  if (!date) return fallback;
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: "short",
+    timeStyle: "short",
+    timeZone: APP_TIME_ZONE,
+    ...options,
+  }).format(date);
+}

--- a/tests/unit/dashboard-calendar-date-keys.test.ts
+++ b/tests/unit/dashboard-calendar-date-keys.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  addDays,
+  addMonths,
+  monthWeeks,
+  toDateKey,
+  weekStartFor,
+} from "@/features/dashboard/lib/calendar-date-keys";
+import {
+  dashboardCalendarStateFromUrl,
+  dashboardCalendarViewPatch,
+} from "@/features/dashboard/lib/calendar-navigation";
+
+describe("dashboard calendar date keys", () => {
+  it("uses campus date keys for dashboard date navigation", () => {
+    expect(toDateKey(new Date("2026-03-01T15:59:59.000Z"))).toBe("2026-03-01");
+    expect(toDateKey(new Date("2026-03-01T16:00:00.000Z"))).toBe("2026-03-02");
+    expect(weekStartFor("2026-03-02")).toBe("2026-03-01");
+    expect(addDays("2026-03-01", 7)).toBe("2026-03-08");
+    expect(addMonths("2026-01", -1)).toBe("2025-12");
+    expect(monthWeeks("2026-03")[0]).toEqual([
+      "2026-03-01",
+      "2026-03-02",
+      "2026-03-03",
+      "2026-03-04",
+      "2026-03-05",
+      "2026-03-06",
+      "2026-03-07",
+    ]);
+  });
+
+  it("normalizes dashboard reference dates before deriving URL state", () => {
+    const calendar = {
+      activeCalendarSemesterId: 42,
+      referenceDate: "2026-03-01T16:00:00.000Z",
+    };
+    const state = dashboardCalendarStateFromUrl(
+      new URL("https://life.test/dashboard?calendarView=week"),
+      calendar,
+    );
+
+    expect(state).toEqual({
+      month: "2026-03",
+      semesterId: 42,
+      view: "week",
+      weekStart: "2026-03-01",
+    });
+    expect(dashboardCalendarViewPatch("week", calendar)).toEqual({
+      semesterId: null,
+      view: "week",
+      week: "2026-03-01",
+    });
+  });
+});

--- a/tests/unit/section-detail-date-display.test.ts
+++ b/tests/unit/section-detail-date-display.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { findCalendarBaseMonth } from "@/features/section-detail/lib/calendar";
+import {
+  calendarMonthDays,
+  dateKey,
+  formatDate,
+  isSameMonth,
+} from "@/features/section-detail/lib/date-display";
+
+describe("section detail date display", () => {
+  it("derives calendar keys with campus date boundaries", () => {
+    const boundary = new Date("2026-03-01T16:00:00.000Z");
+    const campusFormatted = new Intl.DateTimeFormat(undefined, {
+      timeZone: "Asia/Shanghai",
+    }).format(boundary);
+
+    expect(dateKey(new Date("2026-03-01T15:59:59.000Z"))).toBe("2026-03-01");
+    expect(dateKey(boundary)).toBe("2026-03-02");
+    expect(formatDate(boundary, "n/a")).toBe(campusFormatted);
+  });
+
+  it("builds section month grid keys from the shared Sunday week policy", () => {
+    const monthStart = findCalendarBaseMonth([
+      {
+        badges: [],
+        date: "2026-03-01T16:00:00.000Z",
+        dateKey: "2026-03-02",
+        details: [],
+        id: "event-1",
+        kind: "class",
+        meta: "",
+        sortValue: 0,
+        title: "Class",
+      },
+    ]);
+    const days = calendarMonthDays(monthStart);
+    const firstDay = days[0];
+    const lastDay = days.at(-1);
+
+    if (!firstDay || !lastDay) {
+      throw new Error("Expected section month grid days");
+    }
+
+    expect(days).toHaveLength(42);
+    expect(dateKey(monthStart)).toBe("2026-03-01");
+    expect(dateKey(firstDay)).toBe("2026-03-01");
+    expect(dateKey(days[1])).toBe("2026-03-02");
+    expect(dateKey(lastDay)).toBe("2026-04-11");
+    expect(isSameMonth(firstDay, monthStart)).toBe(true);
+    expect(isSameMonth(lastDay, monthStart)).toBe(false);
+  });
+});

--- a/tests/unit/user-profile-contributions.test.ts
+++ b/tests/unit/user-profile-contributions.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildUserProfileContributions } from "@/features/profile/server/user-profile-contributions";
+
+describe("user profile contributions", () => {
+  it("groups contribution events by campus date across Shanghai midnight", async () => {
+    const commentFindMany = vi.fn(async (_input: unknown) => [
+      { createdAt: new Date("2026-03-01T15:59:00.000Z") },
+    ]);
+    const uploadFindMany = vi.fn(async (_input: unknown) => [
+      { createdAt: new Date("2026-03-01T16:00:00.000Z") },
+    ]);
+    const completionFindMany = vi.fn(async (_input: unknown) => [
+      { completedAt: new Date("2026-03-01T16:30:00.000Z") },
+    ]);
+    const homeworkFindMany = vi.fn(async (_input: unknown) => [
+      { createdAt: new Date("2026-03-02T04:00:00.000Z") },
+    ]);
+
+    const result = await buildUserProfileContributions(
+      {
+        comment: { findMany: commentFindMany },
+        homework: { findMany: homeworkFindMany },
+        homeworkCompletion: { findMany: completionFindMany },
+        upload: { findMany: uploadFindMany },
+      },
+      "user-1",
+      new Date("2026-03-02T01:30:00+08:00"),
+    );
+
+    const cells = new Map(
+      result.weeks.flat().map((cell) => [cell.date, cell.count]),
+    );
+    const commentQuery = commentFindMany.mock.calls[0]?.[0] as {
+      where: { createdAt: { gte: Date } };
+    };
+
+    expect(commentQuery.where.createdAt.gte.toISOString()).toBe(
+      "2025-03-02T16:00:00.000Z",
+    );
+    expect(result.totalContributions).toBe(4);
+    expect(result.weeks[0]?.[0]?.date).toBe("2025-03-02");
+    expect(result.weeks.at(-1)?.at(-1)?.date).toBe("2026-03-07");
+    expect(cells.get("2026-03-01")).toBe(1);
+    expect(cells.get("2026-03-02")).toBe(3);
+  });
+});


### PR DESCRIPTION
## Goal

Closes #105 by centralizing campus date keys, Sunday week starts, month grids, and user-facing campus date formatting on shared helpers.

## Changed Surfaces

- Added `src/lib/time/campus-date.ts` for campus date keys, date-key arithmetic, Sunday week grids, and Shanghai-timezone formatting.
- Replaced profile contribution grouping/grid keys with shared campus helpers.
- Replaced section-detail calendar date keys, base month, month grid, and display formatting helpers with shared campus helpers.
- Replaced dashboard calendar date-key navigation and labels with shared campus helpers.
- Added focused unit coverage for profile contribution grouping, section-detail calendar keys, and dashboard calendar navigation around Shanghai midnight.

## Evidence

- `TZ=UTC bun run test -- tests/unit/user-profile-contributions.test.ts tests/unit/section-detail-date-display.test.ts tests/unit/dashboard-calendar-date-keys.test.ts`
- `DATABASE_URL=postgresql://life_ustc:life_ustc@127.0.0.1:5432/life_ustc bun run verify`
- Remote checks on `f94e1b4dc0cafcbe5746d27b9e861967846addec`: CI, CodeQL, Cloudflare Workers Build, and E2E Snapshot Artifacts passed.

## Docs / Contracts

No docs/contracts changes. The existing calendar contract already states Sunday-start calendar weeks and Sun-Sat labels; this change preserves that behavior while removing host/browser-local drift.

## Risk Areas

- Date display now consistently formats through `Asia/Shanghai`; browser-local `Date` objects remain only as documented display adapters for existing Svelte calendar components that read `getDate()`.
- No REST/MCP shape changes, Prisma changes, migrations, auth, uploads, i18n strings, or external API changes.

## Cleanup

No scratch artifacts, one-time probes, unrelated rewrites, or manual generated-file edits are staged. The worktree was rebased onto current `origin/main` before push.
