### PR TITLE
fix(api): API contract metadata drift

### DIFF
--- a/docs/contracts/comment.json
+++ b/docs/contracts/comment.json
@@ -44,6 +44,7 @@
             "returns": "{ success: Boolean, comment: Comment }",
             "auth": "user",
             "notes": [
+              "Only the comment owner may use the public edit endpoint; admins moderate through /api/admin/comments/[id].",
               "Returns 400 Invalid attachments when any requested upload is missing, owned by another user, or already attached to a different comment."
             ]
           },

--- a/docs/contracts/dashboard-link.json
+++ b/docs/contracts/dashboard-link.json
@@ -1,8 +1,8 @@
 {
   "name": "Dashboard Link",
   "access": {
-    "anon": "Can browse frequent links but cannot pin them.",
-    "user": "Can pin, unpin, and record link visits.",
+    "anon": "Can browse frequent links and follow public visit redirects but cannot pin them.",
+    "user": "Can pin and unpin links; authenticated POST visits record click counts before redirecting.",
     "admin": "Has no dedicated link management interface separate from regular users.",
     "agent": "No frequent link management capability is currently provided."
   },
@@ -46,16 +46,26 @@
           {
             "path": "/api/dashboard-links/pin",
             "method": "POST",
-            "returns": "{ pinnedSlugs: String[], maxPinnedLinks: Int, error?: String }"
+            "returns": "200 JSON pin state when Accept requests JSON; otherwise 303 redirect",
+            "notes": [
+              "JSON mode returns { pinnedSlugs: String[], maxPinnedLinks: Int, error: String? } for success and 400/401/500 failures.",
+              "Redirect mode returns to returnTo, adding dashboardLinkPinError=1 on failed writes."
+            ]
+          },
+          {
+            "path": "/api/dashboard-links/visit",
+            "returns": "307 redirect",
+            "auth": "anon",
+            "notes": ["Invalid or missing slug redirects to /."]
           },
           {
             "path": "/api/dashboard-links/visit",
             "method": "POST",
-            "returns": "303 redirect"
-          },
-          {
-            "path": "/api/dashboard-links/visit",
-            "returns": "303 redirect"
+            "returns": "303 redirect",
+            "auth": "anon",
+            "notes": [
+              "Redirect is public; click count is recorded only when the request has an authenticated user."
+            ]
           }
         ]
       },

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -363,6 +363,7 @@
             }
           }
         },
+        "x-auth-role": "admin",
         "security": [
           {
             "bearerAuth": []
@@ -433,6 +434,7 @@
             }
           }
         },
+        "x-auth-role": "admin",
         "security": [
           {
             "bearerAuth": []
@@ -525,6 +527,7 @@
             }
           }
         },
+        "x-auth-role": "admin",
         "security": [
           {
             "bearerAuth": []
@@ -605,6 +608,7 @@
             }
           }
         },
+        "x-auth-role": "admin",
         "security": [
           {
             "bearerAuth": []
@@ -683,6 +687,7 @@
             }
           }
         },
+        "x-auth-role": "admin",
         "security": [
           {
             "bearerAuth": []
@@ -753,6 +758,7 @@
             }
           }
         },
+        "x-auth-role": "admin",
         "security": [
           {
             "bearerAuth": []
@@ -792,6 +798,7 @@
             }
           }
         },
+        "x-auth-role": "admin",
         "security": [
           {
             "bearerAuth": []
@@ -849,6 +856,7 @@
             }
           }
         },
+        "x-auth-role": "admin",
         "security": [
           {
             "bearerAuth": []
@@ -909,6 +917,7 @@
             }
           }
         },
+        "x-auth-role": "admin",
         "security": [
           {
             "bearerAuth": []
@@ -983,6 +992,7 @@
             }
           }
         },
+        "x-auth-role": "admin",
         "security": [
           {
             "bearerAuth": []
@@ -1053,6 +1063,7 @@
             }
           }
         },
+        "x-auth-role": "admin",
         "security": [
           {
             "bearerAuth": []
@@ -2783,6 +2794,16 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/dashboardLinkPinResponseSchema"
+                }
+              }
+            }
+          },
           "303": {
             "description": "Redirect after pin/unpin",
             "headers": {
@@ -2790,6 +2811,36 @@
                 "description": "Redirect target URL",
                 "schema": {
                   "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/dashboardLinkPinResponseSchema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/dashboardLinkPinResponseSchema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/dashboardLinkPinResponseSchema"
                 }
               }
             }
@@ -2835,15 +2886,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          },
-          {
-            "sessionCookie": []
-          }
-        ]
+        }
       },
       "post": {
         "operationId": "recordDashboardLinkVisit",
@@ -2873,15 +2916,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          },
-          {
-            "sessionCookie": []
-          }
-        ]
+        }
       }
     },
     "/api/descriptions": {

--- a/src/features/comments/server/comment-mutations.ts
+++ b/src/features/comments/server/comment-mutations.ts
@@ -417,7 +417,7 @@ async function loadEditableCommentContext({
     return { ok: false, error: "locked" };
   }
 
-  if (!viewer.isAdmin && comment.userId !== viewer.userId) {
+  if (comment.userId !== viewer.userId) {
     return { ok: false, error: "forbidden" };
   }
 

--- a/tests/e2e/src/app/api/comments/[id]/test.ts
+++ b/tests/e2e/src/app/api/comments/[id]/test.ts
@@ -13,7 +13,8 @@
  * - Body: { body, visibility?, isAnonymous?, attachmentIds? }
  * - Response: { success: true, comment: CommentNode }
  * - Auth required (401 if unauthenticated)
- * - Only owner or admin can update (403 otherwise)
+ * - Only the owner can update through the public endpoint (403 otherwise)
+ * - Admin moderation uses PATCH /api/admin/comments/{id}
  * - Cannot update deleted or softbanned comments (403 "Comment locked")
  *
  * ## DELETE /api/comments/{id}
@@ -24,7 +25,7 @@
  * - Returns 404 if comment does not exist
  */
 import { expect, test } from "@playwright/test";
-import { signInAsDebugUser } from "../../../../../utils/auth";
+import { signInAsDebugUser, signInAsDevAdmin } from "../../../../../utils/auth";
 import { DEV_SEED } from "../../../../../utils/dev-seed";
 import { withE2ePrisma } from "../../../../../utils/e2e-db/prisma";
 import { createUploadedFileViaApi } from "../../../../../utils/uploads";
@@ -208,6 +209,45 @@ test("/api/comments/[id] PATCH 可修改评论并 DELETE 清理", async ({ page 
     if (commentId) {
       await page.request.delete(`/api/comments/${commentId}`);
     }
+  }
+});
+
+test("/api/comments/[id] PATCH rejects admin when admin is not owner", async ({
+  page,
+}) => {
+  await signInAsDebugUser(page, "/");
+  const sectionId = await resolveSeedSectionId(page.request);
+
+  const content = `e2e-admin-public-edit-forbidden-${Date.now()}`;
+  const createResponse = await page.request.post("/api/comments", {
+    data: {
+      targetType: "section",
+      targetId: String(sectionId),
+      body: content,
+      visibility: "public",
+    },
+  });
+  expect(createResponse.status()).toBe(200);
+  const commentId = ((await createResponse.json()) as { id?: string }).id;
+  expect(commentId).toBeTruthy();
+  if (!commentId) {
+    throw new Error("Expected created comment id");
+  }
+
+  try {
+    await signInAsDevAdmin(page, "/");
+
+    const patchResponse = await page.request.patch(
+      `/api/comments/${commentId}`,
+      {
+        data: { body: `${content}-admin-edited` },
+      },
+    );
+    expect(patchResponse.status()).toBe(403);
+  } finally {
+    await withE2ePrisma((prisma) =>
+      prisma.comment.deleteMany({ where: { id: commentId } }),
+    );
   }
 });
 

--- a/tests/e2e/src/app/api/comments/[id]/test.ts
+++ b/tests/e2e/src/app/api/comments/[id]/test.ts
@@ -213,13 +213,17 @@ test("/api/comments/[id] PATCH 可修改评论并 DELETE 清理", async ({ page 
 });
 
 test("/api/comments/[id] PATCH rejects admin when admin is not owner", async ({
-  page,
+  browser,
 }) => {
-  await signInAsDebugUser(page, "/");
-  const sectionId = await resolveSeedSectionId(page.request);
+  const debugContext = await browser.newContext();
+  const debugPage = await debugContext.newPage();
+  const adminContext = await browser.newContext();
+  const adminPage = await adminContext.newPage();
+  await signInAsDebugUser(debugPage, "/");
+  const sectionId = await resolveSeedSectionId(debugPage.request);
 
   const content = `e2e-admin-public-edit-forbidden-${Date.now()}`;
-  const createResponse = await page.request.post("/api/comments", {
+  const createResponse = await debugPage.request.post("/api/comments", {
     data: {
       targetType: "section",
       targetId: String(sectionId),
@@ -235,9 +239,9 @@ test("/api/comments/[id] PATCH rejects admin when admin is not owner", async ({
   }
 
   try {
-    await signInAsDevAdmin(page, "/");
+    await signInAsDevAdmin(adminPage, "/");
 
-    const patchResponse = await page.request.patch(
+    const patchResponse = await adminPage.request.patch(
       `/api/comments/${commentId}`,
       {
         data: { body: `${content}-admin-edited` },
@@ -248,6 +252,8 @@ test("/api/comments/[id] PATCH rejects admin when admin is not owner", async ({
     await withE2ePrisma((prisma) =>
       prisma.comment.deleteMany({ where: { id: commentId } }),
     );
+    await adminContext.close();
+    await debugContext.close();
   }
 });
 

--- a/tests/e2e/src/app/api/openapi/test.ts
+++ b/tests/e2e/src/app/api/openapi/test.ts
@@ -149,6 +149,26 @@ test.describe("GET /api/openapi", () => {
       body.paths?.["/api/dashboard-links/visit"]?.post?.responses?.["303"],
     ).toBeTruthy();
     expect(
+      body.paths?.["/api/dashboard-links/pin"]?.post?.requestBody?.content?.[
+        "application/x-www-form-urlencoded"
+      ]?.schema?.$ref,
+    ).toBe("#/components/schemas/dashboardLinkPinRequestSchema");
+    expect(
+      body.paths?.["/api/dashboard-links/pin"]?.post?.responses?.["200"],
+    ).toBeTruthy();
+    expect(
+      body.paths?.["/api/dashboard-links/pin"]?.post?.responses?.["303"],
+    ).toBeTruthy();
+    expect(
+      body.paths?.["/api/dashboard-links/pin"]?.post?.responses?.["400"],
+    ).toBeTruthy();
+    expect(
+      body.paths?.["/api/dashboard-links/pin"]?.post?.responses?.["401"],
+    ).toBeTruthy();
+    expect(
+      body.paths?.["/api/dashboard-links/pin"]?.post?.responses?.["500"],
+    ).toBeTruthy();
+    expect(
       body.paths?.["/api/auth/oauth2/device-authorization"]?.options
         ?.responses?.["204"],
     ).toBeTruthy();
@@ -162,9 +182,14 @@ test.describe("GET /api/openapi", () => {
       paths?: Record<
         string,
         {
-          get?: { parameters?: unknown[]; security?: unknown[] };
+          get?: {
+            parameters?: unknown[];
+            security?: unknown[];
+            "x-auth-role"?: string;
+          };
           options?: { security?: unknown[] };
-          post?: { security?: unknown[] };
+          patch?: { security?: unknown[]; "x-auth-role"?: string };
+          post?: { security?: unknown[]; "x-auth-role"?: string };
         }
       >;
     };
@@ -186,6 +211,22 @@ test.describe("GET /api/openapi", () => {
       { bearerAuth: [] },
       { sessionCookie: [] },
     ]);
+    expect(body.paths?.["/api/admin/users"]?.get?.security).toEqual([
+      { bearerAuth: [] },
+      { sessionCookie: [] },
+    ]);
+    expect(body.paths?.["/api/admin/users"]?.get?.["x-auth-role"]).toBe(
+      "admin",
+    );
+    expect(
+      body.paths?.["/api/admin/comments/{id}"]?.patch?.["x-auth-role"],
+    ).toBe("admin");
+    expect(
+      body.paths?.["/api/dashboard-links/visit"]?.get?.security,
+    ).toBeUndefined();
+    expect(
+      body.paths?.["/api/dashboard-links/visit"]?.post?.security,
+    ).toBeUndefined();
     expect(body.paths?.["/api/mcp"]?.get?.security).toEqual([
       { mcpBearerAuth: [] },
     ]);

--- a/tests/unit/openapi-scenario-examples.test.ts
+++ b/tests/unit/openapi-scenario-examples.test.ts
@@ -45,6 +45,7 @@ type GeneratedOperation = {
   >;
   security?: unknown[];
   summary?: string;
+  "x-auth-role"?: string;
 };
 
 type GeneratedMediaType = {
@@ -267,10 +268,26 @@ describe("buildScenarioOpenApiExamples", () => {
       { bearerAuth: [] },
       { sessionCookie: [] },
     ]);
+    expect(spec.paths["/api/admin/users"]?.get?.["x-auth-role"]).toBe("admin");
+    expect(spec.paths["/api/admin/comments/{id}"]?.patch?.["x-auth-role"]).toBe(
+      "admin",
+    );
     expect(spec.paths["/api/dashboard-links/pin"]?.post?.security).toEqual([
       { bearerAuth: [] },
       { sessionCookie: [] },
     ]);
+    expect(
+      spec.paths["/api/dashboard-links/visit"]?.get?.security,
+    ).toBeUndefined();
+    expect(
+      spec.paths["/api/dashboard-links/visit"]?.post?.security,
+    ).toBeUndefined();
+    expect(
+      spec.paths["/api/dashboard-links/pin"]?.post?.responses?.["200"],
+    ).toBeTruthy();
+    expect(
+      spec.paths["/api/dashboard-links/pin"]?.post?.responses?.["303"],
+    ).toBeTruthy();
     expect(
       spec.paths["/api/users/{userId}/calendar.ics"]?.get?.security,
     ).toEqual([

--- a/tools/build/openapi/generate-spec.ts
+++ b/tools/build/openapi/generate-spec.ts
@@ -1011,21 +1011,41 @@ function buildTagGroups(tags: NonNullable<MutableOpenApiDocument["tags"]>) {
   })).filter((group) => group.tags.length > 0);
 }
 
+function redirectResponse(description: string) {
+  return {
+    description,
+    headers: {
+      Location: {
+        description: "Redirect target URL",
+        schema: { type: "string" },
+      },
+    },
+  };
+}
+
 function setRedirectResponse(
   operation: MutableOpenApiOperation,
   statusCode: number,
   description: string,
 ) {
   operation.responses = {
-    [String(statusCode)]: {
-      description,
-      headers: {
-        Location: {
-          description: "Redirect target URL",
-          schema: { type: "string" },
-        },
-      },
-    },
+    [String(statusCode)]: redirectResponse(description),
+  };
+}
+
+function addRedirectResponse(
+  operation: MutableOpenApiOperation,
+  statusCode: number,
+  description: string,
+) {
+  const responses =
+    operation.responses && typeof operation.responses === "object"
+      ? (operation.responses as Record<string, unknown>)
+      : {};
+
+  operation.responses = {
+    ...responses,
+    [String(statusCode)]: redirectResponse(description),
   };
 }
 
@@ -1056,7 +1076,7 @@ function patchRedirectOperations(
       pinPost,
       "#/components/schemas/dashboardLinkPinRequestSchema",
     );
-    setRedirectResponse(pinPost, 303, "Redirect after pin/unpin");
+    addRedirectResponse(pinPost, 303, "Redirect after pin/unpin");
   }
 
   const visitGet = paths["/api/dashboard-links/visit"]?.get as
@@ -1284,6 +1304,10 @@ function applySecurityMetadata(
       if (contractAuth === "internal") {
         operation.security = INTERNAL_AUTH_SECURITY;
         continue;
+      }
+
+      if (contractAuth === "admin") {
+        operation["x-auth-role"] = "admin";
       }
 
       if (contractAuth === "user" || contractAuth === "admin") {

--- a/tools/dev/check/contracts.ts
+++ b/tools/dev/check/contracts.ts
@@ -71,6 +71,7 @@ function checkContractsDoc() {
 
   type OpenApiOperation = {
     security?: unknown;
+    "x-auth-role"?: unknown;
   };
 
   type OpenApiDocument = {
@@ -289,6 +290,10 @@ function checkContractsDoc() {
     return undefined;
   }
 
+  function expectedOpenApiAuthRole(route: DocumentedRestRoute) {
+    return route.auth === "admin" ? "admin" : undefined;
+  }
+
   function readGeneratedOpenApiSpec(): OpenApiDocument {
     return JSON.parse(
       readFileSync("public/openapi.generated.json", "utf8"),
@@ -311,6 +316,14 @@ function checkContractsDoc() {
       if (JSON.stringify(actualSecurity) !== JSON.stringify(expectedSecurity)) {
         errors.push(
           `${route.method} ${route.path} (${formatRestOwner(route)}) expected OpenAPI security ${JSON.stringify(expectedSecurity ?? null)}, got ${JSON.stringify(actualSecurity ?? null)}`,
+        );
+      }
+
+      const expectedAuthRole = expectedOpenApiAuthRole(route);
+      const actualAuthRole = operation["x-auth-role"];
+      if (actualAuthRole !== expectedAuthRole) {
+        errors.push(
+          `${route.method} ${route.path} (${formatRestOwner(route)}) expected OpenAPI x-auth-role ${JSON.stringify(expectedAuthRole ?? null)}, got ${JSON.stringify(actualAuthRole ?? null)}`,
         );
       }
     }


### PR DESCRIPTION
## Goal

Fix the API/contract drift tracked in #114, #121, and #122.

Fixes #114.
Fixes #121.
Fixes #122.

## Changed Surfaces

- Public comment edit permissions now match the contract: `/api/comments/[id]` edits are owner-only; admin governance remains under `/api/admin/comments/[id]`.
- Dashboard-link contracts and OpenAPI now distinguish public visit redirects from authenticated pin/unpin writes.
- Pin route OpenAPI documents both JSON and redirect response modes.
- Generated OpenAPI now preserves admin role requirements with `x-auth-role: "admin"`; contract checks enforce this metadata.
- E2E coverage now isolates debug-user and admin sessions when asserting public comment edit rejection.

## Evidence

- `bun run openapi:check`
- `bun run check:contracts`
- `bun run test -- tests/unit/openapi-scenario-examples.test.ts tests/unit/dashboard-link-pin-route.test.ts tests/unit/protected-write-auth-order.test.ts`
- `DATABASE_URL='postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev' bun run verify`
- Review-fix focused E2E on a disposable database and `PLAYWRIGHT_PORT=3003`: `bun run e2e:db:prepare`, `bun run e2e:build-artifacts`, `bun run seed`, then `bun run e2e:test -- 'tests/e2e/src/app/api/comments/\\[id\\]/test.ts' -g 'PATCH rejects admin when admin is not owner'` passed with 1 test.

## Docs / Contracts

Updated `docs/contracts/comment.json`, `docs/contracts/dashboard-link.json`, and regenerated `public/openapi.generated.json`.

## Risk Areas

- Clients using admin credentials against the public comment edit endpoint now receive `403` unless they own the comment. Admin moderation remains available through `/api/admin/comments/[id]`.
- Generated OpenAPI has a new extension field, `x-auth-role`, for admin routes.

## Cleanup

No scratch artifacts or unrelated rewrites are committed.
