### PR TITLE
fix(test): deterministic API test fixtures

### DIFF
--- a/tests/e2e/src/app/api/comments/test.ts
+++ b/tests/e2e/src/app/api/comments/test.ts
@@ -21,12 +21,96 @@
  * - parentId with non-existent parent → 404
  * - parentId with target mismatch → 400
  */
-import { expect, test } from "@playwright/test";
+import { expect, type TestInfo, test } from "@playwright/test";
 import { signInAsDebugUser } from "../../../../utils/auth";
 import { DEV_SEED } from "../../../../utils/dev-seed";
 import { withE2ePrisma } from "../../../../utils/e2e-db/prisma";
 import { createUploadedFileViaApi } from "../../../../utils/uploads";
 import { assertApiContract } from "../../_shared/api-contract";
+
+type DisposableSectionTeacherFixture = {
+  courseId: number;
+  sectionId: number;
+  teacherId: number;
+};
+
+let disposableFixtureCounter = 0;
+
+function nextDisposableJwId(testInfo: TestInfo) {
+  const counter = disposableFixtureCounter;
+  disposableFixtureCounter += 1;
+  return (
+    1_000_000_000 +
+    (Date.now() % 10_000_000) * 100 +
+    ((testInfo.workerIndex + counter) % 100)
+  );
+}
+
+async function createDisposableSectionTeacherFixture(
+  testInfo: TestInfo,
+  options: { connectTeacher: boolean },
+): Promise<DisposableSectionTeacherFixture> {
+  const courseJwId = nextDisposableJwId(testInfo);
+  const sectionJwId = nextDisposableJwId(testInfo);
+  const marker = `e2e-section-teacher-${sectionJwId}`;
+
+  return withE2ePrisma((prisma) =>
+    prisma.$transaction(async (tx) => {
+      const course = await tx.course.create({
+        data: {
+          code: marker,
+          jwId: courseJwId,
+          nameCn: marker,
+        },
+        select: { id: true },
+      });
+      const teacher = await tx.teacher.create({
+        data: {
+          code: marker,
+          nameCn: marker,
+        },
+        select: { id: true },
+      });
+      const section = await tx.section.create({
+        data: {
+          code: marker,
+          courseId: course.id,
+          jwId: sectionJwId,
+          ...(options.connectTeacher
+            ? { teachers: { connect: { id: teacher.id } } }
+            : {}),
+        },
+        select: { id: true },
+      });
+
+      return {
+        courseId: course.id,
+        sectionId: section.id,
+        teacherId: teacher.id,
+      };
+    }),
+  );
+}
+
+async function deleteDisposableSectionTeacherFixture(
+  fixture: DisposableSectionTeacherFixture,
+) {
+  await withE2ePrisma(async (prisma) => {
+    await prisma.section.update({
+      where: { id: fixture.sectionId },
+      data: { teachers: { set: [] } },
+    });
+    await prisma.sectionTeacher.deleteMany({
+      where: {
+        sectionId: fixture.sectionId,
+        teacherId: fixture.teacherId,
+      },
+    });
+    await prisma.section.deleteMany({ where: { id: fixture.sectionId } });
+    await prisma.teacher.deleteMany({ where: { id: fixture.teacherId } });
+    await prisma.course.deleteMany({ where: { id: fixture.courseId } });
+  });
+}
 
 /** Resolve the seed section's internal DB id via match-codes. */
 async function resolveSeedSectionId(
@@ -116,30 +200,14 @@ test("/api/comments GET 不存在的目标返回 404", async ({ request }) => {
 
 test("/api/comments GET section-teacher 空目标不会创建关系行", async ({
   request,
-}) => {
-  const marker = `[e2e] section-teacher-read-${Date.now()}`;
-  const { sectionId, teacherId } = await withE2ePrisma(async (prisma) => {
-    const section = await prisma.section.findUniqueOrThrow({
-      where: { jwId: DEV_SEED.section.jwId },
-      select: { id: true },
-    });
-    const teacher = await prisma.teacher.create({
-      data: {
-        code: marker,
-        nameCn: marker,
-      },
-      select: { id: true },
-    });
-    await prisma.section.update({
-      where: { id: section.id },
-      data: { teachers: { connect: { id: teacher.id } } },
-    });
-    return { sectionId: section.id, teacherId: teacher.id };
+}, testInfo) => {
+  const fixture = await createDisposableSectionTeacherFixture(testInfo, {
+    connectTeacher: true,
   });
 
   try {
     const response = await request.get(
-      `/api/comments?targetType=section-teacher&sectionId=${sectionId}&teacherId=${teacherId}`,
+      `/api/comments?targetType=section-teacher&sectionId=${fixture.sectionId}&teacherId=${fixture.teacherId}`,
     );
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -151,16 +219,16 @@ test("/api/comments GET section-teacher 空目标不会创建关系行", async (
       };
     };
     expect(body.comments).toEqual([]);
-    expect(body.target?.sectionId).toBe(sectionId);
-    expect(body.target?.teacherId).toBe(teacherId);
+    expect(body.target?.sectionId).toBe(fixture.sectionId);
+    expect(body.target?.teacherId).toBe(fixture.teacherId);
     expect(body.target?.sectionTeacherId).toBeNull();
 
     const created = await withE2ePrisma((prisma) =>
       prisma.sectionTeacher.findUnique({
         where: {
           sectionId_teacherId: {
-            sectionId,
-            teacherId,
+            sectionId: fixture.sectionId,
+            teacherId: fixture.teacherId,
           },
         },
         select: { id: true },
@@ -168,47 +236,24 @@ test("/api/comments GET section-teacher 空目标不会创建关系行", async (
     );
     expect(created).toBeNull();
   } finally {
-    await withE2ePrisma(async (prisma) => {
-      await prisma.sectionTeacher.deleteMany({
-        where: { sectionId, teacherId },
-      });
-      await prisma.section.update({
-        where: { id: sectionId },
-        data: { teachers: { disconnect: { id: teacherId } } },
-      });
-      await prisma.teacher.deleteMany({ where: { id: teacherId } });
-    });
+    await deleteDisposableSectionTeacherFixture(fixture);
   }
 });
 
 test("/api/comments GET 未关联的 section-teacher 目标返回 404", async ({
   request,
-}) => {
-  const marker = `[e2e] section-teacher-missing-${Date.now()}`;
-  const { sectionId, teacherId } = await withE2ePrisma(async (prisma) => {
-    const section = await prisma.section.findUniqueOrThrow({
-      where: { jwId: DEV_SEED.section.jwId },
-      select: { id: true },
-    });
-    const teacher = await prisma.teacher.create({
-      data: {
-        code: marker,
-        nameCn: marker,
-      },
-      select: { id: true },
-    });
-    return { sectionId: section.id, teacherId: teacher.id };
+}, testInfo) => {
+  const fixture = await createDisposableSectionTeacherFixture(testInfo, {
+    connectTeacher: false,
   });
 
   try {
     const response = await request.get(
-      `/api/comments?targetType=section-teacher&sectionId=${sectionId}&teacherId=${teacherId}`,
+      `/api/comments?targetType=section-teacher&sectionId=${fixture.sectionId}&teacherId=${fixture.teacherId}`,
     );
     expect(response.status()).toBe(404);
   } finally {
-    await withE2ePrisma((prisma) =>
-      prisma.teacher.deleteMany({ where: { id: teacherId } }),
-    );
+    await deleteDisposableSectionTeacherFixture(fixture);
   }
 });
 

--- a/tests/e2e/src/app/api/descriptions/test.ts
+++ b/tests/e2e/src/app/api/descriptions/test.ts
@@ -24,15 +24,103 @@
  * - Non-existent target on POST → 404
  * - Same content twice → updated: false on second call
  */
-import { expect, test } from "@playwright/test";
+import { expect, type TestInfo, test } from "@playwright/test";
 import { signInAsDebugUser } from "../../../../utils/auth";
 import {
-  restoreDescriptionSnapshot,
   snapshotDescriptionForE2e,
   waitForDescriptionAuditRows,
 } from "../../../../utils/description-state";
 import { DEV_SEED } from "../../../../utils/dev-seed";
+import { withE2ePrisma } from "../../../../utils/e2e-db/prisma";
 import { assertApiContract } from "../../_shared/api-contract";
+
+type DisposableDescriptionFixture = {
+  courseId: number;
+  descriptionId: string;
+  originalContent: string;
+  sectionId: number;
+  sectionJwId: number;
+};
+
+let disposableFixtureCounter = 0;
+
+function nextDisposableJwId(testInfo: TestInfo) {
+  const counter = disposableFixtureCounter;
+  disposableFixtureCounter += 1;
+  return (
+    1_000_000_000 +
+    (Date.now() % 10_000_000) * 100 +
+    ((testInfo.workerIndex + counter) % 100)
+  );
+}
+
+async function createDisposableDescriptionFixture(
+  testInfo: TestInfo,
+): Promise<DisposableDescriptionFixture> {
+  const courseJwId = nextDisposableJwId(testInfo);
+  const sectionJwId = nextDisposableJwId(testInfo);
+  const marker = `e2e-description-fixture-${sectionJwId}`;
+  const originalContent = `${marker}-original`;
+
+  return withE2ePrisma((prisma) =>
+    prisma.$transaction(async (tx) => {
+      const course = await tx.course.create({
+        data: {
+          code: marker,
+          jwId: courseJwId,
+          nameCn: marker,
+        },
+        select: { id: true },
+      });
+      const section = await tx.section.create({
+        data: {
+          code: marker,
+          courseId: course.id,
+          jwId: sectionJwId,
+        },
+        select: { id: true },
+      });
+      const description = await tx.description.create({
+        data: {
+          content: originalContent,
+          sectionId: section.id,
+        },
+        select: { id: true },
+      });
+
+      return {
+        courseId: course.id,
+        descriptionId: description.id,
+        originalContent,
+        sectionId: section.id,
+        sectionJwId,
+      };
+    }),
+  );
+}
+
+async function deleteDisposableDescriptionFixture(
+  fixture: DisposableDescriptionFixture,
+) {
+  await withE2ePrisma(async (prisma) => {
+    await prisma.$transaction([
+      prisma.auditLog.deleteMany({
+        where: {
+          targetId: fixture.descriptionId,
+          targetType: "description",
+        },
+      }),
+      prisma.descriptionEdit.deleteMany({
+        where: { descriptionId: fixture.descriptionId },
+      }),
+      prisma.description.deleteMany({
+        where: { id: fixture.descriptionId },
+      }),
+      prisma.section.deleteMany({ where: { id: fixture.sectionId } }),
+      prisma.course.deleteMany({ where: { id: fixture.courseId } }),
+    ]);
+  });
+}
 
 /** Resolve the seed section's internal DB id via match-codes. */
 async function resolveSeedSectionId(
@@ -119,33 +207,36 @@ test("/api/descriptions POST 未登录返回 401", async ({ request }) => {
   expect(response.status()).toBe(401);
 });
 
-test("/api/descriptions POST 登录后可更新描述并还原", async ({ page }) => {
+test("/api/descriptions POST 登录后可更新描述并清理", async ({
+  page,
+}, testInfo) => {
   await signInAsDebugUser(page, "/");
-  const sectionId = await resolveSeedSectionId(page.request);
+  const fixture = await createDisposableDescriptionFixture(testInfo);
+  let snapshot: Awaited<ReturnType<typeof snapshotDescriptionForE2e>> | null =
+    null;
 
-  // Read original content first
-  const originalResponse = await page.request.get(
-    `/api/descriptions?targetType=section&targetId=${sectionId}`,
-  );
-  expect(originalResponse.status()).toBe(200);
-  const originalBody = (await originalResponse.json()) as {
-    description?: { content?: string; id?: string | null } | null;
-  };
-  const descriptionId = originalBody.description?.id;
-  if (!descriptionId) {
-    throw new Error("Expected seed description id");
-  }
-  const snapshot = await snapshotDescriptionForE2e(descriptionId, [
-    "description_edit",
-  ]);
-
-  const newContent = `e2e-description-${Date.now()}`;
   try {
+    // Read original content first
+    const originalResponse = await page.request.get(
+      `/api/descriptions?targetType=section&targetId=${fixture.sectionId}`,
+    );
+    expect(originalResponse.status()).toBe(200);
+    const originalBody = (await originalResponse.json()) as {
+      description?: { content?: string; id?: string | null } | null;
+    };
+    expect(originalBody.description?.id).toBe(fixture.descriptionId);
+    expect(originalBody.description?.content).toBe(fixture.originalContent);
+    snapshot = await snapshotDescriptionForE2e(fixture.descriptionId, [
+      "description_edit",
+    ]);
+
+    const newContent = `e2e-description-${Date.now()}`;
+
     // POST: update description
     const postResponse = await page.request.post("/api/descriptions", {
       data: {
         targetType: "section",
-        targetId: String(sectionId),
+        targetId: String(fixture.sectionId),
         content: newContent,
       },
     });
@@ -159,7 +250,7 @@ test("/api/descriptions POST 登录后可更新描述并还原", async ({ page }
 
     // Verify the update via GET
     const getResponse = await page.request.get(
-      `/api/descriptions?targetType=section&targetId=${sectionId}`,
+      `/api/descriptions?targetType=section&targetId=${fixture.sectionId}`,
     );
     expect(getResponse.status()).toBe(200);
     const getBody = (await getResponse.json()) as {
@@ -171,7 +262,7 @@ test("/api/descriptions POST 登录后可更新描述并还原", async ({ page }
     const idempotentResponse = await page.request.post("/api/descriptions", {
       data: {
         targetType: "section",
-        targetId: String(sectionId),
+        targetId: String(fixture.sectionId),
         content: newContent,
       },
     });
@@ -183,37 +274,41 @@ test("/api/descriptions POST 登录后可更新描述并还原", async ({ page }
     expect(idempotentBody.id).toBeTruthy();
     expect(idempotentBody.updated).toBe(false);
   } finally {
-    await waitForDescriptionAuditRows(snapshot, 1);
-    await restoreDescriptionSnapshot(snapshot);
+    if (snapshot) {
+      await waitForDescriptionAuditRows(snapshot, 1);
+    }
+    await deleteDisposableDescriptionFixture(fixture);
   }
 });
 
 test("/api/descriptions POST accepts public section JW id", async ({
   page,
-}) => {
+}, testInfo) => {
   await signInAsDebugUser(page, "/");
+  const fixture = await createDisposableDescriptionFixture(testInfo);
+  let snapshot: Awaited<ReturnType<typeof snapshotDescriptionForE2e>> | null =
+    null;
 
-  const originalResponse = await page.request.get(
-    `/api/descriptions?targetType=section&sectionJwId=${DEV_SEED.section.jwId}`,
-  );
-  expect(originalResponse.status()).toBe(200);
-  const originalBody = (await originalResponse.json()) as {
-    description?: { content?: string; id?: string | null } | null;
-  };
-  const descriptionId = originalBody.description?.id;
-  if (!descriptionId) {
-    throw new Error("Expected seed description id");
-  }
-  const snapshot = await snapshotDescriptionForE2e(descriptionId, [
-    "description_edit",
-  ]);
-
-  const newContent = `e2e-description-public-id-${Date.now()}`;
   try {
+    const originalResponse = await page.request.get(
+      `/api/descriptions?targetType=section&sectionJwId=${fixture.sectionJwId}`,
+    );
+    expect(originalResponse.status()).toBe(200);
+    const originalBody = (await originalResponse.json()) as {
+      description?: { content?: string; id?: string | null } | null;
+    };
+    expect(originalBody.description?.id).toBe(fixture.descriptionId);
+    expect(originalBody.description?.content).toBe(fixture.originalContent);
+    snapshot = await snapshotDescriptionForE2e(fixture.descriptionId, [
+      "description_edit",
+    ]);
+
+    const newContent = `e2e-description-public-id-${Date.now()}`;
+
     const postResponse = await page.request.post("/api/descriptions", {
       data: {
         targetType: "section",
-        sectionJwId: DEV_SEED.section.jwId,
+        sectionJwId: fixture.sectionJwId,
         content: newContent,
       },
     });
@@ -226,7 +321,7 @@ test("/api/descriptions POST accepts public section JW id", async ({
     expect(postBody.updated).toBe(true);
 
     const getResponse = await page.request.get(
-      `/api/descriptions?targetType=section&sectionJwId=${DEV_SEED.section.jwId}`,
+      `/api/descriptions?targetType=section&sectionJwId=${fixture.sectionJwId}`,
     );
     expect(getResponse.status()).toBe(200);
     const getBody = (await getResponse.json()) as {
@@ -234,8 +329,10 @@ test("/api/descriptions POST accepts public section JW id", async ({
     };
     expect(getBody.description?.content).toContain(newContent);
   } finally {
-    await waitForDescriptionAuditRows(snapshot, 1);
-    await restoreDescriptionSnapshot(snapshot);
+    if (snapshot) {
+      await waitForDescriptionAuditRows(snapshot, 1);
+    }
+    await deleteDisposableDescriptionFixture(fixture);
   }
 });
 

--- a/tests/unit/upload-object-put-route.test.ts
+++ b/tests/unit/upload-object-put-route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   deleteStorageObjectMock,
@@ -32,6 +32,8 @@ vi.mock("@/lib/storage/r2-object", () => ({
   putStorageObject: putStorageObjectMock,
 }));
 
+const FIXED_NOW = new Date("2026-01-15T00:00:00.000Z");
+
 function uploadRequest(input: {
   body?: string;
   contentLength?: string;
@@ -51,7 +53,13 @@ function uploadRequest(input: {
 }
 
 describe("putUploadObjectRoute", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+  });
+
   afterEach(() => {
+    vi.useRealTimers();
     deleteStorageObjectMock.mockReset();
     findUniqueMock.mockReset();
     headStorageObjectMock.mockReset();
@@ -98,7 +106,7 @@ describe("putUploadObjectRoute", () => {
     requireWriteAuthMock.mockResolvedValue({ userId: "user-1" });
     findUniqueMock.mockResolvedValue({
       contentType: "text/plain",
-      expiresAt: new Date(Date.now() - 1_000),
+      expiresAt: new Date(FIXED_NOW.getTime() - 1_000),
       size: 2,
       userId: "user-1",
     });
@@ -121,7 +129,7 @@ describe("putUploadObjectRoute", () => {
     requireWriteAuthMock.mockResolvedValue({ userId: "user-1" });
     findUniqueMock.mockResolvedValue({
       contentType: "text/plain",
-      expiresAt: new Date(Date.now() + 60_000),
+      expiresAt: new Date(FIXED_NOW.getTime() + 60_000),
       size: 1,
       userId: "user-1",
     });
@@ -141,7 +149,7 @@ describe("putUploadObjectRoute", () => {
     requireWriteAuthMock.mockResolvedValue({ userId: "user-1" });
     findUniqueMock.mockResolvedValue({
       contentType: "text/plain",
-      expiresAt: new Date(Date.now() + 60_000),
+      expiresAt: new Date(FIXED_NOW.getTime() + 60_000),
       size: 2,
       userId: "user-1",
     });


### PR DESCRIPTION
## Goal

Make the affected API E2E and upload unit tests deterministic and isolated.

Fixes #123
Fixes #124

## Changed Surfaces

- `tests/e2e/src/app/api/comments/test.ts`: uses disposable section/teacher/course fixtures for section-teacher comment checks instead of modifying the shared seed section.
- `tests/e2e/src/app/api/descriptions/test.ts`: uses disposable section/course/description fixtures for mutating description checks instead of editing and restoring the canonical seed description.
- `tests/unit/upload-object-put-route.test.ts`: freezes system time around upload expiry checks.

## Evidence

- `bun run test -- tests/unit/upload-object-put-route.test.ts`
- `bunx biome check tests/e2e/src/app/api/comments/test.ts tests/e2e/src/app/api/descriptions/test.ts tests/unit/upload-object-put-route.test.ts`
- `bun run tsc --noEmit -p tsconfig.typecheck.tests.json`
- `git diff --check origin/main...HEAD`
- Disposable-DB focused E2E on `PLAYWRIGHT_PORT=3002`: `bun run e2e:db:prepare`, `bun run e2e:build-artifacts`, `bun run seed`, `bun run e2e:test -- tests/e2e/src/app/api/descriptions/test.ts tests/e2e/src/app/api/comments/test.ts` passed with 22 tests.

Local setup retries before the passing E2E run:
- First attempt failed before tests because `AUTH_SECRET` was not exported.
- Second attempt failed before tests because `127.0.0.1:3000` was already in use.

## Docs / Contracts

No docs, contracts, or OpenAPI changes. This is test fixture isolation and unit-test clock control only.

## Risk Areas

- E2E fixture cleanup now removes disposable records plus related description audit/edit rows.
- Tests still read canonical seed data for read-only coverage, but mutating cases no longer edit shared seed records.

## Cleanup

- No generated artifacts or scratch files are present in the worktree.
- Temporary E2E databases were dropped after each run.
