### PR TITLE
feat(data): data import invariants

### DIFF
--- a/prisma/migrations/20260325201110_migrate_to_oauth_provider/migration.sql
+++ b/prisma/migrations/20260325201110_migrate_to_oauth_provider/migration.sql
@@ -19,6 +19,11 @@ DROP INDEX "OAuthRefreshToken_tokenHash_idx";
 -- DropIndex
 DROP INDEX "OAuthRefreshToken_tokenHash_key";
 
+-- Legacy refresh tokens stored only tokenHash values. Plaintext provider tokens
+-- cannot be reconstructed, so this migration explicitly revokes them before
+-- adding the provider-owned non-null token column.
+DELETE FROM "OAuthRefreshToken";
+
 -- AlterTable
 ALTER TABLE "OAuthAccessToken" DROP COLUMN "resource",
 ADD COLUMN     "referenceId" TEXT,
@@ -127,4 +132,3 @@ ALTER TABLE "OAuthConsent" ADD CONSTRAINT "OAuthConsent_clientId_fkey" FOREIGN K
 
 -- AddForeignKey
 ALTER TABLE "OAuthConsent" ADD CONSTRAINT "OAuthConsent_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-

--- a/prisma/migrations/20260625140000_fix_collaborative_invariants/migration.sql
+++ b/prisma/migrations/20260625140000_fix_collaborative_invariants/migration.sql
@@ -1,16 +1,26 @@
-WITH ranked_attachments AS (
+DO $$
+DECLARE
+  duplicate_uploads integer;
+  duplicate_links integer;
+BEGIN
   SELECT
-    "id",
-    ROW_NUMBER() OVER (
-      PARTITION BY "uploadId"
-      ORDER BY "createdAt" ASC, "id" ASC
-    ) AS "attachmentRank"
-  FROM "CommentAttachment"
-)
-DELETE FROM "CommentAttachment"
-USING ranked_attachments
-WHERE "CommentAttachment"."id" = ranked_attachments."id"
-  AND ranked_attachments."attachmentRank" > 1;
+    COUNT(*)::integer,
+    COALESCE(SUM("attachmentCount" - 1), 0)::integer
+  INTO duplicate_uploads, duplicate_links
+  FROM (
+    SELECT "uploadId", COUNT(*) AS "attachmentCount"
+    FROM "CommentAttachment"
+    GROUP BY "uploadId"
+    HAVING COUNT(*) > 1
+  ) duplicates;
+
+  IF duplicate_uploads > 0 THEN
+    RAISE EXCEPTION
+      'Cannot add CommentAttachment_uploadId_key: found % uploads linked to multiple comments (% duplicate links). Resolve duplicate CommentAttachment rows explicitly before applying this migration.',
+      duplicate_uploads,
+      duplicate_links;
+  END IF;
+END $$;
 
 ALTER TABLE "AuditLog" DROP CONSTRAINT "AuditLog_userId_fkey";
 ALTER TABLE "AuditLog" ALTER COLUMN "userId" DROP NOT NULL;

--- a/prisma/migrations/20260625162000_add_section_teacher_retired_at/migration.sql
+++ b/prisma/migrations/20260625162000_add_section_teacher_retired_at/migration.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "SectionTeacher" ADD COLUMN "retiredAt" TIMESTAMP(3);
+
+UPDATE "SectionTeacher" AS st
+SET
+  "retiredAt" = CURRENT_TIMESTAMP,
+  "updatedAt" = CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "_SectionTeachers" AS active
+  WHERE active."A" = st."sectionId"
+    AND active."B" = st."teacherId"
+);
+
+CREATE INDEX "SectionTeacher_retiredAt_idx" ON "SectionTeacher"("retiredAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -693,10 +693,12 @@ model SectionTeacher {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  retiredAt DateTime?
 
   @@unique([sectionId, teacherId])
   @@index([sectionId])
   @@index([teacherId])
+  @@index([retiredAt])
 }
 
 model TeachLanguage {

--- a/src/features/bus/server/bus-import-prisma.ts
+++ b/src/features/bus/server/bus-import-prisma.ts
@@ -11,7 +11,9 @@ export type BusImportWritePrisma = {
   };
   busScheduleVersion: {
     create(args: unknown): Promise<{ id: number; key: string }>;
-    findFirst(args: unknown): Promise<{ id: number } | null>;
+    findUnique(
+      args: unknown,
+    ): Promise<{ id: number; key: string; checksum: string } | null>;
     update(args: unknown): Promise<{ id: number; key: string }>;
     updateMany(args: unknown): Promise<unknown>;
   };

--- a/src/features/bus/server/bus-import-version-upsert.ts
+++ b/src/features/bus/server/bus-import-version-upsert.ts
@@ -12,12 +12,24 @@ export async function findExistingBusScheduleVersion(
     versionKey: string;
   },
 ) {
-  return prisma.busScheduleVersion.findFirst({
-    where: {
-      OR: [{ key: versionKey }, { checksum }],
-    },
-    select: { id: true },
-  });
+  const [byKey, byChecksum] = await Promise.all([
+    prisma.busScheduleVersion.findUnique({
+      where: { key: versionKey },
+      select: { id: true, key: true, checksum: true },
+    }),
+    prisma.busScheduleVersion.findUnique({
+      where: { checksum },
+      select: { id: true, key: true, checksum: true },
+    }),
+  ]);
+
+  if (byKey && byChecksum && byKey.id !== byChecksum.id) {
+    throw new Error(
+      `Bus schedule version conflict: key "${versionKey}" belongs to version ${byKey.id}, but checksum "${checksum}" belongs to version ${byChecksum.id}`,
+    );
+  }
+
+  return byKey ?? byChecksum;
 }
 
 export async function refreshExistingBusScheduleVersion(

--- a/src/features/comments/server/comment-section-teacher.ts
+++ b/src/features/comments/server/comment-section-teacher.ts
@@ -22,7 +22,7 @@ export async function resolveSectionTeacherId(
         teacherId,
       },
     },
-    update: {},
+    update: { retiredAt: null },
     create: { sectionId, teacherId },
   });
 
@@ -41,10 +41,12 @@ export async function findSectionTeacherId(
         teacherId,
       },
     },
-    select: { id: true },
+    select: { id: true, retiredAt: true },
   });
 
-  return sectionTeacher?.id ?? null;
+  return sectionTeacher && sectionTeacher.retiredAt === null
+    ? sectionTeacher.id
+    : null;
 }
 
 export async function findSectionTeacherTarget(

--- a/src/features/comments/server/comment-target-verification.ts
+++ b/src/features/comments/server/comment-target-verification.ts
@@ -41,8 +41,8 @@ export async function verifyCommentTargetEntity(
     targetType === "section-teacher" &&
     typeof whereTarget.sectionTeacherId === "number"
   ) {
-    const st = await prisma.sectionTeacher.findUnique({
-      where: { id: whereTarget.sectionTeacherId },
+    const st = await prisma.sectionTeacher.findFirst({
+      where: { id: whereTarget.sectionTeacherId, retiredAt: null },
       select: { id: true },
     });
     return st !== null;

--- a/tests/unit/bus-import.test.ts
+++ b/tests/unit/bus-import.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { checksumBusPayload } from "@/features/bus/lib/bus-import-metadata";
 import type { BusStaticPayload } from "@/features/bus/lib/bus-types";
 import { importBusStaticPayload } from "@/features/bus/server/bus-import";
 import type {
@@ -70,19 +71,18 @@ function createImportPrismaMock(
         target.versions.push(version);
         return { id: version.id, key: version.key };
       },
-      async findFirst(args) {
-        const filters = (
-          args as { where: { OR: Array<{ checksum?: string; key?: string }> } }
-        ).where.OR;
+      async findUnique(args) {
+        const filter = (args as { where: { checksum?: string; key?: string } })
+          .where;
         const version =
           target.versions.find((candidate) =>
-            filters.some(
-              (filter) =>
-                filter.key === candidate.key ||
-                filter.checksum === candidate.checksum,
-            ),
+            filter.key != null
+              ? candidate.key === filter.key
+              : candidate.checksum === filter.checksum,
           ) ?? null;
-        return version ? { id: version.id } : null;
+        return version
+          ? { id: version.id, key: version.key, checksum: version.checksum }
+          : null;
       },
       async update(args) {
         const input = args as {
@@ -198,6 +198,44 @@ describe("bus schedule imports", () => {
         versionKey: "current-bus",
       }),
     ).rejects.toThrow("injected trip write failure");
+
+    expect(prisma.getState()).toEqual(initialState);
+  });
+
+  it("rejects imports when key and checksum match different versions", async () => {
+    const payload = createPayload();
+    const checksum = await checksumBusPayload(payload);
+    const initialState: ImportState = {
+      nextVersionId: 3,
+      versions: [
+        {
+          id: 1,
+          key: "current-bus",
+          title: "Current bus schedule",
+          checksum: "old-checksum",
+          rawJson: { old: true },
+          isEnabled: true,
+        },
+        {
+          id: 2,
+          key: "same-payload-different-key",
+          title: "Same payload under another key",
+          checksum,
+          rawJson: payload,
+          isEnabled: true,
+        },
+      ],
+      trips: [],
+    };
+    const prisma = createImportPrismaMock(initialState);
+
+    await expect(
+      importBusStaticPayload(prisma, payload, {
+        versionKey: "current-bus",
+      }),
+    ).rejects.toThrow(
+      /Bus schedule version conflict: key "current-bus" belongs to version 1, but checksum ".+" belongs to version 2/,
+    );
 
     expect(prisma.getState()).toEqual(initialState);
   });

--- a/tests/unit/comment-section-teacher.test.ts
+++ b/tests/unit/comment-section-teacher.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  findSectionTeacherId,
+  findSectionTeacherTarget,
+  resolveSectionTeacherId,
+} from "@/features/comments/server/comment-section-teacher";
+import { verifyCommentTargetEntity } from "@/features/comments/server/comment-target-verification";
+
+const prismaMock = vi.hoisted(() => ({
+  section: {
+    findFirst: vi.fn(),
+  },
+  sectionTeacher: {
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    upsert: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+describe("comment section-teacher targets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not resolve retired section-teacher rows as active targets", async () => {
+    prismaMock.sectionTeacher.findUnique.mockResolvedValue({
+      id: 9,
+      retiredAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
+    await expect(findSectionTeacherId(1, 2)).resolves.toBeNull();
+  });
+
+  it("reports stale section-teacher rows as missing when the active assignment is gone", async () => {
+    prismaMock.sectionTeacher.findUnique.mockResolvedValue({
+      id: 9,
+      retiredAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    prismaMock.section.findFirst.mockResolvedValue(null);
+
+    await expect(findSectionTeacherTarget(1, 2)).resolves.toEqual({
+      exists: false,
+      id: null,
+    });
+  });
+
+  it("reactivates an explicit target only after the active assignment exists", async () => {
+    prismaMock.section.findFirst.mockResolvedValue({ id: 1 });
+    prismaMock.sectionTeacher.upsert.mockResolvedValue({ id: 9 });
+
+    await expect(resolveSectionTeacherId(1, 2)).resolves.toBe(9);
+    expect(prismaMock.sectionTeacher.upsert).toHaveBeenCalledWith({
+      where: {
+        sectionId_teacherId: {
+          sectionId: 1,
+          teacherId: 2,
+        },
+      },
+      update: { retiredAt: null },
+      create: { sectionId: 1, teacherId: 2 },
+    });
+  });
+
+  it("rejects direct section-teacher ids when they are retired", async () => {
+    prismaMock.sectionTeacher.findFirst.mockResolvedValue(null);
+
+    await expect(
+      verifyCommentTargetEntity("section-teacher", { sectionTeacherId: 9 }),
+    ).resolves.toBe(false);
+    expect(prismaMock.sectionTeacher.findFirst).toHaveBeenCalledWith({
+      where: { id: 9, retiredAt: null },
+      select: { id: true },
+    });
+  });
+});

--- a/tests/unit/static-course-import-helpers.test.ts
+++ b/tests/unit/static-course-import-helpers.test.ts
@@ -183,6 +183,40 @@ describe("static course import helpers", () => {
     expect(identityKeys.get(newVariant.id)).not.toBe("HS2002");
   });
 
+  it("does not let filtered imports overwrite a stored canonical course", () => {
+    const storedCanonicalVariant = {
+      id: 1,
+      course_code: "HS2002",
+      name: "科学技术史",
+      course_type: "通识课",
+      course_gradation: "本科",
+      course_category: "通识教育",
+      education_type: "本科生",
+      class_type: "理论",
+    };
+    const filteredImportVariant = {
+      id: 2,
+      course_code: "HS2002",
+      name: "科学技术史",
+      course_type: "通识课",
+      course_gradation: "本科",
+      course_category: "人文素质",
+      education_type: "本科生",
+      class_type: "理论",
+    };
+
+    const identityKeys = buildStaticCourseIdentityKeyBySourceId(
+      [filteredImportVariant],
+      {
+        canonicalSignatureByCode: new Map([
+          ["HS2002", staticCourseMetadataSignature(storedCanonicalVariant)],
+        ]),
+      },
+    );
+
+    expect(identityKeys.get(filteredImportVariant.id)).not.toBe("HS2002");
+  });
+
   it("derives static department identity from the name instead of looking up by name", () => {
     expect(staticDepartmentCode("网络空间安全学院")).toMatch(
       /^static-[0-9a-f]{12}$/,

--- a/tests/unit/static-course-import-helpers.test.ts
+++ b/tests/unit/static-course-import-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   assertStaticTeacherReferencesResolvable,
   buildStaticCourseIdentityKeyBySourceId,
   buildStaticCourseImportRows,
+  staticCourseMetadataSignature,
   staticDepartmentCode,
   staticTeacherIdentityKey,
   uniqueStaticTeacherReferences,
@@ -145,6 +146,41 @@ describe("static course import helpers", () => {
     expect(identityKeys.get(1)).not.toBe(identityKeys.get(2));
     expect(rows.map((row) => row.jwId)).toEqual([1_500_000_101, 1_500_000_102]);
     expect(rows.map((row) => row.categoryId)).toEqual([23, 24]);
+  });
+
+  it("preserves the stored canonical course metadata for duplicate codes", () => {
+    const newVariant = {
+      id: 1,
+      course_code: "HS2002",
+      name: "科学技术史",
+      course_type: "通识课",
+      course_gradation: "本科",
+      course_category: "人文素质",
+      education_type: "本科生",
+      class_type: "理论",
+    };
+    const storedCanonicalVariant = {
+      id: 2,
+      course_code: "HS2002",
+      name: "科学技术史",
+      course_type: "通识课",
+      course_gradation: "本科",
+      course_category: "通识教育",
+      education_type: "本科生",
+      class_type: "理论",
+    };
+
+    const identityKeys = buildStaticCourseIdentityKeyBySourceId(
+      [newVariant, storedCanonicalVariant],
+      {
+        canonicalSignatureByCode: new Map([
+          ["HS2002", staticCourseMetadataSignature(storedCanonicalVariant)],
+        ]),
+      },
+    );
+
+    expect(identityKeys.get(storedCanonicalVariant.id)).toBe("HS2002");
+    expect(identityKeys.get(newVariant.id)).not.toBe("HS2002");
   });
 
   it("derives static department identity from the name instead of looking up by name", () => {

--- a/tests/unit/static-course-import-helpers.test.ts
+++ b/tests/unit/static-course-import-helpers.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   assertStaticTeacherReferencesResolvable,
+  buildStaticCourseIdentityKeyBySourceId,
   buildStaticCourseImportRows,
+  staticDepartmentCode,
   staticTeacherIdentityKey,
   uniqueStaticTeacherReferences,
 } from "../../tools/load/static-course-import-helpers";
@@ -39,6 +41,7 @@ describe("static course import helpers", () => {
     const [row] = buildStaticCourseImportRows(
       [
         {
+          id: 1,
           course_code: "MATH1001",
           name: "数学分析",
           course_type: "专业基础课",
@@ -69,5 +72,87 @@ describe("static course import helpers", () => {
       classTypeId: 15,
       classifyId: null,
     });
+  });
+
+  it("keeps duplicate course codes together when metadata matches", () => {
+    const identityKeys = buildStaticCourseIdentityKeyBySourceId([
+      {
+        id: 1,
+        course_code: "MARX6102U",
+        name: "思想政治理论课实践",
+        course_type: "实践课",
+        course_gradation: "本科",
+        course_category: "公共基础课",
+        education_type: "本科生",
+        class_type: "实践",
+      },
+      {
+        id: 2,
+        course_code: "MARX6102U",
+        name: "思想政治理论课实践",
+        course_type: "实践课",
+        course_gradation: "本科",
+        course_category: "公共基础课",
+        education_type: "本科生",
+        class_type: "实践",
+      },
+    ]);
+
+    expect(identityKeys.get(1)).toBe("MARX6102U");
+    expect(identityKeys.get(2)).toBe("MARX6102U");
+  });
+
+  it("splits duplicate course codes when metadata differs", () => {
+    const courses = [
+      {
+        id: 1,
+        course_code: "HS2002",
+        name: "科学技术史",
+        course_type: "通识课",
+        course_gradation: "本科",
+        course_category: "通识教育",
+        education_type: "本科生",
+        class_type: "理论",
+      },
+      {
+        id: 2,
+        course_code: "HS2002",
+        name: "科学技术史",
+        course_type: "通识课",
+        course_gradation: "本科",
+        course_category: "人文素质",
+        education_type: "本科生",
+        class_type: "理论",
+      },
+    ];
+    const identityKeys = buildStaticCourseIdentityKeyBySourceId(courses);
+    const rows = buildStaticCourseImportRows(
+      courses,
+      {
+        courseTypeIdByName: new Map([["通识课", 21]]),
+        courseGradationIdByName: new Map([["本科", 22]]),
+        courseCategoryIdByName: new Map([
+          ["通识教育", 23],
+          ["人文素质", 24],
+        ]),
+        educationLevelIdByName: new Map([["本科生", 25]]),
+        classTypeIdByName: new Map([["理论", 26]]),
+      },
+      (course) => (course.id === 1 ? 1_500_000_101 : 1_500_000_102),
+    );
+
+    expect(identityKeys.get(1)).toBe("HS2002");
+    expect(identityKeys.get(1)).not.toBe(identityKeys.get(2));
+    expect(rows.map((row) => row.jwId)).toEqual([1_500_000_101, 1_500_000_102]);
+    expect(rows.map((row) => row.categoryId)).toEqual([23, 24]);
+  });
+
+  it("derives static department identity from the name instead of looking up by name", () => {
+    expect(staticDepartmentCode("网络空间安全学院")).toMatch(
+      /^static-[0-9a-f]{12}$/,
+    );
+    expect(staticDepartmentCode(" 网络空间安全学院 ")).toBe(
+      staticDepartmentCode("网络空间安全学院"),
+    );
   });
 });

--- a/tools/load/load-from-static.ts
+++ b/tools/load/load-from-static.ts
@@ -20,6 +20,7 @@ import {
   type StaticCourseImportRow,
   type StaticTeacherReference,
   splitStaticTeacherNames,
+  staticCourseMetadataSignature,
   staticDepartmentCode,
   staticTeacherIdentityKey,
   uniqueStaticTeacherReferences,
@@ -588,6 +589,94 @@ function groupByCourseId<T extends { course_id: number }>(rows: T[]) {
 
 function dedupeByJwId<T extends { jwId: number }>(rows: T[]) {
   return [...new Map(rows.map((row) => [row.jwId, row])).values()];
+}
+
+function collectConflictingStaticCourseSignatures(courses: SnapshotCourse[]) {
+  const signaturesByCode = new Map<string, Set<string>>();
+  for (const course of courses) {
+    const code = course.course_code.trim();
+    if (!code) {
+      throw new Error("Static course code is missing");
+    }
+    const signatures = signaturesByCode.get(code) ?? new Set<string>();
+    signatures.add(staticCourseMetadataSignature(course));
+    signaturesByCode.set(code, signatures);
+  }
+  return new Map(
+    [...signaturesByCode].filter(([, signatures]) => signatures.size > 1),
+  );
+}
+
+async function loadExistingCanonicalCourseSignatures(
+  db: ImportDbClient,
+  courses: SnapshotCourse[],
+) {
+  const currentSignaturesByCode =
+    collectConflictingStaticCourseSignatures(courses);
+  const stableCodeByJwId = new Map(
+    [...currentSignaturesByCode.keys()].map((code) => [
+      stableNumericId("course", code),
+      code,
+    ]),
+  );
+  const canonicalSignatureByCode = new Map<string, string>();
+
+  await forEachChunk(
+    [...stableCodeByJwId.keys()],
+    SQLITE_READ_BATCH_SIZE,
+    async (batch) => {
+      const existing = await db.course.findMany({
+        where: { jwId: { in: batch } },
+        select: {
+          jwId: true,
+          code: true,
+          nameCn: true,
+          type: { select: { nameCn: true } },
+          gradation: { select: { nameCn: true } },
+          category: { select: { nameCn: true } },
+          educationLevel: { select: { nameCn: true } },
+          classType: { select: { nameCn: true } },
+        },
+      });
+
+      for (const row of existing) {
+        const expectedCode = stableCodeByJwId.get(row.jwId);
+        if (!expectedCode || row.code !== expectedCode) {
+          continue;
+        }
+
+        const courseGradation = row.gradation?.nameCn?.trim();
+        const courseCategory = row.category?.nameCn?.trim();
+        const educationType = row.educationLevel?.nameCn?.trim();
+        const classType = row.classType?.nameCn?.trim();
+        if (
+          !row.nameCn.trim() ||
+          !courseGradation ||
+          !courseCategory ||
+          !educationType ||
+          !classType
+        ) {
+          continue;
+        }
+
+        const signature = staticCourseMetadataSignature({
+          id: row.jwId,
+          course_code: row.code,
+          name: row.nameCn,
+          course_type: row.type?.nameCn ?? null,
+          course_gradation: courseGradation,
+          course_category: courseCategory,
+          education_type: educationType,
+          class_type: classType,
+        });
+        if (currentSignaturesByCode.get(row.code)?.has(signature)) {
+          canonicalSignatureByCode.set(row.code, signature);
+        }
+      }
+    },
+  );
+
+  return canonicalSignatureByCode;
 }
 
 function buildScheduleKey(row: {
@@ -1557,8 +1646,16 @@ async function importCourses(
     ]),
   );
   const allCourses = [...coursesBySemesterId.values()].flat();
-  const courseIdentityKeyBySourceId =
-    buildStaticCourseIdentityKeyBySourceId(allCourses);
+  const canonicalSignatureByCode = await loadExistingCanonicalCourseSignatures(
+    prisma,
+    allCourses,
+  );
+  const courseIdentityKeyBySourceId = buildStaticCourseIdentityKeyBySourceId(
+    allCourses,
+    {
+      canonicalSignatureByCode,
+    },
+  );
   const courseJwId = (course: SnapshotCourse) => {
     const identityKey = courseIdentityKeyBySourceId.get(course.id);
     if (!identityKey) {

--- a/tools/load/load-from-static.ts
+++ b/tools/load/load-from-static.ts
@@ -591,7 +591,7 @@ function dedupeByJwId<T extends { jwId: number }>(rows: T[]) {
   return [...new Map(rows.map((row) => [row.jwId, row])).values()];
 }
 
-function collectConflictingStaticCourseSignatures(courses: SnapshotCourse[]) {
+function collectStaticCourseSignatures(courses: SnapshotCourse[]) {
   const signaturesByCode = new Map<string, Set<string>>();
   for (const course of courses) {
     const code = course.course_code.trim();
@@ -602,17 +602,14 @@ function collectConflictingStaticCourseSignatures(courses: SnapshotCourse[]) {
     signatures.add(staticCourseMetadataSignature(course));
     signaturesByCode.set(code, signatures);
   }
-  return new Map(
-    [...signaturesByCode].filter(([, signatures]) => signatures.size > 1),
-  );
+  return signaturesByCode;
 }
 
 async function loadExistingCanonicalCourseSignatures(
   db: ImportDbClient,
   courses: SnapshotCourse[],
 ) {
-  const currentSignaturesByCode =
-    collectConflictingStaticCourseSignatures(courses);
+  const currentSignaturesByCode = collectStaticCourseSignatures(courses);
   const stableCodeByJwId = new Map(
     [...currentSignaturesByCode.keys()].map((code) => [
       stableNumericId("course", code),

--- a/tools/load/load-from-static.ts
+++ b/tools/load/load-from-static.ts
@@ -15,10 +15,12 @@ import type {
 } from "../../src/generated/prisma-node/client";
 import { createToolPrisma } from "../shared/tool-prisma";
 import {
+  buildStaticCourseIdentityKeyBySourceId,
   buildStaticCourseImportRows,
   type StaticCourseImportRow,
   type StaticTeacherReference,
   splitStaticTeacherNames,
+  staticDepartmentCode,
   staticTeacherIdentityKey,
   uniqueStaticTeacherReferences,
 } from "./static-course-import-helpers";
@@ -264,10 +266,6 @@ function stableNumericId(namespace: string, value: string) {
     SYNTHETIC_JWID_BASE +
     (Number.parseInt(digest.slice(0, 8), 16) % SYNTHETIC_JWID_SPAN)
   );
-}
-
-function stableDepartmentCode(name: string) {
-  return `static-${createHash("sha256").update(name).digest("hex").slice(0, 12)}`;
 }
 
 function createImportLookupState(): ImportLookupState {
@@ -682,12 +680,21 @@ async function ensureDepartments(
   }
 
   await forEachChunk(unresolved, SQLITE_READ_BATCH_SIZE, async (batch) => {
+    const nameByCode = new Map(
+      batch.map((name) => [staticDepartmentCode(name), name]),
+    );
     const existing = await db.department.findMany({
-      where: { nameCn: { in: batch } },
-      select: { id: true, nameCn: true },
+      where: { code: { in: [...nameByCode.keys()] } },
+      select: { id: true, code: true, nameCn: true },
     });
     for (const row of existing) {
-      state.departmentIdByName.set(row.nameCn, row.id);
+      const expectedName = nameByCode.get(row.code);
+      if (!expectedName || row.nameCn !== expectedName) {
+        throw new Error(
+          `Static department code conflict for ${row.code}: expected ${expectedName ?? "unknown"}, found ${row.nameCn}`,
+        );
+      }
+      state.departmentIdByName.set(expectedName, row.id);
     }
   });
 
@@ -697,7 +704,7 @@ async function ensureDepartments(
   if (missing.length > 0) {
     await db.department.createMany({
       data: missing.map((nameCn) => ({
-        code: stableDepartmentCode(nameCn),
+        code: staticDepartmentCode(nameCn),
         nameCn,
         isCollege: false,
       })),
@@ -706,12 +713,21 @@ async function ensureDepartments(
   }
 
   await forEachChunk(unresolved, SQLITE_READ_BATCH_SIZE, async (batch) => {
+    const nameByCode = new Map(
+      batch.map((name) => [staticDepartmentCode(name), name]),
+    );
     const resolved = await db.department.findMany({
-      where: { nameCn: { in: batch } },
-      select: { id: true, nameCn: true },
+      where: { code: { in: [...nameByCode.keys()] } },
+      select: { id: true, code: true, nameCn: true },
     });
     for (const row of resolved) {
-      state.departmentIdByName.set(row.nameCn, row.id);
+      const expectedName = nameByCode.get(row.code);
+      if (!expectedName || row.nameCn !== expectedName) {
+        throw new Error(
+          `Static department code conflict for ${row.code}: expected ${expectedName ?? "unknown"}, found ${row.nameCn}`,
+        );
+      }
+      state.departmentIdByName.set(expectedName, row.id);
     }
   });
 }
@@ -1031,6 +1047,84 @@ const INSERT_SECTION_TEACHERS_SQL = `
       ON CONFLICT DO NOTHING
       `;
 
+const RETIRE_STALE_SECTION_TEACHER_TARGETS_SQL = `
+      UPDATE "SectionTeacher" AS st
+      SET
+        "retiredAt" = CURRENT_TIMESTAMP,
+        "updatedAt" = CURRENT_TIMESTAMP
+      WHERE st."sectionId" IN (
+        SELECT x."id"
+        FROM jsonb_to_recordset($1::jsonb) AS x("id" int)
+      )
+        AND st."retiredAt" IS NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM jsonb_to_recordset($2::jsonb) AS links(
+            "sectionId" int,
+            "teacherId" int
+          )
+          WHERE links."sectionId" = st."sectionId"
+            AND links."teacherId" = st."teacherId"
+        )
+      `;
+
+const UPSERT_SECTION_TEACHER_TARGETS_SQL = `
+      INSERT INTO "SectionTeacher" (
+        "sectionId",
+        "teacherId",
+        "retiredAt",
+        "updatedAt"
+      )
+      SELECT
+        x."sectionId",
+        x."teacherId",
+        NULL,
+        CURRENT_TIMESTAMP
+      FROM jsonb_to_recordset($1::jsonb) AS x(
+        "sectionId" int,
+        "teacherId" int
+      )
+      ON CONFLICT ("sectionId", "teacherId") DO UPDATE SET
+        "retiredAt" = NULL,
+        "updatedAt" = CURRENT_TIMESTAMP
+      `;
+
+async function syncSectionTeacherTargets(
+  db: ImportDbClient,
+  sectionIds: number[],
+  links: Array<{ sectionId: number; teacherId: number }>,
+) {
+  const linksBySectionId = new Map<
+    number,
+    Array<{ sectionId: number; teacherId: number }>
+  >();
+  for (const link of links) {
+    const sectionLinks = linksBySectionId.get(link.sectionId);
+    if (sectionLinks) {
+      sectionLinks.push(link);
+    } else {
+      linksBySectionId.set(link.sectionId, [link]);
+    }
+  }
+
+  await forEachChunk(sectionIds, SQLITE_READ_BATCH_SIZE, async (batch) => {
+    const batchLinks = batch.flatMap(
+      (sectionId) => linksBySectionId.get(sectionId) ?? [],
+    );
+    await db.$executeRawUnsafe(
+      RETIRE_STALE_SECTION_TEACHER_TARGETS_SQL,
+      JSON.stringify(batch.map((id) => ({ id }))),
+      JSON.stringify(batchLinks),
+    );
+    await executeJsonbBatch(
+      db,
+      batchLinks,
+      UPSERT_SECTION_TEACHER_TARGETS_SQL,
+      JOIN_WRITE_BATCH_SIZE,
+    );
+  });
+}
+
 async function replaceSectionTeachers(
   db: ImportDbClient,
   sectionIds: number[],
@@ -1048,6 +1142,7 @@ async function replaceSectionTeachers(
     INSERT_SECTION_TEACHERS_SQL,
     JOIN_WRITE_BATCH_SIZE,
   );
+  await syncSectionTeacherTargets(db, sectionIds, links);
 }
 
 async function createScheduleGroups(
@@ -1252,6 +1347,7 @@ async function importSemesterCourses(
   lecturesByCourse: Map<number, SnapshotLecture[]>,
   examsByCourse: Map<number, SnapshotExam[]>,
   state: ImportLookupState,
+  courseJwId: (course: SnapshotCourse) => number,
   scheduleGroupJwIdByCourse: Map<number, number>,
 ) {
   const semesterRecord = await measure(
@@ -1264,9 +1360,7 @@ async function importSemesterCourses(
   );
 
   const courseRows = dedupeByJwId(
-    buildStaticCourseImportRows(courses, state, (courseCode) =>
-      stableNumericId("course", courseCode),
-    ),
+    buildStaticCourseImportRows(courses, state, courseJwId),
   );
 
   await measure(`Upsert courses for semester ${semester.id}`, async () => {
@@ -1286,9 +1380,7 @@ async function importSemesterCourses(
     const totalPeriods =
       Math.round(lectures.reduce((sum, lecture) => sum + lecture.periods, 0)) ||
       null;
-    const courseId = courseIdByJwId.get(
-      stableNumericId("course", course.course_code),
-    );
+    const courseId = courseIdByJwId.get(courseJwId(course));
     if (!courseId) {
       throw new Error(`Missing course id for ${course.course_code}`);
     }
@@ -1464,9 +1556,17 @@ async function importCourses(
       snapshot.listCoursesForSemester(semester.id),
     ]),
   );
-  const scheduleGroupJwIdByCourse = buildScheduleGroupJwIdByCourse(
-    [...coursesBySemesterId.values()].flat(),
-  );
+  const allCourses = [...coursesBySemesterId.values()].flat();
+  const courseIdentityKeyBySourceId =
+    buildStaticCourseIdentityKeyBySourceId(allCourses);
+  const courseJwId = (course: SnapshotCourse) => {
+    const identityKey = courseIdentityKeyBySourceId.get(course.id);
+    if (!identityKey) {
+      throw new Error(`Missing static course identity key for ${course.id}`);
+    }
+    return stableNumericId("course", identityKey);
+  };
+  const scheduleGroupJwIdByCourse = buildScheduleGroupJwIdByCourse(allCourses);
   const state = createImportLookupState();
 
   logger.info(
@@ -1495,6 +1595,7 @@ async function importCourses(
         lecturesByCourse,
         examsByCourse,
         state,
+        courseJwId,
         scheduleGroupJwIdByCourse,
       );
     });

--- a/tools/load/static-course-import-helpers.ts
+++ b/tools/load/static-course-import-helpers.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 type LookupCache = ReadonlyMap<string, number>;
 
 export type StaticCourseLookupState = {
@@ -9,6 +11,7 @@ export type StaticCourseLookupState = {
 };
 
 export type StaticCourseForImport = {
+  id: number | string;
   course_code: string;
   name: string;
   course_type: string | null;
@@ -39,6 +42,63 @@ export type StaticTeacherReference = {
 function normalizeName(value: string | null | undefined) {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
+}
+
+function requiredStaticValue(value: string, label: string) {
+  const normalized = normalizeName(value);
+  if (!normalized) {
+    throw new Error(`Static ${label} is missing`);
+  }
+  return normalized;
+}
+
+export function staticDepartmentCode(name: string) {
+  const normalized = requiredStaticValue(name, "department name");
+  return `static-${createHash("sha256").update(normalized).digest("hex").slice(0, 12)}`;
+}
+
+export function staticCourseMetadataSignature(course: StaticCourseForImport) {
+  return JSON.stringify([
+    requiredStaticValue(course.name, "course name"),
+    normalizeName(course.course_type),
+    requiredStaticValue(course.course_gradation, "course gradation"),
+    requiredStaticValue(course.course_category, "course category"),
+    requiredStaticValue(course.education_type, "education type"),
+    requiredStaticValue(course.class_type, "class type"),
+  ]);
+}
+
+export function buildStaticCourseIdentityKeyBySourceId<
+  T extends StaticCourseForImport,
+>(courses: T[]) {
+  const signaturesByCode = new Map<string, Set<string>>();
+  const canonicalSignatureByCode = new Map<string, string>();
+  for (const course of courses) {
+    const code = requiredStaticValue(course.course_code, "course code");
+    const signature = staticCourseMetadataSignature(course);
+    const signatures = signaturesByCode.get(code) ?? new Set<string>();
+    signatures.add(signature);
+    signaturesByCode.set(code, signatures);
+    if (!canonicalSignatureByCode.has(code)) {
+      canonicalSignatureByCode.set(code, signature);
+    }
+  }
+
+  const identityKeyBySourceId = new Map<T["id"], string>();
+  for (const course of courses) {
+    const code = requiredStaticValue(course.course_code, "course code");
+    const signature = staticCourseMetadataSignature(course);
+    const hasConflictingMetadata = (signaturesByCode.get(code)?.size ?? 0) > 1;
+    const canonicalSignature = canonicalSignatureByCode.get(code);
+    identityKeyBySourceId.set(
+      course.id,
+      hasConflictingMetadata && signature !== canonicalSignature
+        ? JSON.stringify(["code+metadata", code, signature])
+        : code,
+    );
+  }
+
+  return identityKeyBySourceId;
 }
 
 export function splitStaticTeacherNames(value: string | null | undefined) {
@@ -160,13 +220,13 @@ export function uniqueStaticTeacherReferences(
   return [...byKey.values()];
 }
 
-export function buildStaticCourseImportRows(
-  courses: StaticCourseForImport[],
+export function buildStaticCourseImportRows<T extends StaticCourseForImport>(
+  courses: T[],
   state: StaticCourseLookupState,
-  jwIdForCourseCode: (courseCode: string) => number,
+  jwIdForCourse: (course: T) => number,
 ): StaticCourseImportRow[] {
   return courses.map((course) => ({
-    jwId: jwIdForCourseCode(course.course_code),
+    jwId: jwIdForCourse(course),
     code: course.course_code,
     nameCn: course.name,
     typeId: course.course_type

--- a/tools/load/static-course-import-helpers.ts
+++ b/tools/load/static-course-import-helpers.ts
@@ -93,13 +93,15 @@ export function buildStaticCourseIdentityKeyBySourceId<
     const code = requiredStaticValue(course.course_code, "course code");
     const signature = staticCourseMetadataSignature(course);
     const signatures = signaturesByCode.get(code);
-    const hasConflictingMetadata = (signatures?.size ?? 0) > 1;
     const storedCanonicalSignature =
       options.canonicalSignatureByCode?.get(code);
     const canonicalSignature =
-      storedCanonicalSignature && signatures?.has(storedCanonicalSignature)
-        ? storedCanonicalSignature
-        : canonicalSignatureByCode.get(code);
+      storedCanonicalSignature ?? canonicalSignatureByCode.get(code);
+    const hasConflictingMetadata =
+      (signatures?.size ?? 0) > 1 ||
+      Boolean(
+        storedCanonicalSignature && signature !== storedCanonicalSignature,
+      );
     identityKeyBySourceId.set(
       course.id,
       hasConflictingMetadata && signature !== canonicalSignature

--- a/tools/load/static-course-import-helpers.ts
+++ b/tools/load/static-course-import-helpers.ts
@@ -39,6 +39,10 @@ export type StaticTeacherReference = {
   source: string;
 };
 
+type StaticCourseIdentityOptions = {
+  canonicalSignatureByCode?: ReadonlyMap<string, string>;
+};
+
 function normalizeName(value: string | null | undefined) {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
@@ -70,7 +74,7 @@ export function staticCourseMetadataSignature(course: StaticCourseForImport) {
 
 export function buildStaticCourseIdentityKeyBySourceId<
   T extends StaticCourseForImport,
->(courses: T[]) {
+>(courses: T[], options: StaticCourseIdentityOptions = {}) {
   const signaturesByCode = new Map<string, Set<string>>();
   const canonicalSignatureByCode = new Map<string, string>();
   for (const course of courses) {
@@ -88,8 +92,14 @@ export function buildStaticCourseIdentityKeyBySourceId<
   for (const course of courses) {
     const code = requiredStaticValue(course.course_code, "course code");
     const signature = staticCourseMetadataSignature(course);
-    const hasConflictingMetadata = (signaturesByCode.get(code)?.size ?? 0) > 1;
-    const canonicalSignature = canonicalSignatureByCode.get(code);
+    const signatures = signaturesByCode.get(code);
+    const hasConflictingMetadata = (signatures?.size ?? 0) > 1;
+    const storedCanonicalSignature =
+      options.canonicalSignatureByCode?.get(code);
+    const canonicalSignature =
+      storedCanonicalSignature && signatures?.has(storedCanonicalSignature)
+        ? storedCanonicalSignature
+        : canonicalSignatureByCode.get(code);
     identityKeyBySourceId.set(
       course.id,
       hasConflictingMetadata && signature !== canonicalSignature


### PR DESCRIPTION
## Goal

Enforce import and migration invariants that were still structurally loose after the review pass.

Fixes #115
Fixes #116
Fixes #117
Fixes #118
Fixes #119
Fixes #120

## Changed Surfaces

- Static course loader: splits duplicate course codes only when metadata differs, preserves the already-imported canonical course variant, and prevents filtered imports from overwriting the stable course identity when the stored canonical metadata is outside the current import window.
- Static loader departments: derives department identity from stable static codes.
- Section-teacher targets: adds `SectionTeacher.retiredAt`, syncs comment target rows from the active `_SectionTeachers` relation, and rejects retired targets for new/direct comment target checks.
- Bus import: detects key/checksum conflicts instead of refreshing the wrong schedule version.
- Migrations: revokes unreconstructable legacy OAuth refresh tokens before the Better Auth provider migration and changes duplicate comment-attachment migration behavior from silent deletion to explicit abort.

## Evidence

- Loader/data invariant checks: `DATABASE_URL=... bun run db:generate`; `bun run test -- tests/unit/static-course-import-helpers.test.ts tests/unit/bus-import.test.ts tests/unit/comment-section-teacher.test.ts`.
- Review follow-up checks: `bunx biome check tools/load/static-course-import-helpers.ts tools/load/load-from-static.ts tests/unit/static-course-import-helpers.test.ts`; `DATABASE_URL=... bun run verify:types`; `git diff --check`.
- Filtered-import follow-up checks: `bun run test -- tests/unit/static-course-import-helpers.test.ts`; `bunx biome check tools/load/static-course-import-helpers.ts tools/load/load-from-static.ts tests/unit/static-course-import-helpers.test.ts`; `DATABASE_URL=... bun run verify:types`; `git diff --check`.
- Clean temporary Postgres replay: `DATABASE_URL=... bun run db:migrate:deploy` applied all 36 migrations.
- Clean temporary Postgres default gate: `DATABASE_URL=... AUTH_SECRET=... bun run verify` passed with 109 test files and 503 tests.

## Docs / Contracts

No REST/MCP contract, OpenAPI, UI copy, or user workflow shape changes. The behavior is internal import, migration, and comment-target validation.

## Risk Areas

- This PR intentionally edits two existing migration files to fix replay-time behavior before those migrations can lose or fail on legacy data. Databases that already applied the old checksums need deliberate Prisma migration-history handling.
- Duplicate `CommentAttachment` rows now abort migration instead of being deleted. Operators must resolve duplicates explicitly before applying.
- Legacy hash-only OAuth refresh-token rows are revoked because plaintext provider tokens cannot be reconstructed.
- Static course metadata conflicts now preserve an existing stable canonical variant when the database has enough metadata to match it; brand-new conflicts still choose a canonical variant from current snapshot order.

## Cleanup

- No generated Prisma/OpenAPI files, scratch reports, or ad hoc probes are present in the worktree.
- Temporary verification databases were dropped after the runs.
