### PR TITLE
fix(ui): dashboard UI accessibility drift

### DIFF
--- a/src/features/comments/components/CommentComposer.svelte
+++ b/src/features/comments/components/CommentComposer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import type { ViewerContext } from "@/lib/auth/viewer-context";
 import MarkdownEditor from "$lib/components/MarkdownEditor.svelte";
 import * as Card from "$lib/components/ui/card/index.js";
@@ -51,13 +52,14 @@ export let visibilityOptions: CommentSelectOption[];
     />
     <MarkdownEditor
       bind:value={body}
-      campusReferences
+      aria-label={commentCopy.markdownModeLabel}
       disabled={!viewer.isAuthenticated || viewer.isSuspended}
       guideLabel={commentCopy.markdownGuide}
       {isDragActive}
       modeLabel={commentCopy.markdownModeLabel}
       placeholder={viewer.isAuthenticated ? commentCopy.editorPlaceholder : commentCopy.loginToComment}
       previewEmptyLabel={commentCopy.previewEmpty}
+      remarkPlugins={campusReferenceMarkdownPlugins}
       tabPreviewLabel={commentCopy.tabPreview}
       tabWriteLabel={commentCopy.tabWrite}
       ondragleave={() => {

--- a/src/features/comments/components/CommentReplyEditor.svelte
+++ b/src/features/comments/components/CommentReplyEditor.svelte
@@ -3,6 +3,7 @@ import type {
   CommentNodeWithContext,
   CommentTargetOption,
 } from "@/features/comments/lib/comment-ui";
+import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import type { ViewerContext } from "@/lib/auth/viewer-context";
 import MarkdownEditor from "$lib/components/MarkdownEditor.svelte";
 import { Button } from "$lib/components/ui/button/index.js";
@@ -45,13 +46,14 @@ $: replyDisabled = !viewer.isAuthenticated || viewer.isSuspended;
 <div class="rounded-2xl border border-dashed border-base-300 bg-base-200/40 p-4">
   <MarkdownEditor
     bind:value={replyDraft}
-    campusReferences
+    aria-label={commentCopy.markdownModeLabel}
     compact
     disabled={replyDisabled}
     guideLabel={commentCopy.markdownGuide}
     modeLabel={commentCopy.markdownModeLabel}
     placeholder={commentCopy.replyPlaceholder}
     previewEmptyLabel={commentCopy.previewEmpty}
+    remarkPlugins={campusReferenceMarkdownPlugins}
     rows={3}
     tabPreviewLabel={commentCopy.tabPreview}
     tabWriteLabel={commentCopy.tabWrite}

--- a/src/features/comments/components/CommentThreadBody.svelte
+++ b/src/features/comments/components/CommentThreadBody.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { CommentNode } from "@/features/comments/server/comment-types";
+import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import MarkdownPreview from "$lib/components/MarkdownPreview.svelte";
 import CommentAttachmentCards from "./CommentAttachmentCards.svelte";
 import CommentLinkCards from "./CommentLinkCards.svelte";
@@ -49,7 +50,11 @@ export let visibilityOptions: CommentSelectOption[];
 {:else if comment.status === "deleted"}
   <p class="text-base-content/60 text-sm">{commentCopy.deletedMessage}</p>
 {:else}
-  <MarkdownPreview campusReferences class="break-words" content={comment.body} />
+  <MarkdownPreview
+    class="break-words"
+    content={comment.body}
+    remarkPlugins={campusReferenceMarkdownPlugins}
+  />
   <CommentLinkCards content={comment.body} copy={commentCopy} />
 {/if}
 

--- a/src/features/comments/components/CommentThreadEditForm.svelte
+++ b/src/features/comments/components/CommentThreadEditForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { CommentNode } from "@/features/comments/server/comment-types";
+import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import MarkdownEditor from "$lib/components/MarkdownEditor.svelte";
 import { Button } from "$lib/components/ui/button/index.js";
 import { Checkbox } from "$lib/components/ui/checkbox/index.js";
@@ -41,12 +42,13 @@ export let visibilityOptions: CommentSelectOption[];
   </div>
   <MarkdownEditor
     bind:value={editDraft}
-    campusReferences
+    aria-label={commentCopy.markdownModeLabel}
     compact
     guideLabel={commentCopy.markdownGuide}
     modeLabel={commentCopy.markdownModeLabel}
     placeholder={commentCopy.editorPlaceholder}
     previewEmptyLabel={commentCopy.previewEmpty}
+    remarkPlugins={campusReferenceMarkdownPlugins}
     rows={4}
     tabPreviewLabel={commentCopy.tabPreview}
     tabWriteLabel={commentCopy.tabWrite}

--- a/src/features/comments/components/CommentUploadButton.svelte
+++ b/src/features/comments/components/CommentUploadButton.svelte
@@ -10,7 +10,7 @@ export let uploadingLabel: string;
 
 <Button
   as="label"
-  class="cursor-pointer"
+  class="cursor-pointer focus-within:border-primary focus-within:ring-3 focus-within:ring-primary/30"
   {disabled}
   size="sm"
   variant="outline"

--- a/src/features/dashboard/components/AnonymousLinksGroup.svelte
+++ b/src/features/dashboard/components/AnonymousLinksGroup.svelte
@@ -4,6 +4,7 @@ import type {
   LinkView,
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
 import * as Table from "$lib/components/ui/table/index.js";
+import DashboardLinkVisitAction from "./DashboardLinkVisitAction.svelte";
 
 export let entry: AnonymousLinkGroup;
 export let linkIconLabel: (icon: string) => string;
@@ -18,31 +19,7 @@ export let linkView: LinkView;
     <div class="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
       {#each entry.links as link}
         <div class="group relative min-w-0 overflow-hidden rounded-md border border-base-300 bg-base-100 transition hover:border-primary hover:bg-base-200/50">
-          <form
-            action="/api/dashboard-links/visit"
-            method="POST"
-            rel="noopener"
-            target="_blank"
-          >
-            <input name="slug" type="hidden" value={link.slug} />
-            <button
-              class="flex min-h-20 w-full items-start gap-3 px-3 py-3 text-left"
-              type="submit"
-            >
-              <span
-                class="inline-flex size-8 shrink-0 items-center justify-center rounded-md border border-base-300 bg-base-200 font-semibold text-[0.6875rem] text-primary"
-                aria-hidden="true"
-              >
-                {linkIconLabel(link.icon)}
-              </span>
-              <div class="min-w-0 space-y-1">
-                <div class="line-clamp-2 font-semibold">{link.title}</div>
-                <p class="line-clamp-2 text-base-content/60 text-sm">
-                  {link.description}
-                </p>
-              </div>
-            </button>
-          </form>
+          <DashboardLinkVisitAction {link} {linkIconLabel} />
         </div>
       {/each}
     </div>
@@ -52,31 +29,7 @@ export let linkView: LinkView;
         {#each entry.links as link}
           <Table.Row>
             <Table.Cell class="p-0">
-              <form
-                action="/api/dashboard-links/visit"
-                method="POST"
-                rel="noopener"
-                target="_blank"
-              >
-                <input name="slug" type="hidden" value={link.slug} />
-                <button
-                  class="flex min-h-14 w-full items-center gap-3 px-3 py-2 text-left"
-                  type="submit"
-                >
-                  <span
-                    class="inline-flex size-8 shrink-0 items-center justify-center rounded-md border border-base-300 bg-base-200 font-semibold text-[0.6875rem] text-primary"
-                    aria-hidden="true"
-                  >
-                    {linkIconLabel(link.icon)}
-                  </span>
-                  <div class="min-w-0 sm:grid sm:grid-cols-[minmax(10rem,16rem)_1fr] sm:items-center sm:gap-4">
-                    <div class="line-clamp-1 font-semibold">{link.title}</div>
-                    <p class="line-clamp-1 text-base-content/60 text-sm">
-                      {link.description}
-                    </p>
-                  </div>
-                </button>
-              </form>
+              <DashboardLinkVisitAction {link} {linkIconLabel} variant="row" />
             </Table.Cell>
           </Table.Row>
         {/each}

--- a/src/features/dashboard/components/DashboardLinkVisitAction.svelte
+++ b/src/features/dashboard/components/DashboardLinkVisitAction.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+import type { DashboardOverviewLinkItem } from "@/features/dashboard/lib/dashboard-controller-helpers";
+
+export let link: DashboardOverviewLinkItem;
+export let linkIconLabel: (icon: string) => string;
+export let reserveActionSpace = false;
+export let variant: "card" | "row" = "card";
+
+$: buttonClass =
+  variant === "row"
+    ? `flex min-h-14 w-full items-center gap-3 px-3 py-2 text-left ${reserveActionSpace ? "pr-16" : ""}`
+    : `flex min-h-20 w-full items-start gap-3 px-3 py-3 text-left ${reserveActionSpace ? "pr-16" : ""}`;
+$: contentClass =
+  variant === "row"
+    ? "min-w-0 sm:grid sm:grid-cols-[minmax(10rem,16rem)_1fr] sm:items-center sm:gap-4"
+    : "min-w-0 space-y-1";
+$: titleClass =
+  variant === "row"
+    ? "line-clamp-1 font-semibold"
+    : "line-clamp-2 font-semibold";
+$: descriptionClass =
+  variant === "row"
+    ? "line-clamp-1 text-base-content/60 text-sm"
+    : "line-clamp-2 text-base-content/60 text-sm";
+</script>
+
+<form
+  action="/api/dashboard-links/visit"
+  method="POST"
+  rel="noopener"
+  target="_blank"
+>
+  <input name="slug" type="hidden" value={link.slug} />
+  <button class={buttonClass} type="submit">
+    <span
+      class="inline-flex size-8 shrink-0 items-center justify-center rounded-md border border-base-300 bg-base-200 font-semibold text-[0.6875rem] text-primary"
+      aria-hidden="true"
+    >
+      {linkIconLabel(link.icon)}
+    </span>
+    <div class={contentClass}>
+      <div class={titleClass}>{link.title}</div>
+      <p class={descriptionClass}>
+        {link.description}
+      </p>
+    </div>
+  </button>
+</form>

--- a/src/features/dashboard/components/DashboardPageController.svelte
+++ b/src/features/dashboard/components/DashboardPageController.svelte
@@ -20,7 +20,10 @@ import { createDashboardCalendarDisplayActions } from "@/features/dashboard/lib/
 import { createDashboardCardViewActions } from "@/features/dashboard/lib/dashboard-controller-card-view-actions";
 import { createDashboardCreateHomeworkActions } from "@/features/dashboard/lib/dashboard-controller-create-homework-actions";
 import { createDashboardControllerDefaultState } from "@/features/dashboard/lib/dashboard-controller-default-state";
-import { buildDashboardControllerDerivedState } from "@/features/dashboard/lib/dashboard-controller-derived-state";
+import {
+  applyLocalHomeworkItemsToSignedData,
+  buildDashboardControllerDerivedState,
+} from "@/features/dashboard/lib/dashboard-controller-derived-state";
 import { createDashboardDisplayActions } from "@/features/dashboard/lib/dashboard-controller-display-actions";
 import { createDashboardFormSubmitActions } from "@/features/dashboard/lib/dashboard-controller-form-actions";
 import {
@@ -466,9 +469,12 @@ $: derivedState = buildDashboardControllerDerivedState({
   currentOverviewLinkItems: overviewLinkSourceItems,
   todoFilter,
 });
-$: signedData = derivedState.signedData;
 $: anonymousData = derivedState.anonymousData;
 $: homeworkItems = derivedState.homeworkItems;
+$: signedData = applyLocalHomeworkItemsToSignedData(
+  derivedState.signedData,
+  homeworkItems,
+);
 $: homeworkReferenceDate = referenceDate(signedData?.referenceNow);
 $: todoItems = derivedState.todoItems;
 $: filteredTodos = derivedState.filteredTodos;

--- a/src/features/dashboard/components/HomeworkCreateAdvancedDateFields.svelte
+++ b/src/features/dashboard/components/HomeworkCreateAdvancedDateFields.svelte
@@ -15,9 +15,10 @@ export let toShanghaiDateTimeLocalValue: (value: Date) => string;
 </script>
 
 <div class="grid gap-3 sm:grid-cols-2">
-  <label class="grid gap-2">
+  <div class="grid gap-2">
     <span class="font-medium text-sm">{homeworksCopy.publishedAt}</span>
     <DateTimePicker
+      aria-label={homeworksCopy.publishedAt}
       bind:value={createHomeworkPublishedAt}
       calendarButtonLabel={homeworksCopy.calendarButtonLabel}
       disabled={isCreatingHomework}
@@ -49,10 +50,11 @@ export let toShanghaiDateTimeLocalValue: (value: Date) => string;
         {homeworksCopy.helperClear}
       </Button>
     </div>
-  </label>
-  <label class="grid gap-2">
+  </div>
+  <div class="grid gap-2">
     <span class="font-medium text-sm">{homeworksCopy.submissionStart}</span>
     <DateTimePicker
+      aria-label={homeworksCopy.submissionStart}
       bind:value={createHomeworkSubmissionStartAt}
       calendarButtonLabel={homeworksCopy.calendarButtonLabel}
       disabled={isCreatingHomework}
@@ -76,5 +78,5 @@ export let toShanghaiDateTimeLocalValue: (value: Date) => string;
         {homeworksCopy.helperClear}
       </Button>
     </div>
-  </label>
+  </div>
 </div>

--- a/src/features/dashboard/components/HomeworkCreateDueDateField.svelte
+++ b/src/features/dashboard/components/HomeworkCreateDueDateField.svelte
@@ -16,9 +16,10 @@ export let isCreatingHomework: boolean;
 export let selectedCreateHomeworkSection: DashboardHomeworkCreateSectionGetter;
 </script>
 
-<label class="grid gap-2">
+<div class="grid gap-2">
   <span class="font-medium text-sm">{homeworksCopy.submissionDue}</span>
   <DateTimePicker
+    aria-label={homeworksCopy.submissionDue}
     bind:value={createHomeworkSubmissionDueAt}
     calendarButtonLabel={homeworksCopy.calendarButtonLabel}
     disabled={isCreatingHomework}
@@ -42,4 +43,4 @@ export let selectedCreateHomeworkSection: DashboardHomeworkCreateSectionGetter;
       {homeworksCopy.helperSemesterEnd}
     </Button>
   </div>
-</label>
+</div>

--- a/src/features/dashboard/components/HomeworkCreateFormFields.svelte
+++ b/src/features/dashboard/components/HomeworkCreateFormFields.svelte
@@ -3,6 +3,7 @@ import {
   HOMEWORK_DESCRIPTION_MAX_LENGTH,
   HOMEWORK_TITLE_MAX_LENGTH,
 } from "@/features/homeworks/lib/homework-limits";
+import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import MarkdownEditor from "$lib/components/MarkdownEditor.svelte";
 import { Alert } from "$lib/components/ui/alert/index.js";
 import { Checkbox } from "$lib/components/ui/checkbox/index.js";
@@ -67,10 +68,10 @@ export let toShanghaiDateTimeLocalValue: (value: Date) => string;
       required
     />
   </label>
-  <label class="grid gap-2">
+  <div class="grid gap-2">
     <span class="font-medium text-sm">{homeworksCopy.descriptionLabel}</span>
     <MarkdownEditor
-      campusReferences
+      aria-label={homeworksCopy.descriptionLabel}
       disabled={isCreatingHomework}
       guideLabel={commentsCopy.markdownGuide}
       maxlength={HOMEWORK_DESCRIPTION_MAX_LENGTH}
@@ -78,10 +79,11 @@ export let toShanghaiDateTimeLocalValue: (value: Date) => string;
       name="description"
       placeholder={homeworksCopy.descriptionPlaceholder}
       previewEmptyLabel={commentsCopy.previewEmpty}
+      remarkPlugins={campusReferenceMarkdownPlugins}
       tabPreviewLabel={commentsCopy.tabPreview}
       tabWriteLabel={commentsCopy.tabWrite}
     />
-  </label>
+  </div>
   <HomeworkCreateScheduleFields
     {applyHomeworkDueAtSemesterEnd}
     {applyHomeworkDueInMonth}

--- a/src/features/dashboard/components/HomeworkDetailDescription.svelte
+++ b/src/features/dashboard/components/HomeworkDetailDescription.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import MarkdownPreview from "$lib/components/MarkdownPreview.svelte";
 import type {
   DashboardHomeworkDetailCopy,
@@ -11,7 +12,10 @@ export let homeworksCopy: DashboardHomeworkDetailCopy;
 
 <section class="rounded-md border border-base-300 border-l-4 border-l-primary bg-base-100 p-4">
   {#if homework.description}
-    <MarkdownPreview campusReferences content={homework.description} />
+    <MarkdownPreview
+      content={homework.description}
+      remarkPlugins={campusReferenceMarkdownPlugins}
+    />
   {:else}
     <p class="text-base-content/60 text-sm">{homeworksCopy.descriptionEmpty}</p>
   {/if}

--- a/src/features/dashboard/components/LinksTabGrid.svelte
+++ b/src/features/dashboard/components/LinksTabGrid.svelte
@@ -4,6 +4,7 @@ import type {
   DashboardLinkPinSubmit,
   DashboardOverviewLinkItem,
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
+import DashboardLinkVisitAction from "./DashboardLinkVisitAction.svelte";
 import LinksTabPinButton from "./LinksTabPinButton.svelte";
 
 export let links: DashboardOverviewLinkItem[];
@@ -20,31 +21,7 @@ export let updatingDashboardLinkSlug: string | null;
 <div class="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
   {#each links as link}
     <div class="group relative min-w-0 overflow-hidden rounded-md border border-base-300 bg-base-100 transition hover:border-primary hover:bg-base-200/50">
-      <form
-        action="/api/dashboard-links/visit"
-        method="POST"
-        rel="noopener"
-        target="_blank"
-      >
-        <input name="slug" type="hidden" value={link.slug} />
-        <button
-          class="flex min-h-20 w-full items-start gap-3 px-3 py-3 pr-16 text-left"
-          type="submit"
-        >
-          <span
-            class="inline-flex size-8 shrink-0 items-center justify-center rounded-md border border-base-300 bg-base-200 font-semibold text-[0.6875rem] text-primary"
-            aria-hidden="true"
-          >
-            {linkIconLabel(link.icon)}
-          </span>
-          <div class="min-w-0 space-y-1">
-            <div class="line-clamp-2 font-semibold">{link.title}</div>
-            <p class="line-clamp-2 text-base-content/60 text-sm">
-              {link.description}
-            </p>
-          </div>
-        </button>
-      </form>
+      <DashboardLinkVisitAction {link} {linkIconLabel} reserveActionSpace />
       <div class={`absolute top-2 right-2 opacity-100 transition-opacity ${link.isPinned ? "" : "md:pointer-events-none md:opacity-0 md:group-focus-within:pointer-events-auto md:group-focus-within:opacity-100 md:group-hover:pointer-events-auto md:group-hover:opacity-100"}`}>
         <LinksTabPinButton
           {link}

--- a/src/features/dashboard/components/LinksTabList.svelte
+++ b/src/features/dashboard/components/LinksTabList.svelte
@@ -5,6 +5,7 @@ import type {
   DashboardOverviewLinkItem,
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
 import * as Table from "$lib/components/ui/table/index.js";
+import DashboardLinkVisitAction from "./DashboardLinkVisitAction.svelte";
 import LinksTabPinButton from "./LinksTabPinButton.svelte";
 
 export let links: DashboardOverviewLinkItem[];
@@ -24,31 +25,12 @@ export let updatingDashboardLinkSlug: string | null;
       <Table.Row class="group">
         <Table.Cell class="p-0">
           <div class="relative">
-            <form
-              action="/api/dashboard-links/visit"
-              method="POST"
-              rel="noopener"
-              target="_blank"
-            >
-              <input name="slug" type="hidden" value={link.slug} />
-              <button
-                class="flex min-h-14 w-full items-center gap-3 px-3 py-2 pr-16 text-left"
-                type="submit"
-              >
-                <span
-                  class="inline-flex size-8 shrink-0 items-center justify-center rounded-md border border-base-300 bg-base-200 font-semibold text-[0.6875rem] text-primary"
-                  aria-hidden="true"
-                >
-                  {linkIconLabel(link.icon)}
-                </span>
-                <div class="min-w-0 sm:grid sm:grid-cols-[minmax(10rem,16rem)_1fr] sm:items-center sm:gap-4">
-                  <div class="line-clamp-1 font-semibold">{link.title}</div>
-                  <p class="line-clamp-1 text-base-content/60 text-sm">
-                    {link.description}
-                  </p>
-                </div>
-              </button>
-            </form>
+            <DashboardLinkVisitAction
+              {link}
+              {linkIconLabel}
+              reserveActionSpace
+              variant="row"
+            />
             <div class={`absolute top-1/2 right-2 -translate-y-1/2 opacity-100 transition-opacity ${link.isPinned ? "" : "md:pointer-events-none md:opacity-0 md:group-focus-within:pointer-events-auto md:group-focus-within:opacity-100 md:group-hover:pointer-events-auto md:group-hover:opacity-100"}`}>
               <LinksTabPinButton
                 {link}

--- a/src/features/dashboard/components/OverviewLinksGrid.svelte
+++ b/src/features/dashboard/components/OverviewLinksGrid.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 import type {
   DashboardDashboardCopy,
+  DashboardLinkPinAction,
   DashboardOverviewLinkItem,
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
-import Pin from "$lib/components/icons/pin.svelte";
 import { Alert } from "$lib/components/ui/alert/index.js";
-import { Button } from "$lib/components/ui/button/index.js";
+import DashboardLinkVisitAction from "./DashboardLinkVisitAction.svelte";
 import type { DashboardCalendarTabHref } from "./dashboard-calendar-component-types";
+import LinksTabPinButton from "./LinksTabPinButton.svelte";
 
 export let dashboardCopy: DashboardDashboardCopy;
 export let dashboardTabHref: DashboardCalendarTabHref;
@@ -17,61 +18,32 @@ export let submitDashboardLinkPin: (
   action: "pin" | "unpin",
 ) => void;
 export let updatingDashboardLinkSlug: string | null;
+
+function pinLabel(link: DashboardOverviewLinkItem) {
+  return link.isPinned
+    ? dashboardCopy.linkHub.unpin
+    : dashboardCopy.linkHub.pin;
+}
+
+function pinAction(link: DashboardOverviewLinkItem): DashboardLinkPinAction {
+  return link.isPinned ? "unpin" : "pin";
+}
 </script>
 
 <div class="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
   {#each links.slice(0, 4) as link}
     <div class="group relative min-w-0 overflow-hidden rounded-md border border-base-300 bg-base-100 transition hover:border-primary hover:bg-base-200/40">
-      <form action="/api/dashboard-links/visit" method="POST" rel="noopener" target="_blank">
-        <input name="slug" type="hidden" value={link.slug} />
-        <button
-          class="flex min-h-20 w-full items-start gap-3 px-3 py-3 pr-16 text-left"
-          type="submit"
-        >
-          <span
-            class="inline-flex size-8 shrink-0 items-center justify-center rounded-md border border-base-300 bg-base-200 font-semibold text-[0.6875rem] text-primary"
-            aria-hidden="true"
-          >
-            {linkIconLabel(link.icon)}
-          </span>
-          <div class="min-w-0 space-y-1">
-            <div class="line-clamp-2 font-semibold">{link.title}</div>
-            <p class="line-clamp-2 text-base-content/60 text-sm">
-              {link.description}
-            </p>
-          </div>
-        </button>
-      </form>
-      <form
-        action="/api/dashboard-links/pin"
-        class={`absolute top-2 right-2 opacity-100 transition-opacity ${link.isPinned ? "" : "md:pointer-events-none md:opacity-0 md:group-focus-within:pointer-events-auto md:group-focus-within:opacity-100 md:group-hover:pointer-events-auto md:group-hover:opacity-100"}`}
-        method="POST"
-        onsubmit={(event) => {
-          event.preventDefault();
-          submitDashboardLinkPin(link.slug, link.isPinned ? "unpin" : "pin");
-        }}
-      >
-        <input name="slug" type="hidden" value={link.slug} />
-        <input name="returnTo" type="hidden" value={dashboardTabHref("overview")} />
-        <input name="action" type="hidden" value={link.isPinned ? "unpin" : "pin"} />
-        <Button
-          aria-label={link.isPinned
-            ? dashboardCopy.linkHub.unpin
-            : dashboardCopy.linkHub.pin}
-          class={link.isPinned
-            ? "border-primary bg-primary/10 text-primary hover:bg-primary/15"
-            : "bg-base-100/90"}
-          disabled={updatingDashboardLinkSlug === link.slug}
-          size="icon-sm"
-          title={link.isPinned
-            ? dashboardCopy.linkHub.unpin
-            : dashboardCopy.linkHub.pin}
-          type="submit"
-          variant="outline"
-        >
-          <Pin class={link.isPinned ? "fill-primary/20" : ""} />
-        </Button>
-      </form>
+      <DashboardLinkVisitAction {link} {linkIconLabel} reserveActionSpace />
+      <div class={`absolute top-2 right-2 opacity-100 transition-opacity ${link.isPinned ? "" : "md:pointer-events-none md:opacity-0 md:group-focus-within:pointer-events-auto md:group-focus-within:opacity-100 md:group-hover:pointer-events-auto md:group-hover:opacity-100"}`}>
+        <LinksTabPinButton
+          {link}
+          linkReturnTo={dashboardTabHref("overview")}
+          {pinAction}
+          {pinLabel}
+          {submitDashboardLinkPin}
+          {updatingDashboardLinkSlug}
+        />
+      </div>
     </div>
   {:else}
     <Alert>{dashboardCopy.linkHub.empty}</Alert>

--- a/src/features/dashboard/components/TodoFormFields.svelte
+++ b/src/features/dashboard/components/TodoFormFields.svelte
@@ -42,19 +42,21 @@ export let todosCopy: DashboardTodosCopy;
     value={priorityValue}
   />
 </label>
-<label class="grid gap-2">
+<div class="grid gap-2">
   <span class="font-medium text-sm">{todosCopy.dueAtLabel}</span>
   <DateTimePicker
+    aria-label={todosCopy.dueAtLabel}
     {disabled}
     calendarButtonLabel={todosCopy.calendarButtonLabel}
     name="dueAt"
     placeholder={todosCopy.dueAtLabel}
     value={dueAtValue}
   />
-</label>
-<label class="grid gap-2">
+</div>
+<div class="grid gap-2">
   <span class="font-medium text-sm">{todosCopy.contentLabel}</span>
   <MarkdownEditor
+    aria-label={todosCopy.contentLabel}
     {disabled}
     guideLabel={commentsCopy.markdownGuide}
     maxlength={TODO_CONTENT_MAX_LENGTH}
@@ -66,4 +68,4 @@ export let todosCopy: DashboardTodosCopy;
     tabWriteLabel={commentsCopy.tabWrite}
     value={contentValue}
   />
-</label>
+</div>

--- a/src/features/dashboard/lib/dashboard-controller-derived-state.ts
+++ b/src/features/dashboard/lib/dashboard-controller-derived-state.ts
@@ -5,8 +5,10 @@ import {
   type DashboardLinkItem,
   type DashboardPageData,
   type ExamRow,
+  type HomeworkItem,
   isAnonymousDashboardData,
   isSignedDashboardData,
+  type SignedDashboardData,
   type TodoFilter,
   type TodoItem,
 } from "./dashboard-controller-helpers";
@@ -14,6 +16,26 @@ import { groupDashboardLinks } from "./dashboard-link-ui";
 import type { ExamFilter } from "./exams";
 import { filterExamRows } from "./exams";
 import { filterTodos } from "./todos";
+
+export function applyLocalHomeworkItemsToSignedData(
+  signedData: SignedDashboardData | null,
+  homeworkItems: HomeworkItem[],
+) {
+  if (!signedData?.homeworks) return signedData;
+
+  return {
+    ...signedData,
+    homeworks: {
+      ...signedData.homeworks,
+      homeworkSummaries: homeworkItems,
+    },
+    navStats: {
+      ...signedData.navStats,
+      pendingHomeworksCount: homeworkItems.filter((item) => !item.completion)
+        .length,
+    },
+  };
+}
 
 export function buildDashboardControllerDerivedState(input: {
   dashboardLinkGroupLabels: Record<DashboardLinkGroup, string>;

--- a/src/features/descriptions/components/DescriptionEditPanel.svelte
+++ b/src/features/descriptions/components/DescriptionEditPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import MarkdownEditor from "$lib/components/MarkdownEditor.svelte";
 import { Button } from "$lib/components/ui/button/index.js";
 
@@ -23,12 +24,13 @@ export let saveDescription: () => void;
 <div class="grid gap-3">
   <MarkdownEditor
     bind:value={draft}
-    campusReferences
+    aria-label={copy.title}
     disabled={isDisabled}
     guideLabel={copy.markdownGuide}
     modeLabel={copy.title}
     placeholder={copy.editorPlaceholder}
     previewEmptyLabel={copy.previewEmpty}
+    remarkPlugins={campusReferenceMarkdownPlugins}
     tabPreviewLabel={copy.tabPreview}
     tabWriteLabel={copy.tabWrite}
   />

--- a/src/features/descriptions/components/DescriptionReadPanel.svelte
+++ b/src/features/descriptions/components/DescriptionReadPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { formatDescriptionCopy } from "@/features/descriptions/lib/description-card-actions";
+import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import MarkdownPreview from "$lib/components/MarkdownPreview.svelte";
 import { Alert } from "$lib/components/ui/alert/index.js";
 import * as Tabs from "$lib/components/ui/tabs/index.js";
@@ -19,7 +20,7 @@ export let formatDate: (value: string | null | undefined) => string;
 export let history: DescriptionHistoryItem[];
 </script>
 
-<Tabs.Root>
+<Tabs.Root aria-label={copy.title}>
   <Tabs.List>
     <Tabs.Button selected={activePanelTab === "description"} onclick={() => (activePanelTab = "description")}>{copy.title}</Tabs.Button>
     <Tabs.Button selected={activePanelTab === "history"} onclick={() => (activePanelTab = "history")}>
@@ -30,7 +31,10 @@ export let history: DescriptionHistoryItem[];
   {#if activePanelTab === "history"}
     <DescriptionHistoryList {copy} {formatDate} {history} />
   {:else if description.content}
-    <MarkdownPreview campusReferences content={description.content} />
+    <MarkdownPreview
+      content={description.content}
+      remarkPlugins={campusReferenceMarkdownPlugins}
+    />
   {:else}
     <Alert>{copy.empty}</Alert>
   {/if}

--- a/src/features/markdown/lib/campus-reference-markdown.ts
+++ b/src/features/markdown/lib/campus-reference-markdown.ts
@@ -1,0 +1,93 @@
+import type { Link, PhrasingContent, Root, Text } from "mdast";
+import type { PluggableList, Plugin } from "unified";
+import { visit } from "unist-util-visit";
+
+export type CampusReferenceKind = "section" | "teacher";
+
+export type CampusReferenceResolver = (
+  kind: CampusReferenceKind,
+  id: string,
+  token: string,
+) => string | null | undefined;
+
+type MutableTextParent = {
+  type?: string;
+  children: PhrasingContent[];
+};
+
+function defaultCampusReferenceHref(kind: CampusReferenceKind, id: string) {
+  return kind === "teacher" ? `/teachers/${id}` : `/sections/${id}`;
+}
+
+function campusReferenceLink(
+  token: string,
+  resolveReference: CampusReferenceResolver,
+): Link | Text {
+  const [, rawKind, id] = /\b(section|teacher)#(\d+)\b/i.exec(token) ?? [];
+  const kind = String(rawKind).toLowerCase() as CampusReferenceKind;
+  const href = resolveReference(kind, String(id), token);
+
+  if (!href) return { type: "text", value: token };
+
+  return {
+    type: "link",
+    url: href,
+    children: [{ type: "text", value: token }],
+  };
+}
+
+function replaceCampusReferences(
+  value: string,
+  resolveReference: CampusReferenceResolver,
+) {
+  const pattern = /\b(section|teacher)#(\d+)\b/gi;
+  const children: PhrasingContent[] = [];
+  let cursor = 0;
+  let match = pattern.exec(value);
+
+  while (match !== null) {
+    if (match.index > cursor) {
+      children.push({ type: "text", value: value.slice(cursor, match.index) });
+    }
+    children.push(campusReferenceLink(match[0], resolveReference));
+    cursor = pattern.lastIndex;
+    match = pattern.exec(value);
+  }
+
+  if (children.length === 0) return null;
+  if (cursor < value.length) {
+    children.push({ type: "text", value: value.slice(cursor) });
+  }
+  return children;
+}
+
+export const remarkCampusReferences: Plugin<
+  [
+    {
+      resolveReference?: CampusReferenceResolver;
+    }?,
+  ],
+  Root
+> = (options = {}) => {
+  const resolveReference =
+    options.resolveReference ?? defaultCampusReferenceHref;
+
+  return (tree) => {
+    visit(tree, "text", (node: Text, index, parent) => {
+      const mutableParent = parent as MutableTextParent | undefined;
+      if (index === undefined || !parent || parent.type === "link") return;
+
+      const children = replaceCampusReferences(
+        String(node.value ?? ""),
+        resolveReference,
+      );
+      if (!children) return;
+
+      mutableParent?.children.splice(index, 1, ...children);
+    });
+  };
+};
+
+export const campusReferenceMarkdownPlugins: PluggableList = [
+  [remarkCampusReferences, { resolveReference: defaultCampusReferenceHref }],
+];

--- a/src/features/section-detail/components/SectionCreateHomeworkFields.svelte
+++ b/src/features/section-detail/components/SectionCreateHomeworkFields.svelte
@@ -3,6 +3,7 @@ import {
   HOMEWORK_DESCRIPTION_MAX_LENGTH,
   HOMEWORK_TITLE_MAX_LENGTH,
 } from "@/features/homeworks/lib/homework-limits";
+import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import SectionHomeworkTagFields from "@/features/section-detail/components/SectionHomeworkTagFields.svelte";
 import SectionHomeworkTimestampFields from "@/features/section-detail/components/SectionHomeworkTimestampFields.svelte";
 import MarkdownEditor from "$lib/components/MarkdownEditor.svelte";
@@ -39,20 +40,21 @@ export let submissionStartAt: string;
       required
     />
   </label>
-  <label class="grid gap-2">
+  <div class="grid gap-2">
     <span class="font-medium text-sm">{homeworkCopy.descriptionLabel}</span>
     <MarkdownEditor
-      campusReferences
+      aria-label={homeworkCopy.descriptionLabel}
       guideLabel={commentsCopy.markdownGuide}
       maxlength={HOMEWORK_DESCRIPTION_MAX_LENGTH}
       modeLabel={homeworkCopy.descriptionLabel}
       name="description"
       placeholder={homeworkCopy.descriptionPlaceholder}
       previewEmptyLabel={commentsCopy.previewEmpty}
+      remarkPlugins={campusReferenceMarkdownPlugins}
       tabPreviewLabel={commentsCopy.tabPreview}
       tabWriteLabel={commentsCopy.tabWrite}
     />
-  </label>
+  </div>
   <SectionHomeworkTimestampFields
     {applyDueAtSemesterEnd}
     {applyDueInMonth}

--- a/src/features/section-detail/components/SectionHomeworkEditForm.svelte
+++ b/src/features/section-detail/components/SectionHomeworkEditForm.svelte
@@ -3,6 +3,7 @@ import {
   HOMEWORK_DESCRIPTION_MAX_LENGTH,
   HOMEWORK_TITLE_MAX_LENGTH,
 } from "@/features/homeworks/lib/homework-limits";
+import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import MarkdownEditor from "$lib/components/MarkdownEditor.svelte";
 import { Button } from "$lib/components/ui/button/index.js";
 import { Checkbox } from "$lib/components/ui/checkbox/index.js";
@@ -48,21 +49,22 @@ export let updateHomework: SectionHomeworkSubmitHandler;
       value={homework.title}
     />
   </label>
-  <label class="grid gap-2">
+  <div class="grid gap-2">
     <span class="font-medium text-sm">{homeworkCopy.descriptionLabel}</span>
     <MarkdownEditor
-      campusReferences
+      aria-label={homeworkCopy.descriptionLabel}
       guideLabel={commentsCopy.markdownGuide}
       maxlength={HOMEWORK_DESCRIPTION_MAX_LENGTH}
       modeLabel={homeworkCopy.descriptionLabel}
       name="description"
       placeholder={homeworkCopy.descriptionPlaceholder}
       previewEmptyLabel={commentsCopy.previewEmpty}
+      remarkPlugins={campusReferenceMarkdownPlugins}
       tabPreviewLabel={commentsCopy.tabPreview}
       tabWriteLabel={commentsCopy.tabWrite}
       value={homework.description?.content ?? ""}
     />
-  </label>
+  </div>
   <SectionHomeworkEditTimestampFields
     {applyDueAtSemesterEnd}
     {applyDueInMonth}

--- a/src/features/section-detail/components/SectionHomeworkEditTimestampFields.svelte
+++ b/src/features/section-detail/components/SectionHomeworkEditTimestampFields.svelte
@@ -21,9 +21,10 @@ export let semesterDate: SectionHomeworkSemesterDate;
 </script>
 
 <div class="grid gap-3 sm:grid-cols-3">
-  <label class="grid gap-2">
+  <div class="grid gap-2">
     <span class="font-medium text-sm">{homeworkCopy.publishedAt}</span>
     <DateTimePicker
+      aria-label={homeworkCopy.publishedAt}
       bind:value={editHomeworkPublishedAt}
       calendarButtonLabel={homeworkCopy.calendarButtonLabel}
       defaultTime="00:00"
@@ -45,10 +46,11 @@ export let semesterDate: SectionHomeworkSemesterDate;
         {homeworkCopy.helperClear}
       </Button>
     </div>
-  </label>
-  <label class="grid gap-2">
+  </div>
+  <div class="grid gap-2">
     <span class="font-medium text-sm">{homeworkCopy.submissionStart}</span>
     <DateTimePicker
+      aria-label={homeworkCopy.submissionStart}
       bind:value={editHomeworkSubmissionStartAt}
       calendarButtonLabel={homeworkCopy.calendarButtonLabel}
       defaultTime="00:00"
@@ -79,10 +81,11 @@ export let semesterDate: SectionHomeworkSemesterDate;
         {homeworkCopy.helperClear}
       </Button>
     </div>
-  </label>
-  <label class="grid gap-2">
+  </div>
+  <div class="grid gap-2">
     <span class="font-medium text-sm">{homeworkCopy.submissionDue}</span>
     <DateTimePicker
+      aria-label={homeworkCopy.submissionDue}
       bind:value={editHomeworkSubmissionDueAt}
       calendarButtonLabel={homeworkCopy.calendarButtonLabel}
       name="submissionDueAt"
@@ -105,5 +108,5 @@ export let semesterDate: SectionHomeworkSemesterDate;
         {homeworkCopy.helperSemesterEnd}
       </Button>
     </div>
-  </label>
+  </div>
 </div>

--- a/src/features/section-detail/components/SectionHomeworkReadOnlySummary.svelte
+++ b/src/features/section-detail/components/SectionHomeworkReadOnlySummary.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import MarkdownPreview from "$lib/components/MarkdownPreview.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
 import type {
@@ -14,7 +15,10 @@ export let homeworkCopy: SectionHomeworkCopy;
 
 <div class="rounded-md border border-base-300 bg-base-200/40 p-4">
   {#if homework.description?.content}
-    <MarkdownPreview campusReferences content={homework.description.content} />
+    <MarkdownPreview
+      content={homework.description.content}
+      remarkPlugins={campusReferenceMarkdownPlugins}
+    />
   {:else}
     <p class="text-base-content/60 text-sm">{homeworkCopy.descriptionEmpty}</p>
   {/if}

--- a/src/features/section-detail/components/SectionHomeworkTimestampFields.svelte
+++ b/src/features/section-detail/components/SectionHomeworkTimestampFields.svelte
@@ -19,9 +19,10 @@ export let submissionStartAt: string;
 </script>
 
 <div class="grid gap-3 sm:grid-cols-3">
-  <label class="grid gap-2">
+  <div class="grid gap-2">
     <span class="font-medium text-sm">{homeworkCopy.publishedAt}</span>
     <DateTimePicker
+      aria-label={homeworkCopy.publishedAt}
       bind:value={publishedAt}
       calendarButtonLabel={homeworkCopy.calendarButtonLabel}
       defaultTime="00:00"
@@ -43,10 +44,11 @@ export let submissionStartAt: string;
         {homeworkCopy.helperClear}
       </Button>
     </div>
-  </label>
-  <label class="grid gap-2">
+  </div>
+  <div class="grid gap-2">
     <span class="font-medium text-sm">{homeworkCopy.submissionStart}</span>
     <DateTimePicker
+      aria-label={homeworkCopy.submissionStart}
       bind:value={submissionStartAt}
       calendarButtonLabel={homeworkCopy.calendarButtonLabel}
       defaultTime="00:00"
@@ -77,10 +79,11 @@ export let submissionStartAt: string;
         {homeworkCopy.helperClear}
       </Button>
     </div>
-  </label>
-  <label class="grid gap-2">
+  </div>
+  <div class="grid gap-2">
     <span class="font-medium text-sm">{homeworkCopy.submissionDue}</span>
     <DateTimePicker
+      aria-label={homeworkCopy.submissionDue}
       bind:value={submissionDueAt}
       calendarButtonLabel={homeworkCopy.calendarButtonLabel}
       name="submissionDueAt"
@@ -103,5 +106,5 @@ export let submissionStartAt: string;
         {homeworkCopy.helperSemesterEnd}
       </Button>
     </div>
-  </label>
+  </div>
 </div>

--- a/src/lib/components/DateTimePicker.svelte
+++ b/src/lib/components/DateTimePicker.svelte
@@ -72,6 +72,8 @@ $: {
 
 <div
   {...rootProps}
+  aria-label={labelledBy ? undefined : label}
+  aria-labelledby={labelledBy}
   class={cn("relative min-w-0", className)}
   role="group"
 >

--- a/src/lib/components/DateTimePicker.svelte
+++ b/src/lib/components/DateTimePicker.svelte
@@ -26,6 +26,11 @@ let selectedDate: CalendarDate | undefined;
 let timeValue = defaultTime;
 let lastSyncedValue = "";
 
+function stringRestProp(name: string) {
+  const value = ($$restProps as Record<string, unknown>)[name];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 function syncFromValue(nextValue: string) {
   const parsed = parseDateTimeLocal(nextValue);
   selectedDate = parsed?.date;
@@ -52,11 +57,20 @@ function handleInput(event: Event) {
 $: if ((value ?? "") !== lastSyncedValue) {
   syncFromValue(value ?? "");
 }
+$: labelledBy = stringRestProp("aria-labelledby");
+$: label = stringRestProp("aria-label") ?? placeholder;
 </script>
 
-<div class={cn("relative min-w-0", className)}>
+<div
+  {...$$restProps}
+  aria-label={labelledBy ? undefined : label}
+  aria-labelledby={labelledBy}
+  class={cn("relative min-w-0", className)}
+  role="group"
+>
   <Input
-    aria-label={placeholder}
+    aria-label={labelledBy ? undefined : label}
+    aria-labelledby={labelledBy}
     class="pe-10 font-mono"
     disabled={disabled}
     {name}

--- a/src/lib/components/DateTimePicker.svelte
+++ b/src/lib/components/DateTimePicker.svelte
@@ -25,6 +25,7 @@ let open = false;
 let selectedDate: CalendarDate | undefined;
 let timeValue = defaultTime;
 let lastSyncedValue = "";
+let rootProps: Record<string, unknown> = {};
 
 function stringRestProp(name: string) {
   const value = ($$restProps as Record<string, unknown>)[name];
@@ -59,12 +60,18 @@ $: if ((value ?? "") !== lastSyncedValue) {
 }
 $: labelledBy = stringRestProp("aria-labelledby");
 $: label = stringRestProp("aria-label") ?? placeholder;
+$: {
+  const {
+    "aria-label": _label,
+    "aria-labelledby": _labelledBy,
+    ...rest
+  } = $$restProps as Record<string, unknown>;
+  rootProps = rest;
+}
 </script>
 
 <div
-  {...$$restProps}
-  aria-label={labelledBy ? undefined : label}
-  aria-labelledby={labelledBy}
+  {...rootProps}
   class={cn("relative min-w-0", className)}
   role="group"
 >

--- a/src/lib/components/MarkdownEditor.svelte
+++ b/src/lib/components/MarkdownEditor.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+import type { PluggableList } from "unified";
 import MarkdownPreview from "$lib/components/MarkdownPreview.svelte";
 import { Button } from "$lib/components/ui/button/index.js";
 import * as Tabs from "$lib/components/ui/tabs/index.js";
 import { Textarea } from "$lib/components/ui/textarea/index.js";
 
 export let disabled = false;
-export let campusReferences = false;
 export let guideHref = "/guides/markdown-support";
 export let guideLabel = "";
 export let isDragActive = false;
@@ -13,6 +13,7 @@ export let modeLabel = "";
 export let name: string | undefined = undefined;
 export let placeholder = "";
 export let previewEmptyLabel = "";
+export let remarkPlugins: PluggableList = [];
 export let rows = 6;
 export let tabPreviewLabel = "";
 export let tabWriteLabel = "";
@@ -21,14 +22,28 @@ let activeTab: "write" | "preview" = "write";
 let className = "";
 
 export { className as class };
+
+function stringRestProp(name: string) {
+  const value = ($$restProps as Record<string, unknown>)[name];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+$: labelledBy = stringRestProp("aria-labelledby");
+$: label = stringRestProp("aria-label");
 </script>
 
-<div class={`grid gap-3 ${className}`} data-slot="markdown-editor">
+<div
+  aria-label={labelledBy ? undefined : label}
+  aria-labelledby={labelledBy}
+  class={`grid gap-3 ${className}`}
+  data-slot="markdown-editor"
+  role={labelledBy || label ? "group" : undefined}
+>
   {#if name}
     <input type="hidden" {name} {value} />
   {/if}
 
-  <Tabs.List aria-label={modeLabel}>
+  <Tabs.List aria-label={modeLabel || undefined}>
     <Tabs.Button
       selected={activeTab === "write"}
       onclick={() => {
@@ -52,6 +67,8 @@ export { className as class };
   >
     {#if activeTab === "write"}
       <Textarea
+        aria-label={labelledBy ? undefined : label}
+        aria-labelledby={labelledBy}
         class="min-h-0 resize-y border-0 bg-transparent shadow-none focus-visible:ring-0"
         bind:value
         {disabled}
@@ -62,7 +79,7 @@ export { className as class };
     {:else}
       <div class="min-h-32 p-3">
         {#if value.trim()}
-          <MarkdownPreview {campusReferences} content={value} />
+          <MarkdownPreview content={value} {remarkPlugins} />
         {:else}
           <p class="text-center text-base-content/50 text-sm italic">
             {previewEmptyLabel}

--- a/src/lib/components/MarkdownPreview.svelte
+++ b/src/lib/components/MarkdownPreview.svelte
@@ -1,17 +1,18 @@
 <script lang="ts">
+import type { PluggableList } from "unified";
 import { renderMarkdown } from "$lib/components/markdown-preview-renderer";
 import "$lib/components/markdown-preview.css";
 import "katex/dist/katex.min.css";
 
 export let content = "";
-export let campusReferences = false;
 export let emptyLabel = "";
+export let remarkPlugins: PluggableList = [];
 let className = "";
 
 export { className as class };
 
 $: renderedHtml = content.trim()
-  ? renderMarkdown(content, { campusReferences })
+  ? renderMarkdown(content, { remarkPlugins })
   : "";
 </script>
 

--- a/src/lib/components/markdown-preview-inline-plugins.ts
+++ b/src/lib/components/markdown-preview-inline-plugins.ts
@@ -69,29 +69,3 @@ export function remarkInlineExtensions() {
     });
   };
 }
-
-export function remarkCampusReferences() {
-  return (tree: unknown) => {
-    visit(tree as MdastRoot, "text", (node: Text, index, parent) => {
-      const mutableParent = parent as MutableMarkdownParent | undefined;
-      if (index === undefined || !parent || parent.type === "link") return;
-      const value = String(node.value ?? "");
-      const children = replaceTextWithInlineTokens(
-        value,
-        /\b(section|teacher)#(\d+)\b/gi,
-        (token) => {
-          const [, rawKind, id] =
-            /\b(section|teacher)#(\d+)\b/i.exec(token) ?? [];
-          const kind = String(rawKind).toLowerCase();
-          return {
-            type: "link",
-            url: kind === "teacher" ? `/teachers/${id}` : `/sections/${id}`,
-            children: [{ type: "text", value: token }],
-          };
-        },
-      );
-      if (!children) return;
-      mutableParent?.children.splice(index, 1, ...children);
-    });
-  };
-}

--- a/src/lib/components/markdown-preview-plugins.ts
+++ b/src/lib/components/markdown-preview-plugins.ts
@@ -3,7 +3,4 @@ export {
   rehypeNormalizeMarkdownElements,
   remarkImageAttributes,
 } from "./markdown-preview-image-plugins";
-export {
-  remarkCampusReferences,
-  remarkInlineExtensions,
-} from "./markdown-preview-inline-plugins";
+export { remarkInlineExtensions } from "./markdown-preview-inline-plugins";

--- a/src/lib/components/markdown-preview-renderer.ts
+++ b/src/lib/components/markdown-preview-renderer.ts
@@ -7,11 +7,10 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
-import { unified } from "unified";
+import { type PluggableList, unified } from "unified";
 import {
   rehypeNormalizeMarkdownElements,
   remarkCalloutDirectives,
-  remarkCampusReferences,
   remarkImageAttributes,
   remarkInlineExtensions,
 } from "./markdown-preview-plugins";
@@ -24,7 +23,7 @@ function normalizeMarkdownInput(value: string) {
   return value.replace(/^::::/gm, ":::");
 }
 
-function createProcessor(options: { campusReferences?: boolean } = {}) {
+function createProcessor(options: { remarkPlugins?: PluggableList } = {}) {
   const processor = unified()
     .use(remarkParse)
     .use(remarkGfm)
@@ -35,8 +34,8 @@ function createProcessor(options: { campusReferences?: boolean } = {}) {
     .use(remarkImageAttributes)
     .use(remarkInlineExtensions);
 
-  if (options.campusReferences) {
-    processor.use(remarkCampusReferences);
+  if (options.remarkPlugins?.length) {
+    processor.use({ plugins: options.remarkPlugins });
   }
 
   return processor
@@ -49,15 +48,14 @@ function createProcessor(options: { campusReferences?: boolean } = {}) {
 }
 
 const defaultProcessor = createProcessor();
-const campusReferencesProcessor = createProcessor({ campusReferences: true });
 
 export function renderMarkdown(
   value: string,
-  options: { campusReferences?: boolean } = {},
+  options: { remarkPlugins?: PluggableList } = {},
 ) {
   try {
-    const processor = options.campusReferences
-      ? campusReferencesProcessor
+    const processor = options.remarkPlugins?.length
+      ? createProcessor(options)
       : defaultProcessor;
     return String(processor.processSync(normalizeMarkdownInput(value)));
   } catch {

--- a/src/lib/components/ui/tabs/tabs-context.ts
+++ b/src/lib/components/ui/tabs/tabs-context.ts
@@ -1,0 +1,5 @@
+export const tabsListLabelContext = Symbol("tabs-list-label");
+
+export type TabsListLabelContext = {
+  getLabel: () => string | undefined;
+};

--- a/src/lib/components/ui/tabs/tabs-list.svelte
+++ b/src/lib/components/ui/tabs/tabs-list.svelte
@@ -1,15 +1,33 @@
 <script lang="ts">
+import { getContext } from "svelte";
+import {
+  type TabsListLabelContext,
+  tabsListLabelContext,
+} from "./tabs-context";
+
 export let role = "group";
 let className = "";
 
 export { className as class };
+
+const rootLabelContext = getContext<TabsListLabelContext | undefined>(
+  tabsListLabelContext,
+);
+
+function explicitListLabel() {
+  const value = ($$restProps as Record<string, unknown>)["aria-label"];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+$: listLabel = explicitListLabel() ?? rootLabelContext?.getLabel();
 </script>
 
 <div
   class={`inline-flex max-w-full w-fit items-center gap-1 overflow-x-auto rounded-xl border border-base-300 bg-base-100 p-1 ${className}`}
   data-slot="tabs-list"
-  {role}
   {...$$restProps}
+  aria-label={listLabel}
+  {role}
 >
   <slot />
 </div>

--- a/src/lib/components/ui/tabs/tabs.svelte
+++ b/src/lib/components/ui/tabs/tabs.svelte
@@ -1,9 +1,33 @@
 <script lang="ts">
+import { setContext } from "svelte";
+import {
+  type TabsListLabelContext,
+  tabsListLabelContext,
+} from "./tabs-context";
+
 let className = "";
+let rootProps: Record<string, unknown> = {};
 
 export { className as class };
+
+const labelContext: TabsListLabelContext = {
+  getLabel: () => {
+    const value = ($$restProps as Record<string, unknown>)["aria-label"];
+    return typeof value === "string" && value.length > 0 ? value : undefined;
+  },
+};
+
+setContext(tabsListLabelContext, labelContext);
+
+$: {
+  const { "aria-label": _label, ...rest } = $$restProps as Record<
+    string,
+    unknown
+  >;
+  rootProps = rest;
+}
 </script>
 
-<div class={`grid min-w-0 gap-4 ${className}`} data-slot="tabs" {...$$restProps}>
+<div class={`grid min-w-0 gap-4 ${className}`} data-slot="tabs" {...rootProps}>
   <slot />
 </div>

--- a/tests/e2e/src/app/admin/users/test.ts
+++ b/tests/e2e/src/app/admin/users/test.ts
@@ -202,7 +202,9 @@ test("/admin/users 自定义封禁时长会展示到期时间输入框", async (
     await durationSelect.click();
     await page.getByRole("option", { name: /自定义|Custom/i }).click();
 
-    const expiresAtInput = dialog.getByLabel(/到期时间|Expires At/i);
+    const expiresAtInput = dialog.getByRole("textbox", {
+      name: /到期时间|Expires At/i,
+    });
     await expect(expiresAtInput).toBeVisible();
     await expiresAtInput.fill("2030-01-01T00:00");
     await expect(expiresAtInput).toHaveValue("2030-01-01T00:00");

--- a/tests/e2e/src/app/dashboard/homeworks/test.ts
+++ b/tests/e2e/src/app/dashboard/homeworks/test.ts
@@ -317,7 +317,9 @@ test.describe("dashboard homeworks", () => {
       createDialog.getByRole("group", { name: /说明|Details/i }),
     ).toBeVisible();
     await expect(
-      createDialog.getByLabel(/提交截止|Submission due/i),
+      createDialog.getByRole("group", {
+        name: /提交截止|Submission due/i,
+      }),
     ).toBeVisible();
     await titleInput.fill(title);
     await page.getByTestId("dashboard-homework-create").click();

--- a/tests/e2e/src/app/dashboard/homeworks/test.ts
+++ b/tests/e2e/src/app/dashboard/homeworks/test.ts
@@ -317,9 +317,7 @@ test.describe("dashboard homeworks", () => {
       createDialog.getByRole("group", { name: /说明|Details/i }),
     ).toBeVisible();
     await expect(
-      createDialog.getByRole("group", {
-        name: /提交截止|Submission due/i,
-      }),
+      createDialog.getByLabel(/提交截止|Submission due/i),
     ).toBeVisible();
     await titleInput.fill(title);
     await page.getByTestId("dashboard-homework-create").click();

--- a/tests/e2e/src/app/dashboard/homeworks/test.ts
+++ b/tests/e2e/src/app/dashboard/homeworks/test.ts
@@ -219,7 +219,14 @@ test.describe("dashboard homeworks", () => {
       .first();
     await expect(completionButton).toHaveCSS("opacity", "1");
 
+    const homeworksTab = page
+      .getByRole("link", { name: /作业|Homework/i })
+      .first();
+    const homeworksBadge = homeworksTab.locator('[data-slot="badge"]');
+    const beforeBadge = Number((await homeworksBadge.textContent())?.trim());
+    expect(Number.isFinite(beforeBadge)).toBe(true);
     const before = (await completionButton.textContent())?.trim() ?? "";
+    const marksComplete = /标记为完成|Mark as complete/i.test(before);
 
     const completionResponse = page.waitForResponse(
       (r) =>
@@ -233,6 +240,9 @@ test.describe("dashboard homeworks", () => {
 
     const after = (await completionButton.textContent())?.trim() ?? "";
     expect(after).not.toBe(before);
+    await expect(homeworksBadge).toHaveText(
+      String(marksComplete ? beforeBadge - 1 : beforeBadge + 1),
+    );
     await captureStepScreenshot(page, testInfo, "homeworks/completion-toggled");
 
     // Restore
@@ -244,6 +254,7 @@ test.describe("dashboard homeworks", () => {
     );
     await completionButton.click();
     await restoreResponse;
+    await expect(homeworksBadge).toHaveText(String(beforeBadge));
   });
 
   test("view details links to section page with homework anchor", async ({
@@ -301,6 +312,15 @@ test.describe("dashboard homeworks", () => {
       timeout: 10_000,
       intervals: [250, 500, 1_000],
     });
+    const createDialog = page.locator('[data-slot="dialog-popup"]').first();
+    await expect(
+      createDialog.getByRole("group", { name: /说明|Details/i }),
+    ).toBeVisible();
+    await expect(
+      createDialog.getByRole("group", {
+        name: /提交截止|Submission due/i,
+      }),
+    ).toBeVisible();
     await titleInput.fill(title);
     await page.getByTestId("dashboard-homework-create").click();
 

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -97,6 +97,9 @@ test.describe("/sections/[jwId]", () => {
     ).toContainText(expectedSubtitle);
     // section.code (monospace)
     await expect(page.getByText(DEV_SEED.section.code).first()).toBeVisible();
+    await expect(
+      page.getByRole("group", { name: /授课班级|Teaching section/i }),
+    ).toBeVisible();
 
     await captureStepScreenshot(page, testInfo, "section/heading");
   });
@@ -850,6 +853,21 @@ test.describe("/sections/[jwId]", () => {
       })
       .first();
     await expect(composerCard).toBeVisible();
+    const uploadInput = composerCard.locator('input[type="file"]').first();
+    await expect(uploadInput).toBeAttached();
+    const uploadControl = uploadInput.locator(
+      "xpath=ancestor::label[@data-slot='button'][1]",
+    );
+    await uploadInput.evaluate((input: HTMLInputElement) => {
+      input.focus();
+    });
+    await expect
+      .poll(() =>
+        uploadControl.evaluate(
+          (element) => getComputedStyle(element).boxShadow,
+        ),
+      )
+      .not.toBe("none");
 
     // Upload attachment (upload.yml three-step flow)
     const filename = `e2e-attachment-${Date.now()}.txt`;

--- a/tests/unit/dashboard-controller-derived-state.test.ts
+++ b/tests/unit/dashboard-controller-derived-state.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { buildDashboardControllerDerivedState } from "@/features/dashboard/lib/dashboard-controller-derived-state";
+import {
+  applyLocalHomeworkItemsToSignedData,
+  buildDashboardControllerDerivedState,
+} from "@/features/dashboard/lib/dashboard-controller-derived-state";
 import type {
   DashboardLinkItem,
   DashboardPageData,
+  HomeworkItem,
+  SignedDashboardData,
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
 import {
   DASHBOARD_LINK_GROUP_ORDER,
@@ -57,6 +62,15 @@ function signedDashboardData(
   };
 }
 
+function homework(id: string, completed: boolean): HomeworkItem {
+  return {
+    completion: completed ? { completedAt: "2026-06-22T10:00:00.000Z" } : null,
+    id,
+    submissionDueAt: null,
+    title: id,
+  };
+}
+
 describe("dashboard controller derived state", () => {
   it.each([
     { currentPinned: true, loadedPinned: false, name: "pin" },
@@ -89,5 +103,32 @@ describe("dashboard controller derived state", () => {
         slug: "jw",
       }),
     ]);
+  });
+
+  it("derives the signed dashboard homework badge count from local homework items", () => {
+    const data = {
+      ...signedDashboardData([]),
+      homeworks: {
+        homeworkSummaries: [homework("homework-1", false)],
+        sections: [],
+      },
+      navStats: {
+        calendarItemsCount: 0,
+        examsCount: 0,
+        pendingHomeworksCount: 2,
+        pendingTodosCount: 0,
+      },
+      subscribedSectionCount: 0,
+    } as SignedDashboardData;
+
+    const nextHomeworks = [
+      homework("homework-1", true),
+      homework("homework-2", false),
+    ];
+
+    const result = applyLocalHomeworkItemsToSignedData(data, nextHomeworks);
+
+    expect(result?.navStats.pendingHomeworksCount).toBe(1);
+    expect(result?.homeworks?.homeworkSummaries).toBe(nextHomeworks);
   });
 });

--- a/tests/unit/markdown-renderer.test.ts
+++ b/tests/unit/markdown-renderer.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CampusReferenceKind,
+  campusReferenceMarkdownPlugins,
+  remarkCampusReferences,
+} from "@/features/markdown/lib/campus-reference-markdown";
+import { renderMarkdown } from "@/lib/components/markdown-preview-renderer";
+
+describe("markdown renderer", () => {
+  it("keeps campus references inert without injected feature plugins", () => {
+    const html = renderMarkdown("See section#123 and teacher#456.");
+
+    expect(html).toContain("section#123");
+    expect(html).not.toContain('href="/sections/123"');
+    expect(html).not.toContain('href="/teachers/456"');
+  });
+
+  it("links campus references when the feature plugin is injected", () => {
+    const html = renderMarkdown("See section#123 and teacher#456.", {
+      remarkPlugins: campusReferenceMarkdownPlugins,
+    });
+
+    expect(html).toContain('href="/sections/123"');
+    expect(html).toContain('href="/teachers/456"');
+  });
+
+  it("allows feature callers to inject a custom campus reference resolver", () => {
+    const html = renderMarkdown("See teacher#456.", {
+      remarkPlugins: [
+        [
+          remarkCampusReferences,
+          {
+            resolveReference: (kind: CampusReferenceKind, id: string) =>
+              `/catalog/${kind}/${id}`,
+          },
+        ],
+      ],
+    });
+
+    expect(html).toContain('href="/catalog/teacher/456"');
+  });
+});


### PR DESCRIPTION
## Goal

Resolve the confirmed dashboard, markdown, tab, compound-control, and upload-focus accessibility/design issues from the review pass.

Fixes #125
Fixes #126
Fixes #127
Fixes #128
Fixes #129
Fixes #130

## Changed Surfaces

- Dashboard homework state: local completion changes now update the nav badge immediately.
- Dashboard links: shared visit action removes duplicated visit forms; overview links reuse the same pin button as the links tab.
- Shared controls: `MarkdownEditor`, `Tabs`, and `DateTimePicker` expose usable group labels; DateTimePicker tests now use role-specific locators so the compound group and editable textbox can share the field name without strict-mode ambiguity.
- Markdown ownership: campus reference linking moved out of shared markdown primitives into `src/features/markdown` and is injected only by feature callers.
- Comment upload: file input label now exposes a visible focus style.
- Section/dashboard homework forms: compound markdown/date controls avoid labels containing nested interactive controls.

## Evidence

- Unit/component checks: `bun run test -- tests/unit/dashboard-controller-derived-state.test.ts tests/unit/markdown-renderer.test.ts`; `bunx biome check ...` on changed shared/component/test files; `bun run verify:conventions`; `DATABASE_URL=... bun run verify:types`.
- Initial disposable-DB browser pass on `PLAYWRIGHT_PORT=3003`: dashboard homework create/toggle focused E2E passed with 2 tests.
- Initial disposable-DB browser pass on `PLAYWRIGHT_PORT=3003`: section heading/upload focused E2E passed with 2 tests.
- DateTimePicker follow-up checks: `bunx biome check src/lib/components/DateTimePicker.svelte tests/e2e/src/app/dashboard/homeworks/test.ts tests/e2e/src/app/admin/users/test.ts`; `DATABASE_URL=... bun run verify:types`; `git diff --check`; `PLAYWRIGHT_PORT=3004 DATABASE_URL=... AUTH_SECRET=... bun run e2e:build-artifacts && bun run seed && bun run e2e:test -- tests/e2e/src/app/dashboard/homeworks/test.ts tests/e2e/src/app/admin/users/test.ts -g 'can create a new homework|自定义封禁时长会展示到期时间输入框'` passed with 2 tests.
- Manual browser screenshot inspected for the signed-in section comments surface at desktop viewport `1280x900`; upload control focus style and labeled tab groups were asserted before capture. The screenshot was kept outside the repo and removed after inspection.

Local setup retries before the passing evidence:
- `verify:types` initially failed before typechecking because the shell had no `DATABASE_URL`; rerun with local Postgres URL passed.
- One section E2E attempt failed before running tests because `[jwId]` was not escaped in the Playwright path pattern.
- One manual screenshot attempt failed before capture because it searched for the upload control before switching to the comments tab.
- One local Compose start in the UI worktree failed because shared Postgres was already bound to `127.0.0.1:5432`; the failed worktree-local container was removed and the focused E2E reran against the existing shared Postgres container.

## Docs / Contracts

No docs, contracts, OpenAPI, or message files changed. This is UI/component behavior and accessibility structure only.

## Risk Areas

- Shared Tabs label propagation affects every `Tabs.Root`/`Tabs.List` pair, so focused type/convention checks and representative browser coverage were run.
- Markdown campus reference behavior is now opt-in through feature-owned plugins; unit coverage checks that shared markdown remains inert by default.
- E2E used disposable databases where browser state mattered; the final DateTimePicker follow-up used the shared local Postgres container after reseeding.

## Cleanup

- No screenshots, Playwright output, temporary databases, or ad hoc probes remain in the worktree.
