### PR TITLE
refactor(db): use static Prisma imports

### DIFF
--- a/src/features/admin/server/admin-api.ts
+++ b/src/features/admin/server/admin-api.ts
@@ -1,3 +1,5 @@
+import { prisma } from "@/lib/db/prisma";
+
 export type AdminSession = {
   userId: string;
 };
@@ -7,7 +9,6 @@ export async function resolveAdminByUserId(
 ): Promise<AdminSession | null> {
   if (!userId) return null;
 
-  const { prisma } = await import("@/lib/db/prisma");
   const user = await prisma.user.findUnique({
     where: { id: userId },
     select: { id: true, isAdmin: true },

--- a/src/features/admin/server/admin-bus-page-server.ts
+++ b/src/features/admin/server/admin-bus-page-server.ts
@@ -6,6 +6,7 @@ import {
 import { loadBusStaticPayload } from "@/features/bus/lib/bus-static-source";
 import { importBusStaticPayload } from "@/features/bus/server/bus-import";
 import type { AppLocale } from "@/i18n/config";
+import { prisma } from "@/lib/db/prisma";
 import enUsMessages from "../../../../messages/en-us.json";
 import zhCnMessages from "../../../../messages/zh-cn.json";
 import {
@@ -45,7 +46,6 @@ export const adminBusActions = {
     const form = await request.formData();
     const id = parseAdminBusVersionId(form);
     if (id === null) return failure(copy.invalidVersionId);
-    const { prisma } = await import("@/lib/db/prisma");
     const version = await prisma.busScheduleVersion.findUnique({
       where: { id },
       select: { id: true },
@@ -69,7 +69,6 @@ export const adminBusActions = {
     const form = await request.formData();
     const id = parseAdminBusVersionId(form);
     if (id === null) return failure(copy.invalidVersionId);
-    const { prisma } = await import("@/lib/db/prisma");
     const version = await prisma.busScheduleVersion.findUnique({
       where: { id },
       select: { id: true, isEnabled: true },
@@ -82,7 +81,6 @@ export const adminBusActions = {
   importStatic: async ({ locals, request }: AdminBusEvent) => {
     const copy = getCopy(locals.locale).adminBus;
     await requireAdminPage(request);
-    const { prisma } = await import("@/lib/db/prisma");
     let result: Awaited<ReturnType<typeof importBusStaticPayload>>;
     try {
       const payload = await loadBusStaticPayload();

--- a/src/features/admin/server/admin-home-page-data.ts
+++ b/src/features/admin/server/admin-home-page-data.ts
@@ -2,6 +2,7 @@ import {
   getPrismaClient,
   requireAdminPage,
 } from "@/features/admin/server/admin-page-auth";
+import { getPrisma } from "@/lib/db/prisma";
 
 export async function getAdminHomeData(request: Request) {
   await requireAdminPage(request);
@@ -41,7 +42,6 @@ export async function getAdminHomeData(request: Request) {
 }
 
 export async function getAdminSummary(locale = "zh-cn") {
-  const { getPrisma } = await import("@/lib/db/prisma");
   const prisma = getPrisma(locale);
   const [users, comments, homeworks, oauthClients, suspensions] =
     await Promise.all([

--- a/src/features/admin/server/admin-oauth-delete-action.ts
+++ b/src/features/admin/server/admin-oauth-delete-action.ts
@@ -2,6 +2,7 @@ import { fail } from "@sveltejs/kit";
 import { getAdminOAuthCopy } from "@/features/admin/lib/admin-oauth-page-copy";
 import { requireAdminPage } from "@/features/admin/server/admin-page-data";
 import type { AppLocale } from "@/i18n/config";
+import { prisma } from "@/lib/db/prisma";
 
 export async function deleteAdminOAuthClientAction(
   request: Request,
@@ -12,7 +13,6 @@ export async function deleteAdminOAuthClientAction(
   const form = await request.formData();
   const clientId = String(form.get("clientId") ?? "");
   if (!clientId) return fail(400, { message: copy.missingClientId });
-  const { prisma } = await import("@/lib/db/prisma");
   try {
     await prisma.oAuthClient.delete({ where: { clientId } });
   } catch (error) {

--- a/src/features/admin/server/admin-page-auth.ts
+++ b/src/features/admin/server/admin-page-auth.ts
@@ -1,8 +1,8 @@
 import { error, redirect } from "@sveltejs/kit";
 import { buildSignInPageUrl } from "@/lib/auth/auth-routing";
+import { prisma } from "@/lib/db/prisma";
 
 export async function getPrismaClient() {
-  const { prisma } = await import("@/lib/db/prisma");
   return prisma;
 }
 

--- a/src/features/catalog/server/public-course-list-data.ts
+++ b/src/features/catalog/server/public-course-list-data.ts
@@ -1,6 +1,8 @@
 import { CATALOG_PAGE_SIZE } from "@/features/catalog/server/catalog-page-constants";
+import { listCourseSummaries } from "@/features/catalog/server/course-section-queries";
 import { type AppLocale, DEFAULT_LOCALE } from "@/i18n/config";
 import { getMessages } from "@/i18n/messages.server";
+import { getPrisma } from "@/lib/db/prisma";
 import {
   optionalValue,
   parsePositivePage,
@@ -28,10 +30,6 @@ async function getUncachedCourseListPage(
   url: URL,
   locale: AppLocale = DEFAULT_LOCALE,
 ) {
-  const [{ listCourseSummaries }, { getPrisma }] = await Promise.all([
-    import("@/features/catalog/server/course-section-queries"),
-    import("@/lib/db/prisma"),
-  ]);
   const page = parsePositivePage(url.searchParams.get("page"));
   const search = optionalValue(url.searchParams.get("search"));
   const educationLevelId = optionalValue(

--- a/src/features/catalog/server/public-section-list-data.ts
+++ b/src/features/catalog/server/public-section-list-data.ts
@@ -1,6 +1,8 @@
 import { CATALOG_PAGE_SIZE } from "@/features/catalog/server/catalog-page-constants";
+import { listSectionSummaries } from "@/features/catalog/server/course-section-queries";
 import { type AppLocale, DEFAULT_LOCALE } from "@/i18n/config";
 import { getMessages } from "@/i18n/messages.server";
+import { getPrisma } from "@/lib/db/prisma";
 import {
   optionalValue,
   parsePositivePage,
@@ -28,10 +30,6 @@ async function getUncachedSectionListPage(
   url: URL,
   locale: AppLocale = DEFAULT_LOCALE,
 ) {
-  const [{ listSectionSummaries }, { getPrisma }] = await Promise.all([
-    import("@/features/catalog/server/course-section-queries"),
-    import("@/lib/db/prisma"),
-  ]);
   const page = parsePositivePage(url.searchParams.get("page"));
   const search = optionalValue(url.searchParams.get("search"));
   const semesterId = optionalValue(url.searchParams.get("semesterId"));

--- a/src/features/catalog/server/public-teacher-list-data.ts
+++ b/src/features/catalog/server/public-teacher-list-data.ts
@@ -1,6 +1,8 @@
+import { paginatedTeacherQuery } from "@/features/catalog/server/academic-paginated-queries";
 import { CATALOG_PAGE_SIZE } from "@/features/catalog/server/catalog-page-constants";
 import { buildTeacherWhere } from "@/features/catalog/server/teacher-query";
 import { getMessages } from "@/i18n/messages.server";
+import { getPrisma } from "@/lib/db/prisma";
 import {
   optionalValue,
   parsePositivePage,
@@ -22,10 +24,6 @@ export async function getTeacherListPage(url: URL, locale = "zh-cn") {
 }
 
 async function getUncachedTeacherListPage(url: URL, locale = "zh-cn") {
-  const [{ paginatedTeacherQuery }, { getPrisma }] = await Promise.all([
-    import("@/features/catalog/server/academic-paginated-queries"),
-    import("@/lib/db/prisma"),
-  ]);
   const page = parsePositivePage(url.searchParams.get("page"));
   const search = optionalValue(url.searchParams.get("search"));
   const departmentId = optionalValue(url.searchParams.get("departmentId"));

--- a/src/features/comments/server/comment-section-teacher.ts
+++ b/src/features/comments/server/comment-section-teacher.ts
@@ -1,8 +1,9 @@
+import { prisma } from "@/lib/db/prisma";
+
 export async function resolveSectionTeacherId(
   sectionId: number,
   teacherId: number,
 ) {
-  const { prisma } = await import("@/lib/db/prisma");
   const section = await prisma.section.findFirst({
     where: {
       id: sectionId,
@@ -33,7 +34,6 @@ export async function findSectionTeacherId(
   sectionId: number,
   teacherId: number,
 ) {
-  const { prisma } = await import("@/lib/db/prisma");
   const sectionTeacher = await prisma.sectionTeacher.findUnique({
     where: {
       sectionId_teacherId: {
@@ -53,7 +53,6 @@ export async function findSectionTeacherTarget(
   sectionId: number,
   teacherId: number,
 ) {
-  const { prisma } = await import("@/lib/db/prisma");
   const sectionTeacherId = await findSectionTeacherId(sectionId, teacherId);
   if (sectionTeacherId) {
     return { exists: true, id: sectionTeacherId } as const;

--- a/src/features/comments/server/comment-target-verification.ts
+++ b/src/features/comments/server/comment-target-verification.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@/lib/db/prisma";
 import type { CommentTargetType } from "./comment-utils";
 
 /**
@@ -8,7 +9,6 @@ export async function verifyCommentTargetEntity(
   targetType: CommentTargetType,
   whereTarget: Record<string, number | string>,
 ): Promise<boolean> {
-  const { prisma } = await import("@/lib/db/prisma");
   if (targetType === "section" && typeof whereTarget.sectionId === "number") {
     const section = await prisma.section.findUnique({
       where: { id: whereTarget.sectionId },

--- a/src/features/dashboard-links/server/dashboard-link-service.ts
+++ b/src/features/dashboard-links/server/dashboard-link-service.ts
@@ -1,4 +1,5 @@
 import { USTC_DASHBOARD_LINKS } from "@/features/dashboard-links/lib/dashboard-links";
+import { prisma } from "@/lib/db/prisma";
 import { logAppEvent } from "@/lib/log/app-logger";
 
 export const MAX_PINNED_LINKS = 4;
@@ -48,7 +49,6 @@ export function sanitizeDashboardReturnTo(value: string | undefined): string {
 
 export async function recordDashboardLinkClick(userId: string, slug: string) {
   try {
-    const { prisma } = await import("@/lib/db/prisma");
     await prisma.dashboardLinkClick.upsert({
       where: {
         userId_slug: {
@@ -90,7 +90,6 @@ export async function updateDashboardLinkPinState({
   slug: string;
   userId: string;
 }) {
-  const { prisma } = await import("@/lib/db/prisma");
   if (action === "pin") {
     return pinDashboardLink(prisma, userId, slug);
   }

--- a/src/features/dashboard/server/dashboard-page-load.ts
+++ b/src/features/dashboard/server/dashboard-page-load.ts
@@ -9,6 +9,7 @@ import {
   parsePositiveCalendarSemester,
   parseSnapshotReferenceTime,
 } from "@/features/dashboard/server/dashboard-page-server";
+import { getPrisma } from "@/lib/db/prisma";
 import { logAppEvent } from "@/lib/log/app-logger";
 
 function recordDashboardLoadFinish(input: {
@@ -55,7 +56,6 @@ export async function loadDashboardPage({
   const publicSummaryPromise = (async () => {
     let publicSummary: Awaited<ReturnType<typeof loadDashboardPublicSummary>>;
     try {
-      const { getPrisma } = await import("@/lib/db/prisma");
       publicSummary = await loadDashboardPublicSummary(
         getPrisma(locale),
         referenceNow ?? null,

--- a/src/features/descriptions/server/description-targets.ts
+++ b/src/features/descriptions/server/description-targets.ts
@@ -5,6 +5,7 @@ export {
   type DescriptionTargetType,
 } from "@/features/descriptions/lib/description-target-types";
 
+import { prisma } from "@/lib/db/prisma";
 import { parseInteger } from "@/lib/integers";
 
 type DescriptionTargetIdMap = {
@@ -53,7 +54,6 @@ const descriptionTargetConfig: {
   section: {
     parseId: parsePositiveIntegerId,
     findTarget: async (targetId) => {
-      const { prisma } = await import("@/lib/db/prisma");
       return prisma.section.findUnique({
         where: { id: targetId },
         select: { id: true },
@@ -64,7 +64,6 @@ const descriptionTargetConfig: {
   course: {
     parseId: parsePositiveIntegerId,
     findTarget: async (targetId) => {
-      const { prisma } = await import("@/lib/db/prisma");
       return prisma.course.findUnique({
         where: { id: targetId },
         select: { id: true },
@@ -75,7 +74,6 @@ const descriptionTargetConfig: {
   teacher: {
     parseId: parsePositiveIntegerId,
     findTarget: async (targetId) => {
-      const { prisma } = await import("@/lib/db/prisma");
       return prisma.teacher.findUnique({
         where: { id: targetId },
         select: { id: true },
@@ -86,7 +84,6 @@ const descriptionTargetConfig: {
   homework: {
     parseId: parseHomeworkTargetId,
     findTarget: async (targetId) => {
-      const { prisma } = await import("@/lib/db/prisma");
       return prisma.homework.findUnique({
         where: { id: targetId },
         select: { id: true },
@@ -141,7 +138,6 @@ export type ResolvedDescriptionTargetReference =
     };
 
 async function findSectionIdByJwId(jwId: number) {
-  const { prisma } = await import("@/lib/db/prisma");
   const section = await prisma.section.findUnique({
     where: { jwId },
     select: { id: true },
@@ -150,7 +146,6 @@ async function findSectionIdByJwId(jwId: number) {
 }
 
 async function findCourseIdByJwId(jwId: number) {
-  const { prisma } = await import("@/lib/db/prisma");
   const course = await prisma.course.findUnique({
     where: { jwId },
     select: { id: true },

--- a/src/features/descriptions/server/description-upsert.ts
+++ b/src/features/descriptions/server/description-upsert.ts
@@ -1,5 +1,6 @@
 import { fireAuditLog } from "@/lib/audit/write-audit-log";
 import { getViewerContext } from "@/lib/auth/viewer-context";
+import { prisma } from "@/lib/db/prisma";
 import { isPrismaUniqueConstraintError } from "@/lib/db/prisma-errors";
 import {
   type DescriptionTargetType,
@@ -55,7 +56,6 @@ export async function upsertDescriptionContent({
     return { ok: false as const, error: "not_found" as DescriptionUpsertError };
   }
 
-  const { prisma } = await import("@/lib/db/prisma");
   const writeDescription = () =>
     prisma.$transaction(async (tx) => {
       const existing = await tx.description.findFirst({

--- a/src/features/home/server/dashboard-link-data.ts
+++ b/src/features/home/server/dashboard-link-data.ts
@@ -1,4 +1,5 @@
 import { DASHBOARD_LINK_GROUPS } from "@/features/dashboard-links/lib/dashboard-links";
+import { prisma } from "@/lib/db/prisma";
 import {
   buildDashboardLinkSummaries,
   dashboardLinksForSlugs,
@@ -37,7 +38,6 @@ export function getPublicDashboardLinksData(): {
 export async function getSignedInDashboardLinksData(
   userId: string,
 ): Promise<DashboardLinksData> {
-  const { prisma } = await import("@/lib/db/prisma");
   const [clickRows, pinRows] = await Promise.all([
     prisma.dashboardLinkClick.findMany({
       where: { userId },

--- a/src/features/oauth/server/device-approval-state.server.ts
+++ b/src/features/oauth/server/device-approval-state.server.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@/lib/db/prisma";
 import { normalizeUserCode } from "@/lib/oauth/device-code";
 import { getDeviceApprovalFailureReason } from "./device-approval-validation.server";
 import { requireDeviceUserId } from "./device-auth.server";
@@ -15,7 +16,6 @@ export async function loadDeviceApprovalState({
   request: Request;
   url: URL;
 }) {
-  const { prisma } = await import("@/lib/db/prisma");
   const userCode = normalizeUserCode(code);
   const record = await prisma.deviceCode.findUnique({
     where: { userCode },

--- a/src/features/oauth/server/device-decision.server.ts
+++ b/src/features/oauth/server/device-decision.server.ts
@@ -1,4 +1,5 @@
 import { redirect } from "@sveltejs/kit";
+import { prisma } from "@/lib/db/prisma";
 import { DEVICE_CODE_STATUS, normalizeUserCode } from "@/lib/oauth/device-code";
 import { getDeviceApprovalFailureReason } from "./device-approval-validation.server";
 import { requireDeviceUserId } from "./device-auth.server";
@@ -24,7 +25,6 @@ export async function completeDeviceCodeDecision(
     );
   }
 
-  const { prisma } = await import("@/lib/db/prisma");
   const userCode = normalizeUserCode(rawCode);
   const record = await prisma.deviceCode.findUnique({
     where: { userCode },

--- a/src/features/settings/server/settings-account-actions.ts
+++ b/src/features/settings/server/settings-account-actions.ts
@@ -7,6 +7,7 @@ import {
   applyAuthResponseCookies,
   linkAccountFromSvelteAction,
 } from "@/lib/auth/svelte-auth-actions";
+import { prisma } from "@/lib/db/prisma";
 import { deleteOwnAccount } from "./account-deletion-service";
 
 export async function unlinkSettingsAccountAction({
@@ -18,7 +19,6 @@ export async function unlinkSettingsAccountAction({
   const user = await requireSettingsUser(request, url);
   const form = await request.formData();
   const provider = String(form.get("provider") ?? "");
-  const { prisma } = await import("@/lib/db/prisma");
   const accounts = await prisma.account.findMany({
     where: { userId: user.id },
     select: { id: true, provider: true },

--- a/src/features/settings/server/settings-page-data.ts
+++ b/src/features/settings/server/settings-page-data.ts
@@ -2,6 +2,7 @@ import { redirect } from "@sveltejs/kit";
 import { normalizeSettingsTab } from "@/features/settings/lib/settings-tabs";
 import { buildSettingsAccountProviders } from "@/features/settings/server/settings-account-providers";
 import { buildSignInPageUrl } from "@/lib/auth/auth-routing";
+import { prisma } from "@/lib/db/prisma";
 
 export type SettingsAccountProvider = {
   id: "oidc" | "github" | "google";
@@ -23,7 +24,6 @@ export async function requireSettingsUser(request: Request, url: URL) {
 
 export async function getSettingsPageData(request: Request, url: URL) {
   const sessionUser = await requireSettingsUser(request, url);
-  const { prisma } = await import("@/lib/db/prisma");
   const user = await prisma.user.findUnique({
     where: { id: sessionUser.id },
     select: {

--- a/src/features/welcome/server/welcome-page-server.ts
+++ b/src/features/welcome/server/welcome-page-server.ts
@@ -2,6 +2,7 @@ import { redirect, type ServerLoadEvent } from "@sveltejs/kit";
 import { getCurrentSemester } from "@/features/catalog/server/academic-metadata-read-model";
 import { buildSignInPageUrl } from "@/lib/auth/auth-routing";
 import { getSessionFromHeaders } from "@/lib/auth/core";
+import { prisma } from "@/lib/db/prisma";
 import { resolveWelcomeCallbackUrl } from "./welcome-callback-url";
 import { completeWelcomeProfile } from "./welcome-complete-action";
 import { getWelcomeCopy } from "./welcome-page-copy";
@@ -24,7 +25,6 @@ export const loadWelcomePage = async ({
     );
   }
 
-  const { prisma } = await import("@/lib/db/prisma");
   const [user, semesters, currentSemester] = await Promise.all([
     prisma.user.findUnique({
       where: { id: session.user.id },

--- a/src/lib/api/routes/auth-device-client-resolution.ts
+++ b/src/lib/api/routes/auth-device-client-resolution.ts
@@ -2,6 +2,7 @@ import {
   deviceAuthJsonError,
   resolveRequestedDeviceScopes,
 } from "@/lib/api/routes/auth-device-authorization-helpers";
+import { prisma } from "@/lib/db/prisma";
 import { logOAuthDebug } from "@/lib/log/oauth-debug";
 
 export async function resolveDeviceAuthorizationClient(
@@ -9,7 +10,6 @@ export async function resolveDeviceAuthorizationClient(
   clientId: string,
   scope: FormDataEntryValue | null,
 ) {
-  const { prisma } = await import("@/lib/db/prisma");
   const client = await prisma.oAuthClient.findUnique({
     where: { clientId },
     select: { clientId: true, disabled: true, scopes: true, name: true },

--- a/src/lib/api/routes/auth-device-grant-creation.ts
+++ b/src/lib/api/routes/auth-device-grant-creation.ts
@@ -1,4 +1,5 @@
 import { deviceAuthJsonError } from "@/lib/api/routes/auth-device-authorization-helpers";
+import { prisma } from "@/lib/db/prisma";
 import { logOAuthDebug } from "@/lib/log/oauth-debug";
 import {
   DEVICE_CODE_EXPIRES_IN,
@@ -11,7 +12,6 @@ export async function createDeviceAuthorizationGrant(
   clientId: string,
   requestedScopes: string[],
 ) {
-  const { prisma } = await import("@/lib/db/prisma");
   const deviceCode = generateDeviceCode();
   const userCode = generateUserCode();
   const expiresAt = new Date(Date.now() + DEVICE_CODE_EXPIRES_IN * 1000);

--- a/src/lib/api/routes/auth-token-device-grant.ts
+++ b/src/lib/api/routes/auth-token-device-grant.ts
@@ -1,4 +1,5 @@
 import { issueDeviceGrantTokens } from "@/lib/api/routes/auth-token-device-token-issuer";
+import { prisma } from "@/lib/db/prisma";
 import { logOAuthDebug } from "@/lib/log/oauth-debug";
 import { deviceCodeError } from "./auth-token-device-errors";
 import { resolveDeviceGrantRecord } from "./auth-token-device-record";
@@ -15,7 +16,6 @@ export async function handleDeviceCodeGrant(
     return deviceCodeError("invalid_request");
   }
 
-  const { prisma } = await import("@/lib/db/prisma");
   const recordResult = await resolveDeviceGrantRecord({
     clientId,
     deviceCode,

--- a/src/lib/api/routes/auth-token-loopback-normalization.ts
+++ b/src/lib/api/routes/auth-token-loopback-normalization.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@/lib/db/prisma";
 import {
   logOAuthDebug,
   summarizeOAuthRedirectUri,
@@ -15,7 +16,6 @@ export async function maybeNormalizeTokenLoopbackRedirectRequest(
     return request;
   }
 
-  const { prisma } = await import("@/lib/db/prisma");
   const client = await prisma.oAuthClient.findUnique({
     where: { clientId },
     select: { redirectUris: true },

--- a/src/lib/api/routes/auth-token-mcp-refresh-binding.ts
+++ b/src/lib/api/routes/auth-token-mcp-refresh-binding.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@/lib/db/prisma";
 import { logOAuthDebug } from "@/lib/log/oauth-debug";
 import { getOAuthMcpResourceUrl } from "@/lib/mcp/urls";
 import {
@@ -25,7 +26,6 @@ export async function maybeBindMcpRefreshRequest(
 
   const refreshTokenHash =
     await hashOAuthClientSecretForDbStorage(refreshToken);
-  const { prisma } = await import("@/lib/db/prisma");
   const refreshRecord = await prisma.oAuthRefreshToken.findUnique({
     where: { token: refreshTokenHash },
     select: { scopes: true },

--- a/src/lib/api/routes/auth.ts
+++ b/src/lib/api/routes/auth.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@/lib/db/prisma";
 import {
   logOAuthDebug,
   summarizeOAuthForwardingHeaders,
@@ -139,7 +140,6 @@ async function restoreDeviceRegistrationGrantTypes(
     return response;
   }
 
-  const { prisma } = await import("@/lib/db/prisma");
   await prisma.oAuthClient.update({
     where: { clientId: body.client_id },
     data: {
@@ -193,7 +193,6 @@ async function maybeNormalizeAuthorizeLoopbackRedirectRequest(
     ...summarizeOAuthForwardingHeaders(request, url),
   });
 
-  const { prisma } = await import("@/lib/db/prisma");
   const client = await prisma.oAuthClient.findUnique({
     where: { clientId },
     select: { redirectUris: true },

--- a/src/lib/audit/write-audit-log.ts
+++ b/src/lib/audit/write-audit-log.ts
@@ -1,4 +1,5 @@
 import type { AuditAction, Prisma } from "@/generated/prisma/client";
+import { prisma } from "@/lib/db/prisma";
 import { logAppEvent } from "@/lib/log/app-logger";
 import { recordAuditWriteMetric } from "@/lib/metrics/observability-metrics";
 
@@ -16,7 +17,6 @@ export async function writeAuditLog(params: {
   const { metadata, ...rest } = params;
   const start = Date.now();
   try {
-    const { prisma } = await import("@/lib/db/prisma");
     await prisma.auditLog.create({
       data: {
         ...rest,

--- a/src/routes/api/readiness/+server.ts
+++ b/src/routes/api/readiness/+server.ts
@@ -1,5 +1,6 @@
 import { jsonResponse, notFoundText } from "@/lib/api/helpers";
 import { svelteRequestHandler } from "@/lib/api/svelte-route";
+import { prisma } from "@/lib/db/prisma";
 import { canReadInternalEndpoint } from "@/lib/http/access-control";
 import { observedApiRoute } from "@/lib/log/api-observability";
 import { storageReadiness } from "@/lib/storage/r2-object";
@@ -9,7 +10,6 @@ const startedAt = Date.now();
 async function checkDatabase() {
   const start = Date.now();
   try {
-    const { prisma } = await import("@/lib/db/prisma");
     await prisma.$queryRaw`SELECT 1`;
     return { status: "ok", durationMs: Date.now() - start };
   } catch {


### PR DESCRIPTION
## Goal

Replace unnecessary server-side runtime imports of `@/lib/db/prisma` with static imports so ordinary feature/server and route helper code follows the repo's normal Prisma import pattern. This addresses the Prisma-specific slice of #85; it does not close #85 because other dynamic imports remain intentionally classified or still need separate review.

## Changed Surfaces

- Feature server data/actions across admin, catalog, comments, dashboard links, descriptions, home, OAuth, settings, and welcome.
- API route helper modules under `src/lib/api/routes`.
- Audit logging and readiness DB probing.
- No route contract, MCP tool, UI, data-shape, migration, or workflow behavior changes.

## Evidence

- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run verify`
- `AUTH_SECRET=local-build-secret-for-prisma-static-imports DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run build`
- `rg -n 'await import\(["'"'"']@/lib/db/prisma["'"'"']\)|import\(["'"'"']@/lib/db/prisma["'"'"']\)' src --glob '!src/generated/**'` returned no matches.

## Docs / Contracts

No docs, contracts, OpenAPI, or message changes are needed because this is an import-shape refactor with unchanged behavior and public surfaces.

## Risk Areas

- Prisma import-time and bundling behavior: covered by the existing lazy Prisma proxy plus `bun run verify` and production `bun run build`.
- Auth/OAuth route helpers touched mechanically; no auth logic changed.

## Cleanup

No scratch artifacts, generated-file edits, one-time probes, or unrelated rewrites remain in the worktree.