### PR TITLE
test(boundaries): ratchet route adapter imports

### DIFF
--- a/src/lib/AGENTS.md
+++ b/src/lib/AGENTS.md
@@ -6,6 +6,7 @@ Infrastructure and shared helpers.
 
 ```
 api/       Request/response, schemas, status
+api/routes/ HTTP route adapters; scoped feature-import exception
 auth/      Session resolution, permissions
 components/ Shared UI primitives and layout components
 db/        Prisma instances
@@ -41,7 +42,8 @@ import { formatShanghaiDate } from "@/lib/time/shanghai-format";
 ## Rules
 
 - No business logic (use `src/features/`)
-- `src/lib/api/routes` adapts HTTP to feature/server functions; do not call route handlers from features or page actions
+- `src/lib/api/routes` is the scoped HTTP adapter exception: it may import feature server code to parse HTTP requests, call features, and serialize responses
+- Do not import route adapters from features, page actions, or generic `src/lib` helpers; `src/routes/api/**/+server.ts` should stay thin and delegate to them
 - No raw `@prisma/client` imports outside approved adapters/scripts
 - Use shared helpers
 - OAuth: never log tokens/secrets

--- a/src/lib/api/routes/AGENTS.md
+++ b/src/lib/api/routes/AGENTS.md
@@ -4,7 +4,7 @@ HTTP route adapters for SvelteKit API endpoints.
 
 ## Rules
 
-- This directory is the intentional exception to the generic `src/lib` infrastructure boundary: adapters may import `@/features/*/server` when adapting REST requests to feature operations.
+- This directory is the intentional exception to the generic `src/lib` infrastructure boundary: adapters may import feature-owned server operations and narrow feature-owned helpers when adapting REST requests to feature behavior.
 - Keep adapters transport-level: parse params/query/body, resolve auth or locale, call feature server functions, and shape HTTP success/error responses.
 - Keep business rules and reusable read/write operations in `src/features/<feature>/server`; do not add domain services here.
 - Do not import these adapters from features, page actions, or generic `src/lib` helpers. `src/routes/api/**/+server.ts` files may import them to keep SvelteKit route entries thin.

--- a/src/lib/api/routes/AGENTS.md
+++ b/src/lib/api/routes/AGENTS.md
@@ -1,0 +1,13 @@
+# src/lib/api/routes/
+
+HTTP route adapters for SvelteKit API endpoints.
+
+## Rules
+
+- This directory is the intentional exception to the generic `src/lib` infrastructure boundary: adapters may import `@/features/*/server` when adapting REST requests to feature operations.
+- Keep adapters transport-level: parse params/query/body, resolve auth or locale, call feature server functions, and shape HTTP success/error responses.
+- Keep business rules and reusable read/write operations in `src/features/<feature>/server`; do not add domain services here.
+- Do not import these adapters from features, page actions, or generic `src/lib` helpers. `src/routes/api/**/+server.ts` files may import them to keep SvelteKit route entries thin.
+- If a change increases adapter imports from `@/features`, update the boundary ratchet in `tests/unit/feature-boundaries.test.ts` deliberately.
+
+See `src/lib/AGENTS.md` and the root `AGENTS.md` for the broader source boundaries.

--- a/tests/unit/feature-boundaries.test.ts
+++ b/tests/unit/feature-boundaries.test.ts
@@ -29,18 +29,39 @@ function importSpecifiers(source: string) {
   );
 }
 
+function relativeSourcePath(filePath: string) {
+  return path.relative(process.cwd(), filePath).replace(/\\/g, "/");
+}
+
+function featureImports(source: string) {
+  return importSpecifiers(source).filter((specifier) =>
+    specifier.startsWith("@/features/"),
+  );
+}
+
+const routeAdapterPrefix = "src/lib/api/routes/";
+const maxRouteAdapterFeatureImportFiles = 58;
+const maxRouteAdapterFeatureImports = 90;
+
 const libFeatureImportAllowedPrefixes = [
-  "src/lib/api/routes/",
+  routeAdapterPrefix,
   "src/lib/api/schemas/",
   "src/lib/mcp/",
 ];
 
 function isAllowedLibFeatureAdapter(filePath: string) {
-  const relativePath = path
-    .relative(process.cwd(), filePath)
-    .replace(/\\/g, "/");
+  const relativePath = relativeSourcePath(filePath);
   return libFeatureImportAllowedPrefixes.some((prefix) =>
     relativePath.startsWith(prefix),
+  );
+}
+
+function isAllowedRouteAdapterConsumer(filePath: string) {
+  const relativePath = relativeSourcePath(filePath);
+  return (
+    relativePath.startsWith(routeAdapterPrefix) ||
+    (relativePath.startsWith("src/routes/api/") &&
+      relativePath.endsWith("/+server.ts"))
   );
 }
 
@@ -66,17 +87,59 @@ describe("source import boundaries", () => {
     for (const filePath of libFiles) {
       if (isAllowedLibFeatureAdapter(filePath)) continue;
       const source = await fs.readFile(filePath, "utf8");
-      const featureImports = importSpecifiers(source).filter((specifier) =>
-        specifier.startsWith("@/features/"),
-      );
-      if (featureImports.length > 0) {
+      const imports = featureImports(source);
+      if (imports.length > 0) {
         violations.push(
-          `${path.relative(process.cwd(), filePath)} -> ${featureImports.join(", ")}`,
+          `${relativeSourcePath(filePath)} -> ${imports.join(", ")}`,
         );
       }
     }
 
     expect(violations).toEqual([]);
+  });
+
+  it("keeps route adapters out of feature, page action, and generic lib callers", async () => {
+    const sourceFiles = await collectSourceFiles(
+      path.join(process.cwd(), "src"),
+    );
+    const violations: string[] = [];
+
+    for (const filePath of sourceFiles) {
+      if (isAllowedRouteAdapterConsumer(filePath)) continue;
+
+      const source = await fs.readFile(filePath, "utf8");
+      const routeAdapterImports = importSpecifiers(source).filter((specifier) =>
+        specifier.startsWith("@/lib/api/routes"),
+      );
+      if (routeAdapterImports.length > 0) {
+        violations.push(
+          `${relativeSourcePath(filePath)} -> ${routeAdapterImports.join(", ")}`,
+        );
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it("keeps the HTTP route adapter feature-import ratchet from growing", async () => {
+    const routeAdapterFiles = await collectSourceFiles(
+      path.join(process.cwd(), routeAdapterPrefix),
+    );
+    const featureImportingFiles = new Set<string>();
+    const imports: string[] = [];
+
+    for (const filePath of routeAdapterFiles) {
+      const source = await fs.readFile(filePath, "utf8");
+      for (const specifier of featureImports(source)) {
+        featureImportingFiles.add(relativeSourcePath(filePath));
+        imports.push(`${relativeSourcePath(filePath)} -> ${specifier}`);
+      }
+    }
+
+    expect(featureImportingFiles.size).toBeLessThanOrEqual(
+      maxRouteAdapterFeatureImportFiles,
+    );
+    expect(imports.length).toBeLessThanOrEqual(maxRouteAdapterFeatureImports);
   });
 
   it("keeps feature code off deprecated src/lib domain barrels", async () => {

--- a/tests/unit/feature-boundaries.test.ts
+++ b/tests/unit/feature-boundaries.test.ts
@@ -23,7 +23,7 @@ async function collectSourceFiles(rootDir: string): Promise<string[]> {
 function importSpecifiers(source: string) {
   return Array.from(
     source.matchAll(
-      /\b(?:import\s*(?:type\s*)?(?:[^"']*?\s+from\s*)?|export\s*(?:type\s*)?[^"']*?\s+from\s*|import\s*\(\s*)(["'])(@\/[^"']+)\1/g,
+      /\b(?:import\s*(?:type\s*)?(?:[^"']*?\s+from\s*)?|export\s*(?:type\s*)?[^"']*?\s+from\s*|import\s*\(\s*)(["'])([^"']+)\1/g,
     ),
     (match) => match[2],
   );
@@ -33,13 +33,21 @@ function relativeSourcePath(filePath: string) {
   return path.relative(process.cwd(), filePath).replace(/\\/g, "/");
 }
 
-function featureImports(source: string) {
+function sourceImportPath(filePath: string, specifier: string) {
+  if (specifier.startsWith("@/")) return `src/${specifier.slice(2)}`;
+  if (!specifier.startsWith(".")) return null;
+
+  return relativeSourcePath(path.resolve(path.dirname(filePath), specifier));
+}
+
+function featureImports(filePath: string, source: string) {
   return importSpecifiers(source).filter((specifier) =>
-    specifier.startsWith("@/features/"),
+    sourceImportPath(filePath, specifier)?.startsWith("src/features/"),
   );
 }
 
 const routeAdapterPrefix = "src/lib/api/routes/";
+const routeAdapterRoot = routeAdapterPrefix.slice(0, -1);
 const maxRouteAdapterFeatureImportFiles = 58;
 const maxRouteAdapterFeatureImports = 90;
 
@@ -65,6 +73,14 @@ function isAllowedRouteAdapterConsumer(filePath: string) {
   );
 }
 
+function isRouteAdapterImport(filePath: string, specifier: string) {
+  const sourcePath = sourceImportPath(filePath, specifier);
+  return (
+    sourcePath === routeAdapterRoot ||
+    sourcePath?.startsWith(routeAdapterPrefix) === true
+  );
+}
+
 const deprecatedFeatureLibImports = [
   /^@\/lib\/admin-/,
   /^@\/lib\/course-(?:page|query|section)/,
@@ -78,6 +94,21 @@ const deprecatedFeatureLibImports = [
 ];
 
 describe("source import boundaries", () => {
+  it("resolves relative route adapter imports before applying the consumer rule", () => {
+    const featureFile = path.join(
+      process.cwd(),
+      "src/features/comments/server/example.ts",
+    );
+
+    expect(
+      isRouteAdapterImport(featureFile, "../../../lib/api/routes/comments"),
+    ).toBe(true);
+    expect(isRouteAdapterImport(featureFile, "@/lib/api/routes/comments")).toBe(
+      true,
+    );
+    expect(isRouteAdapterImport(featureFile, "@/lib/api/helpers")).toBe(false);
+  });
+
   it("keeps src/lib infrastructure from importing feature modules outside surface adapters", async () => {
     const libFiles = await collectSourceFiles(
       path.join(process.cwd(), "src/lib"),
@@ -87,7 +118,7 @@ describe("source import boundaries", () => {
     for (const filePath of libFiles) {
       if (isAllowedLibFeatureAdapter(filePath)) continue;
       const source = await fs.readFile(filePath, "utf8");
-      const imports = featureImports(source);
+      const imports = featureImports(filePath, source);
       if (imports.length > 0) {
         violations.push(
           `${relativeSourcePath(filePath)} -> ${imports.join(", ")}`,
@@ -109,7 +140,7 @@ describe("source import boundaries", () => {
 
       const source = await fs.readFile(filePath, "utf8");
       const routeAdapterImports = importSpecifiers(source).filter((specifier) =>
-        specifier.startsWith("@/lib/api/routes"),
+        isRouteAdapterImport(filePath, specifier),
       );
       if (routeAdapterImports.length > 0) {
         violations.push(
@@ -130,7 +161,7 @@ describe("source import boundaries", () => {
 
     for (const filePath of routeAdapterFiles) {
       const source = await fs.readFile(filePath, "utf8");
-      for (const specifier of featureImports(source)) {
+      for (const specifier of featureImports(filePath, source)) {
         featureImportingFiles.add(relativeSourcePath(filePath));
         imports.push(`${relativeSourcePath(filePath)} -> ${specifier}`);
       }


### PR DESCRIPTION
## Goal

Clarify that `src/lib/api/routes` is the scoped HTTP adapter exception, not generic `src/lib` infrastructure, and add boundary tests that keep route adapter usage from drifting. Closes #86.

## Changed Surfaces

- `src/lib/AGENTS.md` now names `src/lib/api/routes` as the HTTP adapter exception and states who may import it.
- New `src/lib/api/routes/AGENTS.md` gives scoped rules for adapters that import feature server code.
- `tests/unit/feature-boundaries.test.ts` now blocks route adapter imports from features, page actions, and generic lib callers, and ratchets adapter-to-feature imports.

## Evidence

- `bun run test -- tests/unit/feature-boundaries.test.ts`
- `bun run biome check src/lib/AGENTS.md src/lib/api/routes/AGENTS.md tests/unit/feature-boundaries.test.ts`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run verify`

## Docs / Contracts

Updated scoped agent guidance only. No product contracts, OpenAPI, or message files changed because this is architecture guidance plus test ratcheting, not a user-visible or API/MCP behavior change.

## Risk Areas

- Boundary test brittleness: the thresholds use current adapter usage as a ratchet so intentional growth must update the test deliberately.
- Architecture interpretation: this chooses the explicit scoped-exception path instead of a broad file move.

## Cleanup

No scratch artifacts, generated-file edits, one-time probes, or unrelated rewrites remain in the worktree.