### PR TITLE
fix(calendar): make feed token creation atomic

### DIFF
--- a/src/features/subscriptions/server/calendar-feed-token.ts
+++ b/src/features/subscriptions/server/calendar-feed-token.ts
@@ -18,6 +18,23 @@ export async function ensureUserCalendarFeedToken(
   }
 
   const token = createCalendarFeedToken();
+  const updateResult = await prisma.user.updateMany({
+    where: { id: userId, calendarFeedToken: null },
+    data: { calendarFeedToken: token },
+  });
+
+  if (updateResult.count === 1) {
+    return token;
+  }
+
+  const current = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { calendarFeedToken: true },
+  });
+
+  if (current?.calendarFeedToken) {
+    return current.calendarFeedToken;
+  }
 
   await prisma.user.update({
     where: { id: userId },

--- a/src/features/subscriptions/server/subscription-read-model-shared.ts
+++ b/src/features/subscriptions/server/subscription-read-model-shared.ts
@@ -1,10 +1,10 @@
 import type { Prisma } from "@/generated/prisma/client";
+import { prisma } from "@/lib/db/prisma";
+import { toShanghaiIsoString } from "@/lib/time/serialize-date-output";
 import {
   buildUserCalendarFeedPath,
   ensureUserCalendarFeedToken,
-} from "@/lib/calendar-feed-token";
-import { prisma } from "@/lib/db/prisma";
-import { toShanghaiIsoString } from "@/lib/time/serialize-date-output";
+} from "./calendar-feed-token";
 
 export const SECTION_SUBSCRIPTION_NOTE =
   "Life@USTC section subscriptions only affect your dashboard and calendar here. They are not official USTC course enrollment.";

--- a/tests/unit/calendar-feed-token.test.ts
+++ b/tests/unit/calendar-feed-token.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ensureUserCalendarFeedToken } from "@/features/subscriptions/server/calendar-feed-token";
+import { randomBytesBase64Url } from "@/lib/crypto/web-crypto";
+import { prisma } from "@/lib/db/prisma";
+
+vi.mock("@/lib/crypto/web-crypto", () => ({
+  randomBytesBase64Url: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  },
+}));
+
+const findUniqueMock = vi.mocked(prisma.user.findUnique);
+const randomBytesBase64UrlMock = vi.mocked(randomBytesBase64Url);
+const updateMock = vi.mocked(prisma.user.update);
+const updateManyMock = vi.mocked(prisma.user.updateMany);
+
+function userWithToken(calendarFeedToken: string | null) {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+  return {
+    calendarFeedToken,
+    createdAt: now,
+    email: "user@example.com",
+    emailVerified: true,
+    id: "user-1",
+    image: null,
+    isAdmin: false,
+    name: "User",
+    profilePictures: [],
+    updatedAt: now,
+    username: null,
+  };
+}
+
+describe("ensureUserCalendarFeedToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the generated token when it wins first-time creation", async () => {
+    findUniqueMock.mockResolvedValueOnce(userWithToken(null));
+    randomBytesBase64UrlMock.mockReturnValue("generated-token");
+    updateManyMock.mockResolvedValueOnce({ count: 1 });
+
+    await expect(ensureUserCalendarFeedToken("user-1")).resolves.toBe(
+      "generated-token",
+    );
+
+    expect(updateManyMock).toHaveBeenCalledWith({
+      where: { id: "user-1", calendarFeedToken: null },
+      data: { calendarFeedToken: "generated-token" },
+    });
+    expect(findUniqueMock).toHaveBeenCalledTimes(1);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("rereads and returns the persisted token when a competing write wins", async () => {
+    findUniqueMock
+      .mockResolvedValueOnce(userWithToken(null))
+      .mockResolvedValueOnce(userWithToken("persisted-token"));
+    randomBytesBase64UrlMock.mockReturnValue("discarded-token");
+    updateManyMock.mockResolvedValueOnce({ count: 0 });
+
+    await expect(ensureUserCalendarFeedToken("user-1")).resolves.toBe(
+      "persisted-token",
+    );
+
+    expect(updateManyMock).toHaveBeenCalledWith({
+      where: { id: "user-1", calendarFeedToken: null },
+      data: { calendarFeedToken: "discarded-token" },
+    });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Goal

Make first-time calendar feed token creation race-safe so concurrent subscription reads never return a discarded token. Closes #146.

## Changed Surfaces

- Moved the calendar feed token helper from top-level `src/lib` into `src/features/subscriptions/server`, its owning feature area.
- `ensureUserCalendarFeedToken()` now conditionally writes only when `calendarFeedToken` is still null, and losing callers reread the persisted token.
- Added focused unit tests for winning first-time creation and losing a competing write.

## Evidence

- `bun run test -- tests/unit/calendar-feed-token.test.ts`
- `bun run biome check src/features/subscriptions/server/calendar-feed-token.ts src/features/subscriptions/server/subscription-read-model-shared.ts tests/unit/calendar-feed-token.test.ts`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run verify`
- Subagent review found no blocking issues and confirmed the race fix, helper move, and unit coverage are appropriate.

## Docs / Contracts

No product contracts, OpenAPI, MCP docs, or message files changed. Public REST/MCP output shape, auth, permissions, and validation semantics stay the same; this only makes token generation atomic.

## Risk Areas

- Calendar subscription URL generation: covered by the new unit race cases and full default verification.
- Missing-user behavior: intentionally preserved by allowing the final Prisma update path to throw as before if the user disappears between reads.

## Cleanup

No scratch artifacts, generated-file edits, one-time probes, or unrelated rewrites remain in the worktree.