### PR TITLE
fix(dashboard): align legacy subscription route redirect

### DIFF
--- a/docs/contracts/overview.json
+++ b/docs/contracts/overview.json
@@ -25,7 +25,7 @@
         "pages": [
           "/dashboard/overview",
           "/dashboard/calendar",
-          "/dashboard/subscriptions/sections",
+          "/dashboard/subscriptions",
           "/dashboard/exams",
           "/dashboard/homeworks",
           "/dashboard/todos",

--- a/docs/contracts/subscribed-sections.json
+++ b/docs/contracts/subscribed-sections.json
@@ -8,7 +8,8 @@
   },
   "rules": {
     "grouped-by-semester": "The list is grouped by semester rather than presented as a single flat list.",
-    "section-codes-promoted": "In the 'subscribed context', users manage specific section relationships, so section codes are intentionally promoted."
+    "section-codes-promoted": "In the 'subscribed context', users manage specific section relationships, so section codes are intentionally promoted.",
+    "legacy-sections-route": "/dashboard/subscriptions/sections is a legacy redirect-only route to /dashboard/subscriptions and must not expose page actions."
   },
   "capabilities": {
     "subscribed-sections-tab": {
@@ -19,7 +20,7 @@
         "ui": ["List Table"]
       },
       "web": {
-        "pages": ["/dashboard/subscriptions/sections", "/?tab=subscriptions"]
+        "pages": ["/dashboard/subscriptions", "/?tab=subscriptions"]
       },
       "rest": {
         "routes": [

--- a/docs/contracts/subscription.json
+++ b/docs/contracts/subscription.json
@@ -58,11 +58,7 @@
         "models": ["Section", "User"]
       },
       "web": {
-        "pages": [
-          "/dashboard/subscriptions/sections",
-          "/?tab=subscriptions",
-          "/welcome"
-        ]
+        "pages": ["/dashboard/subscriptions", "/?tab=subscriptions", "/welcome"]
       },
       "rest": {
         "routes": [

--- a/src/routes/dashboard/subscriptions/sections/+page.server.ts
+++ b/src/routes/dashboard/subscriptions/sections/+page.server.ts
@@ -1,9 +1,6 @@
 import { redirect } from "@sveltejs/kit";
-import { dashboardPageActions } from "@/features/dashboard/server/dashboard-page-actions";
-import type { Actions, PageServerLoad } from "./$types";
+import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
   redirect(308, `/dashboard/subscriptions${event.url.search}`);
 };
-
-export const actions: Actions = dashboardPageActions;

--- a/src/routes/dashboard/subscriptions/sections/+page.svelte
+++ b/src/routes/dashboard/subscriptions/sections/+page.svelte
@@ -1,9 +1,1 @@
-<script lang="ts">
-import DashboardPage from "../../../+page.svelte";
-import type { ActionData, PageData } from "./$types";
-
-export let data: PageData;
-export let form: ActionData | undefined = undefined;
-</script>
-
-<DashboardPage {data} {form} />
+<!-- Redirect-only legacy route; +page.server.ts always redirects. -->

--- a/tests/unit/subscription-legacy-route.test.ts
+++ b/tests/unit/subscription-legacy-route.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import * as legacySubscriptionsRoute from "@/routes/dashboard/subscriptions/sections/+page.server";
+import overviewContract from "../../docs/contracts/overview.json";
+import subscribedSectionsContract from "../../docs/contracts/subscribed-sections.json";
+import subscriptionContract from "../../docs/contracts/subscription.json";
+
+const canonicalPath = "/dashboard/subscriptions";
+const legacyPath = "/dashboard/subscriptions/sections";
+
+type ContractModule = {
+  rules?: Record<string, string>;
+  capabilities: Record<
+    string,
+    {
+      web?: string | { pages: string[] };
+    }
+  >;
+};
+
+function capabilityPages(contract: ContractModule, capability: string) {
+  const web = contract.capabilities[capability]?.web;
+  if (!web || typeof web === "string") {
+    throw new Error(`Missing web pages for ${capability}`);
+  }
+  return web.pages;
+}
+
+describe("legacy subscription sections route", () => {
+  it("redirects GET requests to the canonical subscriptions page", async () => {
+    await expect(
+      legacySubscriptionsRoute.load({
+        url: new URL(
+          "https://life.example/dashboard/subscriptions/sections?semester=2026-spring",
+        ),
+      } as Parameters<typeof legacySubscriptionsRoute.load>[0]),
+    ).rejects.toMatchObject({
+      status: 308,
+      location: `${canonicalPath}?semester=2026-spring`,
+    });
+  });
+
+  it("does not expose page actions on the legacy redirect route", () => {
+    expect("actions" in legacySubscriptionsRoute).toBe(false);
+  });
+
+  it("documents the canonical page and keeps the legacy URL redirect-only", () => {
+    const canonicalCapabilities = [
+      [subscriptionContract, "batch-subscribe-by-codes"],
+      [subscribedSectionsContract, "subscribed-sections-tab"],
+      [overviewContract, "authenticated-overview"],
+    ] as const satisfies readonly [ContractModule, string][];
+
+    for (const [contract, capability] of canonicalCapabilities) {
+      const pages = capabilityPages(contract, capability);
+      expect(pages).toContain(canonicalPath);
+      expect(pages).not.toContain(legacyPath);
+    }
+
+    const legacyRule =
+      subscribedSectionsContract.rules["legacy-sections-route"];
+    expect(legacyRule).toContain(legacyPath);
+    expect(legacyRule).toContain(canonicalPath);
+    expect(legacyRule).toMatch(/redirect-only/);
+    expect(legacyRule).toMatch(/must not expose page actions/);
+  });
+});


### PR DESCRIPTION
## Goal

Align the legacy `/dashboard/subscriptions/sections` route and contracts with the actual redirect behavior. Closes #147.

## Changed Surfaces

- Removed page actions from the legacy redirect route so it is not a writable surface.
- Kept the legacy GET route as a 308 redirect to `/dashboard/subscriptions`, preserving query strings.
- Updated subscription, subscribed-sections, and overview contracts to document `/dashboard/subscriptions` as canonical and `/dashboard/subscriptions/sections` as redirect-only.
- Added a unit test for redirect behavior, absence of actions, and contract URL alignment.

## Evidence

- `bun run test -- tests/unit/subscription-legacy-route.test.ts`
- `bun run biome check src/routes/dashboard/subscriptions/sections/+page.server.ts src/routes/dashboard/subscriptions/sections/+page.svelte tests/unit/subscription-legacy-route.test.ts`
- `bun run check:contracts && bun run check:routes`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run verify`

## Docs / Contracts

Updated `docs/contracts/subscription.json`, `docs/contracts/subscribed-sections.json`, and `docs/contracts/overview.json` to make `/dashboard/subscriptions` canonical and keep the legacy path redirect-only.

## Risk Areas

- Legacy URL compatibility: GET redirect is pinned by the new unit test and existing E2E coverage.
- Removed POST/action compatibility from the legacy route intentionally; direct writes should use canonical dashboard surfaces or API routes.

## Cleanup

No scratch artifacts, generated-file edits, one-time probes, or unrelated rewrites remain in the worktree.