### PR TITLE
fix(mcp): add bus preference tools

### DIFF
--- a/docs/contracts/bus.json
+++ b/docs/contracts/bus.json
@@ -4,7 +4,7 @@
     "anon": "Can query bus information.",
     "user": "Can query bus information and save preferences.",
     "admin": "Can maintain bus data.",
-    "agent": "Can read bus timetable capabilities."
+    "agent": "Can read bus timetable capabilities and manage own bus preferences."
   },
   "rules": {
     "public-no-signin": "Bus is public campus life information; sign-in should not be a prerequisite.",
@@ -17,7 +17,7 @@
     "raw-data-returned": "/api/bus and query_bus_timetable return raw route/stop/trip data within the selected timetable version; the preferences field is null for anonymous callers and returns the authenticated caller's saved preferences; the server does not pre-apply recommendations, filtering, or sorting.",
     "current-version-only": "list_bus_routes only lists routes actually present in the current active timetable version; it does not expose historical route IDs outside the current version.",
     "dashboard-vs-map": "The dashboard prioritizes answering 'how to get the next trip'; the map page handles spatial understanding.",
-    "task-oriented-tool-hierarchy": "Use query_bus_timetable for raw/full datasets, list_bus_routes for unfiltered discovery, search_bus_routes for filtered discovery, get_bus_route_timetable for one route, and get_next_buses for immediate departure answers.",
+    "task-oriented-tool-hierarchy": "Use query_bus_timetable for raw/full datasets, list_bus_routes for unfiltered discovery, search_bus_routes for filtered discovery, get_bus_route_timetable for one route, get_next_buses for immediate departure answers, and get_my_bus_preferences/save_my_bus_preferences for personal defaults.",
     "summary-mode-compact": "query_bus_timetable summary mode should return compact counts, route/campus summaries, and only a few relevant departures rather than the full trip dataset."
   },
   "capabilities": {
@@ -74,6 +74,23 @@
             "rest_equivalent": "GET /api/bus",
             "notes": [
               "Single-route raw timetable tool; use get_next_buses when the caller only needs the next few departures."
+            ]
+          },
+          {
+            "name": "get_my_bus_preferences",
+            "returns": "{ preference: BusPreferences }",
+            "rest_equivalent": "GET /api/bus/preferences",
+            "notes": [
+              "Returns the authenticated caller's saved bus preferences or the default null-campus preference."
+            ]
+          },
+          {
+            "name": "save_my_bus_preferences",
+            "returns": "{ preference: BusPreferences }",
+            "rest_equivalent": "POST /api/bus/preferences",
+            "notes": [
+              "preferredOriginCampusId and preferredDestinationCampusId may be null to reset saved campuses.",
+              "Unknown non-null preferred origin or destination campus IDs return a serialized validation result with success=false and do not write preferences."
             ]
           }
         ]

--- a/docs/contracts/mcp.json
+++ b/docs/contracts/mcp.json
@@ -137,6 +137,8 @@
               "query_bus_timetable",
               "list_bus_routes",
               "get_bus_route_timetable",
+              "get_my_bus_preferences",
+              "save_my_bus_preferences",
               "search_bus_routes",
               "get_next_buses"
             ]

--- a/src/lib/mcp/tools/bus-preference-tool-handlers.ts
+++ b/src/lib/mcp/tools/bus-preference-tool-handlers.ts
@@ -1,0 +1,85 @@
+import {
+  getBusPreference,
+  saveBusPreference,
+} from "@/features/bus/server/bus-service";
+import {
+  getUserId,
+  jsonToolResult,
+  resolveMcpMode,
+} from "@/lib/mcp/tools/_helpers";
+import type { McpModeInput, ToolExtra } from "./bus-tool-types";
+
+type BusPreferenceToolInput = {
+  preferredOriginCampusId?: number | null;
+  preferredDestinationCampusId?: number | null;
+  showDepartedTrips: boolean;
+  mode?: McpModeInput;
+};
+
+type BusPreferenceToolPayload = {
+  preferredOriginCampusId: number | null;
+  preferredDestinationCampusId: number | null;
+  showDepartedTrips: boolean;
+};
+
+function busPreferencePayload(
+  preference: BusPreferenceToolPayload,
+): BusPreferenceToolPayload {
+  return {
+    preferredOriginCampusId: preference.preferredOriginCampusId,
+    preferredDestinationCampusId: preference.preferredDestinationCampusId,
+    showDepartedTrips: preference.showDepartedTrips,
+  };
+}
+
+export async function getMyBusPreferencesTool(
+  { mode }: { mode?: McpModeInput },
+  extra: ToolExtra,
+) {
+  const userId = getUserId(extra.authInfo);
+  const preference = await getBusPreference(userId);
+
+  return jsonToolResult(
+    {
+      preference: preference ? busPreferencePayload(preference) : null,
+    },
+    { mode: resolveMcpMode(mode) },
+  );
+}
+
+export async function saveMyBusPreferencesTool(
+  {
+    preferredOriginCampusId,
+    preferredDestinationCampusId,
+    showDepartedTrips,
+    mode,
+  }: BusPreferenceToolInput,
+  extra: ToolExtra,
+) {
+  const resolvedMode = resolveMcpMode(mode);
+  const userId = getUserId(extra.authInfo);
+  const result = await saveBusPreference(userId, {
+    preferredOriginCampusId: preferredOriginCampusId ?? null,
+    preferredDestinationCampusId: preferredDestinationCampusId ?? null,
+    showDepartedTrips,
+  });
+
+  if (!result.ok) {
+    return jsonToolResult(
+      {
+        success: false,
+        error: "invalid_bus_preference",
+        message: result.error,
+        hint: "Use list_bus_routes to find valid campus IDs before saving preferences.",
+      },
+      { mode: resolvedMode },
+    );
+  }
+
+  return jsonToolResult(
+    {
+      preference: busPreferencePayload(result.preference),
+    },
+    { mode: resolvedMode },
+  );
+}

--- a/src/lib/mcp/tools/bus-tool-handlers.ts
+++ b/src/lib/mcp/tools/bus-tool-handlers.ts
@@ -1,5 +1,9 @@
 export { getNextBusesTool } from "./bus-next-tool-handler";
 export {
+  getMyBusPreferencesTool,
+  saveMyBusPreferencesTool,
+} from "./bus-preference-tool-handlers";
+export {
   getBusRouteTimetableTool,
   listBusRoutesTool,
   searchBusRoutesTool,

--- a/src/lib/mcp/tools/bus-tools.ts
+++ b/src/lib/mcp/tools/bus-tools.ts
@@ -7,13 +7,21 @@ import {
 } from "@/lib/mcp/tools/_helpers";
 import {
   getBusRouteTimetableTool,
+  getMyBusPreferencesTool,
   getNextBusesTool,
   listBusRoutesTool,
   queryBusTimetableTool,
+  saveMyBusPreferencesTool,
   searchBusRoutesTool,
 } from "@/lib/mcp/tools/bus-tool-handlers";
 
 const busDayTypeSchema = z.enum(["auto", "weekday", "weekend"]).default("auto");
+const busPreferenceCampusIdSchema = z
+  .number()
+  .int()
+  .positive()
+  .nullable()
+  .default(null);
 
 export function registerBusTools(server: McpServer) {
   server.registerTool(
@@ -55,6 +63,33 @@ export function registerBusTools(server: McpServer) {
       },
     },
     getBusRouteTimetableTool,
+  );
+
+  server.registerTool(
+    "get_my_bus_preferences",
+    {
+      description:
+        "Read the authenticated user's saved shuttle bus preferences.",
+      inputSchema: {
+        mode: mcpModeInputSchema,
+      },
+    },
+    getMyBusPreferencesTool,
+  );
+
+  server.registerTool(
+    "save_my_bus_preferences",
+    {
+      description:
+        "Save the authenticated user's preferred shuttle bus campuses and show-departed setting.",
+      inputSchema: {
+        preferredOriginCampusId: busPreferenceCampusIdSchema,
+        preferredDestinationCampusId: busPreferenceCampusIdSchema,
+        showDepartedTrips: z.boolean(),
+        mode: mcpModeInputSchema,
+      },
+    },
+    saveMyBusPreferencesTool,
   );
 
   server.registerTool(

--- a/tests/integration/mcp-tools.test.ts
+++ b/tests/integration/mcp-tools.test.ts
@@ -28,6 +28,18 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function integrationUserEmail(prefix: string) {
+  return `integration-${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}@example.test`;
+}
+
+type BusPreferenceToolResponse = {
+  preference?: {
+    preferredOriginCampusId?: number | null;
+    preferredDestinationCampusId?: number | null;
+    showDepartedTrips?: boolean;
+  };
+};
+
 async function findDescriptionEditAuditLog(descriptionId: string) {
   for (let attempt = 0; attempt < 20; attempt += 1) {
     const log = await prisma.auditLog.findFirst({
@@ -1635,6 +1647,113 @@ describe("get_next_buses — default mode drops repeated campus objects", () => 
       // No departures → guidance message should be present
       expect(typeof result.message).toBe("string");
     }
+  });
+});
+
+describe("bus preference tools", () => {
+  let preferenceUserId: string | null = null;
+  let preferenceMcp: McpHarness | undefined;
+
+  beforeAll(async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: integrationUserEmail("bus-preferences"),
+        name: "Bus Preference Integration",
+      },
+      select: { id: true },
+    });
+    preferenceUserId = user.id;
+    preferenceMcp = await createMcpHarness(user.id);
+  });
+
+  afterAll(async () => {
+    await preferenceMcp?.close();
+    if (preferenceUserId) {
+      await prisma.user.deleteMany({ where: { id: preferenceUserId } });
+    }
+  });
+
+  function preferenceHarness() {
+    if (!preferenceMcp) {
+      throw new Error("Bus preference MCP harness was not initialized");
+    }
+    return preferenceMcp;
+  }
+
+  function readPreference() {
+    return preferenceHarness().call<BusPreferenceToolResponse>(
+      "get_my_bus_preferences",
+    );
+  }
+
+  it("reads, saves, and resets the authenticated user's bus preferences", async () => {
+    const initial = await readPreference();
+
+    expect(initial.preference).toEqual({
+      preferredOriginCampusId: null,
+      preferredDestinationCampusId: null,
+      showDepartedTrips: false,
+    });
+
+    const saved = await preferenceHarness().call<BusPreferenceToolResponse>(
+      "save_my_bus_preferences",
+      {
+        preferredOriginCampusId: DEV_SEED.bus.originCampusId,
+        preferredDestinationCampusId: DEV_SEED.bus.destinationCampusId,
+        showDepartedTrips: true,
+      },
+    );
+
+    expect(saved.preference).toEqual({
+      preferredOriginCampusId: DEV_SEED.bus.originCampusId,
+      preferredDestinationCampusId: DEV_SEED.bus.destinationCampusId,
+      showDepartedTrips: true,
+    });
+
+    const readBack = await readPreference();
+
+    expect(readBack.preference).toEqual(saved.preference);
+
+    const reset = await preferenceHarness().call<BusPreferenceToolResponse>(
+      "save_my_bus_preferences",
+      {
+        preferredOriginCampusId: null,
+        preferredDestinationCampusId: null,
+        showDepartedTrips: false,
+      },
+    );
+
+    expect(reset.preference).toEqual({
+      preferredOriginCampusId: null,
+      preferredDestinationCampusId: null,
+      showDepartedTrips: false,
+    });
+  });
+
+  it("serializes unknown campus validation failures without writing", async () => {
+    const before = await readPreference();
+
+    const result = await preferenceHarness().call<{
+      success?: boolean;
+      error?: string;
+      message?: string;
+      hint?: string;
+    }>("save_my_bus_preferences", {
+      preferredOriginCampusId: 999_999_999,
+      preferredDestinationCampusId: null,
+      showDepartedTrips: false,
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "invalid_bus_preference",
+      message: "Unknown preferred origin campus",
+    });
+    expect(result.hint).toContain("list_bus_routes");
+
+    const readBack = await readPreference();
+
+    expect(readBack.preference).toEqual(before.preference);
   });
 });
 


### PR DESCRIPTION
## Goal

Close the bus-preferences slice of #87 by giving MCP agents the same ordinary-user bus preference read/save capability that web/REST already expose.

This references #87 but does not close it; comments, dashboard links, and upload management still need separate parity/non-parity work.

## Changed Surfaces

- Added `get_my_bus_preferences` and `save_my_bus_preferences` MCP tools.
- Reused the existing shared bus preference service for reads, saves, and campus validation.
- Updated `docs/contracts/bus.json` and `docs/contracts/mcp.json` for the new MCP capability.
- Added MCP integration coverage for default read, save, reset, and invalid-campus validation output.

## Evidence

- `git diff --check origin/main...HEAD`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run vitest run --config vitest.integration.config.ts tests/integration/mcp-tools.test.ts -t "bus preference tools"`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run verify`
- Complete-loop MCP evidence: the focused harness inspected serialized tool results for default preference read, save, null reset, and unknown-campus validation failure.

## Docs / Contracts

- Updated `docs/contracts/bus.json` to list the new agent preference tools and validation behavior.
- Updated `docs/contracts/mcp.json` to include the new bus tools.
- No OpenAPI change; REST behavior and routes are unchanged.

## Risk Areas

- MCP auth remains bearer-only and scoped to the authenticated user through `getUserId(extra.authInfo)`.
- Invalid campus IDs return a serialized MCP validation result with `success: false`; REST still returns its existing `400` response.
- The integration test creates a unique user and deletes it after the harness closes.

## Cleanup

No scratch artifacts, one-time probes, unrelated rewrites, or manual generated-file edits remain.
