### PR TITLE
test(seed): reset dev jwks during cleanup

### DIFF
--- a/tests/unit/dev-scenario-cleanup.test.ts
+++ b/tests/unit/dev-scenario-cleanup.test.ts
@@ -1,0 +1,58 @@
+import { cleanupDevScenarioData } from "@tools/dev/seed/dev-scenario-cleanup";
+import type { ToolPrismaClient } from "@tools/shared/tool-prisma";
+import { describe, expect, it, vi } from "vitest";
+
+function createPrismaMock() {
+  const methods = new Map<string, ReturnType<typeof vi.fn>>();
+  const delegates = new Map<string, unknown>();
+
+  const prisma = new Proxy(
+    {},
+    {
+      get(_target, modelKey) {
+        if (typeof modelKey !== "string") return undefined;
+        if (!delegates.has(modelKey)) {
+          delegates.set(
+            modelKey,
+            new Proxy(
+              {},
+              {
+                get(_delegateTarget, methodKey) {
+                  if (typeof methodKey !== "string") return undefined;
+                  const key = `${modelKey}.${methodKey}`;
+                  if (!methods.has(key)) {
+                    methods.set(
+                      key,
+                      vi.fn(async () =>
+                        methodKey === "findMany" ? [] : { count: 0 },
+                      ),
+                    );
+                  }
+                  return methods.get(key);
+                },
+              },
+            ),
+          );
+        }
+        return delegates.get(modelKey);
+      },
+    },
+  ) as ToolPrismaClient;
+
+  return { prisma, methods };
+}
+
+describe("cleanupDevScenarioData", () => {
+  it("clears Better Auth JWKS rows with the dev auth fixture state", async () => {
+    const { prisma, methods } = createPrismaMock();
+
+    await cleanupDevScenarioData(prisma, ["debug-user-id"], {
+      removeBusVersion: false,
+      removePersonalState: false,
+    });
+
+    expect(methods.get("jwks.deleteMany")).toHaveBeenCalledWith();
+    expect(methods.get("session.deleteMany")).toHaveBeenCalled();
+    expect(methods.get("account.deleteMany")).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/dev-scenario-cleanup.test.ts
+++ b/tests/unit/dev-scenario-cleanup.test.ts
@@ -1,6 +1,7 @@
 import { cleanupDevScenarioData } from "@tools/dev/seed/dev-scenario-cleanup";
-import type { ToolPrismaClient } from "@tools/shared/tool-prisma";
 import { describe, expect, it, vi } from "vitest";
+
+type PrismaMock = Record<string, Record<string, ReturnType<typeof vi.fn>>>;
 
 function createPrismaMock() {
   const methods = new Map<string, ReturnType<typeof vi.fn>>();
@@ -37,7 +38,7 @@ function createPrismaMock() {
         return delegates.get(modelKey);
       },
     },
-  ) as ToolPrismaClient;
+  ) as PrismaMock;
 
   return { prisma, methods };
 }
@@ -46,7 +47,7 @@ describe("cleanupDevScenarioData", () => {
   it("clears Better Auth JWKS rows with the dev auth fixture state", async () => {
     const { prisma, methods } = createPrismaMock();
 
-    await cleanupDevScenarioData(prisma, ["debug-user-id"], {
+    await cleanupDevScenarioData(prisma as never, ["debug-user-id"], {
       removeBusVersion: false,
       removePersonalState: false,
     });

--- a/tools/dev/seed/dev-scenario-cleanup.ts
+++ b/tools/dev/seed/dev-scenario-cleanup.ts
@@ -44,6 +44,7 @@ export async function cleanupDevScenarioData(
   // or constant; userSuspension also fits because it doesn't FK into the
   // tables above).
   await Promise.all([
+    prisma.jwks.deleteMany(),
     prisma.session.deleteMany({
       where: {
         sessionToken: { startsWith: `${DEV_SCENARIO_KEY_PREFIX}session-` },


### PR DESCRIPTION
## Goal

Make `bun run seed` / `bun run verify:full` deterministic when a dev database contains Better Auth JWKS rows encrypted with an old `AUTH_SECRET`. Closes #156.

## Changed Surfaces

- `tools/dev/seed/dev-scenario-cleanup.ts`: clears Better Auth `Jwks` rows alongside other dev auth fixture state.
- `tests/unit/dev-scenario-cleanup.test.ts`: verifies the seed cleanup clears JWKS, sessions, and accounts through the shared cleanup helper.

## Evidence

Seed cleanup contract:
- `bun run test tests/unit/dev-scenario-cleanup.test.ts`

Full local gate for seed/auth/browser reproducibility:
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev PLAYWRIGHT_PORT=3100 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3100 bun run verify:full`
- Result: default checks passed, integration passed, build/seed passed, Playwright `533 passed`.

## Docs / Contracts

No product/API contract changes. This is dev seed fixture cleanup only.

## Risk Areas

- Auth/OAuth/MCP: intentionally resets Better Auth JWT key material only in the dev seed cleanup path.
- Seeds: affects local/test fixture reset behavior; production runtime is not touched.

## Cleanup

No scratch artifacts, one-time probes, unrelated rewrites, or manual generated-file edits are included.
