### PR TITLE
fix(ci): workflow release, snapshot, and PR CI gates

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -6,7 +6,7 @@ CI/CD pipelines.
 
 | Workflow | Trigger | Jobs |
 |----------|---------|------|
-| CI | push/PR to any branch | Default verification, Worker E2E artifact build, E2E shards |
+| CI | push to main, PR to any branch | Default verification, Worker E2E artifact build, E2E shards |
 | DB-backed Bun job | workflow_call | Reusable Postgres-backed Bun job |
 | E2E Snapshot Artifacts | push except preview branch, manual | Snapshot capture, artifact upload, screenshot preview publishing, commit comment |
 | Copilot Setup Steps | manual or setup workflow changes | Copilot bootstrap validation |

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -10,7 +10,7 @@ CI/CD pipelines.
 | DB-backed Bun job | workflow_call | Reusable Postgres-backed Bun job |
 | E2E Snapshot Artifacts | push except preview branch, manual | Snapshot capture, artifact upload, screenshot preview publishing, commit comment |
 | Copilot Setup Steps | manual or setup workflow changes | Copilot bootstrap validation |
-| Release | push to main | Semantic release |
+| Release | successful CI completion on main | Semantic release |
 
 ## Version Alignment
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/e2e-snapshot-artifacts.yml
+++ b/.github/workflows/e2e-snapshot-artifacts.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Publish screenshot previews
         id: previews
-        if: ${{ always() }}
+        if: ${{ steps.snapshots.outcome == 'success' }}
         shell: bash
         run: >
           bun run snapshot:publish-previews --

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,11 @@
 name: Release
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
     branches:
       - main
 
@@ -9,7 +13,7 @@ jobs:
   semantic-release:
     name: Semantic
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.repository == 'Life-USTC/server' && !contains(github.event.head_commit.message, '[skip ci]')
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' && github.repository == 'Life-USTC/server' && !contains(github.event.workflow_run.head_commit.message || '', '[skip ci]')
     permissions:
       contents: write
       issues: write
@@ -21,6 +25,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup workspace


### PR DESCRIPTION
## Goal

Make workflow side effects wait for the right successful prerequisite instead of racing, publishing partial state, or running duplicate full CI on PR branch updates. Closes #163. Closes #164. Closes #175.

## Changed Surfaces

CI/workflows only: release sequencing, E2E snapshot preview publishing, PR branch CI trigger behavior, and the scoped workflow guide trigger table.

## Evidence

- Parsed `.github/workflows/ci.yml`, `.github/workflows/release.yml`, and `.github/workflows/e2e-snapshot-artifacts.yml` with the repo-installed `yaml` package.
- `bun run verify:conventions`
- `bun run verify`
- After pushing `128659e4`, PR #180 shows one CI check run for the new head commit instead of duplicate push + pull_request CI runs.

## Docs / Contracts

Updated `.github/workflows/AGENTS.md` so the CI and Release trigger descriptions match the workflows. No product contract, OpenAPI, message, REST, MCP, Prisma, or UI changes.

## Risk Areas

CI/release behavior. Release now checks out the exact successful CI `workflow_run.head_sha`; snapshot failure artifacts and comments still run, but preview-branch publishing only runs after capture succeeds. Push CI now runs only for `main`; PR CI remains comprehensive for pull requests.

## Cleanup

`git diff --check` passed. No scratch artifacts, one-time probes, unrelated rewrites, or manual generated-file edits remain.
