### PR TITLE
fix(static): snapshot failure comments when previews are skipped

### DIFF
--- a/tests/unit/snapshot-report.test.ts
+++ b/tests/unit/snapshot-report.test.ts
@@ -12,9 +12,15 @@ import { describe, expect, it } from "vitest";
 
 function renderSnapshotComment(options: {
   output: string;
+  screenshotBaseUrl?: string;
   snapshotDir: string;
   status: string;
 }) {
+  const screenshotBaseUrlArgs =
+    options.screenshotBaseUrl === undefined
+      ? []
+      : ["--screenshot-base-url", options.screenshotBaseUrl];
+
   execFileSync(
     "bun",
     [
@@ -29,6 +35,7 @@ function renderSnapshotComment(options: {
       "0123456789abcdef0123456789abcdef01234567",
       "--status",
       options.status,
+      ...screenshotBaseUrlArgs,
       "--output",
       options.output,
     ],
@@ -61,6 +68,32 @@ describe("snapshot artifact report", () => {
       );
       expect(comment).not.toContain(
         "snapshot capture completed without failed entries.",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("renders failed capture comments when screenshot previews were skipped", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "life-ustc-snapshot-report-"));
+    try {
+      const snapshotDir = path.join(root, "snapshots");
+      const output = path.join(root, "comment.md");
+      mkdirSync(path.join(snapshotDir, "pages"), { recursive: true });
+      writeFileSync(
+        path.join(snapshotDir, "pages", "manifest.json"),
+        JSON.stringify({ entries: [] }),
+      );
+
+      renderSnapshotComment({
+        output,
+        screenshotBaseUrl: "",
+        snapshotDir,
+        status: "failure",
+      });
+
+      expect(readFileSync(output, "utf8")).toContain(
+        "snapshot capture failed before failed manifest entries were recorded.",
       );
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/tools/dev/artifacts/snapshots/snapshot-report.ts
+++ b/tools/dev/artifacts/snapshots/snapshot-report.ts
@@ -305,7 +305,7 @@ function parseRenderArgs(argv: string[]): RenderOptions {
       options.output = readValue(argv, index);
       index += 1;
     } else if (arg === "--screenshot-base-url") {
-      options.screenshotBaseUrl = readValue(argv, index);
+      options.screenshotBaseUrl = argv[index + 1] || undefined;
       index += 1;
     } else if (arg === "--workflow-url") {
       options.workflowUrl = readValue(argv, index);


### PR DESCRIPTION
## Goal

Preserve the E2E snapshot diagnostic commit comment when snapshot capture fails and screenshot preview publishing is skipped. This follows up the valid review comment on merged PR #180.

## Changed Surfaces

- Snapshot report CLI optional argument parsing.
- Snapshot report unit coverage for skipped screenshot preview output.

## Evidence

- Focused snapshot report regression: `bun run test -- tests/unit/snapshot-report.test.ts`.
- Focused formatting/lint: `bunx biome check tools/dev/artifacts/snapshots/snapshot-report.ts tests/unit/snapshot-report.test.ts`.
- Whitespace sanity: `git diff --check origin/main...HEAD`.
- Default repo gate: `bun run verify`.

## Docs / Contracts

No product, REST, MCP, OpenAPI, or user-facing contract changed.

## Risk Areas

CI snapshot reporting path only. The change treats an empty optional screenshot preview URL the same as an omitted URL; artifact and workflow links remain present in failure comments.

## Cleanup

`git status -sb` showed only the intentional branch delta before push; no scratch artifacts or generated files were left behind.
