### PR TITLE
fix(api): HEAD and OPTIONS in contract route parity

### DIFF
--- a/docs/contracts.schema.json
+++ b/docs/contracts.schema.json
@@ -273,7 +273,7 @@
         },
         "method": {
           "type": "string",
-          "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+          "enum": ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
           "default": "GET"
         },
         "description": {
@@ -364,7 +364,7 @@
         },
         "rest_equivalent": {
           "type": "string",
-          "pattern": "^(GET|POST|PUT|PATCH|DELETE) /",
+          "pattern": "^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS) /",
           "maxLength": 180
         },
         "notes": {
@@ -523,7 +523,7 @@
             "routes": {
               "type": "array",
               "minItems": 1,
-              "maxItems": 12,
+              "maxItems": 24,
               "items": {
                 "$ref": "#/$defs/routeEntry"
               }
@@ -700,7 +700,7 @@
       "type": "string",
       "oneOf": [
         {
-          "pattern": "^(GET|POST|PUT|PATCH|DELETE) /"
+          "pattern": "^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS) /"
         },
         {
           "const": "Reserved"

--- a/docs/contracts/mcp.json
+++ b/docs/contracts/mcp.json
@@ -45,6 +45,15 @@
             "path": "/api/mcp",
             "method": "DELETE",
             "returns": "MCP transport response"
+          },
+          {
+            "path": "/api/mcp",
+            "method": "OPTIONS",
+            "returns": "204 CORS preflight response",
+            "auth": "anon",
+            "notes": [
+              "Foreign Origin headers are rejected with 403 before CORS headers are returned."
+            ]
           }
         ]
       },

--- a/docs/contracts/oauth.json
+++ b/docs/contracts/oauth.json
@@ -62,8 +62,20 @@
             "auth": "anon"
           },
           {
+            "path": "/api/auth/.well-known/openid-configuration",
+            "method": "OPTIONS",
+            "returns": "204 CORS preflight response",
+            "auth": "anon"
+          },
+          {
             "path": "/.well-known/oauth-authorization-server",
             "returns": "307 redirect to /.well-known/oauth-authorization-server/api/auth",
+            "auth": "anon"
+          },
+          {
+            "path": "/.well-known/oauth-authorization-server",
+            "method": "OPTIONS",
+            "returns": "204 CORS preflight response",
             "auth": "anon"
           },
           {
@@ -72,8 +84,20 @@
             "auth": "anon"
           },
           {
+            "path": "/.well-known/openid-configuration",
+            "method": "OPTIONS",
+            "returns": "204 CORS preflight response",
+            "auth": "anon"
+          },
+          {
             "path": "/.well-known/oauth-protected-resource",
             "returns": "307 redirect to /.well-known/oauth-protected-resource/api/mcp",
+            "auth": "anon"
+          },
+          {
+            "path": "/.well-known/oauth-protected-resource",
+            "method": "OPTIONS",
+            "returns": "204 CORS preflight response",
             "auth": "anon"
           },
           {
@@ -88,8 +112,20 @@
             "auth": "anon"
           },
           {
+            "path": "/.well-known/oauth-authorization-server/api/auth",
+            "method": "OPTIONS",
+            "returns": "204 CORS preflight response",
+            "auth": "anon"
+          },
+          {
             "path": "/.well-known/oauth-authorization-server/api/mcp",
             "returns": "307 redirect to /.well-known/oauth-authorization-server/api/auth",
+            "auth": "anon"
+          },
+          {
+            "path": "/.well-known/oauth-authorization-server/api/mcp",
+            "method": "OPTIONS",
+            "returns": "204 CORS preflight response",
             "auth": "anon"
           },
           {
@@ -98,8 +134,20 @@
             "auth": "anon"
           },
           {
+            "path": "/.well-known/openid-configuration/api/auth",
+            "method": "OPTIONS",
+            "returns": "204 CORS preflight response",
+            "auth": "anon"
+          },
+          {
             "path": "/.well-known/openid-configuration/api/mcp",
             "returns": "307 redirect to /api/auth/.well-known/openid-configuration",
+            "auth": "anon"
+          },
+          {
+            "path": "/.well-known/openid-configuration/api/mcp",
+            "method": "OPTIONS",
+            "returns": "204 CORS preflight response",
             "auth": "anon"
           },
           {
@@ -108,13 +156,31 @@
             "auth": "anon"
           },
           {
+            "path": "/.well-known/oauth-protected-resource/api/mcp",
+            "method": "OPTIONS",
+            "returns": "204 CORS preflight response",
+            "auth": "anon"
+          },
+          {
             "path": "/api/mcp/.well-known/oauth-authorization-server",
             "returns": "307 redirect to /.well-known/oauth-authorization-server/api/auth",
             "auth": "anon"
           },
           {
+            "path": "/api/mcp/.well-known/oauth-authorization-server",
+            "method": "OPTIONS",
+            "returns": "204 CORS preflight response",
+            "auth": "anon"
+          },
+          {
             "path": "/api/mcp/.well-known/openid-configuration",
             "returns": "307 redirect to /api/auth/.well-known/openid-configuration",
+            "auth": "anon"
+          },
+          {
+            "path": "/api/mcp/.well-known/openid-configuration",
+            "method": "OPTIONS",
+            "returns": "204 CORS preflight response",
             "auth": "anon"
           }
         ]
@@ -149,6 +215,12 @@
               "Supports CORS (Access-Control-Allow-Origin: *); OPTIONS returns a 204 CORS preflight response.",
               ".well-known/openid-configuration already includes device_authorization_endpoint and urn:ietf:params:oauth:grant-type:device_code in grant_types_supported."
             ]
+          },
+          {
+            "path": "/api/auth/oauth2/device-authorization",
+            "method": "OPTIONS",
+            "returns": "204 CORS preflight response",
+            "auth": "anon"
           },
           {
             "path": "/api/auth/oauth2/token",

--- a/tests/unit/contracts-check.test.ts
+++ b/tests/unit/contracts-check.test.ts
@@ -1,0 +1,25 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { collectImplementedRestRoutes } from "../../tools/dev/check/contracts";
+
+describe("contract route parity check", () => {
+  it("collects HEAD and OPTIONS route exports", () => {
+    const originalCwd = process.cwd();
+    const fixtureRoot = join(
+      originalCwd,
+      "tests/unit/fixtures/contract-routes",
+    );
+
+    try {
+      process.chdir(fixtureRoot);
+
+      expect([...collectImplementedRestRoutes(["src/routes/api"])]).toEqual([
+        "GET /api/parity",
+        "HEAD /api/parity",
+        "OPTIONS /api/parity",
+      ]);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});

--- a/tests/unit/fixtures/contract-routes/src/routes/api/parity/+server.ts
+++ b/tests/unit/fixtures/contract-routes/src/routes/api/parity/+server.ts
@@ -1,0 +1,14 @@
+const handlers = {
+  HEAD() {
+    return new Response(null, { status: 204 });
+  },
+  OPTIONS() {
+    return new Response(null, { status: 204 });
+  },
+};
+
+export function GET() {
+  return new Response("{}");
+}
+
+export const { HEAD, OPTIONS } = handlers;

--- a/tools/dev/check/contracts.ts
+++ b/tools/dev/check/contracts.ts
@@ -3,15 +3,53 @@ import { join, relative } from "node:path";
 import Ajv2020 from "ajv/dist/2020";
 import {
   getExportedRouteMethods,
+  HTTP_METHODS,
   type HttpMethod,
 } from "../../shared/route-exports";
 import { fail, reportUnexpectedError, walkFiles } from "./common";
+
+const REST_ROUTE_ROOTS = ["src/routes/api", "src/routes/.well-known"] as const;
+
+function parseImplementedRoutePath(filePath: string): string {
+  const routePath = relative("src/routes", filePath)
+    .replace(/\\/g, "/")
+    .replace(/\/\+server\.ts$/, "");
+
+  return `/${routePath
+    .split("/")
+    .map((segment) => {
+      const catchAll = segment.match(/^\[\.\.\.(.+)\]$/);
+      if (catchAll) return `{${catchAll[1]}}`;
+      return segment;
+    })
+    .join("/")}`;
+}
+
+export function collectImplementedRestRoutes(
+  routeRoots: readonly string[] = REST_ROUTE_ROOTS,
+  methods: readonly HttpMethod[] = HTTP_METHODS,
+): Set<string> {
+  const routes = new Set<string>();
+
+  for (const routeRoot of routeRoots) {
+    for (const file of walkFiles(routeRoot).filter((item) =>
+      item.endsWith("/+server.ts"),
+    )) {
+      const source = readFileSync(file, "utf8");
+      const routePath = parseImplementedRoutePath(file);
+      for (const method of getExportedRouteMethods(source, methods)) {
+        routes.add(`${method} ${routePath}`);
+      }
+    }
+  }
+
+  return routes;
+}
 
 function checkContractsDoc() {
   const contractsDir = "docs/contracts";
   const schemaPath = "docs/contracts.schema.json";
   const prismaPath = "prisma/schema.prisma";
-  const restRouteRoots = ["src/routes/api", "src/routes/.well-known"];
   const mcpDir = "src/lib/mcp/tools";
 
   type PrismaDocs = {
@@ -111,46 +149,6 @@ function checkContractsDoc() {
     }
 
     return { enums, models };
-  }
-
-  function parseImplementedRoutePath(filePath: string): string {
-    const routePath = relative("src/routes", filePath)
-      .replace(/\\/g, "/")
-      .replace(/\/\+server\.ts$/, "");
-
-    return `/${routePath
-      .split("/")
-      .map((segment) => {
-        const catchAll = segment.match(/^\[\.\.\.(.+)\]$/);
-        if (catchAll) return `{${catchAll[1]}}`;
-        return segment;
-      })
-      .join("/")}`;
-  }
-
-  function collectImplementedRestRoutes(): Set<string> {
-    const contractMethods = [
-      "GET",
-      "POST",
-      "PUT",
-      "PATCH",
-      "DELETE",
-    ] as const satisfies readonly HttpMethod[];
-    const routes = new Set<string>();
-
-    for (const routeRoot of restRouteRoots) {
-      for (const file of walkFiles(routeRoot).filter((item) =>
-        item.endsWith("/+server.ts"),
-      )) {
-        const source = readFileSync(file, "utf8");
-        const routePath = parseImplementedRoutePath(file);
-        for (const method of getExportedRouteMethods(source, contractMethods)) {
-          routes.add(`${method} ${routePath}`);
-        }
-      }
-    }
-
-    return routes;
   }
 
   function collectDocumentedRestRoutes(
@@ -595,8 +593,10 @@ function checkContractsDoc() {
   }
 }
 
-try {
-  checkContractsDoc();
-} catch (error: unknown) {
-  reportUnexpectedError(error);
+if (process.argv[1]?.endsWith("contracts.ts")) {
+  try {
+    checkContractsDoc();
+  } catch (error: unknown) {
+    reportUnexpectedError(error);
+  }
 }


### PR DESCRIPTION
## Goal

Make contract route parity use the same HTTP method set as route export detection, including `HEAD` and `OPTIONS`. Closes #174.

## Changed Surfaces

- Contract checker now collects implemented REST routes with shared `HTTP_METHODS` instead of a local five-method subset.
- Focused unit coverage proves `GET`, `HEAD`, and `OPTIONS` route exports are collected.
- Contract schema accepts `HEAD`/`OPTIONS` in REST routes and REST-equivalent references.
- OAuth and MCP contracts now document existing CORS/preflight routes surfaced by the stricter parity check.

## Evidence

- Focused regression: `bun run test -- tests/unit/contracts-check.test.ts`.
- Contract parity: `bun run check:contracts`.
- Focused formatting/lint: `bunx biome check tools/dev/check/contracts.ts tests/unit/contracts-check.test.ts tests/unit/fixtures/contract-routes/src/routes/api/parity/+server.ts docs/contracts.schema.json docs/contracts/oauth.json docs/contracts/mcp.json`.
- Whitespace sanity: `git diff --check origin/main...HEAD`.
- Default repo gate: `DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev" bun run verify`.

## Docs / Contracts

Updated contract schema plus OAuth/MCP contract modules because the checker now exposes implemented `OPTIONS` routes that were previously invisible to parity.

## Risk Areas

Contract docs are more explicit about CORS/preflight routes. This is intentionally stricter; future implemented `HEAD`/`OPTIONS` routes now need contract ownership like other REST methods.

## Skipped / Notes

This worktree also needs explicit `DATABASE_URL` for Prisma generation during `bun run verify`, because separate git worktrees do not carry the root checkout's local `.env` file.

## Cleanup

`git status -sb` was clean before push; no scratch artifacts or generated files were left behind.
