### PR TITLE
fix(ui): target-scoped panels on navigation

### DIFF
--- a/src/features/catalog/components/CourseDetailPageController.svelte
+++ b/src/features/catalog/components/CourseDetailPageController.svelte
@@ -134,13 +134,15 @@ onMount(() => {
 
   <div class="grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
     <div class="grid min-w-0 gap-5">
-      <DescriptionCard
-        targetType="course"
-        targetId={data.course.id}
-        initialData={data.descriptionData}
-        locale={data.locale as "en-us" | "zh-cn"}
-        copy={copy.descriptions}
-      />
+      {#key `description:course:${data.course.id}`}
+        <DescriptionCard
+          targetType="course"
+          targetId={data.course.id}
+          initialData={data.descriptionData}
+          locale={data.locale as "en-us" | "zh-cn"}
+          copy={copy.descriptions}
+        />
+      {/key}
 
       <CatalogDetailTabs
         {activeTab}
@@ -150,11 +152,13 @@ onMount(() => {
       />
 
       {#if activeTab === "comments"}
-        <CommentsPanel
-          initialData={data.commentsData}
-          targetType="course"
-          targetId={data.course.id}
-        />
+        {#key `comments:course:${data.course.id}`}
+          <CommentsPanel
+            initialData={data.commentsData}
+            targetType="course"
+            targetId={data.course.id}
+          />
+        {/key}
       {:else}
         <CourseDetailSections
           copy={detailCopy}

--- a/src/features/catalog/components/TeacherDetailPageController.svelte
+++ b/src/features/catalog/components/TeacherDetailPageController.svelte
@@ -111,13 +111,15 @@ onMount(() => {
 
   <div class="grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
     <div class="grid min-w-0 gap-5">
-      <DescriptionCard
-        targetType="teacher"
-        targetId={data.teacher.id}
-        initialData={data.descriptionData}
-        locale={data.locale as "en-us" | "zh-cn"}
-        copy={copy.descriptions}
-      />
+      {#key `description:teacher:${data.teacher.id}`}
+        <DescriptionCard
+          targetType="teacher"
+          targetId={data.teacher.id}
+          initialData={data.descriptionData}
+          locale={data.locale as "en-us" | "zh-cn"}
+          copy={copy.descriptions}
+        />
+      {/key}
 
       <CatalogDetailTabs
         {activeTab}
@@ -127,11 +129,13 @@ onMount(() => {
       />
 
       {#if activeTab === "comments"}
-        <CommentsPanel
-          initialData={data.commentsData}
-          targetType="teacher"
-          targetId={data.teacher.id}
-        />
+        {#key `comments:teacher:${data.teacher.id}`}
+          <CommentsPanel
+            initialData={data.commentsData}
+            targetType="teacher"
+            targetId={data.teacher.id}
+          />
+        {/key}
       {:else}
         <TeacherDetailSections
           copy={detailCopy}

--- a/src/features/dashboard/components/HomeworkDetailCommentsAside.svelte
+++ b/src/features/dashboard/components/HomeworkDetailCommentsAside.svelte
@@ -13,5 +13,7 @@ export let homeworksCopy: DashboardHomeworkDetailCopy;
 <aside class="min-w-0 border-base-300 border-t pt-5 lg:border-t-0 lg:border-l lg:pl-5 lg:pt-0">
   <h3 class="font-semibold text-base">{homeworksCopy.commentsTitle}</h3>
   <p class="mt-1 mb-3 text-base-content/60 text-sm">{homeworksCopy.commentsLabel}</p>
-  <CommentsPanel targetId={homework.id} targetType="homework" />
+  {#key `comments:homework:${homework.id}`}
+    <CommentsPanel targetId={homework.id} targetType="homework" />
+  {/key}
 </aside>

--- a/src/features/section-detail/components/SectionDetailMainContent.svelte
+++ b/src/features/section-detail/components/SectionDetailMainContent.svelte
@@ -56,13 +56,15 @@ export let yesNo: SectionDetailMainContentProps["yesNo"];
 
 <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-start">
   <div class="grid min-w-0 gap-5">
-    <DescriptionCard
-      targetType="section"
-      targetId={data.section.id}
-      initialData={data.descriptionData}
-      locale={data.locale}
-      copy={data.copy.descriptions}
-    />
+    {#key `description:section:${data.section.id}`}
+      <DescriptionCard
+        targetType="section"
+        targetId={data.section.id}
+        initialData={data.descriptionData}
+        locale={data.locale}
+        copy={data.copy.descriptions}
+      />
+    {/key}
 
     <Tabs.Root aria-label={sectionCopy.teachingSection}>
       <Tabs.List>
@@ -105,13 +107,15 @@ export let yesNo: SectionDetailMainContentProps["yesNo"];
       />
     {:else if activeTab === "comments"}
       <section class="grid gap-3">
-        <CommentsPanel
-          initialData={data.commentsData}
-          targetType="section"
-          targetId={data.section.id}
-          targets={commentTargets}
-          showAllTargets
-        />
+        {#key `comments:section:${data.section.id}`}
+          <CommentsPanel
+            initialData={data.commentsData}
+            targetType="section"
+            targetId={data.section.id}
+            targets={commentTargets}
+            showAllTargets
+          />
+        {/key}
       </section>
     {/if}
   </div>

--- a/src/features/section-detail/components/SectionHomeworkDetailDialog.svelte
+++ b/src/features/section-detail/components/SectionHomeworkDetailDialog.svelte
@@ -133,7 +133,9 @@ export let close: () => void;
         </section>
 
         <section class="min-w-0 border-base-300 border-t pt-4 lg:border-t-0 lg:border-l lg:pt-0 lg:pl-5">
-          <CommentsPanel targetType="homework" targetId={_selectedHomework.id} />
+          {#key `comments:homework:${_selectedHomework.id}`}
+            <CommentsPanel targetType="homework" targetId={_selectedHomework.id} />
+          {/key}
         </section>
       </div>
     </section>

--- a/tests/e2e/src/app/courses/[jwId]/test.ts
+++ b/tests/e2e/src/app/courses/[jwId]/test.ts
@@ -24,6 +24,9 @@
  * - Comment CRUD: post → edit → delete
  */
 import { expect, test } from "@playwright/test";
+import scenarioData from "../../../../fixtures/scenario.json" with {
+  type: "json",
+};
 import { signInAsDebugUser } from "../../../../utils/auth";
 import { DEV_SEED } from "../../../../utils/dev-seed";
 import { visibleText } from "../../../../utils/locators";
@@ -32,6 +35,8 @@ import { captureStepScreenshot } from "../../../../utils/screenshot";
 import { assertPageContract } from "../../_shared/page-contract";
 
 const COURSE_URL = `/courses/${DEV_SEED.course.jwId}`;
+const COURSE_WITH_DESCRIPTION_URL = `/courses/${scenarioData.courses[2].jwId}`;
+const COURSE_WITH_DESCRIPTION_TEXT = "实验课建议准备护目镜并提前完成预习问答。";
 
 test.describe("/courses/[jwId]", () => {
   test("contract", async ({ page }, testInfo) => {
@@ -202,6 +207,27 @@ test.describe("/courses/[jwId]", () => {
   });
 
   // ── Description ─────────────────────────────────────────────────────────────
+
+  test("same-route navigation resets target-scoped description state", async ({
+    page,
+  }, testInfo) => {
+    await gotoAndWaitForReady(page, COURSE_WITH_DESCRIPTION_URL);
+    await expect(page.getByText(COURSE_WITH_DESCRIPTION_TEXT)).toBeVisible();
+
+    await page.evaluate((href) => {
+      const link = document.createElement("a");
+      link.href = href;
+      link.dataset.e2eSameRouteLink = "true";
+      link.textContent = "same-route target";
+      document.body.append(link);
+    }, COURSE_URL);
+
+    await page.locator("[data-e2e-same-route-link]").click();
+    await expect(page).toHaveURL(new RegExp(`${COURSE_URL}$`));
+    await expect(visibleText(page, DEV_SEED.course.code)).toBeVisible();
+    await expect(page.getByText(COURSE_WITH_DESCRIPTION_TEXT)).toHaveCount(0);
+    await captureStepScreenshot(page, testInfo, "course/same-route-reset");
+  });
 
   test("signed-in user can edit description (description.content)", async ({
     page,


### PR DESCRIPTION
## Goal

Close #166 by preventing target-scoped description and comment panels from retaining stale local state when SvelteKit reuses a detail-page component during same-route navigation or dialog target changes.

## Changed Surfaces

- Keyed course, teacher, section, and homework description/comment panel mounts by target type and target id.
- Added a Playwright regression for client-side same-route course navigation from one target to another.

## Evidence

- `bunx biome check src/features/catalog/components/CourseDetailPageController.svelte src/features/catalog/components/TeacherDetailPageController.svelte src/features/section-detail/components/SectionDetailMainContent.svelte src/features/dashboard/components/HomeworkDetailCommentsAside.svelte src/features/section-detail/components/SectionHomeworkDetailDialog.svelte tests/e2e/src/app/courses/[jwId]/test.ts`
- `DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev" bun run db:generate && bun run svelte-check --tsconfig ./tsconfig.json`
- `DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev" bun run verify`
- Focused browser loop: E2E DB/artifact/seed setup, then `PLAYWRIGHT_PORT=3100 bun run e2e:test -- tests/e2e/src/app/courses/\[jwId\]/test.ts -g "same-route navigation resets target-scoped description state"` with the main local env sourced.

## Docs / Contracts

No docs/contracts/OpenAPI changes. This is a UI lifecycle bug fix with no public API or product contract shape change.

## Risk Areas

- UI lifecycle: keyed remounts intentionally clear unsaved drafts/messages when the backing target changes.
- Browser runtime: local ports 3000/3001 were already in use, so the focused Playwright run used port 3100.

## Cleanup

No scratch artifacts or generated files are included.
