### PR TITLE
fix(db): dev seed timestamps timezone stable

### DIFF
--- a/tests/unit/dev-seed-time.test.ts
+++ b/tests/unit/dev-seed-time.test.ts
@@ -30,11 +30,23 @@ describe("dev seed time helpers", () => {
     );
   });
 
+  it.each([
+    "UTC",
+    "America/New_York",
+  ])("constructs date-only seed values under %s host timezone", async (timezone) => {
+    const { makeSeedDateOnly } = await importSeedTimeWithTimezone(timezone);
+
+    expect(makeSeedDateOnly().toISOString()).toBe("2026-04-29T00:00:00.000Z");
+    expect(makeSeedDateOnly(1).toISOString()).toBe("2026-04-30T00:00:00.000Z");
+    expect(makeSeedDateOnly(-1).toISOString()).toBe("2026-04-28T00:00:00.000Z");
+  });
+
   it("derives weekdays from Shanghai calendar days under a UTC host timezone", async () => {
-    const { makeShanghaiSeedDateAt, toShanghaiWeekday } =
+    const { makeSeedDateOnly, makeShanghaiSeedDateAt, toShanghaiWeekday } =
       await importSeedTimeWithTimezone("UTC");
 
     expect(toShanghaiWeekday(makeShanghaiSeedDateAt(0, 0))).toBe(3);
     expect(toShanghaiWeekday(makeShanghaiSeedDateAt(23, 59, 4))).toBe(7);
+    expect(toShanghaiWeekday(makeSeedDateOnly())).toBe(3);
   });
 });

--- a/tests/unit/dev-seed-time.test.ts
+++ b/tests/unit/dev-seed-time.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function importSeedTimeWithTimezone(timezone: string) {
+  vi.stubEnv("TZ", timezone);
+  vi.resetModules();
+  return import("@tools/dev/seed/dev-seed-time");
+}
+
+describe("dev seed time helpers", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    "UTC",
+    "America/New_York",
+  ])("constructs Shanghai seed instants under %s host timezone", async (timezone) => {
+    const { makeShanghaiSeedDateAt } =
+      await importSeedTimeWithTimezone(timezone);
+
+    expect(makeShanghaiSeedDateAt(0, 0).toISOString()).toBe(
+      "2026-04-28T16:00:00.000Z",
+    );
+    expect(makeShanghaiSeedDateAt(8, 30, 1).toISOString()).toBe(
+      "2026-04-30T00:30:00.000Z",
+    );
+    expect(makeShanghaiSeedDateAt(23, 59, -1).toISOString()).toBe(
+      "2026-04-28T15:59:00.000Z",
+    );
+  });
+
+  it("derives weekdays from Shanghai calendar days under a UTC host timezone", async () => {
+    const { makeShanghaiSeedDateAt, toShanghaiWeekday } =
+      await importSeedTimeWithTimezone("UTC");
+
+    expect(toShanghaiWeekday(makeShanghaiSeedDateAt(0, 0))).toBe(3);
+    expect(toShanghaiWeekday(makeShanghaiSeedDateAt(23, 59, 4))).toBe(7);
+  });
+});

--- a/tools/dev/seed/dev-seed-time.ts
+++ b/tools/dev/seed/dev-seed-time.ts
@@ -1,0 +1,32 @@
+import { DEV_SEED_ANCHOR } from "./dev-seed";
+
+const SHANGHAI_UTC_OFFSET_HOURS = 8;
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+const [SEED_ANCHOR_YEAR, SEED_ANCHOR_MONTH, SEED_ANCHOR_DAY] =
+  DEV_SEED_ANCHOR.date.split("-").map(Number) as [number, number, number];
+
+export function makeShanghaiSeedDateAt(
+  hour: number,
+  minute: number,
+  offsetDays = 0,
+) {
+  return new Date(
+    Date.UTC(
+      SEED_ANCHOR_YEAR,
+      SEED_ANCHOR_MONTH - 1,
+      SEED_ANCHOR_DAY + offsetDays,
+      hour - SHANGHAI_UTC_OFFSET_HOURS,
+      minute,
+      0,
+      0,
+    ),
+  );
+}
+
+export function toShanghaiWeekday(date: Date) {
+  const day = new Date(
+    date.getTime() + SHANGHAI_UTC_OFFSET_HOURS * MS_PER_HOUR,
+  ).getUTCDay();
+  return day === 0 ? 7 : day;
+}

--- a/tools/dev/seed/dev-seed-time.ts
+++ b/tools/dev/seed/dev-seed-time.ts
@@ -24,6 +24,16 @@ export function makeShanghaiSeedDateAt(
   );
 }
 
+export function makeSeedDateOnly(offsetDays = 0) {
+  return new Date(
+    Date.UTC(
+      SEED_ANCHOR_YEAR,
+      SEED_ANCHOR_MONTH - 1,
+      SEED_ANCHOR_DAY + offsetDays,
+    ),
+  );
+}
+
 export function toShanghaiWeekday(date: Date) {
   const day = new Date(
     date.getTime() + SHANGHAI_UTC_OFFSET_HOURS * MS_PER_HOUR,

--- a/tools/dev/seed/seed-dev-scenarios.ts
+++ b/tools/dev/seed/seed-dev-scenarios.ts
@@ -22,7 +22,11 @@ import {
   DEV_SEED,
   getDevScenarioRuntimeConfig,
 } from "./dev-seed";
-import { makeShanghaiSeedDateAt, toShanghaiWeekday } from "./dev-seed-time";
+import {
+  makeSeedDateOnly,
+  makeShanghaiSeedDateAt,
+  toShanghaiWeekday,
+} from "./dev-seed-time";
 
 const prisma = createToolPrisma();
 const scenario = scenarioData;
@@ -235,6 +239,10 @@ function makeDateAt(hour: number, minute: number, offsetDays = 0) {
   return makeShanghaiSeedDateAt(hour, minute, offsetDays);
 }
 
+function makeDateOnly(offsetDays = 0) {
+  return makeSeedDateOnly(offsetDays);
+}
+
 function toWeekday(date: Date) {
   return toShanghaiWeekday(date);
 }
@@ -243,7 +251,7 @@ async function resolveDevBusSeed(): Promise<DevBusSeed> {
   return {
     payload: DEV_BUS_PAYLOAD,
     versionTitle: DEV_SEED.bus.versionTitle,
-    effectiveFrom: makeDateAt(0, 0, -7),
+    effectiveFrom: makeDateOnly(-7),
     effectiveUntil: null,
   };
 }
@@ -526,10 +534,10 @@ async function main() {
     },
   });
 
-  const semesterStart = makeDateAt(0, 0, -21);
-  const semesterEnd = makeDateAt(0, 0, 130);
-  const previousSemesterStart = makeDateAt(0, 0, -190);
-  const previousSemesterEnd = makeDateAt(0, 0, -30);
+  const semesterStart = makeDateOnly(-21);
+  const semesterEnd = makeDateOnly(130);
+  const previousSemesterStart = makeDateOnly(-190);
+  const previousSemesterEnd = makeDateOnly(-30);
 
   const [rooms, semester, previousSemester] = await Promise.all([
     prisma.room.findMany({
@@ -865,8 +873,8 @@ async function main() {
         }),
       ]);
 
-      const morningDate = makeDateAt(8, 30, index);
-      const afternoonDate = makeDateAt(14, 0, index + 1);
+      const morningDate = makeDateOnly(index);
+      const afternoonDate = makeDateOnly(index + 1);
       const morningRoom = rooms[index % rooms.length];
       const afternoonRoom = rooms[(index + 1) % rooms.length];
 
@@ -914,7 +922,7 @@ async function main() {
     }),
   );
 
-  const customPlaceDate = makeDateAt(15, 30, 2);
+  const customPlaceDate = makeDateOnly(2);
   await Promise.all([
     ...sectionScheduleData.flatMap(({ schedules }) =>
       schedules.map((data) => prisma.schedule.create({ data })),
@@ -953,7 +961,7 @@ async function main() {
           examType: 1,
           startTime: 900,
           endTime: 1100,
-          examDate: makeDateAt(0, 0, index === 3 ? -40 : 10 + index),
+          examDate: makeDateOnly(index === 3 ? -40 : 10 + index),
           examTakeCount: 1,
           examMode: "闭卷",
         },
@@ -964,7 +972,7 @@ async function main() {
           examType: 1,
           startTime: 900,
           endTime: 1100,
-          examDate: makeDateAt(0, 0, index === 3 ? -40 : 10 + index),
+          examDate: makeDateOnly(index === 3 ? -40 : 10 + index),
           examTakeCount: 1,
           examMode: "闭卷",
         },

--- a/tools/dev/seed/seed-dev-scenarios.ts
+++ b/tools/dev/seed/seed-dev-scenarios.ts
@@ -22,6 +22,7 @@ import {
   DEV_SEED,
   getDevScenarioRuntimeConfig,
 } from "./dev-seed";
+import { makeShanghaiSeedDateAt, toShanghaiWeekday } from "./dev-seed-time";
 
 const prisma = createToolPrisma();
 const scenario = scenarioData;
@@ -230,23 +231,12 @@ type DevBusSeed = {
   effectiveUntil: Date | null;
 };
 
-const SEED_ANCHOR_DATE = new Date(2026, 3, 29, 0, 0, 0, 0);
-
 function makeDateAt(hour: number, minute: number, offsetDays = 0) {
-  return new Date(
-    SEED_ANCHOR_DATE.getFullYear(),
-    SEED_ANCHOR_DATE.getMonth(),
-    SEED_ANCHOR_DATE.getDate() + offsetDays,
-    hour,
-    minute,
-    0,
-    0,
-  );
+  return makeShanghaiSeedDateAt(hour, minute, offsetDays);
 }
 
 function toWeekday(date: Date) {
-  const day = date.getDay();
-  return day === 0 ? 7 : day;
+  return toShanghaiWeekday(date);
 }
 
 async function resolveDevBusSeed(): Promise<DevBusSeed> {


### PR DESCRIPTION
## Goal

Close #173 by making dev scenario seed timestamps deterministic regardless of the host machine timezone, while keeping Prisma `@db.Date` seed values on their intended calendar dates.

## Changed Surfaces

- Added separate helpers for Shanghai-local timestamp instants and UTC-midnight date-only fixture values.
- Updated the dev scenario seeder so timestamp fields use Shanghai instants, and date-only fields such as semesters, schedules, exams, and bus effective dates use UTC-midnight date values.
- Added unit coverage under UTC and America/New_York host timezones.

## Evidence

- `bun run test -- tests/unit/dev-seed-time.test.ts tests/unit/dev-seed.test.ts`
- `bunx biome check tools/dev/seed/dev-seed-time.ts tools/dev/seed/seed-dev-scenarios.ts tests/unit/dev-seed-time.test.ts`
- `DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev" bun run verify`
- `TZ=UTC DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev" bun run seed`
- Queried seeded `Semester`, `Exam`, and `BusScheduleVersion` date columns after the UTC seed run; they persisted as the intended dates, including semester `2026-04-08..2026-09-06`, exam dates `2026-05-09..2026-05-11` / `2026-03-20`, and bus effective date `2026-04-22`.

## Docs / Contracts

No docs/contracts/OpenAPI changes. This is deterministic seed tooling behavior, not a public API or product contract change.

## Risk Areas

- Seed data timestamps intentionally use Shanghai-local instants.
- Date-only seed columns intentionally remain UTC midnight to avoid one-day shifts in Prisma `@db.Date` persistence.

## Cleanup

No scratch artifacts, generated files, or unrelated rewrites are included.
