### PR TITLE
fix(comment): inactive comment owner deletes

### DIFF
--- a/docs/contracts/comment.json
+++ b/docs/contracts/comment.json
@@ -12,7 +12,7 @@
     "rich-content": "Supports Markdown, math formulas, emoji, tables, replies, and reactions.",
     "visibility-modes": "Supports public, signed-in-only, and anonymous posting; anonymous comments hide identity from regular users but are traceable by admins in governance scenarios.",
     "shared-read-policy": "Web, REST, and MCP comment reads share the same target resolution, thread serialization, visibility filtering, author masking, reaction, attachment, and viewer action-flag logic; read-only paths must not create durable comment targets and valid empty section-teacher targets load as empty threads.",
-    "interaction-gate": "Edits, replies, and reaction changes require an authenticated, unsuspended viewer and an active visible comment target; deleted or softbanned comments must not expose canEdit/canReply/canReact or accept those write actions."
+    "interaction-gate": "Edits, deletes, replies, and reaction changes require an authenticated, unsuspended viewer and an active visible comment target; deleted or softbanned comments must not expose canEdit/canDelete/canReply/canReact or accept those write actions."
   },
   "capabilities": {
     "object-comment-section": {

--- a/src/features/comments/server/comment-mutations.ts
+++ b/src/features/comments/server/comment-mutations.ts
@@ -267,7 +267,7 @@ export async function deleteOwnComment(input: {
 
   const comment = await prisma.comment.findUnique({
     where: { id: input.commentId },
-    select: { id: true, userId: true },
+    select: { id: true, status: true, userId: true, visibility: true },
   });
 
   if (!comment) {
@@ -276,6 +276,10 @@ export async function deleteOwnComment(input: {
 
   if (comment.userId !== input.userId) {
     return { ok: false as const, error: "forbidden" as const };
+  }
+
+  if (!canViewerWriteCommentInteraction(comment, actor.viewer)) {
+    return { ok: false as const, error: "locked" as const };
   }
 
   await prisma.comment.update({

--- a/src/features/comments/server/serialized-comment-node.ts
+++ b/src/features/comments/server/serialized-comment-node.ts
@@ -35,7 +35,6 @@ export function buildVisibleCommentNode({
   const author = authorHidden ? null : buildAuthorSummary(comment);
   const status =
     rawStatus === "softbanned" && !viewer.isAdmin ? "active" : rawStatus;
-  const canWrite = viewer.isAuthenticated && !viewer.isSuspended;
   const canInteract = canViewerWriteCommentInteraction(
     {
       status: rawStatus,
@@ -72,7 +71,7 @@ export function buildVisibleCommentNode({
     canReact: canInteract,
     canReply: canInteract,
     canEdit: canInteract && isAuthor,
-    canDelete: rawStatus !== "deleted" && canWrite && isAuthor,
+    canDelete: canInteract && isAuthor,
     canModerate: viewer.isAdmin,
   };
 }

--- a/src/lib/api/routes/comment-delete-action.ts
+++ b/src/lib/api/routes/comment-delete-action.ts
@@ -18,6 +18,7 @@ export async function deleteOwnCommentAction(input: {
     if (result.error === "suspended") {
       return suspensionForbidden("reason" in result ? result.reason : null);
     }
+    if (result.error === "locked") return forbidden("Comment locked");
     return result.error === "not_found" ? notFound() : forbidden();
   }
 

--- a/tests/e2e/src/app/api/comments/[id]/test.ts
+++ b/tests/e2e/src/app/api/comments/[id]/test.ts
@@ -15,7 +15,7 @@
  * - Auth required (401 if unauthenticated)
  * - Only the owner can update through the public endpoint (403 otherwise)
  * - Admin moderation uses PATCH /api/admin/comments/{id}
- * - Cannot update deleted or softbanned comments (403 "Comment locked")
+ * - Cannot update or delete deleted/softbanned comments (403 "Comment locked")
  *
  * ## DELETE /api/comments/{id}
  * - Response: { success: true }
@@ -353,6 +353,17 @@ test("/api/comments/[id] PATCH refuses inactive comments", async ({ page }) => {
       },
     );
     expect(softbannedResponse.status()).toBe(403);
+    await expect(softbannedResponse.json()).resolves.toEqual({
+      error: "Comment locked",
+    });
+
+    const softbannedDeleteResponse = await page.request.delete(
+      `/api/comments/${commentId}`,
+    );
+    expect(softbannedDeleteResponse.status()).toBe(403);
+    await expect(softbannedDeleteResponse.json()).resolves.toEqual({
+      error: "Comment locked",
+    });
 
     await withE2ePrisma((prisma) =>
       prisma.comment.update({
@@ -368,6 +379,17 @@ test("/api/comments/[id] PATCH refuses inactive comments", async ({ page }) => {
       },
     );
     expect(deletedResponse.status()).toBe(403);
+    await expect(deletedResponse.json()).resolves.toEqual({
+      error: "Comment locked",
+    });
+
+    const deletedDeleteResponse = await page.request.delete(
+      `/api/comments/${commentId}`,
+    );
+    expect(deletedDeleteResponse.status()).toBe(403);
+    await expect(deletedDeleteResponse.json()).resolves.toEqual({
+      error: "Comment locked",
+    });
   } finally {
     await withE2ePrisma((prisma) =>
       prisma.comment.deleteMany({ where: { id: commentId } }),

--- a/tests/integration/mcp-02-comments.test.ts
+++ b/tests/integration/mcp-02-comments.test.ts
@@ -794,6 +794,15 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
         }),
       ).resolves.toEqual({ success: true });
 
+      const repeatedDelete = await context.client.call<{
+        success?: boolean;
+        error?: string;
+      }>("delete_own_comment", { commentId });
+      expect(repeatedDelete).toMatchObject({
+        success: false,
+        error: "locked",
+      });
+
       const reply = await context.client.call<{
         success?: boolean;
         error?: string;
@@ -813,6 +822,44 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
         type: "heart",
       });
       expect(reaction).toMatchObject({ success: false, error: "locked" });
+    } finally {
+      await fixtures.deleteCommentRecords(commentId ? [commentId] : []);
+    }
+  });
+
+  it("comment write tools reject owner delete on softbanned comments", async () => {
+    const marker = `[integration-test] mcp-comment-softbanned-delete-${Date.now()}`;
+    let commentId: string | undefined;
+
+    try {
+      const created = await context.client.call<{
+        success?: boolean;
+        id?: string;
+      }>("create_comment", {
+        targetType: "section",
+        sectionJwId: fixtures.DEV_SEED.section.jwId,
+        body: `${marker} locked`,
+      });
+      expect(created.success).toBe(true);
+      commentId = created.id;
+      expect(typeof commentId).toBe("string");
+
+      await fixtures.prisma.comment.update({
+        where: { id: commentId },
+        data: { status: "softbanned" },
+      });
+
+      const deletion = await context.client.call<{
+        success?: boolean;
+        error?: string;
+        message?: string;
+      }>("delete_own_comment", { commentId });
+
+      expect(deletion).toMatchObject({
+        success: false,
+        error: "locked",
+        message: "Comment locked",
+      });
     } finally {
       await fixtures.deleteCommentRecords(commentId ? [commentId] : []);
     }

--- a/tests/unit/comment-serialization-permissions.test.ts
+++ b/tests/unit/comment-serialization-permissions.test.ts
@@ -130,6 +130,7 @@ describe("comment serialization permissions", () => {
     expect(roots[0]).toMatchObject({
       status: "deleted",
       attachments: [],
+      canDelete: false,
       canReact: false,
       canReply: false,
     });
@@ -147,12 +148,14 @@ describe("comment serialization permissions", () => {
     );
 
     expect(authorView.roots[0]).toMatchObject({
+      canDelete: false,
       canEdit: false,
       canReact: false,
       canReply: false,
       status: "active",
     });
     expect(adminView.roots[0]).toMatchObject({
+      canDelete: false,
       canEdit: false,
       canReact: false,
       canReply: false,


### PR DESCRIPTION
## Goal

Close #197 by making owner delete follow the same active-comment gate as edit, reply, and reaction writes. Softbanned/deleted comments should not expose `canDelete` and should reject ordinary-user delete through REST and MCP.

Closes #197

## Changed Surfaces

- `src/features/comments/server/comment-mutations.ts`: `deleteOwnComment` selects status/visibility and returns `locked` for inactive comments.
- `src/features/comments/server/serialized-comment-node.ts`: `canDelete` now derives from the shared comment interaction gate.
- `src/lib/api/routes/comment-delete-action.ts`: REST delete maps locked comments to `403 { "error": "Comment locked" }`.
- `docs/contracts/comment.json`: interaction-gate rule now includes delete/canDelete.
- Unit, REST E2E, and MCP integration coverage updated.

## Evidence

- `bun run test -- tests/unit/comment-serialization-permissions.test.ts`
- `set -a; source /home/tiankaima/Source/Life-USTC/server/.env; set +a; bun run db:migrate:deploy; bun run seed; bun run vitest run --config vitest.integration.config.ts tests/integration/mcp-02-comments.test.ts`
- `set -a; source /home/tiankaima/Source/Life-USTC/server/.env; set +a; PLAYWRIGHT_PORT=3024 bun run e2e:db:prepare; PLAYWRIGHT_PORT=3024 bun run e2e:build-artifacts; PLAYWRIGHT_PORT=3024 bun run seed; PLAYWRIGHT_PORT=3024 bun run e2e:test -- 'tests/e2e/src/app/api/comments/\\[id\\]/test.ts'`
- `set -a; source /home/tiankaima/Source/Life-USTC/server/.env; set +a; bun run verify`

Complete-loop output inspected:
- REST inactive owner delete is covered by the Playwright API test: `DELETE /api/comments/[id]` returns `403` with `{ "error": "Comment locked" }` for softbanned and deleted comments.
- MCP inactive owner delete is covered by the integration harness: `delete_own_comment` returns `{ success: false, error: "locked", message: "Comment locked" }` for a softbanned owner comment.

## Docs / Contracts

Updated `docs/contracts/comment.json` for the public interaction rule. No OpenAPI generated output changed; the route shape is unchanged and reuses the existing forbidden JSON error shape.

## Risk Areas

- Ordinary-user comment delete permissions across UI action flags, REST, and MCP.
- Admin moderation is separate and unchanged.
- Failed locked deletes remain audit-log silent; successful deletes still write audit logs.

## Cleanup

- `git diff --check` passed.
- No generated files, scratch reports, temporary probes, or unrelated rewrites are committed.
- Subagent review was attempted but blocked by the environment thread limit (`agent thread limit reached`).
