### PR TITLE
refactor(auth): stale JWT_SECRET plumbing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     uses: ./.github/workflows/db-backed-bun-job.yml
     with:
       database-name: life_ustc_ci
-      jwt-secret: ci-check-secret-0123456789abcdef0123456789abcdef
       auth-secret: ci-check-secret-0123456789abcdef0123456789abcdef
       job-command: bun run verify
 
@@ -26,7 +25,6 @@ jobs:
     uses: ./.github/workflows/db-backed-bun-job.yml
     with:
       database-name: life_ustc_e2e
-      jwt-secret: e2e-ci-secret
       webhook-secret: e2e-ci-secret
       auth-secret: e2e-ci-secret
       extra-env: NO_PROXY=127.0.0.1,localhost,::1
@@ -72,7 +70,6 @@ jobs:
     with:
       database-name: life_ustc_e2e
       install-playwright: true
-      jwt-secret: e2e-ci-secret
       webhook-secret: e2e-ci-secret
       auth-secret: e2e-ci-secret
       extra-env: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -43,7 +43,6 @@ jobs:
         run: |
           {
             echo "DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_copilot"
-            echo "JWT_SECRET=copilot-local-secret"
             echo "WEBHOOK_SECRET=copilot-local-secret"
             echo "AUTH_SECRET=copilot-local-secret"
           } >> "$GITHUB_ENV"

--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -21,10 +21,6 @@ on:
         required: false
         type: boolean
         default: false
-      jwt-secret:
-        required: false
-        type: string
-        default: ""
       webhook-secret:
         required: false
         type: string
@@ -101,9 +97,6 @@ jobs:
         run: |
           {
             echo "DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/${{ inputs.database-name }}"
-            if [ -n "${{ inputs.jwt-secret }}" ]; then
-              echo "JWT_SECRET=${{ inputs.jwt-secret }}"
-            fi
             if [ -n "${{ inputs.webhook-secret }}" ]; then
               echo "WEBHOOK_SECRET=${{ inputs.webhook-secret }}"
             fi

--- a/.github/workflows/e2e-snapshot-artifacts.yml
+++ b/.github/workflows/e2e-snapshot-artifacts.yml
@@ -16,7 +16,6 @@ jobs:
       database-name: life_ustc_e2e_snapshots
       install-playwright: true
       timeout-minutes: 45
-      jwt-secret: e2e-snapshot-ci-secret
       webhook-secret: e2e-snapshot-ci-secret
       auth-secret: e2e-snapshot-ci-secret
       extra-env: |

--- a/tests/unit/playwright-runtime.test.ts
+++ b/tests/unit/playwright-runtime.test.ts
@@ -12,6 +12,7 @@ import {
   appendLocalNoProxy,
   buildPlaywrightServerEnv,
   E2E_WORKER_ARTIFACT_DIR,
+  E2E_WORKER_VAR_KEYS,
   preparePlaywrightWorkerRuntime,
   resolvePlaywrightHarnessRuntime,
   validatePlaywrightWorkerRuntime,
@@ -159,6 +160,12 @@ describe("playwright runtime", () => {
       DEV_ADMIN_EMAIL: "admin@example.test",
       DEV_ADMIN_PASSWORD: "admin-secret",
     });
+  });
+
+  it("passes current auth worker vars without stale JWT_SECRET", () => {
+    expect(E2E_WORKER_VAR_KEYS).toContain("AUTH_SECRET");
+    expect(E2E_WORKER_VAR_KEYS).toContain("WEBHOOK_SECRET");
+    expect(E2E_WORKER_VAR_KEYS).not.toContain("JWT_SECRET");
   });
 
   it("sets the pinned port without rewriting unrelated env", () => {

--- a/tools/dev/e2e.ts
+++ b/tools/dev/e2e.ts
@@ -45,9 +45,8 @@ const E2E_WORKER_CONTRACT_FILES = [
   path.join("cloudflare-tmp", "manifest.js"),
   path.join("output", "server", "index.js"),
 ] as const;
-const E2E_WORKER_VAR_KEYS = [
+export const E2E_WORKER_VAR_KEYS = [
   "AUTH_SECRET",
-  "JWT_SECRET",
   "WEBHOOK_SECRET",
   "OAUTH_PROXY_SECRET",
   "E2E_DEBUG_AUTH",


### PR DESCRIPTION
## Goal

Close #202 by removing stale `JWT_SECRET` setup from CI, Copilot setup, and E2E Worker env pass-through. Runtime auth uses `AUTH_SECRET`; keeping `JWT_SECRET` in setup paths made the required secret surface look larger than it is.

Closes #202

## Changed Surfaces

- `.github/workflows/db-backed-bun-job.yml`: removed `jwt-secret` reusable workflow input and env write.
- `.github/workflows/ci.yml`: removed `jwt-secret` callers from check, E2E artifact build, and E2E shards.
- `.github/workflows/e2e-snapshot-artifacts.yml`: removed the snapshot workflow caller.
- `.github/workflows/copilot-setup-steps.yml`: stopped writing `JWT_SECRET` into Copilot setup env.
- `tools/dev/e2e.ts`: removed `JWT_SECRET` from Worker var pass-through and exported the var list for tests.
- `tests/unit/playwright-runtime.test.ts`: added regression coverage that current auth vars are passed without stale `JWT_SECRET`.

## Evidence

- `bun run vitest run tests/unit/playwright-runtime.test.ts`
- `bun run check:e2e`
- `bun run tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bun run tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bun run verify`
- `if rg -n 'JWT_SECRET|jwt-secret' .github tools src .env.example; then exit 1; else echo 'no stale JWT_SECRET matches outside regression tests'; fi`
- `git diff --check`

## Docs / Contracts

No docs/contracts changes: this removes dead setup plumbing only. Runtime behavior, public APIs, and MCP contracts are unchanged.

## Risk Areas

- CI/Copilot/E2E environment setup. `AUTH_SECRET` and `WEBHOOK_SECRET` remain where needed.
- E2E Worker runtime var pass-through changed; covered by focused unit test and default verification.

## Cleanup

- No generated files, scratch reports, or one-time probes committed.
- The remaining `JWT_SECRET` text is only in the regression test assertion.
