### PR TITLE
refactor(auth): debug credential users

### DIFF
--- a/src/lib/auth/debug-auth-user.ts
+++ b/src/lib/auth/debug-auth-user.ts
@@ -4,10 +4,24 @@ import { prisma } from "@/lib/db/prisma";
 import { getDebugProviderConfig } from "./debug-auth-config";
 import type { DebugProviderId } from "./provider-ids";
 
+type DebugCredentialUserData = {
+  username: string;
+  email: string;
+  emailVerified: boolean;
+  name: string;
+  image: string;
+  isAdmin: boolean;
+  profilePictures: string[];
+};
+
+function staleDebugIdentityEmail(userId: string) {
+  return `debug-auth-stale-${userId}@debug.local`;
+}
+
 export async function ensureDebugCredentialUser(providerId: DebugProviderId) {
   const config = getDebugProviderConfig(providerId);
   const hashedPassword = await hashPassword(config.password);
-  const userData = {
+  const userData: DebugCredentialUserData = {
     username: config.username,
     email: config.email,
     emailVerified: true,
@@ -18,19 +32,42 @@ export async function ensureDebugCredentialUser(providerId: DebugProviderId) {
   };
 
   const upsertDebugUserByIdentity = async () => {
-    const existing = await prisma.user.findFirst({
+    const matches = await prisma.user.findMany({
       where: {
         OR: [{ username: config.username }, { email: config.email }],
       },
-      select: { id: true, image: true, profilePictures: true },
+      select: {
+        id: true,
+        username: true,
+        email: true,
+        image: true,
+        profilePictures: true,
+      },
+      orderBy: { createdAt: "asc" },
     });
+    const existing =
+      matches.find((user) => user.username === config.username) ?? matches[0];
 
     if (existing) {
+      for (const conflict of matches.filter(
+        (user) => user.id !== existing.id,
+      )) {
+        await prisma.user.update({
+          where: { id: conflict.id },
+          data: {
+            username: null,
+            email: staleDebugIdentityEmail(conflict.id),
+          },
+        });
+      }
+
       return prisma.user.update({
         where: { id: existing.id },
         data: {
+          username: userData.username,
           email: userData.email,
           emailVerified: userData.emailVerified,
+          name: userData.name,
           isAdmin: userData.isAdmin,
           image: existing.image || userData.image,
           ...(existing.profilePictures.length > 0

--- a/tests/unit/debug-auth.test.ts
+++ b/tests/unit/debug-auth.test.ts
@@ -1,19 +1,38 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEV_ADMIN_PROVIDER_ID,
   DEV_DEBUG_PROVIDER_ID,
 } from "@/lib/auth/provider-ids";
 
+const hashPasswordMock = vi.hoisted(() => vi.fn());
+const prismaMock = vi.hoisted(() => ({
+  account: { upsert: vi.fn() },
+  user: {
+    create: vi.fn(),
+    findMany: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
 vi.mock("better-auth/crypto", () => ({
-  hashPassword: vi.fn(),
+  hashPassword: hashPasswordMock,
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
-  prisma: {},
+  prisma: prismaMock,
 }));
 
 describe("debug auth config", () => {
+  beforeEach(() => {
+    hashPasswordMock.mockResolvedValue("hashed-debug-password");
+    prismaMock.account.upsert.mockResolvedValue({});
+    prismaMock.user.create.mockResolvedValue({ id: "created-user" });
+    prismaMock.user.findMany.mockResolvedValue([]);
+    prismaMock.user.update.mockResolvedValue({ id: "updated-user" });
+  });
+
   afterEach(() => {
+    vi.clearAllMocks();
     vi.resetModules();
     vi.unstubAllEnvs();
   });
@@ -63,5 +82,103 @@ describe("debug auth config", () => {
     expect(() => getDebugProviderConfig(DEV_DEBUG_PROVIDER_ID)).toThrow(
       "DEV_DEBUG_PASSWORD is required when E2E_DEBUG_AUTH=1 (non-development NODE_ENV)",
     );
+  });
+
+  it("completes matched stale debug users", async () => {
+    const { ensureDebugCredentialUser, getDebugProviderConfig } = await import(
+      "@/lib/auth/debug-auth"
+    );
+    const config = getDebugProviderConfig(DEV_DEBUG_PROVIDER_ID);
+    prismaMock.user.findMany.mockResolvedValue([
+      {
+        id: "stale-debug-user",
+        username: null,
+        email: config.email,
+        image: null,
+        profilePictures: [],
+      },
+    ]);
+
+    await ensureDebugCredentialUser(DEV_DEBUG_PROVIDER_ID);
+
+    expect(prismaMock.user.update).toHaveBeenCalledWith({
+      where: { id: "stale-debug-user" },
+      data: {
+        username: config.username,
+        email: config.email,
+        emailVerified: true,
+        name: config.name,
+        isAdmin: config.isAdmin,
+        image: config.image,
+        profilePictures: { set: [config.image] },
+      },
+      select: { id: true },
+    });
+    expect(prismaMock.account.upsert).toHaveBeenCalledWith({
+      where: {
+        provider_providerAccountId: {
+          provider: "credential",
+          providerAccountId: "updated-user",
+        },
+      },
+      update: {
+        userId: "updated-user",
+        type: "credential",
+        provider: "credential",
+        password: "hashed-debug-password",
+      },
+      create: {
+        userId: "updated-user",
+        type: "credential",
+        provider: "credential",
+        providerAccountId: "updated-user",
+        password: "hashed-debug-password",
+      },
+    });
+  });
+
+  it("prefers username identity and neutralizes duplicate debug-email users", async () => {
+    const { ensureDebugCredentialUser, getDebugProviderConfig } = await import(
+      "@/lib/auth/debug-auth"
+    );
+    const config = getDebugProviderConfig(DEV_DEBUG_PROVIDER_ID);
+    prismaMock.user.findMany.mockResolvedValue([
+      {
+        id: "canonical-debug-user",
+        username: config.username,
+        email: `${config.username}@users.local`,
+        image: "https://example.test/existing-avatar.svg",
+        profilePictures: ["https://example.test/existing-avatar.svg"],
+      },
+      {
+        id: "stale-email-user",
+        username: null,
+        email: config.email,
+        image: null,
+        profilePictures: [],
+      },
+    ]);
+
+    await ensureDebugCredentialUser(DEV_DEBUG_PROVIDER_ID);
+
+    expect(prismaMock.user.update).toHaveBeenNthCalledWith(1, {
+      where: { id: "stale-email-user" },
+      data: {
+        username: null,
+        email: "debug-auth-stale-stale-email-user@debug.local",
+      },
+    });
+    expect(prismaMock.user.update).toHaveBeenNthCalledWith(2, {
+      where: { id: "canonical-debug-user" },
+      data: {
+        username: config.username,
+        email: config.email,
+        emailVerified: true,
+        name: config.name,
+        isAdmin: config.isAdmin,
+        image: "https://example.test/existing-avatar.svg",
+      },
+      select: { id: true },
+    });
   });
 });

--- a/tools/dev/seed/seed-dev-scenarios.ts
+++ b/tools/dev/seed/seed-dev-scenarios.ts
@@ -20,6 +20,7 @@ import {
   DEV_SCENARIO_KEY_PREFIX,
   DEV_SCENARIO_MARKER,
   DEV_SEED,
+  getDevDebugCredentialConfig,
   getDevScenarioRuntimeConfig,
 } from "./dev-seed";
 import {
@@ -33,6 +34,8 @@ const scenario = scenarioData;
 
 const { debugUsername, debugName, adminUsername, adminName } =
   getDevScenarioRuntimeConfig();
+const { debug: debugCredential, admin: adminCredential } =
+  getDevDebugCredentialConfig();
 
 const SEMESTER_JW_ID = DEV_SCENARIO_IDS.semesterJwId;
 const COURSE_JW_IDS = DEV_SCENARIO_IDS.courseJwIds;
@@ -228,6 +231,14 @@ const DEV_BUS_PAYLOAD: BusStaticPayload = {
   },
 };
 
+type DevScenarioUserData = {
+  email: string;
+  emailVerified: boolean;
+  name: string;
+  image: string;
+  isAdmin?: boolean;
+};
+
 type DevBusSeed = {
   payload: BusStaticPayload;
   versionTitle: string;
@@ -256,33 +267,59 @@ async function resolveDevBusSeed(): Promise<DevBusSeed> {
   };
 }
 
+async function upsertDevScenarioUser(
+  username: string,
+  data: DevScenarioUserData,
+) {
+  const matches = await prisma.user.findMany({
+    where: { OR: [{ username }, { email: data.email }] },
+    select: { id: true, username: true, email: true },
+    orderBy: { createdAt: "asc" },
+  });
+  const primary =
+    matches.find((user) => user.username === username) ?? matches[0];
+
+  if (!primary) {
+    return prisma.user.create({
+      data: { username, ...data },
+      select: { id: true, username: true },
+    });
+  }
+
+  for (const conflict of matches.filter((user) => user.id !== primary.id)) {
+    await prisma.user.update({
+      where: { id: conflict.id },
+      data: {
+        username: null,
+        email: `${DEV_SCENARIO_KEY_PREFIX}stale-debug-${conflict.id}@debug.local`,
+      },
+    });
+  }
+
+  return prisma.user.update({
+    where: { id: primary.id },
+    data: { username, ...data },
+    select: { id: true, username: true },
+  });
+}
+
 async function main() {
   const debugUserData = {
-    email: `${debugUsername}@users.local`,
+    email: debugCredential.email,
     emailVerified: true,
     name: debugName,
     image: `https://api.dicebear.com/9.x/shapes/svg?seed=${DEV_SEED.debugAvatarSeed}`,
   };
   const adminUserData = {
-    email: `${adminUsername}@users.local`,
+    email: adminCredential.email,
     emailVerified: true,
     name: adminName,
     isAdmin: true,
     image: `https://api.dicebear.com/9.x/shapes/svg?seed=${DEV_SEED.adminAvatarSeed}`,
   };
   const [debugUser, adminUser] = await Promise.all([
-    prisma.user.upsert({
-      where: { username: debugUsername },
-      update: debugUserData,
-      create: { username: debugUsername, ...debugUserData },
-      select: { id: true, username: true },
-    }),
-    prisma.user.upsert({
-      where: { username: adminUsername },
-      update: adminUserData,
-      create: { username: adminUsername, ...adminUserData },
-      select: { id: true, username: true },
-    }),
+    upsertDevScenarioUser(debugUsername, debugUserData),
+    upsertDevScenarioUser(adminUsername, adminUserData),
   ]);
   const busSeed = await resolveDevBusSeed();
 


### PR DESCRIPTION
## Goal

Closes #203 by making debug credential bootstrap deterministic when stale or split debug users already exist. Debug sign-in should land on the requested callback instead of being trapped on `/welcome` by an incomplete stale profile.

## Changed Surfaces

- `src/lib/auth/debug-auth-user.ts`: completes the matched debug user by username or email, preserves an existing avatar when present, neutralizes duplicate debug identity rows, and then refreshes the credential account.
- `tools/dev/seed/seed-dev-scenarios.ts`: seeds dev users from the same debug credential email source and repairs split username/email rows before seeding scenario data.
- `tests/unit/debug-auth.test.ts`: covers stale email-only debug users and duplicate username/email identity reconciliation.

## Evidence

Local verification:
- `bun run test -- tests/unit/debug-auth.test.ts tests/unit/dev-seed.test.ts tests/unit/playwright-runtime.test.ts`
- Focused E2E reproduction loop with reset Worker state, DB prepare, artifact build, seed, and `tests/e2e/src/app/welcome/test.ts`
- `PLAYWRIGHT_PORT=3027 bun run verify:full` on the merged HEAD: type/convention/unit, integration, Worker build, seed, and 544 Playwright tests passed

Complete-loop evidence:
- `/signin` debug-login callback tests passed in the full Playwright run.
- `/welcome` incomplete-profile and completion-flow tests passed in the full Playwright run.
- Seeded MCP tool coverage passed in the full Playwright run.

## Docs / Contracts

No docs or contract JSON changes. This is dev/test identity bootstrap behavior; public REST, MCP, OpenAPI, UI copy, and product contracts are unchanged.

## Risk Areas

Auth/dev seed behavior is the main risk. The change is limited to debug credential users and dev scenario seed users, with local full verification covering auth redirects, profile completion, seeded REST/MCP flows, and browser flows.

## Cleanup

`git status -sb` is clean. No scratch artifacts, one-time probes, unrelated rewrites, or manual generated-file edits remain.
