### PR TITLE
feat(auth): single active user suspension

### DIFF
--- a/docs/contracts/admin.json
+++ b/docs/contracts/admin.json
@@ -13,6 +13,7 @@
     "admin-self-protection": "Admin user management must reject self-suspension, self-demotion, and removing the final remaining admin.",
     "admin-rest-session-only": "Admin REST endpoints require the in-site Better Auth session cookie and do not accept OAuth bearer tokens.",
     "suspension-expiration-validation": "Suspension expiration accepts omitted, null, or empty input as permanent and rejects invalid non-empty date strings.",
+    "single-active-suspension": "Each user may have at most one active suspension. Creating a new suspension replaces any existing active suspension, and lifting an active suspension clears any legacy duplicate active rows for that user.",
     "suspension-retention": "Suspension history is retained when an admin account is deleted; creator and lifter actor references may be null after account deletion."
   },
   "capabilities": {

--- a/prisma/migrations/20260626133000_enforce_single_active_user_suspension/migration.sql
+++ b/prisma/migrations/20260626133000_enforce_single_active_user_suspension/migration.sql
@@ -3,7 +3,13 @@ WITH active_suspensions AS (
     id,
     ROW_NUMBER() OVER (
       PARTITION BY "userId"
-      ORDER BY "createdAt" DESC, id DESC
+      ORDER BY
+        CASE
+          WHEN "expiresAt" IS NULL OR "expiresAt" > NOW() THEN 0
+          ELSE 1
+        END,
+        "createdAt" DESC,
+        id DESC
     ) AS active_rank
   FROM "UserSuspension"
   WHERE "liftedAt" IS NULL

--- a/prisma/migrations/20260626133000_enforce_single_active_user_suspension/migration.sql
+++ b/prisma/migrations/20260626133000_enforce_single_active_user_suspension/migration.sql
@@ -1,0 +1,19 @@
+WITH active_suspensions AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY "userId"
+      ORDER BY "createdAt" DESC, id DESC
+    ) AS active_rank
+  FROM "UserSuspension"
+  WHERE "liftedAt" IS NULL
+)
+UPDATE "UserSuspension" suspension
+SET "liftedAt" = NOW()
+FROM active_suspensions ranked
+WHERE suspension.id = ranked.id
+  AND ranked.active_rank > 1;
+
+CREATE UNIQUE INDEX "UserSuspension_one_active_per_user_key"
+  ON "UserSuspension"("userId")
+  WHERE "liftedAt" IS NULL;

--- a/src/features/admin/server/admin-api-service.ts
+++ b/src/features/admin/server/admin-api-service.ts
@@ -4,6 +4,7 @@ import { isValidProfileUsername } from "@/features/profile/lib/profile-username"
 import type { CommentStatus } from "@/generated/prisma/client";
 import { fireAuditLog } from "@/lib/audit/write-audit-log";
 import { prisma } from "@/lib/db/prisma";
+import { isPrismaUniqueConstraintError } from "@/lib/db/prisma-errors";
 import { runSerializableTransaction } from "@/lib/db/serializable-transaction";
 import { parseDateInput } from "@/lib/time/parse-date-input";
 import { adminDescriptionInclude } from "./admin-description-filters";
@@ -159,21 +160,43 @@ export async function createAdminSuspension(
     return { ok: false as const, reason: "cannot_suspend_self" as const };
   }
 
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { id: true },
-  });
-  if (!user) return { ok: false as const, reason: "user_not_found" as const };
+  const createSuspension = () =>
+    runSerializableTransaction(async (tx) => {
+      const user = await tx.user.findUnique({
+        where: { id: userId },
+        select: { id: true },
+      });
+      if (!user) {
+        return { ok: false as const, reason: "user_not_found" as const };
+      }
 
-  const suspension = await prisma.userSuspension.create({
-    data: {
-      userId,
-      createdById: adminUserId,
-      reason: input.reason?.trim() || null,
-      note: input.note?.trim() || null,
-      expiresAt: expiresAt.expiresAt,
-    },
-  });
+      const liftedAt = new Date();
+      await tx.userSuspension.updateMany({
+        where: { userId, liftedAt: null },
+        data: { liftedAt, liftedById: adminUserId },
+      });
+
+      const suspension = await tx.userSuspension.create({
+        data: {
+          userId,
+          createdById: adminUserId,
+          reason: input.reason?.trim() || null,
+          note: input.note?.trim() || null,
+          expiresAt: expiresAt.expiresAt,
+        },
+      });
+
+      return { ok: true as const, suspension };
+    }, "Failed to create admin suspension");
+
+  let result: Awaited<ReturnType<typeof createSuspension>>;
+  try {
+    result = await createSuspension();
+  } catch (error) {
+    if (!isPrismaUniqueConstraintError(error)) throw error;
+    result = await createSuspension();
+  }
+  if (!result.ok) return result;
 
   fireAuditLog({
     action: "admin_user_suspend",
@@ -183,33 +206,44 @@ export async function createAdminSuspension(
     metadata: { reason: input.reason ?? null },
   });
 
-  return { ok: true as const, suspension };
+  return result;
 }
 
 export async function liftAdminSuspension(adminUserId: string, id: string) {
-  const existing = await prisma.userSuspension.findUnique({
-    where: { id },
-    select: { id: true },
-  });
-  if (!existing) return { ok: false as const, reason: "not_found" as const };
+  const result = await runSerializableTransaction(async (tx) => {
+    const existing = await tx.userSuspension.findUnique({
+      where: { id },
+      select: { id: true, liftedAt: true, userId: true },
+    });
+    if (!existing) return { ok: false as const, reason: "not_found" as const };
 
-  const suspension = await prisma.userSuspension.update({
-    where: { id },
-    data: {
-      liftedAt: new Date(),
-      liftedById: adminUserId,
-    },
-  });
+    const liftedAt = new Date();
+    let suspension = await tx.userSuspension.update({
+      where: { id },
+      data: { liftedAt, liftedById: adminUserId },
+    });
+
+    if (existing.liftedAt === null) {
+      await tx.userSuspension.updateMany({
+        where: { userId: existing.userId, liftedAt: null },
+        data: { liftedAt, liftedById: adminUserId },
+      });
+      suspension = await tx.userSuspension.findUniqueOrThrow({ where: { id } });
+    }
+
+    return { ok: true as const, suspension };
+  }, "Failed to lift admin suspension");
+  if (!result.ok) return result;
 
   fireAuditLog({
     action: "admin_user_unsuspend",
     userId: adminUserId,
-    targetId: suspension.userId,
+    targetId: result.suspension.userId,
     targetType: "user",
     metadata: { suspensionId: id },
   });
 
-  return { ok: true as const, suspension };
+  return result;
 }
 
 export async function moderateComment(

--- a/tests/unit/admin-api-service.test.ts
+++ b/tests/unit/admin-api-service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { fireAuditLogMock, getAdminUserListItemMock, prismaMock } = vi.hoisted(
   () => ({
@@ -13,6 +13,10 @@ const { fireAuditLogMock, getAdminUserListItemMock, prismaMock } = vi.hoisted(
       },
       userSuspension: {
         create: vi.fn(),
+        findUnique: vi.fn(),
+        findUniqueOrThrow: vi.fn(),
+        update: vi.fn(),
+        updateMany: vi.fn(),
       },
     },
   }),
@@ -36,13 +40,24 @@ describe("admin API service", () => {
     getAdminUserListItemMock.mockReset();
     prismaMock.$transaction.mockReset();
     prismaMock.$transaction.mockImplementation(async (action) =>
-      action({ user: prismaMock.user }),
+      action({
+        user: prismaMock.user,
+        userSuspension: prismaMock.userSuspension,
+      }),
     );
     prismaMock.user.count.mockReset();
     prismaMock.user.findUnique.mockReset();
     prismaMock.user.update.mockReset();
     prismaMock.userSuspension.create.mockReset();
+    prismaMock.userSuspension.findUnique.mockReset();
+    prismaMock.userSuspension.findUniqueOrThrow.mockReset();
+    prismaMock.userSuspension.update.mockReset();
+    prismaMock.userSuspension.updateMany.mockReset();
     vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("rejects self-demotion before updating the user", async () => {
@@ -155,5 +170,100 @@ describe("admin API service", () => {
     expect(prismaMock.user.findUnique).not.toHaveBeenCalled();
     expect(prismaMock.userSuspension.create).not.toHaveBeenCalled();
     expect(fireAuditLogMock).not.toHaveBeenCalled();
+  });
+
+  it("lifts an existing active suspension before creating the replacement", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-06-26T01:02:03.000Z");
+    vi.setSystemTime(now);
+    const suspension = { id: "suspension-2", userId: "user-1" };
+    prismaMock.user.findUnique.mockResolvedValue({ id: "user-1" });
+    prismaMock.userSuspension.create.mockResolvedValue(suspension);
+    const { createAdminSuspension } = await import(
+      "@/features/admin/server/admin-api-service"
+    );
+
+    const result = await createAdminSuspension("admin-1", {
+      note: "  note  ",
+      reason: "  reason  ",
+      userId: " user-1 ",
+    });
+
+    expect(result).toEqual({ ok: true, suspension });
+    expect(prismaMock.userSuspension.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", liftedAt: null },
+      data: { liftedAt: now, liftedById: "admin-1" },
+    });
+    expect(prismaMock.userSuspension.create).toHaveBeenCalledWith({
+      data: {
+        userId: "user-1",
+        createdById: "admin-1",
+        reason: "reason",
+        note: "note",
+        expiresAt: null,
+      },
+    });
+    expect(fireAuditLogMock).toHaveBeenCalledWith({
+      action: "admin_user_suspend",
+      userId: "admin-1",
+      targetId: "user-1",
+      targetType: "user",
+      metadata: { reason: "  reason  " },
+    });
+  });
+
+  it("clears duplicate active suspensions when lifting the selected active row", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-06-26T04:05:06.000Z");
+    vi.setSystemTime(now);
+    const suspension = { id: "suspension-1", userId: "user-1" };
+    prismaMock.userSuspension.findUnique.mockResolvedValue({
+      id: "suspension-1",
+      liftedAt: null,
+      userId: "user-1",
+    });
+    prismaMock.userSuspension.update.mockResolvedValue(suspension);
+    prismaMock.userSuspension.findUniqueOrThrow.mockResolvedValue(suspension);
+    const { liftAdminSuspension } = await import(
+      "@/features/admin/server/admin-api-service"
+    );
+
+    const result = await liftAdminSuspension("admin-1", "suspension-1");
+
+    expect(result).toEqual({ ok: true, suspension });
+    expect(prismaMock.userSuspension.update).toHaveBeenCalledWith({
+      where: { id: "suspension-1" },
+      data: { liftedAt: now, liftedById: "admin-1" },
+    });
+    expect(prismaMock.userSuspension.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", liftedAt: null },
+      data: { liftedAt: now, liftedById: "admin-1" },
+    });
+    expect(fireAuditLogMock).toHaveBeenCalledWith({
+      action: "admin_user_unsuspend",
+      userId: "admin-1",
+      targetId: "user-1",
+      targetType: "user",
+      metadata: { suspensionId: "suspension-1" },
+    });
+  });
+
+  it("does not clear a newer active suspension when re-lifting a history row", async () => {
+    const liftedAt = new Date("2026-06-25T04:05:06.000Z");
+    const suspension = { id: "suspension-1", userId: "user-1" };
+    prismaMock.userSuspension.findUnique.mockResolvedValue({
+      id: "suspension-1",
+      liftedAt,
+      userId: "user-1",
+    });
+    prismaMock.userSuspension.update.mockResolvedValue(suspension);
+    const { liftAdminSuspension } = await import(
+      "@/features/admin/server/admin-api-service"
+    );
+
+    const result = await liftAdminSuspension("admin-1", "suspension-1");
+
+    expect(result).toEqual({ ok: true, suspension });
+    expect(prismaMock.userSuspension.updateMany).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Goal

Close #198 by making “one active suspension per user” a service and database invariant.

## Changed Surfaces

- `src/features/admin/server/admin-api-service.ts`: suspension creation now lifts existing active rows before creating the replacement, and active lift clears legacy duplicate active rows for the same user.
- `prisma/migrations/20260626133000_enforce_single_active_user_suspension/migration.sql`: normalizes legacy duplicate active rows and adds a partial unique index on active suspensions, preserving permanent/non-expired rows ahead of expired rows during cleanup.
- `tests/unit/admin-api-service.test.ts`: covers replacement creation, duplicate-active cleanup on lift, and preserving newer active rows when re-lifting historical rows.
- `docs/contracts/admin.json`: documents the single-active-suspension rule.

## Evidence

- Unit/service: `bun run test -- tests/unit/admin-api-service.test.ts` passed.
- Formatting/sanity: `bunx biome check docs/contracts/admin.json src/features/admin/server/admin-api-service.ts tests/unit/admin-api-service.test.ts` and `git diff --check` passed.
- Migration/contract: `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run db:migrate:deploy` applied the migration; `bun run check:contracts` passed.
- Migration review fix: scratch-schema `psql` migration check passed for preserving an effective suspension over a newer expired row and rejecting a duplicate active row with the new partial unique index.
- Default gate: `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run verify` passed: types, conventions, OpenAPI/contracts/i18n/routes, and 605 unit tests.
- Full-gate follow-up: `verify:full` passed default and 75 integration tests. The long E2E pass later hit Workerd hang/broken-pipe instability; after reseeding with a consistent `AUTH_SECRET`, focused reruns of all failed files passed: 27/27 and 28/28 browser/API tests.

## Docs / Contracts

Updated `docs/contracts/admin.json`; no OpenAPI shape change because the routes and response bodies are unchanged.

## Risk Areas

- Prisma migration uses a Postgres partial unique index that Prisma schema cannot represent directly.
- Existing duplicate active rows are auto-lifted with `liftedById = null` during migration because there is no reliable acting admin for historical cleanup.
- Admin suspension REST behavior intentionally changes from “append another active suspension” to “replace current active suspension.”

## Cleanup

- No generated files, scratch reports, screenshots, or one-time probes are tracked.
- The failed throwaway Compose project from local verification was removed with `docker compose -f docker-compose.dev.yml down`.
