### PR TITLE
fix(admin): enforce single open suspension

### DIFF
--- a/docs/contracts/admin.json
+++ b/docs/contracts/admin.json
@@ -13,6 +13,7 @@
     "admin-self-protection": "Admin user management must reject self-suspension, self-demotion, and removing the final remaining admin.",
     "admin-rest-session-only": "Admin REST endpoints require the in-site Better Auth session cookie and do not accept OAuth bearer tokens.",
     "suspension-expiration-validation": "Suspension expiration accepts omitted, null, or empty input as permanent and rejects invalid non-empty date strings.",
+    "single-open-suspension": "Each user can have at most one open suspension. Creating a new suspension closes any previous open suspension for that user while retaining history; lifting an open suspension clears the user's open suspension state.",
     "suspension-retention": "Suspension history is retained when an admin account is deleted; creator and lifter actor references may be null after account deletion."
   },
   "capabilities": {

--- a/prisma/migrations/20260626143000_enforce_single_open_user_suspension/migration.sql
+++ b/prisma/migrations/20260626143000_enforce_single_open_user_suspension/migration.sql
@@ -1,0 +1,29 @@
+UPDATE "UserSuspension"
+SET
+  "liftedAt" = "expiresAt",
+  "liftedById" = NULL
+WHERE "liftedAt" IS NULL
+  AND "expiresAt" IS NOT NULL
+  AND "expiresAt" <= NOW();
+
+WITH ranked_open_suspensions AS (
+  SELECT
+    "id",
+    ROW_NUMBER() OVER (
+      PARTITION BY "userId"
+      ORDER BY "createdAt" DESC, "id" DESC
+    ) AS "rank"
+  FROM "UserSuspension"
+  WHERE "liftedAt" IS NULL
+)
+UPDATE "UserSuspension"
+SET
+  "liftedAt" = NOW(),
+  "liftedById" = NULL
+FROM ranked_open_suspensions
+WHERE "UserSuspension"."id" = ranked_open_suspensions."id"
+  AND ranked_open_suspensions."rank" > 1;
+
+CREATE UNIQUE INDEX "UserSuspension_one_open_per_user_key"
+  ON "UserSuspension"("userId")
+  WHERE "liftedAt" IS NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,12 +2,14 @@ generator client {
   provider = "prisma-client"
   runtime  = "cloudflare"
   output   = "../src/generated/prisma"
+  previewFeatures = ["partialIndexes"]
 }
 
 generator toolClient {
   provider = "prisma-client"
   runtime  = "nodejs"
   output   = "../src/generated/prisma-node"
+  previewFeatures = ["partialIndexes"]
 }
 
 datasource db {
@@ -976,6 +978,7 @@ model UserSuspension {
   createdBy User? @relation("SuspensionCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
   liftedBy  User? @relation("SuspensionLiftedBy", fields: [liftedById], references: [id], onDelete: SetNull)
 
+  @@unique([userId], map: "UserSuspension_one_open_per_user_key", where: raw("\"liftedAt\" IS NULL"))
   @@index([userId])
   @@index([createdById])
   @@index([liftedAt])

--- a/src/features/admin/server/admin-api-service.ts
+++ b/src/features/admin/server/admin-api-service.ts
@@ -4,6 +4,7 @@ import { isValidProfileUsername } from "@/features/profile/lib/profile-username"
 import type { CommentStatus } from "@/generated/prisma/client";
 import { fireAuditLog } from "@/lib/audit/write-audit-log";
 import { prisma } from "@/lib/db/prisma";
+import { isPrismaUniqueConstraintError } from "@/lib/db/prisma-errors";
 import { runSerializableTransaction } from "@/lib/db/serializable-transaction";
 import { parseDateInput } from "@/lib/time/parse-date-input";
 import { adminDescriptionInclude } from "./admin-description-filters";
@@ -159,21 +160,46 @@ export async function createAdminSuspension(
     return { ok: false as const, reason: "cannot_suspend_self" as const };
   }
 
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { id: true },
-  });
-  if (!user) return { ok: false as const, reason: "user_not_found" as const };
+  const createSuspension = () =>
+    runSerializableTransaction(async (tx) => {
+      const user = await tx.user.findUnique({
+        where: { id: userId },
+        select: { id: true },
+      });
+      if (!user) {
+        return { ok: false as const, reason: "user_not_found" as const };
+      }
 
-  const suspension = await prisma.userSuspension.create({
-    data: {
-      userId,
-      createdById: adminUserId,
-      reason: input.reason?.trim() || null,
-      note: input.note?.trim() || null,
-      expiresAt: expiresAt.expiresAt,
-    },
-  });
+      const now = new Date();
+      await tx.userSuspension.updateMany({
+        where: { userId, liftedAt: null },
+        data: {
+          liftedAt: now,
+          liftedById: adminUserId,
+        },
+      });
+
+      const suspension = await tx.userSuspension.create({
+        data: {
+          userId,
+          createdById: adminUserId,
+          reason: input.reason?.trim() || null,
+          note: input.note?.trim() || null,
+          expiresAt: expiresAt.expiresAt,
+        },
+      });
+
+      return { ok: true as const, suspension };
+    }, "Failed to create admin suspension");
+
+  let result: Awaited<ReturnType<typeof createSuspension>>;
+  try {
+    result = await createSuspension();
+  } catch (error) {
+    if (!isPrismaUniqueConstraintError(error)) throw error;
+    result = await createSuspension();
+  }
+  if (!result.ok) return result;
 
   fireAuditLog({
     action: "admin_user_suspend",
@@ -183,33 +209,49 @@ export async function createAdminSuspension(
     metadata: { reason: input.reason ?? null },
   });
 
-  return { ok: true as const, suspension };
+  return result;
 }
 
 export async function liftAdminSuspension(adminUserId: string, id: string) {
-  const existing = await prisma.userSuspension.findUnique({
-    where: { id },
-    select: { id: true },
-  });
-  if (!existing) return { ok: false as const, reason: "not_found" as const };
+  const result = await runSerializableTransaction(async (tx) => {
+    const existing = await tx.userSuspension.findUnique({
+      where: { id },
+      select: { id: true, liftedAt: true, userId: true },
+    });
+    if (!existing) return { ok: false as const, reason: "not_found" as const };
 
-  const suspension = await prisma.userSuspension.update({
-    where: { id },
-    data: {
-      liftedAt: new Date(),
-      liftedById: adminUserId,
-    },
-  });
+    const now = new Date();
+    if (existing.liftedAt === null) {
+      await tx.userSuspension.updateMany({
+        where: { userId: existing.userId, liftedAt: null },
+        data: {
+          liftedAt: now,
+          liftedById: adminUserId,
+        },
+      });
+    }
+
+    const suspension = await tx.userSuspension.update({
+      where: { id },
+      data: {
+        liftedAt: now,
+        liftedById: adminUserId,
+      },
+    });
+
+    return { ok: true as const, suspension };
+  }, "Failed to lift admin suspension");
+  if (!result.ok) return result;
 
   fireAuditLog({
     action: "admin_user_unsuspend",
     userId: adminUserId,
-    targetId: suspension.userId,
+    targetId: result.suspension.userId,
     targetType: "user",
     metadata: { suspensionId: id },
   });
 
-  return { ok: true as const, suspension };
+  return result;
 }
 
 export async function moderateComment(

--- a/src/lib/auth/api-auth.ts
+++ b/src/lib/auth/api-auth.ts
@@ -9,6 +9,7 @@ import {
   OAUTH_REST_READ_SCOPE,
   OAUTH_REST_WRITE_SCOPE,
 } from "@/lib/oauth/constants";
+import { hasRequestAuthSignal } from "./request-auth-signal";
 
 type RestBearerScopeRequirement = "read" | "write";
 
@@ -89,6 +90,8 @@ export async function resolveApiUserId(
     return null;
   }
 
+  if (!hasRequestAuthSignal(request.headers)) return null;
+
   const { getSessionFromHeaders } = await import("@/lib/auth/core");
   const session = await getSessionFromHeaders(request.headers);
   return session?.user?.id ?? null;
@@ -101,6 +104,7 @@ export async function resolveSessionUserId(
   if (/^Bearer(?:\s|$)/i.test(authHeader?.trimStart() ?? "")) {
     return null;
   }
+  if (!hasRequestAuthSignal(request.headers)) return null;
 
   const { getSessionFromHeaders } = await import("@/lib/auth/core");
   const session = await getSessionFromHeaders(request.headers);

--- a/tests/e2e/src/app/api/admin/suspensions/[id]/test.ts
+++ b/tests/e2e/src/app/api/admin/suspensions/[id]/test.ts
@@ -3,7 +3,7 @@
  *
  * Admin-only endpoint to lift (un-suspend) a single suspension.
  *
- * - PATCH sets liftedAt and liftedById on the suspension record
+ * - PATCH sets liftedAt and liftedById on the suspension record and clears the user's open suspension state
  * - No request body is needed
  * - Returns the updated suspension in `{ suspension: {...} }`
  * - Returns 401 for unauthenticated or non-admin requests

--- a/tests/e2e/src/app/api/admin/suspensions/test.ts
+++ b/tests/e2e/src/app/api/admin/suspensions/test.ts
@@ -4,7 +4,8 @@
  * Admin-only endpoint for listing and creating user suspensions.
  *
  * - GET returns `{ suspensions: [...] }` with user info, ordered by createdAt desc
- * - POST creates a new suspension; body: userId (required), reason, note, expiresAt
+ * - POST creates a new suspension and closes any previous open suspension for the user
+ * - POST body: userId (required), reason, note, expiresAt
  * - POST returns 404 if the target user does not exist
  * - POST returns 400 for invalid request body
  * - Both methods return 401 for unauthenticated or non-admin requests
@@ -158,9 +159,50 @@ test.describe("GET/POST /api/admin/suspensions", () => {
       expect(postBody.suspension?.reason).toBe("e2e suspension test");
       expect(postBody.suspension?.expiresAt).toBeNull();
 
+      const replacementResponse = await page.request.post(BASE, {
+        data: {
+          userId,
+          reason: "e2e suspension replacement",
+        },
+      });
+      expect(replacementResponse.status()).toBe(200);
+      const replacementBody = (await replacementResponse.json()) as {
+        suspension?: {
+          id?: string;
+          userId?: string;
+          reason?: string | null;
+        };
+      };
+      expect(replacementBody.suspension?.userId).toBe(userId);
+      expect(replacementBody.suspension?.reason).toBe(
+        "e2e suspension replacement",
+      );
+
+      const listResponse = await page.request.get(BASE);
+      expect(listResponse.status()).toBe(200);
+      const listBody = (await listResponse.json()) as {
+        suspensions?: Array<{
+          id?: string;
+          liftedAt?: string | null;
+          userId?: string;
+        }>;
+      };
+      const userSuspensions = (listBody.suspensions ?? []).filter(
+        (item) => item.userId === userId,
+      );
+      expect(
+        userSuspensions.filter((item) => item.liftedAt === null),
+      ).toHaveLength(1);
+      expect(
+        userSuspensions.some(
+          (item) =>
+            item.id === postBody.suspension?.id && item.liftedAt !== null,
+        ),
+      ).toBe(true);
+
       // Lift the suspension so user can be cleanly deleted.
-      if (postBody.suspension?.id) {
-        await page.request.patch(`${BASE}/${postBody.suspension.id}`);
+      if (replacementBody.suspension?.id) {
+        await page.request.patch(`${BASE}/${replacementBody.suspension.id}`);
       }
     } finally {
       await deleteUsersByPrefix(prefix);

--- a/tests/integration/collaborative-invariants.test.ts
+++ b/tests/integration/collaborative-invariants.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, describe, expect, it } from "vitest";
+import { createAdminSuspension } from "@/features/admin/server/admin-api-service";
 import { upsertDescriptionContent } from "@/features/descriptions/server/description-upsert";
 import { deleteOwnAccount } from "@/features/settings/server/account-deletion-service";
 import { prisma } from "@/lib/db/prisma";
@@ -22,6 +23,104 @@ afterAll(async () => {
 });
 
 describe("collaborative data invariants", () => {
+  it("prevents direct duplicate open suspensions for one user", async () => {
+    const prefix = marker("suspension-unique");
+    const user = await prisma.user.create({
+      data: {
+        email: `${prefix}-user@example.test`,
+        name: "Suspension Unique User",
+      },
+      select: { id: true },
+    });
+    const suspension = await prisma.userSuspension.create({
+      data: {
+        userId: user.id,
+        reason: prefix,
+      },
+      select: { id: true },
+    });
+
+    try {
+      await expect(
+        prisma.userSuspension.create({
+          data: {
+            userId: user.id,
+            reason: `${prefix} duplicate`,
+          },
+        }),
+      ).rejects.toThrow();
+    } finally {
+      await prisma.userSuspension.deleteMany({
+        where: { id: suspension.id },
+      });
+      await prisma.user.deleteMany({ where: { id: user.id } });
+    }
+  });
+
+  it("creates a replacement suspension while closing the previous open row", async () => {
+    const prefix = marker("suspension-replace");
+    const [admin, user] = await Promise.all([
+      prisma.user.create({
+        data: {
+          email: `${prefix}-admin@example.test`,
+          name: "Suspension Admin",
+          isAdmin: true,
+        },
+        select: { id: true },
+      }),
+      prisma.user.create({
+        data: {
+          email: `${prefix}-user@example.test`,
+          name: "Suspension Replacement User",
+        },
+        select: { id: true },
+      }),
+    ]);
+    const previousSuspension = await prisma.userSuspension.create({
+      data: {
+        userId: user.id,
+        createdById: admin.id,
+        reason: `${prefix} previous`,
+      },
+      select: { id: true },
+    });
+
+    try {
+      const result = await createAdminSuspension(admin.id, {
+        userId: user.id,
+        reason: `${prefix} current`,
+      });
+
+      expect(result.ok).toBe(true);
+      await waitForAuditLogCount(user.id, 1);
+      const suspensions = await prisma.userSuspension.findMany({
+        where: { userId: user.id },
+        orderBy: { createdAt: "asc" },
+        select: { id: true, liftedAt: true, reason: true },
+      });
+      expect(suspensions).toHaveLength(2);
+      expect(
+        suspensions.filter((suspension) => suspension.liftedAt === null),
+      ).toHaveLength(1);
+      expect(
+        suspensions.find(
+          (suspension) => suspension.id === previousSuspension.id,
+        )?.liftedAt,
+      ).toBeInstanceOf(Date);
+      expect(suspensions.at(-1)?.reason).toBe(`${prefix} current`);
+    } finally {
+      await prisma.userSuspension.deleteMany({
+        where: { userId: user.id },
+      });
+      await prisma.auditLog.deleteMany({
+        where: { targetId: user.id, targetType: "user" },
+      });
+      await prisma.user.deleteMany({
+        where: { id: { in: [admin.id, user.id] } },
+      });
+    }
+  });
+
   it("deletes accounts while anonymizing audit rows and issued suspensions", async () => {
     const prefix = marker("account-delete");
     const [remainingAdmin, deletingAdmin, suspendedUser] = await Promise.all([

--- a/tests/unit/admin-api-service.test.ts
+++ b/tests/unit/admin-api-service.test.ts
@@ -1,22 +1,29 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { fireAuditLogMock, getAdminUserListItemMock, prismaMock } = vi.hoisted(
-  () => ({
-    fireAuditLogMock: vi.fn(),
-    getAdminUserListItemMock: vi.fn(),
-    prismaMock: {
-      $transaction: vi.fn(),
-      user: {
-        count: vi.fn(),
-        findUnique: vi.fn(),
-        update: vi.fn(),
-      },
-      userSuspension: {
-        create: vi.fn(),
-      },
+const {
+  fireAuditLogMock,
+  getAdminUserListItemMock,
+  isPrismaUniqueConstraintErrorMock,
+  prismaMock,
+} = vi.hoisted(() => ({
+  fireAuditLogMock: vi.fn(),
+  getAdminUserListItemMock: vi.fn(),
+  isPrismaUniqueConstraintErrorMock: vi.fn(),
+  prismaMock: {
+    $transaction: vi.fn(),
+    user: {
+      count: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
     },
-  }),
-);
+    userSuspension: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  },
+}));
 
 vi.mock("@/features/admin/server/admin-user-read-model", () => ({
   getAdminUserListItem: getAdminUserListItemMock,
@@ -24,6 +31,10 @@ vi.mock("@/features/admin/server/admin-user-read-model", () => ({
 
 vi.mock("@/lib/audit/write-audit-log", () => ({
   fireAuditLog: fireAuditLogMock,
+}));
+
+vi.mock("@/lib/db/prisma-errors", () => ({
+  isPrismaUniqueConstraintError: isPrismaUniqueConstraintErrorMock,
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
@@ -34,14 +45,22 @@ describe("admin API service", () => {
   beforeEach(() => {
     fireAuditLogMock.mockReset();
     getAdminUserListItemMock.mockReset();
+    isPrismaUniqueConstraintErrorMock.mockReset();
+    isPrismaUniqueConstraintErrorMock.mockReturnValue(false);
     prismaMock.$transaction.mockReset();
     prismaMock.$transaction.mockImplementation(async (action) =>
-      action({ user: prismaMock.user }),
+      action({
+        user: prismaMock.user,
+        userSuspension: prismaMock.userSuspension,
+      }),
     );
     prismaMock.user.count.mockReset();
     prismaMock.user.findUnique.mockReset();
     prismaMock.user.update.mockReset();
     prismaMock.userSuspension.create.mockReset();
+    prismaMock.userSuspension.findUnique.mockReset();
+    prismaMock.userSuspension.update.mockReset();
+    prismaMock.userSuspension.updateMany.mockReset();
     vi.resetModules();
   });
 
@@ -154,6 +173,128 @@ describe("admin API service", () => {
     });
     expect(prismaMock.user.findUnique).not.toHaveBeenCalled();
     expect(prismaMock.userSuspension.create).not.toHaveBeenCalled();
+    expect(prismaMock.userSuspension.updateMany).not.toHaveBeenCalled();
     expect(fireAuditLogMock).not.toHaveBeenCalled();
+  });
+
+  it("closes existing open suspensions before creating the current suspension", async () => {
+    const createdSuspension = {
+      id: "suspension-new",
+      userId: "user-1",
+      reason: "fresh reason",
+      note: null,
+      expiresAt: null,
+    };
+    prismaMock.user.findUnique.mockResolvedValue({ id: "user-1" });
+    prismaMock.userSuspension.create.mockResolvedValue(createdSuspension);
+    const { createAdminSuspension } = await import(
+      "@/features/admin/server/admin-api-service"
+    );
+
+    const result = await createAdminSuspension("admin-1", {
+      userId: " user-1 ",
+      reason: " fresh reason ",
+      note: " ",
+    });
+
+    expect(result).toEqual({ ok: true, suspension: createdSuspension });
+    expect(prismaMock.userSuspension.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", liftedAt: null },
+      data: {
+        liftedAt: expect.any(Date),
+        liftedById: "admin-1",
+      },
+    });
+    expect(prismaMock.userSuspension.create).toHaveBeenCalledWith({
+      data: {
+        userId: "user-1",
+        createdById: "admin-1",
+        reason: "fresh reason",
+        note: null,
+        expiresAt: null,
+      },
+    });
+    expect(fireAuditLogMock).toHaveBeenCalledWith({
+      action: "admin_user_suspend",
+      userId: "admin-1",
+      targetId: "user-1",
+      targetType: "user",
+      metadata: { reason: " fresh reason " },
+    });
+  });
+
+  it("retries suspension creation after an open-suspension uniqueness race", async () => {
+    const uniqueConflict = new Error("unique conflict");
+    const createdSuspension = {
+      id: "suspension-after-retry",
+      userId: "user-1",
+    };
+    isPrismaUniqueConstraintErrorMock.mockReturnValueOnce(true);
+    prismaMock.$transaction
+      .mockRejectedValueOnce(uniqueConflict)
+      .mockImplementationOnce(async (action) =>
+        action({
+          user: prismaMock.user,
+          userSuspension: prismaMock.userSuspension,
+        }),
+      );
+    prismaMock.user.findUnique.mockResolvedValue({ id: "user-1" });
+    prismaMock.userSuspension.create.mockResolvedValue(createdSuspension);
+    const { createAdminSuspension } = await import(
+      "@/features/admin/server/admin-api-service"
+    );
+
+    const result = await createAdminSuspension("admin-1", {
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ ok: true, suspension: createdSuspension });
+    expect(isPrismaUniqueConstraintErrorMock).toHaveBeenCalledWith(
+      uniqueConflict,
+    );
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("lifts every open suspension for the requested suspension user", async () => {
+    const liftedSuspension = {
+      id: "suspension-1",
+      userId: "user-1",
+      liftedAt: new Date("2026-06-26T04:00:00.000Z"),
+      liftedById: "admin-1",
+    };
+    prismaMock.userSuspension.findUnique.mockResolvedValue({
+      id: "suspension-1",
+      liftedAt: null,
+      userId: "user-1",
+    });
+    prismaMock.userSuspension.update.mockResolvedValue(liftedSuspension);
+    const { liftAdminSuspension } = await import(
+      "@/features/admin/server/admin-api-service"
+    );
+
+    const result = await liftAdminSuspension("admin-1", "suspension-1");
+
+    expect(result).toEqual({ ok: true, suspension: liftedSuspension });
+    expect(prismaMock.userSuspension.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", liftedAt: null },
+      data: {
+        liftedAt: expect.any(Date),
+        liftedById: "admin-1",
+      },
+    });
+    expect(prismaMock.userSuspension.update).toHaveBeenCalledWith({
+      where: { id: "suspension-1" },
+      data: {
+        liftedAt: expect.any(Date),
+        liftedById: "admin-1",
+      },
+    });
+    expect(fireAuditLogMock).toHaveBeenCalledWith({
+      action: "admin_user_unsuspend",
+      userId: "admin-1",
+      targetId: "user-1",
+      targetType: "user",
+      metadata: { suspensionId: "suspension-1" },
+    });
   });
 });

--- a/tests/unit/admin-route-auth.test.ts
+++ b/tests/unit/admin-route-auth.test.ts
@@ -49,6 +49,7 @@ describe("admin route auth", () => {
 
     expect(response).toBeInstanceOf(Response);
     expect((response as Response).status).toBe(401);
+    expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
     expect(resolveAdminByUserIdMock).not.toHaveBeenCalled();
   });
 
@@ -86,7 +87,11 @@ describe("admin route auth", () => {
     );
 
     const response = await requireAdminRequest(
-      new Request("https://example.test/api/admin/homeworks/homework-1"),
+      new Request("https://example.test/api/admin/homeworks/homework-1", {
+        headers: {
+          cookie: "better-auth.session_token=session-token",
+        },
+      }),
     );
 
     expect(response).toBeInstanceOf(Response);

--- a/tools/dev/seed/seed-dev-scenarios.ts
+++ b/tools/dev/seed/seed-dev-scenarios.ts
@@ -1577,6 +1577,10 @@ async function main() {
     },
   });
 
+  // JWKS rows are runtime-generated and encrypted with AUTH_SECRET; dev seed
+  // must not leave tool-process keys behind for the E2E Worker.
+  await prisma.jwks.deleteMany();
+
   console.log("测试场景数据初始化完成");
   console.log(`用户: ${debugUser.username}`);
   console.log(`管理员: ${adminUser.username}`);


### PR DESCRIPTION
## Goal

Closes #198 by encoding a single-open-suspension invariant in the admin service and database so lifting the surfaced suspension cannot leave older open rows blocking user writes.

## Changed Surfaces

- Admin suspension service now closes existing open suspensions before creating a replacement and clears all open suspensions for the user when lifting an open row.
- Prisma schema/migration add a partial unique index for one open `UserSuspension` per user, after closing expired or duplicate open rows during migration.
- Admin contract and unit/integration/E2E coverage now describe and verify replacement/lift behavior.
- Dev seed removes Better Auth JWKS rows after seeding so the E2E Worker generates runtime keys with the active `AUTH_SECRET`.
- API session auth avoids importing Better Auth when a request has no auth signal.

## Evidence

- Focused touched-file convention check: `bun run biome check ...`
- Full local default and integration gates passed inside `bun run verify:full` before E2E startup hit an occupied local `127.0.0.1:3000`.
- Full E2E gate passed on an alternate free port: `PLAYWRIGHT_PORT=3023 bun run verify:e2e` (544 passed).
- REST complete-loop evidence: Playwright API tests exercised POST replacement, GET serialized suspension rows, PATCH lift, auth failures, and invalid `expiresAt` responses for `/api/admin/suspensions`.

## Docs / Contracts

- Updated `docs/contracts/admin.json` with the single-open-suspension rule.
- OpenAPI response shape did not change; no OpenAPI annotation update needed.
- No MCP update needed because admin suspensions are REST/admin UI only and no MCP suspension tool exists.

## Risk Areas

- Prisma migration/partial index, admin suspension replacement semantics, Better Auth JWKS seed cleanup, and API auth short-circuit behavior.
- The database invariant is intentionally `liftedAt IS NULL` because PostgreSQL cannot index a time-relative `expiresAt > now` active condition safely; service reads still apply expiration when deciding whether a user is currently suspended.

## Cleanup

- No scratch artifacts, one-time probes, unrelated schema formatting rewrites, or manual generated-file edits remain. Generated Prisma/OpenAPI artifacts were not committed.
