### PR TITLE
fix(e2e): E2E snapshot artifact flow

### DIFF
--- a/.github/workflows/e2e-snapshot-artifacts.yml
+++ b/.github/workflows/e2e-snapshot-artifacts.yml
@@ -56,6 +56,14 @@ jobs:
 
       - name: Download E2E snapshot artifact
         id: download
+        if: ${{ needs.capture-artifacts.result == 'success' }}
+        uses: actions/download-artifact@v8
+        with:
+          name: e2e-snapshot-artifacts-${{ github.sha }}
+          path: test-results
+
+      - name: Download failed E2E snapshot artifact
+        if: ${{ needs.capture-artifacts.result != 'success' }}
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
@@ -68,7 +76,7 @@ jobs:
 
       - name: Publish screenshot previews
         id: previews
-        if: ${{ needs.capture-artifacts.result == 'success' }}
+        if: ${{ needs.capture-artifacts.result == 'success' && steps.download.outcome == 'success' }}
         shell: bash
         run: >
           bun run snapshot:publish-previews --

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "check:e2e": "bun run tools/dev/check/e2e.ts",
     "check:i18n": "bun run tools/dev/check/i18n.ts",
     "check:routes": "bun run tools/dev/check/routes.ts",
-    "e2e:build-worker": "bun run app:prepare && bun run vite build",
+    "e2e:build-worker": "bun run app:prepare && bun run openapi:generate && bun run vite build",
     "e2e:build-artifacts": "bun run e2e:build-worker && bun run e2e:prepare",
     "e2e:db:prepare": "bun run db:migrate:deploy && bun run check:e2e",
     "e2e:prepare": "bun run tools/dev/e2e.ts prepare",


### PR DESCRIPTION
## Goal

Fixes #210.

Close the remaining E2E Worker artifact flow gaps: standalone E2E artifact builds regenerate OpenAPI before the Worker build, and successful snapshot captures cannot publish previews from a missing downloaded artifact.

## Changed Surfaces

- Tooling: `e2e:build-worker` now runs `openapi:generate` before `vite build`.
- CI/workflows: snapshot comments require a successful artifact download after successful capture, while failed captures keep a best-effort artifact download for diagnostics.

## Evidence

- Local checks: `bunx biome check package.json .github/workflows/e2e-snapshot-artifacts.yml`, `bun run verify:conventions`, `bun run test tests/unit/playwright-runtime.test.ts`
- Changed build path: `bun run e2e:build-artifacts`
- Prior full gate on the same functional diff: `PLAYWRIGHT_PORT=3010 bun run verify:full` passed, including 544 E2E tests; port 3000 was occupied by an unrelated local Docker container.

## Docs / Contracts

No docs or contract JSON changes. OpenAPI generation/checks were run and left no generated-file diff.

## Risk Areas

CI, E2E Worker artifact packaging, snapshot artifact publishing, generated OpenAPI freshness.

## Cleanup

No scratch reports, generated Worker artifacts, Playwright output, or manual generated-file edits are committed.