### PR TITLE
test(e2e): page E2E mutation state

### DIFF
--- a/tests/e2e/src/app/courses/[jwId]/test.ts
+++ b/tests/e2e/src/app/courses/[jwId]/test.ts
@@ -28,6 +28,12 @@ import scenarioData from "../../../../fixtures/scenario.json" with {
   type: "json",
 };
 import { signInAsDebugUser } from "../../../../utils/auth";
+import { cleanupCommentsForE2e } from "../../../../utils/comments";
+import {
+  restoreDescriptionTargetSnapshot,
+  snapshotDescriptionTargetForE2e,
+  waitForDescriptionAuditRows,
+} from "../../../../utils/description-state";
 import { DEV_SEED } from "../../../../utils/dev-seed";
 import { visibleText } from "../../../../utils/locators";
 import { gotoAndWaitForReady } from "../../../../utils/page-ready";
@@ -39,6 +45,8 @@ const COURSE_WITH_DESCRIPTION_URL = `/courses/${scenarioData.courses[2].jwId}`;
 const COURSE_WITH_DESCRIPTION_TEXT = "实验课建议准备护目镜并提前完成预习问答。";
 
 test.describe("/courses/[jwId]", () => {
+  test.describe.configure({ mode: "serial" });
+
   test("contract", async ({ page }, testInfo) => {
     await assertPageContract(page, { routePath: "/courses/[jwId]", testInfo });
   });
@@ -234,34 +242,46 @@ test.describe("/courses/[jwId]", () => {
   }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, COURSE_URL);
-
-    const descCard = page
-      .locator('[data-slot="card"]')
-      .filter({ has: page.getByText(/简介|Description/i) })
-      .first();
-    await expect(descCard).toBeVisible();
-
-    const content = `e2e-course-desc-${Date.now()}`;
-    const editor = descCard.locator("textarea").first();
-    await expect(async () => {
-      await descCard.getByRole("button", { name: /^编辑$|^Edit$/i }).click();
-      await expect(editor).toBeVisible({ timeout: 3_000 });
-    }).toPass({
-      timeout: 10_000,
-      intervals: [250, 500, 1_000],
-    });
-    await editor.fill(content);
-
-    const saveResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/descriptions") &&
-        r.request().method() === "POST" &&
-        r.status() === 200,
+    const snapshot = await snapshotDescriptionTargetForE2e(
+      page.request,
+      { courseJwId: DEV_SEED.course.jwId, targetType: "course" },
+      ["description_edit"],
     );
-    await descCard.getByRole("button", { name: /保存|Save/i }).click();
-    await saveResponse;
-    await expect(page.getByText(content).first()).toBeVisible();
-    await captureStepScreenshot(page, testInfo, "course/description-updated");
+
+    try {
+      const descCard = page
+        .locator('[data-slot="card"]')
+        .filter({ has: page.getByText(/简介|Description/i) })
+        .first();
+      await expect(descCard).toBeVisible();
+
+      const content = `e2e-course-desc-${Date.now()}`;
+      const editor = descCard.locator("textarea").first();
+      await expect(async () => {
+        await descCard.getByRole("button", { name: /^编辑$|^Edit$/i }).click();
+        await expect(editor).toBeVisible({ timeout: 3_000 });
+      }).toPass({
+        timeout: 10_000,
+        intervals: [250, 500, 1_000],
+      });
+      await editor.fill(content);
+
+      const saveResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/descriptions") &&
+          r.request().method() === "POST" &&
+          r.status() === 200,
+      );
+      await descCard.getByRole("button", { name: /保存|Save/i }).click();
+      await saveResponse;
+      await expect(page.getByText(content).first()).toBeVisible();
+      await captureStepScreenshot(page, testInfo, "course/description-updated");
+    } finally {
+      if (snapshot.original) {
+        await waitForDescriptionAuditRows(snapshot.original, 1);
+      }
+      await restoreDescriptionTargetSnapshot(page.request, snapshot);
+    }
   });
 
   // ── Comment CRUD ─────────────────────────────────────────────────────────────
@@ -271,82 +291,94 @@ test.describe("/courses/[jwId]", () => {
   }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, COURSE_URL);
+    let commentId: string | undefined;
 
-    const commentsTab = page
-      .getByRole("button", { name: /评论|Comments/i })
-      .first();
-    await expect(commentsTab).toBeVisible();
-    await commentsTab.click();
-    await expect(commentsTab).toHaveAttribute("aria-pressed", "true");
+    try {
+      const commentsTab = page
+        .getByRole("button", { name: /评论|Comments/i })
+        .first();
+      await expect(commentsTab).toBeVisible();
+      await commentsTab.click();
+      await expect(commentsTab).toHaveAttribute("aria-pressed", "true");
 
-    const body = `e2e-course-comment-${Date.now()}`;
-    const composer = page.locator("textarea").first();
-    await expect(composer).toBeVisible({ timeout: 15_000 });
-    await composer.fill(body);
-    const createResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/comments") &&
-        r.request().method() === "POST" &&
-        r.status() === 200,
-    );
-    await page.getByRole("button", { name: /发布评论|Post comment/i }).click();
-    await createResponse;
+      const body = `e2e-course-comment-${Date.now()}`;
+      const composer = page.locator("textarea").first();
+      await expect(composer).toBeVisible({ timeout: 15_000 });
+      await composer.fill(body);
+      const createResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/comments") &&
+          r.request().method() === "POST" &&
+          r.status() === 200,
+      );
+      await page
+        .getByRole("button", { name: /发布评论|Post comment/i })
+        .click();
+      const createdCommentResponse = await createResponse;
+      const createResponseBody = (await createdCommentResponse.json()) as {
+        id?: string;
+      };
+      expect(createResponseBody.id).toBeTruthy();
+      commentId = createResponseBody.id;
 
-    const commentCard = page
-      .locator('[id^="comment-"]')
-      .filter({ hasText: body })
-      .first();
-    await expect(commentCard).toBeVisible();
-    // comment.author.name visible
-    await expect(
-      commentCard.getByText(DEV_SEED.debugName).first(),
-    ).toBeVisible();
-    await captureStepScreenshot(page, testInfo, "course/comment-posted");
+      const commentCard = page
+        .locator('[id^="comment-"]')
+        .filter({ hasText: body })
+        .first();
+      await expect(commentCard).toBeVisible();
+      // comment.author.name visible
+      await expect(
+        commentCard.getByText(DEV_SEED.debugName).first(),
+      ).toBeVisible();
+      await captureStepScreenshot(page, testInfo, "course/comment-posted");
 
-    // Edit
-    await commentCard.hover();
-    await commentCard.getByRole("button", { name: /编辑|Edit/i }).click();
-    const editedBody = `${body}-edited`;
-    const editCard = page
-      .locator('[id^="comment-"]')
-      .filter({ has: page.locator(".sr-only", { hasText: body }) })
-      .first();
-    await expect(editCard.locator("textarea").first()).toBeVisible();
-    await editCard.locator("textarea").first().fill(editedBody);
-    const editResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/comments/") &&
-        r.request().method() === "PATCH" &&
-        r.status() === 200,
-    );
-    await editCard.getByRole("button", { name: /保存|Save/i }).click();
-    await editResponse;
-    await expect(page.getByText(editedBody).first()).toBeVisible();
-    const editedCommentCard = page
-      .locator('[id^="comment-"]')
-      .filter({ hasText: editedBody })
-      .first();
-    await expect(editedCommentCard).toBeVisible();
+      // Edit
+      await commentCard.hover();
+      await commentCard.getByRole("button", { name: /编辑|Edit/i }).click();
+      const editedBody = `${body}-edited`;
+      const editCard = page
+        .locator('[id^="comment-"]')
+        .filter({ has: page.locator(".sr-only", { hasText: body }) })
+        .first();
+      await expect(editCard.locator("textarea").first()).toBeVisible();
+      await editCard.locator("textarea").first().fill(editedBody);
+      const editResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/comments/") &&
+          r.request().method() === "PATCH" &&
+          r.status() === 200,
+      );
+      await editCard.getByRole("button", { name: /保存|Save/i }).click();
+      await editResponse;
+      await expect(page.getByText(editedBody).first()).toBeVisible();
+      const editedCommentCard = page
+        .locator('[id^="comment-"]')
+        .filter({ hasText: editedBody })
+        .first();
+      await expect(editedCommentCard).toBeVisible();
 
-    // Delete
-    await editedCommentCard.hover();
-    await editedCommentCard
-      .getByRole("button", { name: /更多操作|More actions/i })
-      .first()
-      .click();
-    const deleteResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/comments/") &&
-        r.request().method() === "DELETE" &&
-        r.status() === 200,
-    );
-    await page.getByRole("menuitem", { name: /删除|Delete/i }).click();
-    const dialog = page.getByRole("dialog", {
-      name: /删除评论|Delete Comment/i,
-    });
-    await expect(dialog).toBeVisible();
-    await dialog.getByRole("button", { name: /删除|Delete/i }).click();
-    await deleteResponse;
-    await captureStepScreenshot(page, testInfo, "course/comment-deleted");
+      // Delete
+      await editedCommentCard.hover();
+      await editedCommentCard
+        .getByRole("button", { name: /更多操作|More actions/i })
+        .first()
+        .click();
+      const deleteResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/comments/") &&
+          r.request().method() === "DELETE" &&
+          r.status() === 200,
+      );
+      await page.getByRole("menuitem", { name: /删除|Delete/i }).click();
+      const dialog = page.getByRole("dialog", {
+        name: /删除评论|Delete Comment/i,
+      });
+      await expect(dialog).toBeVisible();
+      await dialog.getByRole("button", { name: /删除|Delete/i }).click();
+      await deleteResponse;
+      await captureStepScreenshot(page, testInfo, "course/comment-deleted");
+    } finally {
+      await cleanupCommentsForE2e([commentId]);
+    }
   });
 });

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -35,12 +35,15 @@
  */
 import { expect, type Page, test } from "@playwright/test";
 import { signInAsDebugUser, signInAsDevAdmin } from "../../../../utils/auth";
+import { cleanupCommentsForE2e } from "../../../../utils/comments";
 import { DEV_SEED } from "../../../../utils/dev-seed";
+import { cleanupHomeworksForE2e } from "../../../../utils/homeworks";
 import {
   gotoAndWaitForReady,
   waitForUiSettled,
 } from "../../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
+import { deleteUploadById } from "../../../../utils/uploads";
 import { assertPageContract } from "../../_shared/page-contract";
 
 const SECTION_URL = `/sections/${DEV_SEED.section.jwId}`;
@@ -595,100 +598,110 @@ test.describe("/sections/[jwId]", () => {
   }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, SECTION_URL);
+    let homeworkId: string | undefined;
 
-    const homeworksTab = page
-      .getByRole("button", { name: /作业|Homework/i })
-      .first();
-    if ((await homeworksTab.count()) === 0) {
-      await expect(page.locator("#main-content")).toBeVisible();
-      return;
+    try {
+      const homeworksTab = page
+        .getByRole("button", { name: /作业|Homework/i })
+        .first();
+      if ((await homeworksTab.count()) === 0) {
+        await expect(page.locator("#main-content")).toBeVisible();
+        return;
+      }
+      await homeworksTab.click();
+
+      // Create
+      const showCreate = page
+        .getByRole("button", { name: /^新建$|^Create$/i })
+        .first();
+      if ((await showCreate.count()) > 0) {
+        await showCreate.click();
+      }
+      const createDialog = page.locator('[data-slot="dialog-popup"]').first();
+      await expect(createDialog).toBeVisible({ timeout: 5_000 });
+
+      const title = `e2e-section-hw-${Date.now()}`;
+      await createDialog.getByTestId("section-homework-title").fill(title);
+      const createResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/homeworks") &&
+          r.request().method() === "POST" &&
+          r.status() === 200,
+      );
+      await createDialog
+        .getByRole("button", { name: /创建作业|Create homework/i })
+        .click();
+      const createdHomeworkResponse = await createResponse;
+      const createResponseBody = (await createdHomeworkResponse.json()) as {
+        id?: string;
+      };
+      expect(createResponseBody.id).toBeTruthy();
+      homeworkId = createResponseBody.id;
+      await waitForUiSettled(page);
+
+      const hwCard = page
+        .getByRole("button", { name: new RegExp(escapeForRegExp(title)) })
+        .first();
+      await expect(hwCard).toBeVisible();
+
+      // homework.title is displayed
+      await expect(hwCard.getByText(title)).toBeVisible();
+      await captureStepScreenshot(page, testInfo, "section/homework-created");
+      await hwCard.click();
+      const homeworkPopout = page.locator('[data-slot="dialog-popup"]').first();
+      await expect(homeworkPopout).toBeVisible();
+
+      // Homework discussion is embedded in the detail dialog.
+      await expect(
+        homeworkPopout.getByText(/评论|Comments/i).first(),
+      ).toBeVisible();
+      await captureStepScreenshot(page, testInfo, "section/homework-discuss");
+
+      // Toggle completion (section-homework-tab.display.fields: user completion status)
+      const completionButton = homeworkPopout
+        .getByRole("button", {
+          name: /标记为完成|取消完成|Mark as complete|Mark as incomplete/i,
+        })
+        .first();
+      await expect(completionButton).toBeVisible();
+      const toggleResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/homeworks/") &&
+          r.url().includes("/completion") &&
+          r.request().method() === "PUT" &&
+          r.status() === 200,
+      );
+      await completionButton.click();
+      await toggleResponse;
+      await captureStepScreenshot(
+        page,
+        testInfo,
+        "section/homework-completion-toggled",
+      );
+
+      // Delete
+      const deleteButton = homeworkPopout
+        .getByRole("button", { name: /删除|Delete/i })
+        .first();
+      await expect(deleteButton).toBeVisible();
+      await deleteButton.click();
+      const deleteDialog = page.locator('[data-slot="dialog-popup"]').last();
+      await expect(deleteDialog).toBeVisible();
+      const deleteResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/homeworks/") &&
+          r.request().method() === "DELETE" &&
+          r.status() === 200,
+      );
+      await deleteDialog
+        .getByRole("button", { name: /确认删除|Delete/i })
+        .click();
+      await deleteResponse;
+      await page.waitForLoadState("networkidle");
+      await expect(hwCard).toHaveCount(0);
+    } finally {
+      await cleanupHomeworksForE2e([homeworkId]);
     }
-    await homeworksTab.click();
-
-    // Create
-    const showCreate = page
-      .getByRole("button", { name: /^新建$|^Create$/i })
-      .first();
-    if ((await showCreate.count()) > 0) {
-      await showCreate.click();
-    }
-    const createDialog = page.locator('[data-slot="dialog-popup"]').first();
-    await expect(createDialog).toBeVisible({ timeout: 5_000 });
-
-    const title = `e2e-section-hw-${Date.now()}`;
-    await createDialog.getByTestId("section-homework-title").fill(title);
-    const createResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/homeworks") &&
-        r.request().method() === "POST" &&
-        r.status() === 200,
-    );
-    await createDialog
-      .getByRole("button", { name: /创建作业|Create homework/i })
-      .click();
-    await createResponse;
-    await waitForUiSettled(page);
-
-    const hwCard = page
-      .getByRole("button", { name: new RegExp(escapeForRegExp(title)) })
-      .first();
-    await expect(hwCard).toBeVisible();
-
-    // homework.title is displayed
-    await expect(hwCard.getByText(title)).toBeVisible();
-    await captureStepScreenshot(page, testInfo, "section/homework-created");
-    await hwCard.click();
-    const homeworkPopout = page.locator('[data-slot="dialog-popup"]').first();
-    await expect(homeworkPopout).toBeVisible();
-
-    // Homework discussion is embedded in the detail dialog.
-    await expect(
-      homeworkPopout.getByText(/评论|Comments/i).first(),
-    ).toBeVisible();
-    await captureStepScreenshot(page, testInfo, "section/homework-discuss");
-
-    // Toggle completion (section-homework-tab.display.fields: user completion status)
-    const completionButton = homeworkPopout
-      .getByRole("button", {
-        name: /标记为完成|取消完成|Mark as complete|Mark as incomplete/i,
-      })
-      .first();
-    await expect(completionButton).toBeVisible();
-    const toggleResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/homeworks/") &&
-        r.url().includes("/completion") &&
-        r.request().method() === "PUT" &&
-        r.status() === 200,
-    );
-    await completionButton.click();
-    await toggleResponse;
-    await captureStepScreenshot(
-      page,
-      testInfo,
-      "section/homework-completion-toggled",
-    );
-
-    // Delete
-    const deleteButton = homeworkPopout
-      .getByRole("button", { name: /删除|Delete/i })
-      .first();
-    await expect(deleteButton).toBeVisible();
-    await deleteButton.click();
-    const deleteDialog = page.locator('[data-slot="dialog-popup"]').last();
-    await expect(deleteDialog).toBeVisible();
-    const deleteResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/homeworks/") &&
-        r.request().method() === "DELETE" &&
-        r.status() === 200,
-    );
-    await deleteDialog
-      .getByRole("button", { name: /确认删除|Delete/i })
-      .click();
-    await deleteResponse;
-    await page.waitForLoadState("networkidle");
-    await expect(hwCard).toHaveCount(0);
   });
 
   // ── Comment CRUD ────────────────────────────────────────────────────────────
@@ -698,129 +711,151 @@ test.describe("/sections/[jwId]", () => {
   }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDevAdmin(page, SECTION_URL);
+    let commentId: string | undefined;
+    let replyId: string | undefined;
 
-    const commentsTab = page
-      .getByRole("button", { name: /评论|Comments/i })
-      .first();
-    await commentsTab.click();
-    await expect(commentsTab).toHaveAttribute("aria-pressed", "true");
+    try {
+      const commentsTab = page
+        .getByRole("button", { name: /评论|Comments/i })
+        .first();
+      await commentsTab.click();
+      await expect(commentsTab).toHaveAttribute("aria-pressed", "true");
 
-    // Post comment
-    const body = `e2e-section-comment-${Date.now()}`;
-    const composer = page.locator("textarea").first();
-    await composer.fill(body);
-    const createResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/comments") &&
-        r.request().method() === "POST" &&
-        r.status() === 200,
-    );
-    await page.getByRole("button", { name: /发布评论|Post comment/i }).click();
-    await createResponse;
-    await page.waitForLoadState("networkidle");
-    await expect(page.getByText(body).first()).toBeVisible();
-    await captureStepScreenshot(page, testInfo, "section/comment-posted");
+      // Post comment
+      const body = `e2e-section-comment-${Date.now()}`;
+      const composer = page.locator("textarea").first();
+      await composer.fill(body);
+      const createResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/comments") &&
+          r.request().method() === "POST" &&
+          r.status() === 200,
+      );
+      await page
+        .getByRole("button", { name: /发布评论|Post comment/i })
+        .click();
+      const createdCommentResponse = await createResponse;
+      const createResponseBody = (await createdCommentResponse.json()) as {
+        id?: string;
+      };
+      expect(createResponseBody.id).toBeTruthy();
+      commentId = createResponseBody.id;
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByText(body).first()).toBeVisible();
+      await captureStepScreenshot(page, testInfo, "section/comment-posted");
 
-    const commentCard = page
-      .locator('[id^="comment-"]')
-      .filter({ hasText: body })
-      .first();
-    await expect(commentCard).toBeVisible();
-    const commentCardId = await commentCard.getAttribute("id");
-    expect(commentCardId).toBeTruthy();
+      const commentCard = page
+        .locator('[id^="comment-"]')
+        .filter({ hasText: body })
+        .first();
+      await expect(commentCard).toBeVisible();
+      const commentCardId = await commentCard.getAttribute("id");
+      expect(commentCardId).toBeTruthy();
 
-    // comment.author.name (display.fields)
-    await expect(
-      commentCard.getByText(DEV_SEED.adminName).first(),
-    ).toBeVisible();
-    // comment.body (markdown rendered)
-    await expect(commentCard.getByText(body).first()).toBeVisible();
+      // comment.author.name (display.fields)
+      await expect(
+        commentCard.getByText(DEV_SEED.adminName).first(),
+      ).toBeVisible();
+      // comment.body (markdown rendered)
+      await expect(commentCard.getByText(body).first()).toBeVisible();
 
-    // React with upvote (comment.reactions[])
-    const reactionResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/comments/") &&
-        r.url().includes("/reactions") &&
-        r.request().method() === "POST" &&
-        r.status() === 200,
-    );
-    await commentCard
-      .getByRole("button", { name: /表情|Reactions/i })
-      .click({ force: true });
-    await page.getByRole("menuitemcheckbox", { name: /点赞|Upvote/i }).click();
-    await reactionResponse;
-    await waitForUiSettled(page);
-    await expect(commentCard.getByRole("button", { name: /👍/ })).toBeVisible();
-    await captureStepScreenshot(page, testInfo, "section/comment-upvoted");
+      // React with upvote (comment.reactions[])
+      const reactionResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/comments/") &&
+          r.url().includes("/reactions") &&
+          r.request().method() === "POST" &&
+          r.status() === 200,
+      );
+      await commentCard
+        .getByRole("button", { name: /表情|Reactions/i })
+        .click({ force: true });
+      await page
+        .getByRole("menuitemcheckbox", { name: /点赞|Upvote/i })
+        .click();
+      await reactionResponse;
+      await waitForUiSettled(page);
+      await expect(
+        commentCard.getByRole("button", { name: /👍/ }),
+      ).toBeVisible();
+      await captureStepScreenshot(page, testInfo, "section/comment-upvoted");
 
-    // Edit comment (canEdit action)
-    await commentCard.hover();
-    await commentCard.getByRole("button", { name: /编辑|Edit/i }).click();
-    const editedBody = `${body}-edited`;
-    const editCard = page.locator(`[id="${commentCardId}"]`);
-    await expect(editCard.locator("textarea").first()).toBeVisible();
-    await editCard.locator("textarea").first().fill(editedBody);
-    const editResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/comments/") &&
-        r.request().method() === "PATCH" &&
-        r.status() === 200,
-    );
-    await editCard.getByRole("button", { name: /保存|Save/i }).click();
-    await editResponse;
-    await page.waitForLoadState("networkidle");
-    // comment.updatedAt / edited timestamp visible
-    await expect(page.getByText(editedBody).first()).toBeVisible();
-    await captureStepScreenshot(page, testInfo, "section/comment-edited");
-    const editedCommentCard = page
-      .locator('[id^="comment-"]')
-      .filter({ hasText: editedBody })
-      .first();
-    await expect(editedCommentCard).toBeVisible();
+      // Edit comment (canEdit action)
+      await commentCard.hover();
+      await commentCard.getByRole("button", { name: /编辑|Edit/i }).click();
+      const editedBody = `${body}-edited`;
+      const editCard = page.locator(`[id="${commentCardId}"]`);
+      await expect(editCard.locator("textarea").first()).toBeVisible();
+      await editCard.locator("textarea").first().fill(editedBody);
+      const editResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/comments/") &&
+          r.request().method() === "PATCH" &&
+          r.status() === 200,
+      );
+      await editCard.getByRole("button", { name: /保存|Save/i }).click();
+      await editResponse;
+      await page.waitForLoadState("networkidle");
+      // comment.updatedAt / edited timestamp visible
+      await expect(page.getByText(editedBody).first()).toBeVisible();
+      await captureStepScreenshot(page, testInfo, "section/comment-edited");
+      const editedCommentCard = page
+        .locator('[id^="comment-"]')
+        .filter({ hasText: editedBody })
+        .first();
+      await expect(editedCommentCard).toBeVisible();
 
-    // Reply (canReply action, comment.replies[])
-    await editedCommentCard
-      .getByRole("button", { name: /回复|Reply/i })
-      .click({ force: true });
-    const replyBody = `e2e-reply-${Date.now()}`;
-    const replyEditor = page
-      .locator(".rounded-2xl.border.border-dashed")
-      .first();
-    await expect(replyEditor).toBeVisible();
-    await replyEditor.locator("textarea").fill(replyBody);
-    const replyResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/comments") &&
-        r.request().method() === "POST" &&
-        r.status() === 200,
-    );
-    await replyEditor.getByRole("button", { name: /回复|Reply/i }).click();
-    await replyResponse;
-    await page.waitForLoadState("networkidle");
-    await expect(page.getByText(replyBody).first()).toBeVisible();
-    await captureStepScreenshot(page, testInfo, "section/comment-replied");
+      // Reply (canReply action, comment.replies[])
+      await editedCommentCard
+        .getByRole("button", { name: /回复|Reply/i })
+        .click({ force: true });
+      const replyBody = `e2e-reply-${Date.now()}`;
+      const replyEditor = page
+        .locator(".rounded-2xl.border.border-dashed")
+        .first();
+      await expect(replyEditor).toBeVisible();
+      await replyEditor.locator("textarea").fill(replyBody);
+      const replyResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/comments") &&
+          r.request().method() === "POST" &&
+          r.status() === 200,
+      );
+      await replyEditor.getByRole("button", { name: /回复|Reply/i }).click();
+      const createdReplyResponse = await replyResponse;
+      const replyResponseBody = (await createdReplyResponse.json()) as {
+        id?: string;
+      };
+      expect(replyResponseBody.id).toBeTruthy();
+      replyId = replyResponseBody.id;
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByText(replyBody).first()).toBeVisible();
+      await captureStepScreenshot(page, testInfo, "section/comment-replied");
 
-    // Delete comment
-    await editedCommentCard
-      .getByRole("button", { name: /更多操作|More actions/i })
-      .first()
-      .click({ force: true });
-    const deleteResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/comments/") &&
-        r.request().method() === "DELETE" &&
-        r.status() === 200,
-    );
-    await page.getByRole("menuitem", { name: /删除|Delete/i }).click();
-    const deleteDialog = page.getByRole("dialog", {
-      name: /删除评论|Delete Comment/i,
-    });
-    await expect(deleteDialog).toBeVisible();
-    await deleteDialog.getByRole("button", { name: /删除|Delete/i }).click();
-    await deleteResponse;
-    await page.waitForLoadState("networkidle");
-    await expect(editedCommentCard).toHaveCount(0);
-    await captureStepScreenshot(page, testInfo, "section/comment-deleted");
+      // Delete comment
+      await editedCommentCard
+        .getByRole("button", { name: /更多操作|More actions/i })
+        .first()
+        .click({ force: true });
+      const deleteResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/comments/") &&
+          r.request().method() === "DELETE" &&
+          r.status() === 200,
+      );
+      await page.getByRole("menuitem", { name: /删除|Delete/i }).click();
+      const deleteDialog = page.getByRole("dialog", {
+        name: /删除评论|Delete Comment/i,
+      });
+      await expect(deleteDialog).toBeVisible();
+      await deleteDialog.getByRole("button", { name: /删除|Delete/i }).click();
+      await deleteResponse;
+      await page.waitForLoadState("networkidle");
+      await expect(editedCommentCard).toHaveCount(0);
+      await captureStepScreenshot(page, testInfo, "section/comment-deleted");
+    } finally {
+      await cleanupCommentsForE2e([replyId, commentId]);
+    }
   });
 
   // ── Attachment upload ────────────────────────────────────────────────────────
@@ -829,133 +864,153 @@ test.describe("/sections/[jwId]", () => {
     page,
   }, testInfo) => {
     test.setTimeout(60_000);
-    await signInAsDebugUser(page, "/");
-    await gotoAndWaitForReady(page, SECTION_URL);
-
-    await expect(async () => {
-      if (!page.url().includes(`/sections/${DEV_SEED.section.jwId}`)) {
-        await gotoAndWaitForReady(page, SECTION_URL);
-      }
-      const commentsTab = page
-        .getByRole("button", { name: /评论|Comments/i })
-        .first();
-      await commentsTab.click();
-      await expect(commentsTab).toHaveAttribute("aria-pressed", "true");
-    }).toPass({
-      timeout: 10_000,
-      intervals: [250, 500, 1_000],
-    });
-
-    const composerCard = page
-      .locator('[data-slot="card"]')
-      .filter({
-        has: page.getByRole("button", { name: /发布评论|Post comment/i }),
-      })
-      .first();
-    await expect(composerCard).toBeVisible();
-    const uploadInput = composerCard.locator('input[type="file"]').first();
-    await expect(uploadInput).toBeAttached();
-    const uploadControl = uploadInput.locator(
-      "xpath=ancestor::label[@data-slot='button'][1]",
-    );
-    await uploadInput.evaluate((input: HTMLInputElement) => {
-      input.focus();
-    });
-    await expect
-      .poll(() =>
-        uploadControl.evaluate(
-          (element) => getComputedStyle(element).boxShadow,
-        ),
-      )
-      .not.toBe("none");
-
-    // Upload attachment (upload.yml three-step flow)
     const filename = `e2e-attachment-${Date.now()}.txt`;
-    const uploadCreate = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/uploads") &&
-        r.request().method() === "POST" &&
-        r.status() === 200,
-    );
-    const uploadPut = page.waitForResponse(
-      (r) =>
-        r.request().method() === "PUT" &&
-        r.status() >= 200 &&
-        r.status() < 300 &&
-        r.url().startsWith("http"),
-    );
-    const uploadComplete = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/uploads/complete") &&
-        r.request().method() === "POST" &&
-        r.status() === 200,
-    );
-
-    await composerCard.locator('input[type="file"]').setInputFiles({
-      name: filename,
-      mimeType: "text/plain",
-      buffer: Buffer.from("section-attachment"),
-    });
-    await uploadCreate;
-    await uploadPut;
-    await uploadComplete;
-
     const body = `e2e-attachment-comment-${Date.now()}`;
-    await composerCard.locator("textarea").first().fill(body);
-    const createComment = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/comments") &&
-        r.request().method() === "POST" &&
-        r.status() === 200,
-    );
-    await composerCard
-      .getByRole("button", { name: /发布评论|Post comment/i })
-      .click();
-    await createComment;
-    await waitForUiSettled(page);
+    let uploadId: string | undefined;
+    let commentId: string | undefined;
 
-    const commentCard = page
-      .locator('[id^="comment-"]')
-      .filter({ hasText: body })
-      .first();
-    await expect(commentCard).toBeVisible();
-    // comment.attachments[] filename/open action (comment.yml display.fields)
-    await expect(
-      commentCard
+    try {
+      await signInAsDebugUser(page, "/");
+      await gotoAndWaitForReady(page, SECTION_URL);
+
+      await expect(async () => {
+        if (!page.url().includes(`/sections/${DEV_SEED.section.jwId}`)) {
+          await gotoAndWaitForReady(page, SECTION_URL);
+        }
+        const commentsTab = page
+          .getByRole("button", { name: /评论|Comments/i })
+          .first();
+        await commentsTab.click();
+        await expect(commentsTab).toHaveAttribute("aria-pressed", "true");
+      }).toPass({
+        timeout: 10_000,
+        intervals: [250, 500, 1_000],
+      });
+
+      const composerCard = page
+        .locator('[data-slot="card"]')
+        .filter({
+          has: page.getByRole("button", { name: /发布评论|Post comment/i }),
+        })
+        .first();
+      await expect(composerCard).toBeVisible();
+      const uploadInput = composerCard.locator('input[type="file"]').first();
+      await expect(uploadInput).toBeAttached();
+      const uploadControl = uploadInput.locator(
+        "xpath=ancestor::label[@data-slot='button'][1]",
+      );
+      await uploadInput.evaluate((input: HTMLInputElement) => {
+        input.focus();
+      });
+      await expect
+        .poll(() =>
+          uploadControl.evaluate(
+            (element) => getComputedStyle(element).boxShadow,
+          ),
+        )
+        .not.toBe("none");
+
+      // Upload attachment (upload.yml three-step flow)
+      const uploadCreate = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/uploads") &&
+          r.request().method() === "POST" &&
+          r.status() === 200,
+      );
+      const uploadPut = page.waitForResponse(
+        (r) =>
+          r.request().method() === "PUT" &&
+          r.status() >= 200 &&
+          r.status() < 300 &&
+          r.url().startsWith("http"),
+      );
+      const uploadComplete = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/uploads/complete") &&
+          r.request().method() === "POST" &&
+          r.status() === 200,
+      );
+
+      await composerCard.locator('input[type="file"]').setInputFiles({
+        name: filename,
+        mimeType: "text/plain",
+        buffer: Buffer.from("section-attachment"),
+      });
+      await uploadCreate;
+      await uploadPut;
+      const uploadCompleteResponse = await uploadComplete;
+      const uploadCompleteBody = (await uploadCompleteResponse.json()) as {
+        upload?: { id?: string };
+      };
+      expect(typeof uploadCompleteBody.upload?.id).toBe("string");
+      uploadId = uploadCompleteBody.upload?.id;
+
+      await composerCard.locator("textarea").first().fill(body);
+      const createComment = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/comments") &&
+          r.request().method() === "POST" &&
+          r.status() === 200,
+      );
+      await composerCard
+        .getByRole("button", { name: /发布评论|Post comment/i })
+        .click();
+      const createCommentResponse = await createComment;
+      const createCommentBody = (await createCommentResponse.json()) as {
+        id?: string;
+      };
+      expect(typeof createCommentBody.id).toBe("string");
+      commentId = createCommentBody.id;
+      await waitForUiSettled(page);
+
+      const commentCard = page
+        .locator('[id^="comment-"]')
+        .filter({ hasText: body })
+        .first();
+      await expect(commentCard).toBeVisible();
+      // comment.attachments[] filename/open action (comment.yml display.fields)
+      await expect(
+        commentCard
+          .getByRole("link", { name: /打开附件|Open attachment/i })
+          .first(),
+      ).toBeVisible();
+      await captureStepScreenshot(page, testInfo, "section/comment-attachment");
+
+      // Download is served by the authorized on-site R2 streaming route.
+      const popupPromise = page.waitForEvent("popup");
+      await commentCard
         .getByRole("link", { name: /打开附件|Open attachment/i })
-        .first(),
-    ).toBeVisible();
-    await captureStepScreenshot(page, testInfo, "section/comment-attachment");
+        .first()
+        .click();
+      const popup = await popupPromise;
+      await popup.waitForLoadState("domcontentloaded");
+      await expect(popup).toHaveURL(/\/api\/uploads\/.*\/download/);
+      await popup.close();
 
-    // Download is served by the authorized on-site R2 streaming route.
-    const popupPromise = page.waitForEvent("popup");
-    await commentCard
-      .getByRole("link", { name: /打开附件|Open attachment/i })
-      .first()
-      .click();
-    const popup = await popupPromise;
-    await popup.waitForLoadState("domcontentloaded");
-    await expect(popup).toHaveURL(/\/api\/uploads\/.*\/download/);
-    await popup.close();
-
-    // Cleanup
-    await commentCard.hover();
-    await commentCard
-      .getByRole("button", { name: /更多操作|More actions/i })
-      .first()
-      .click();
-    const deleteResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/comments/") &&
-        r.request().method() === "DELETE" &&
-        r.status() === 200,
-    );
-    await page.getByRole("menuitem", { name: /删除|Delete/i }).click();
-    const dlg = page.getByRole("dialog", {
-      name: /删除评论|Delete Comment/i,
-    });
-    await expect(dlg).toBeVisible();
-    await dlg.getByRole("button", { name: /删除|Delete/i }).click();
-    await deleteResponse;
+      // Cleanup
+      await commentCard.hover();
+      await commentCard
+        .getByRole("button", { name: /更多操作|More actions/i })
+        .first()
+        .click();
+      const deleteResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/comments/") &&
+          r.request().method() === "DELETE" &&
+          r.status() === 200,
+      );
+      await page.getByRole("menuitem", { name: /删除|Delete/i }).click();
+      const dlg = page.getByRole("dialog", {
+        name: /删除评论|Delete Comment/i,
+      });
+      await expect(dlg).toBeVisible();
+      await dlg.getByRole("button", { name: /删除|Delete/i }).click();
+      await deleteResponse;
+    } finally {
+      await cleanupCommentsForE2e([commentId]);
+      if (uploadId) {
+        await deleteUploadById(page, uploadId);
+      }
+    }
   });
 });

--- a/tests/e2e/src/app/teachers/[id]/test.ts
+++ b/tests/e2e/src/app/teachers/[id]/test.ts
@@ -25,6 +25,12 @@
  */
 import { expect, test } from "@playwright/test";
 import { signInAsDebugUser } from "../../../../utils/auth";
+import { cleanupCommentsForE2e } from "../../../../utils/comments";
+import {
+  restoreDescriptionTargetSnapshot,
+  snapshotDescriptionTargetForE2e,
+  waitForDescriptionAuditRows,
+} from "../../../../utils/description-state";
 import { DEV_SEED } from "../../../../utils/dev-seed";
 import { visibleText } from "../../../../utils/locators";
 import {
@@ -197,37 +203,58 @@ test.describe("/teachers/[id]", () => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, "/teachers");
     await navigateToSeedTeacher(page);
-
-    const descCard = page
-      .locator('[data-slot="card"]')
-      .filter({ has: page.getByText(/简介|Description/i) })
-      .first();
-    await expect(descCard).toBeVisible();
-
-    await descCard.getByRole("button", { name: /^编辑$|^Edit$/i }).click();
-    const content = `e2e-teacher-desc-${Date.now()}`;
-    await descCard.locator("textarea").first().fill(content);
-
-    const saveResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/descriptions") &&
-        r.request().method() === "POST" &&
-        r.status() === 200,
+    const teacherId = page.url().match(/\/teachers\/(\d+)/)?.[1];
+    expect(teacherId).toBeTruthy();
+    if (!teacherId) {
+      throw new Error("Expected teacher id in URL");
+    }
+    const snapshot = await snapshotDescriptionTargetForE2e(
+      page.request,
+      { targetType: "teacher", teacherId },
+      ["description_edit"],
     );
-    await descCard.getByRole("button", { name: /保存|Save/i }).click();
-    await saveResponse;
-    await waitForUiSettled(page);
 
-    // description.content rendered
-    await expect(page.getByText(content).first()).toBeVisible();
-    // description.lastEditedBy.name
-    await expect(
-      page.getByText(DEV_SEED.debugName, { exact: false }).first(),
-    ).toBeVisible();
-    // description.lastEditedAt — some date/time text present near description
-    await expect(descCard.getByText(/\d{4}/).first()).toBeVisible();
+    try {
+      const descCard = page
+        .locator('[data-slot="card"]')
+        .filter({ has: page.getByText(/简介|Description/i) })
+        .first();
+      await expect(descCard).toBeVisible();
 
-    await captureStepScreenshot(page, testInfo, "teacher/description-updated");
+      await descCard.getByRole("button", { name: /^编辑$|^Edit$/i }).click();
+      const content = `e2e-teacher-desc-${Date.now()}`;
+      await descCard.locator("textarea").first().fill(content);
+
+      const saveResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/descriptions") &&
+          r.request().method() === "POST" &&
+          r.status() === 200,
+      );
+      await descCard.getByRole("button", { name: /保存|Save/i }).click();
+      await saveResponse;
+      await waitForUiSettled(page);
+
+      // description.content rendered
+      await expect(page.getByText(content).first()).toBeVisible();
+      // description.lastEditedBy.name
+      await expect(
+        page.getByText(DEV_SEED.debugName, { exact: false }).first(),
+      ).toBeVisible();
+      // description.lastEditedAt — some date/time text present near description
+      await expect(descCard.getByText(/\d{4}/).first()).toBeVisible();
+
+      await captureStepScreenshot(
+        page,
+        testInfo,
+        "teacher/description-updated",
+      );
+    } finally {
+      if (snapshot.original) {
+        await waitForDescriptionAuditRows(snapshot.original, 1);
+      }
+      await restoreDescriptionTargetSnapshot(page.request, snapshot);
+    }
   });
 
   // ── Comment CRUD ─────────────────────────────────────────────────────────────
@@ -238,102 +265,114 @@ test.describe("/teachers/[id]", () => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, "/teachers");
     await navigateToSeedTeacher(page);
+    let commentId: string | undefined;
 
-    await expect(async () => {
-      if (!page.url().includes("/teachers/")) {
-        await navigateToSeedTeacher(page);
+    try {
+      await expect(async () => {
+        if (!page.url().includes("/teachers/")) {
+          await navigateToSeedTeacher(page);
+        }
+        const commentsTab = page
+          .getByRole("button", { name: /评论|Comments/i })
+          .first();
+        await expect(commentsTab).toBeVisible();
+        await commentsTab.click();
+        await expect(commentsTab).toHaveAttribute("aria-pressed", "true");
+      }).toPass({
+        timeout: 10_000,
+        intervals: [250, 500, 1_000],
+      });
+
+      const anonymousCheckbox = page.getByRole("checkbox", {
+        name: /匿名|Anonymous/i,
+      });
+      if (await anonymousCheckbox.isChecked()) {
+        await anonymousCheckbox.click();
       }
-      const commentsTab = page
-        .getByRole("button", { name: /评论|Comments/i })
+      await expect(anonymousCheckbox).not.toBeChecked();
+
+      const body = `e2e-teacher-comment-${Date.now()}`;
+      const composer = page.locator("textarea").first();
+      await expect(composer).toBeVisible({ timeout: 15_000 });
+      await composer.fill(body);
+      const createResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/comments") &&
+          r.request().method() === "POST" &&
+          r.status() === 200,
+      );
+      await page
+        .getByRole("button", { name: /发布评论|Post comment/i })
+        .click();
+      const createdCommentResponse = await createResponse;
+      const createResponseBody = (await createdCommentResponse.json()) as {
+        id?: string;
+      };
+      expect(createResponseBody.id).toBeTruthy();
+      commentId = createResponseBody.id;
+      await waitForUiSettled(page);
+
+      const commentCard = page
+        .locator('[id^="comment-"]')
+        .filter({ hasText: body })
         .first();
-      await expect(commentsTab).toBeVisible();
-      await commentsTab.click();
-      await expect(commentsTab).toHaveAttribute("aria-pressed", "true");
-    }).toPass({
-      timeout: 10_000,
-      intervals: [250, 500, 1_000],
-    });
+      await expect(commentCard).toBeVisible();
+      // comment.body
+      await expect(commentCard.getByText(body).first()).toBeVisible();
+      // comment.createdAt (timestamp text)
+      await expect(
+        commentCard.getByText(/ago|\d{4}|\d+\s*(分钟|小时|天)/i).first(),
+      ).toBeVisible();
+      await captureStepScreenshot(page, testInfo, "teacher/comment-posted");
 
-    const anonymousCheckbox = page.getByRole("checkbox", {
-      name: /匿名|Anonymous/i,
-    });
-    if (await anonymousCheckbox.isChecked()) {
-      await anonymousCheckbox.click();
+      // Edit
+      await commentCard.hover();
+      await commentCard.getByRole("button", { name: /编辑|Edit/i }).click();
+      const editedBody = `${body}-edited`;
+      const editCard = page
+        .locator('[id^="comment-"]')
+        .filter({ has: page.locator(".sr-only", { hasText: body }) })
+        .first();
+      await expect(editCard.locator("textarea").first()).toBeVisible();
+      await editCard.locator("textarea").first().fill(editedBody);
+      const editResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/comments/") &&
+          r.request().method() === "PATCH" &&
+          r.status() === 200,
+      );
+      await editCard.getByRole("button", { name: /保存|Save/i }).click();
+      await editResponse;
+      await waitForUiSettled(page);
+      await expect(page.getByText(editedBody).first()).toBeVisible();
+      const editedCommentCard = page
+        .locator('[id^="comment-"]')
+        .filter({ hasText: editedBody })
+        .first();
+      await expect(editedCommentCard).toBeVisible();
+
+      // Delete
+      await editedCommentCard.hover();
+      await editedCommentCard
+        .getByRole("button", { name: /更多操作|More actions/i })
+        .first()
+        .click();
+      const deleteResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/comments/") &&
+          r.request().method() === "DELETE" &&
+          r.status() === 200,
+      );
+      await page.getByRole("menuitem", { name: /删除|Delete/i }).click();
+      const dialog = page.getByRole("dialog", {
+        name: /删除评论|Delete Comment/i,
+      });
+      await expect(dialog).toBeVisible();
+      await dialog.getByRole("button", { name: /删除|Delete/i }).click();
+      await deleteResponse;
+      await captureStepScreenshot(page, testInfo, "teacher/comment-deleted");
+    } finally {
+      await cleanupCommentsForE2e([commentId]);
     }
-    await expect(anonymousCheckbox).not.toBeChecked();
-
-    const body = `e2e-teacher-comment-${Date.now()}`;
-    const composer = page.locator("textarea").first();
-    await expect(composer).toBeVisible({ timeout: 15_000 });
-    await composer.fill(body);
-    const createResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/comments") &&
-        r.request().method() === "POST" &&
-        r.status() === 200,
-    );
-    await page.getByRole("button", { name: /发布评论|Post comment/i }).click();
-    await createResponse;
-    await waitForUiSettled(page);
-
-    const commentCard = page
-      .locator('[id^="comment-"]')
-      .filter({ hasText: body })
-      .first();
-    await expect(commentCard).toBeVisible();
-    // comment.body
-    await expect(commentCard.getByText(body).first()).toBeVisible();
-    // comment.createdAt (timestamp text)
-    await expect(
-      commentCard.getByText(/ago|\d{4}|\d+\s*(分钟|小时|天)/i).first(),
-    ).toBeVisible();
-    await captureStepScreenshot(page, testInfo, "teacher/comment-posted");
-
-    // Edit
-    await commentCard.hover();
-    await commentCard.getByRole("button", { name: /编辑|Edit/i }).click();
-    const editedBody = `${body}-edited`;
-    const editCard = page
-      .locator('[id^="comment-"]')
-      .filter({ has: page.locator(".sr-only", { hasText: body }) })
-      .first();
-    await expect(editCard.locator("textarea").first()).toBeVisible();
-    await editCard.locator("textarea").first().fill(editedBody);
-    const editResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/comments/") &&
-        r.request().method() === "PATCH" &&
-        r.status() === 200,
-    );
-    await editCard.getByRole("button", { name: /保存|Save/i }).click();
-    await editResponse;
-    await waitForUiSettled(page);
-    await expect(page.getByText(editedBody).first()).toBeVisible();
-    const editedCommentCard = page
-      .locator('[id^="comment-"]')
-      .filter({ hasText: editedBody })
-      .first();
-    await expect(editedCommentCard).toBeVisible();
-
-    // Delete
-    await editedCommentCard.hover();
-    await editedCommentCard
-      .getByRole("button", { name: /更多操作|More actions/i })
-      .first()
-      .click();
-    const deleteResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/comments/") &&
-        r.request().method() === "DELETE" &&
-        r.status() === 200,
-    );
-    await page.getByRole("menuitem", { name: /删除|Delete/i }).click();
-    const dialog = page.getByRole("dialog", {
-      name: /删除评论|Delete Comment/i,
-    });
-    await expect(dialog).toBeVisible();
-    await dialog.getByRole("button", { name: /删除|Delete/i }).click();
-    await deleteResponse;
-    await captureStepScreenshot(page, testInfo, "teacher/comment-deleted");
   });
 });

--- a/tests/e2e/utils/comments.ts
+++ b/tests/e2e/utils/comments.ts
@@ -1,0 +1,23 @@
+import { cleanupAuditTargetsForE2e } from "./e2e-db/audit";
+import { withE2ePrisma } from "./e2e-db/prisma";
+
+function uniqueIds(ids: readonly (string | undefined)[]) {
+  return [...new Set(ids.filter((id): id is string => Boolean(id)))];
+}
+
+export async function cleanupCommentsForE2e(
+  ids: readonly (string | undefined)[],
+) {
+  const commentIds = uniqueIds(ids);
+  if (commentIds.length === 0) return;
+
+  await cleanupAuditTargetsForE2e(
+    commentIds.map((targetId) => ({ targetId, targetType: "comment" })),
+  );
+  await withE2ePrisma((prisma) =>
+    prisma.comment.deleteMany({ where: { id: { in: commentIds } } }),
+  );
+  await cleanupAuditTargetsForE2e(
+    commentIds.map((targetId) => ({ targetId, targetType: "comment" })),
+  );
+}

--- a/tests/e2e/utils/description-state.ts
+++ b/tests/e2e/utils/description-state.ts
@@ -1,8 +1,11 @@
+import type { APIRequestContext } from "@playwright/test";
 import { withE2ePrisma } from "./e2e-db/prisma";
 
-type DescriptionAuditAction = "admin_description_moderate" | "description_edit";
+export type DescriptionAuditAction =
+  | "admin_description_moderate"
+  | "description_edit";
 
-type DescriptionSnapshot = {
+export type DescriptionSnapshot = {
   auditActions: DescriptionAuditAction[];
   auditIds: string[];
   content: string;
@@ -11,6 +14,21 @@ type DescriptionSnapshot = {
   lastEditedAt: Date | null;
   lastEditedById: string | null;
   updatedAt: Date;
+};
+
+type DescriptionTargetReference = {
+  courseJwId?: number | string;
+  homeworkId?: number | string;
+  sectionJwId?: number | string;
+  targetId?: number | string;
+  targetType: "course" | "homework" | "section" | "teacher";
+  teacherId?: number | string;
+};
+
+type DescriptionTargetSnapshot = {
+  auditActions: DescriptionAuditAction[];
+  original: DescriptionSnapshot | null;
+  target: DescriptionTargetReference;
 };
 
 function sleep(ms: number) {
@@ -80,6 +98,48 @@ export async function snapshotDescriptionForE2e(
   });
 }
 
+function descriptionTargetSearchParams(target: DescriptionTargetReference) {
+  const params = new URLSearchParams({ targetType: target.targetType });
+  for (const [key, value] of Object.entries(target)) {
+    if (key === "targetType" || value === undefined) continue;
+    params.set(key, String(value));
+  }
+  return params;
+}
+
+async function findDescriptionIdForTarget(
+  request: APIRequestContext,
+  target: DescriptionTargetReference,
+) {
+  const response = await request.get(
+    `/api/descriptions?${descriptionTargetSearchParams(target).toString()}`,
+  );
+  if (response.status() !== 200) {
+    throw new Error(
+      `Expected description lookup to return 200, got ${response.status()}`,
+    );
+  }
+  const body = (await response.json()) as {
+    description?: { id?: string | null } | null;
+  };
+  return body.description?.id ?? null;
+}
+
+export async function snapshotDescriptionTargetForE2e(
+  request: APIRequestContext,
+  target: DescriptionTargetReference,
+  auditActions: DescriptionAuditAction[],
+): Promise<DescriptionTargetSnapshot> {
+  const descriptionId = await findDescriptionIdForTarget(request, target);
+  return {
+    auditActions,
+    original: descriptionId
+      ? await snapshotDescriptionForE2e(descriptionId, auditActions)
+      : null,
+    target,
+  };
+}
+
 export async function waitForDescriptionAuditRows(
   snapshot: DescriptionSnapshot,
   expectedNewRows: number,
@@ -117,4 +177,43 @@ export async function restoreDescriptionSnapshot(
   await restoreOnce();
   await sleep(50);
   await restoreOnce();
+}
+
+export async function restoreDescriptionTargetSnapshot(
+  request: APIRequestContext,
+  snapshot: DescriptionTargetSnapshot,
+) {
+  if (snapshot.original) {
+    await restoreDescriptionSnapshot(snapshot.original);
+    return;
+  }
+
+  const descriptionId = await findDescriptionIdForTarget(
+    request,
+    snapshot.target,
+  );
+  if (!descriptionId) return;
+  const createdDescriptionId = descriptionId;
+
+  async function deleteCreatedDescriptionOnce() {
+    await withE2ePrisma(async (prisma) => {
+      await prisma.$transaction([
+        prisma.auditLog.deleteMany({
+          where: {
+            action: { in: snapshot.auditActions },
+            targetId: createdDescriptionId,
+            targetType: "description",
+          },
+        }),
+        prisma.descriptionEdit.deleteMany({
+          where: { descriptionId: createdDescriptionId },
+        }),
+        prisma.description.deleteMany({ where: { id: createdDescriptionId } }),
+      ]);
+    });
+  }
+
+  await deleteCreatedDescriptionOnce();
+  await sleep(50);
+  await deleteCreatedDescriptionOnce();
 }

--- a/tests/e2e/utils/homeworks.ts
+++ b/tests/e2e/utils/homeworks.ts
@@ -1,0 +1,54 @@
+import { cleanupAuditTargetsForE2e } from "./e2e-db/audit";
+import { withE2ePrisma } from "./e2e-db/prisma";
+
+function uniqueIds(ids: readonly (string | undefined)[]) {
+  return [...new Set(ids.filter((id): id is string => Boolean(id)))];
+}
+
+export async function cleanupHomeworksForE2e(
+  ids: readonly (string | undefined)[],
+) {
+  const homeworkIds = uniqueIds(ids);
+  if (homeworkIds.length === 0) return;
+
+  const auditTargets = await withE2ePrisma(async (prisma) => {
+    const homeworks = await prisma.homework.findMany({
+      where: { id: { in: homeworkIds } },
+      select: {
+        comments: { select: { id: true } },
+        description: { select: { id: true } },
+        id: true,
+      },
+    });
+
+    return homeworks.flatMap((homework) => [
+      ...homework.comments.map((comment) => ({
+        targetId: comment.id,
+        targetType: "comment",
+      })),
+      ...(homework.description
+        ? [
+            {
+              targetId: homework.description.id,
+              targetType: "description",
+            },
+          ]
+        : []),
+    ]);
+  });
+
+  if (auditTargets.length > 0) {
+    await cleanupAuditTargetsForE2e(auditTargets);
+  }
+  await withE2ePrisma((prisma) =>
+    prisma.$transaction([
+      prisma.homeworkAuditLog.deleteMany({
+        where: { homeworkId: { in: homeworkIds } },
+      }),
+      prisma.homework.deleteMany({ where: { id: { in: homeworkIds } } }),
+    ]),
+  );
+  if (auditTargets.length > 0) {
+    await cleanupAuditTargetsForE2e(auditTargets);
+  }
+}


### PR DESCRIPTION
## Goal

Fixes #200.

Focused page E2E mutation tests should restore or remove the data they create so repeated focused runs do not poison the shared dev seed state.

## Changed Surfaces

- E2E helpers: added cleanup helpers for temporary page-created comments and homeworks, and extended description snapshots to work from public target references.
- Course page E2E: description edits snapshot/restore the target and temporary comments are cleaned in `finally`.
- Teacher page E2E: description edits snapshot/restore the target and temporary comments are cleaned in `finally`.
- Section page E2E: temporary homeworks, comments/replies, and attachment comments/uploads are cleaned in `finally`.

## Evidence

- Static gates: `bun run verify:conventions`, `bun run verify:types`, `bun run check:e2e`
- Unit coverage: `bun run test`, `bun run test tests/unit/feature-boundaries.test.ts`
- Browser coverage: `bun run e2e:db:prepare`, `bun run e2e:build-artifacts`, `bun run seed`, `PLAYWRIGHT_PORT=3010 bun run e2e:test -- tests/e2e/src/app/courses/\[jwId\]/test.ts tests/e2e/src/app/teachers/\[id\]/test.ts tests/e2e/src/app/sections/\[jwId\]/test.ts` passed 43 tests
- Cleanup probe: after the targeted run, DB counts for current test-created comment, description, and homework markers were zero; old local `e2e-attachment-*` uploads predated this run and the run did not add a newer one.

## Docs / Contracts

No docs, contract JSON, OpenAPI, or message changes. This is test isolation/cleanup behavior only.

## Risk Areas

E2E seed state, direct test-fixture cleanup, comment/homework/description audit cleanup, upload cleanup through the public route.

## Cleanup

No generated artifacts, Playwright traces, scratch reports, or manual generated-file edits are committed.