### PR TITLE
ci(static): snapshot prerequisites for local verification

### DIFF
--- a/.agents/skills/life-ustc-pr-workflow/SKILL.md
+++ b/.agents/skills/life-ustc-pr-workflow/SKILL.md
@@ -47,7 +47,9 @@ Use the highest relevant gate:
   - `bun run seed`
   - `bun run e2e:test -- <paths>`
 - Snapshot workflow changes:
-  - `bun run snapshot:capture`
+  - Local verification: `bun run snapshot:verify`
+  - CI capture phase only, after workflow-managed prerequisites:
+    `bun run snapshot:capture`
 
 Stop local Docker services you started with:
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "snapshot:capture": "bun run tools/dev/artifacts/snapshots/snapshot-ci.ts capture",
     "snapshot:publish-previews": "bun run tools/dev/artifacts/snapshots/snapshot-ci.ts publish-previews",
     "snapshot:report": "bun run tools/dev/artifacts/snapshots/snapshot-report.ts",
+    "snapshot:verify": "bun run e2e:db:prepare && bun run e2e:build-artifacts && bun run seed && bun run snapshot:capture",
     "test": "vitest run",
     "verify": "bun run verify:default",
     "verify:default": "bun run verify:types && bun run verify:conventions && bun run test",


### PR DESCRIPTION
## Goal

Fixes #217.

Make local snapshot verification use current E2E artifacts and seed state instead of relying on whatever ignored Worker output happens to exist locally.

## Changed Surfaces

- Tooling: adds `snapshot:verify` as the local snapshot verification command, running DB preparation, E2E artifact build, seed, then snapshot capture.
- Agent workflow docs: `$life-ustc-pr-workflow` now points local snapshot workflow checks at `snapshot:verify`, while keeping `snapshot:capture` documented as the CI capture phase after workflow-managed prerequisites.

## Evidence

- Focused checks: `bunx biome check package.json .agents/skills/life-ustc-pr-workflow/SKILL.md`, `bun run check:e2e`, `git diff --check HEAD~1..HEAD`
- Commit hook verification after installing dependencies in the worktree: Biome and commitlint passed on amended commit.
- Skipped in this worktree: `bun run verify:conventions` and full `bun run snapshot:verify`; the sibling worktree does not have the untracked local `.env`, so Prisma generation cannot resolve `DATABASE_URL`. CI will run the full repository gates on the PR.

## Docs / Contracts

No API contracts, OpenAPI output, messages, or product docs changed. Repo agent workflow guidance was updated because this is a repeated PR verification workflow.

## Risk Areas

Local snapshot verification runtime, E2E artifact freshness, DB seed setup, agent PR workflow guidance.

## Cleanup

No generated artifacts, traces, scratch reports, or manual generated-file edits are committed.