### PR TITLE
ci: Copilot setup for setup inputs

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -4,14 +4,38 @@ on:
   workflow_dispatch:
   push:
     paths:
+      - .bun-version
       - .github/actions/setup-bun-env/action.yml
       - .github/workflows/copilot-setup-steps.yml
       - .github/workflows/db-backed-bun-job.yml
+      - bun.lock
+      - package.json
+      - prisma.config.ts
+      - prisma/migrations/**
+      - prisma/schema.prisma
+      - svelte.config.js
+      - svelte.openapi.json
+      - tests/e2e/fixtures/scenario.json
+      - tools/build/openapi/**
+      - tools/dev/seed/**
+      - tools/shared/**
   pull_request:
     paths:
+      - .bun-version
       - .github/actions/setup-bun-env/action.yml
       - .github/workflows/copilot-setup-steps.yml
       - .github/workflows/db-backed-bun-job.yml
+      - bun.lock
+      - package.json
+      - prisma.config.ts
+      - prisma/migrations/**
+      - prisma/schema.prisma
+      - svelte.config.js
+      - svelte.openapi.json
+      - tests/e2e/fixtures/scenario.json
+      - tools/build/openapi/**
+      - tools/dev/seed/**
+      - tools/shared/**
 
 jobs:
   # The job name must be exactly `copilot-setup-steps`


### PR DESCRIPTION
## Goal

Fixes #219.

Make Copilot setup validation run when files that materially affect its setup command change, not only when setup workflow files change.

## Changed Surfaces

- CI/workflows: expanded `copilot-setup-steps.yml` path filters for Bun/package inputs, Prisma config/schema/migrations, Svelte/OpenAPI config and tooling, seed tooling/fixture data, shared tooling, and setup workflow/action files.
- Job body is unchanged.

## Evidence

- Workflow lint: `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/copilot-setup-steps.yml`
- Whitespace: `git diff --check HEAD~1..HEAD -- .github/workflows/copilot-setup-steps.yml`
- Commit hooks after installing dependencies in the worktree: repo Biome and commitlint passed.
- Note: `bunx biome check .github/workflows/copilot-setup-steps.yml` processes zero files because workflow YAML is ignored by repo Biome config; actionlint is the relevant YAML check.

## Docs / Contracts

No docs, contracts, OpenAPI, or message changes. This is CI trigger coverage only.

## Risk Areas

GitHub Actions path filtering and Copilot setup validation coverage.

## Cleanup

No generated artifacts, scratch reports, or manual generated-file edits are committed.