### PR TITLE
refactor(api): API schema boundary for comment targets

### DIFF
--- a/src/features/comments/lib/comment-target-input-schemas.ts
+++ b/src/features/comments/lib/comment-target-input-schemas.ts
@@ -1,0 +1,95 @@
+import * as z from "zod";
+import { parseInteger } from "@/lib/integers";
+import { COMMENT_TARGET_TYPES } from "./comment-target-types";
+
+export const commentTargetTypeSchema = z.enum(COMMENT_TARGET_TYPES);
+
+const commentTargetIdReferenceSchema = z.union([z.string(), z.number()]);
+
+const commentTargetIntegerStringSchema = z
+  .string()
+  .trim()
+  .refine((value) => parseInteger(value) !== null, {
+    message: "Invalid integer",
+  })
+  .meta({ override: { type: "integer", format: "int64" } });
+
+const positiveIntegerTargetIdReferenceSchema = z.union([
+  z
+    .string()
+    .trim()
+    .refine(
+      (value) => {
+        const parsed = parseInteger(value);
+        return parsed !== null && parsed > 0;
+      },
+      { message: "Invalid integer" },
+    )
+    .meta({ override: { type: "integer", format: "int64", minimum: 1 } }),
+  z
+    .number()
+    .int()
+    .min(1)
+    .meta({ override: { type: "integer", minimum: 1 } }),
+]);
+
+const mcpCommentTargetIdSchema = z.union([
+  z.number().int().positive(),
+  z.string().trim().min(1),
+]);
+
+const mcpPositiveIntegerTargetIdSchema = z.number().int().positive();
+
+export const commentTargetQueryInputSchema = z.object({
+  targetType: commentTargetTypeSchema,
+  targetId: z.string().optional(),
+  sectionId: commentTargetIntegerStringSchema.optional(),
+  sectionJwId: commentTargetIntegerStringSchema.optional(),
+  courseJwId: commentTargetIntegerStringSchema.optional(),
+  teacherId: commentTargetIntegerStringSchema.optional(),
+  homeworkId: z.string().trim().min(1).optional(),
+  sectionTeacherId: commentTargetIntegerStringSchema.optional(),
+});
+
+export const commentTargetMutationInputSchema = z.object({
+  targetType: commentTargetTypeSchema,
+  targetId: commentTargetIdReferenceSchema.optional(),
+  sectionId: commentTargetIdReferenceSchema.optional(),
+  sectionJwId: positiveIntegerTargetIdReferenceSchema.optional(),
+  courseJwId: positiveIntegerTargetIdReferenceSchema.optional(),
+  teacherId: commentTargetIdReferenceSchema.optional(),
+  homeworkId: z.string().trim().min(1).optional(),
+  sectionTeacherId: positiveIntegerTargetIdReferenceSchema.optional(),
+});
+
+export const commentMcpTargetReadInputSchema = z.object({
+  targetType: commentTargetTypeSchema,
+  targetId: mcpCommentTargetIdSchema
+    .optional()
+    .describe(
+      "Internal target id matching REST /api/comments. Prefer public identifiers such as sectionJwId or courseJwId when available.",
+    ),
+  sectionJwId: mcpPositiveIntegerTargetIdSchema
+    .optional()
+    .describe("Public JW section id for section or section-teacher comments."),
+  courseJwId: mcpPositiveIntegerTargetIdSchema
+    .optional()
+    .describe("Public JW course id for course comments."),
+  teacherId: mcpPositiveIntegerTargetIdSchema
+    .optional()
+    .describe("Teacher id for teacher or section-teacher comments."),
+  homeworkId: z.string().trim().min(1).optional(),
+  sectionTeacherId: mcpPositiveIntegerTargetIdSchema
+    .optional()
+    .describe("Direct section-teacher relationship id."),
+});
+
+export const commentMcpTargetMutationInputSchema =
+  commentMcpTargetReadInputSchema.extend({
+    sectionId: mcpCommentTargetIdSchema
+      .optional()
+      .describe("Internal section id for section-teacher comments."),
+    teacherId: mcpCommentTargetIdSchema
+      .optional()
+      .describe("Teacher id for teacher or section-teacher comments."),
+  });

--- a/src/lib/AGENTS.md
+++ b/src/lib/AGENTS.md
@@ -43,6 +43,7 @@ import { formatShanghaiDate } from "@/lib/time/shanghai-format";
 
 - No business logic (use `src/features/`)
 - `src/lib/api/routes` is the scoped HTTP adapter exception: it may import feature server code to parse HTTP requests, call features, and serialize responses
+- `src/lib/api/schemas` is the scoped API schema contract exception: it may import feature-owned constants or schema helpers to describe request/response/OpenAPI shapes, but feature rules stay in `src/features/`
 - Do not import route adapters from features, page actions, or generic `src/lib` helpers; `src/routes/api/**/+server.ts` should stay thin and delegate to them
 - No raw `@prisma/client` imports outside approved adapters/scripts
 - Use shared helpers

--- a/src/lib/api/schemas/content-query-schemas.ts
+++ b/src/lib/api/schemas/content-query-schemas.ts
@@ -1,20 +1,11 @@
 import * as z from "zod";
+import { commentTargetQueryInputSchema } from "@/features/comments/lib/comment-target-input-schemas";
 import {
-  commentTargetTypeSchema,
   descriptionTargetTypeSchema,
   integerStringSchema,
 } from "./request-schema-primitives";
 
-export const commentsQuerySchema = z.object({
-  targetType: commentTargetTypeSchema,
-  targetId: z.string().optional(),
-  sectionId: integerStringSchema.optional(),
-  sectionJwId: integerStringSchema.optional(),
-  courseJwId: integerStringSchema.optional(),
-  teacherId: integerStringSchema.optional(),
-  homeworkId: z.string().trim().min(1).optional(),
-  sectionTeacherId: integerStringSchema.optional(),
-});
+export const commentsQuerySchema = commentTargetQueryInputSchema;
 
 export const descriptionsQuerySchema = z.object({
   targetType: descriptionTargetTypeSchema,

--- a/src/lib/api/schemas/request-comment-mutation-schemas.ts
+++ b/src/lib/api/schemas/request-comment-mutation-schemas.ts
@@ -1,47 +1,18 @@
 import * as z from "zod";
+import { commentTargetMutationInputSchema } from "@/features/comments/lib/comment-target-input-schemas";
 import {
   commentReactionTypeSchema,
-  commentTargetTypeSchema,
   commentVisibilitySchema,
-  parseOptionalInt,
 } from "./request-schema-primitives";
 
-const commentTargetIdReferenceSchema = z.union([z.string(), z.number()]);
-
-const positiveIntegerTargetIdReferenceSchema = z.union([
-  z
-    .string()
-    .trim()
-    .refine(
-      (value) => {
-        const parsed = parseOptionalInt(value);
-        return parsed !== null && parsed > 0;
-      },
-      { message: "Invalid integer" },
-    )
-    .meta({ override: { type: "integer", format: "int64", minimum: 1 } }),
-  z
-    .number()
-    .int()
-    .min(1)
-    .meta({ override: { type: "integer", minimum: 1 } }),
-]);
-
-export const commentCreateRequestSchema = z.object({
-  targetType: commentTargetTypeSchema,
-  targetId: commentTargetIdReferenceSchema.optional(),
-  sectionId: commentTargetIdReferenceSchema.optional(),
-  sectionJwId: positiveIntegerTargetIdReferenceSchema.optional(),
-  courseJwId: positiveIntegerTargetIdReferenceSchema.optional(),
-  teacherId: commentTargetIdReferenceSchema.optional(),
-  homeworkId: z.string().trim().min(1).optional(),
-  sectionTeacherId: positiveIntegerTargetIdReferenceSchema.optional(),
-  body: z.string().trim().min(1).max(8000),
-  visibility: commentVisibilitySchema.optional(),
-  isAnonymous: z.boolean().optional(),
-  parentId: z.string().optional().nullable(),
-  attachmentIds: z.array(z.string()).optional(),
-});
+export const commentCreateRequestSchema =
+  commentTargetMutationInputSchema.extend({
+    body: z.string().trim().min(1).max(8000),
+    visibility: commentVisibilitySchema.optional(),
+    isAnonymous: z.boolean().optional(),
+    parentId: z.string().optional().nullable(),
+    attachmentIds: z.array(z.string()).optional(),
+  });
 
 export const commentUpdateRequestSchema = z.object({
   body: z.string().trim().min(1).max(8000),

--- a/src/lib/api/schemas/request-schema-primitives.ts
+++ b/src/lib/api/schemas/request-schema-primitives.ts
@@ -1,6 +1,6 @@
 import * as z from "zod";
 import { sectionCodeSchema } from "@/features/catalog/lib/section-code-schema";
-import { COMMENT_TARGET_TYPES } from "@/features/comments/lib/comment-target-types";
+import { commentTargetTypeSchema } from "@/features/comments/lib/comment-target-input-schemas";
 import { todoPrioritySchema } from "@/features/todos/lib/todo-schema";
 import { parseDateInput } from "@/lib/time/parse-date-input";
 import { parseInteger } from "../request-integers";
@@ -60,9 +60,7 @@ export const commentReactionTypeSchema = z.enum([
   "eyes",
 ]);
 
-export { commentVisibilitySchema, sectionCodeSchema };
-
-export const commentTargetTypeSchema = z.enum(COMMENT_TARGET_TYPES);
+export { commentTargetTypeSchema, commentVisibilitySchema, sectionCodeSchema };
 
 export const descriptionTargetTypeSchema = z.enum([
   "section",

--- a/src/lib/mcp/tools/comment-tools.ts
+++ b/src/lib/mcp/tools/comment-tools.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod";
-import { COMMENT_TARGET_TYPES } from "@/features/comments/lib/comment-target-types";
+import { commentMcpTargetReadInputSchema } from "@/features/comments/lib/comment-target-input-schemas";
 import {
   loadCommentThread,
   loadFocusedCommentThread,
@@ -29,43 +29,7 @@ import {
   updateOwnCommentTool,
 } from "./comment-write-tool-handlers";
 
-const commentTargetIdSchema = z.union([
-  z.number().int().positive(),
-  z.string().trim().min(1),
-]);
-
-const commentsTargetInputSchema = z.object({
-  targetType: z.enum(COMMENT_TARGET_TYPES),
-  targetId: commentTargetIdSchema
-    .optional()
-    .describe(
-      "Internal target id matching REST /api/comments. Prefer public identifiers such as sectionJwId or courseJwId when available.",
-    ),
-  sectionJwId: z
-    .number()
-    .int()
-    .positive()
-    .optional()
-    .describe("Public JW section id for section or section-teacher comments."),
-  courseJwId: z
-    .number()
-    .int()
-    .positive()
-    .optional()
-    .describe("Public JW course id for course comments."),
-  teacherId: z
-    .number()
-    .int()
-    .positive()
-    .optional()
-    .describe("Teacher id for teacher or section-teacher comments."),
-  homeworkId: z.string().trim().min(1).optional(),
-  sectionTeacherId: z
-    .number()
-    .int()
-    .positive()
-    .optional()
-    .describe("Direct section-teacher relationship id."),
+const commentsTargetInputSchema = commentMcpTargetReadInputSchema.extend({
   mode: mcpModeInputSchema,
 });
 

--- a/src/lib/mcp/tools/comment-write-tool-handlers.ts
+++ b/src/lib/mcp/tools/comment-write-tool-handlers.ts
@@ -1,5 +1,6 @@
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import * as z from "zod";
+import { commentMcpTargetMutationInputSchema } from "@/features/comments/lib/comment-target-input-schemas";
 import {
   writeCommentCreateAuditLog,
   writeCommentDeleteAuditLog,
@@ -26,42 +27,8 @@ import {
 } from "@/lib/mcp/tools/_helpers";
 import { commentMutationErrorPayload } from "./comment-tool-errors";
 
-const commentTargetIdSchema = z.union([
-  z.number().int().positive(),
-  z.string().trim().min(1),
-]);
-
 export const commentCreateInputSchema = commentCreateRequestSchema.extend({
-  targetId: commentTargetIdSchema
-    .optional()
-    .describe(
-      "Internal target id matching REST /api/comments. Prefer public identifiers such as sectionJwId or courseJwId when available.",
-    ),
-  sectionId: commentTargetIdSchema
-    .optional()
-    .describe("Internal section id for section-teacher comments."),
-  teacherId: commentTargetIdSchema
-    .optional()
-    .describe("Teacher id for teacher or section-teacher comments."),
-  sectionJwId: z
-    .number()
-    .int()
-    .positive()
-    .optional()
-    .describe("Public JW section id for section or section-teacher comments."),
-  courseJwId: z
-    .number()
-    .int()
-    .positive()
-    .optional()
-    .describe("Public JW course id for course comments."),
-  homeworkId: z.string().trim().min(1).optional(),
-  sectionTeacherId: z
-    .number()
-    .int()
-    .positive()
-    .optional()
-    .describe("Direct section-teacher relationship id."),
+  ...commentMcpTargetMutationInputSchema.shape,
   mode: mcpModeInputSchema,
 });
 

--- a/tests/unit/api-schemas.test.ts
+++ b/tests/unit/api-schemas.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vitest";
+import {
+  commentMcpTargetMutationInputSchema,
+  commentMcpTargetReadInputSchema,
+} from "@/features/comments/lib/comment-target-input-schemas";
 import { HOMEWORK_DESCRIPTION_MAX_LENGTH } from "@/features/homeworks/lib/homework-limits";
 import { TODO_CONTENT_MAX_LENGTH } from "@/features/todos/lib/todo-limits";
 import {
@@ -276,6 +280,46 @@ describe("other request schemas", () => {
         targetId: "123",
         sectionTeacherId: 0,
         body: "hello",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("validates centralized MCP comment target identifiers", () => {
+    expect(
+      commentMcpTargetReadInputSchema.safeParse({
+        targetType: "section",
+        sectionJwId: 9902001,
+      }).success,
+    ).toBe(true);
+    expect(
+      commentMcpTargetReadInputSchema.safeParse({
+        targetType: "course",
+        courseJwId: 9901001,
+      }).success,
+    ).toBe(true);
+    expect(
+      commentMcpTargetReadInputSchema.safeParse({
+        targetType: "homework",
+        homeworkId: "homework-1",
+      }).success,
+    ).toBe(true);
+    expect(
+      commentMcpTargetReadInputSchema.safeParse({
+        targetType: "section-teacher",
+        sectionTeacherId: 123,
+      }).success,
+    ).toBe(true);
+    expect(
+      commentMcpTargetMutationInputSchema.safeParse({
+        targetType: "section-teacher",
+        sectionId: "123",
+        teacherId: "456",
+      }).success,
+    ).toBe(true);
+    expect(
+      commentMcpTargetReadInputSchema.safeParse({
+        targetType: "section",
+        sectionJwId: "9902001",
       }).success,
     ).toBe(false);
   });

--- a/tests/unit/feature-boundaries.test.ts
+++ b/tests/unit/feature-boundaries.test.ts
@@ -51,10 +51,13 @@ const routeAdapterPrefix = "src/lib/api/routes/";
 const routeAdapterRoot = routeAdapterPrefix.slice(0, -1);
 const maxRouteAdapterFeatureImportFiles = 58;
 const maxRouteAdapterFeatureImports = 95;
+const apiSchemaPrefix = "src/lib/api/schemas/";
+const maxApiSchemaFeatureImportFiles = 10;
+const maxApiSchemaFeatureImports = 12;
 
 const libFeatureImportAllowedPrefixes = [
   routeAdapterPrefix,
-  "src/lib/api/schemas/",
+  apiSchemaPrefix,
   "src/lib/mcp/",
 ];
 
@@ -191,6 +194,27 @@ describe("source import boundaries", () => {
       maxRouteAdapterFeatureImportFiles,
     );
     expect(imports.length).toBeLessThanOrEqual(maxRouteAdapterFeatureImports);
+  });
+
+  it("keeps the API schema feature-import ratchet from growing", async () => {
+    const schemaFiles = await collectSourceFiles(
+      path.join(process.cwd(), apiSchemaPrefix),
+    );
+    const featureImportingFiles = new Set<string>();
+    const imports: string[] = [];
+
+    for (const filePath of schemaFiles) {
+      const source = await fs.readFile(filePath, "utf8");
+      for (const specifier of featureImports(filePath, source)) {
+        featureImportingFiles.add(relativeSourcePath(filePath));
+        imports.push(`${relativeSourcePath(filePath)} -> ${specifier}`);
+      }
+    }
+
+    expect(featureImportingFiles.size).toBeLessThanOrEqual(
+      maxApiSchemaFeatureImportFiles,
+    );
+    expect(imports.length).toBeLessThanOrEqual(maxApiSchemaFeatureImports);
   });
 
   it("keeps feature code off deprecated src/lib domain barrels", async () => {


### PR DESCRIPTION
## Goal

Close #216 by making the API schema import boundary explicit and centralizing comment target input schemas shared by REST and MCP.

## Changed Surfaces

- Added `src/features/comments/lib/comment-target-input-schemas.ts` as the feature-owned source for REST query, REST mutation, MCP read, and MCP mutation comment target inputs.
- Updated REST comment query/create schemas and MCP comment tools to consume the shared feature-owned target schemas.
- Documented `src/lib/api/schemas` as the API schema contract exception in `src/lib/AGENTS.md`.
- Added a feature-import ratchet for API schemas and focused schema tests for REST/MCP comment target validation.

## Evidence

- `bun test tests/unit/api-schemas.test.ts tests/unit/feature-boundaries.test.ts`
- `bun run openapi:check`
- Worker also ran `bunx biome check ...`, `DATABASE_URL=... bun run db:generate`, `bun run tsc --noEmit -p tsconfig.typecheck.tests.json`, `bun run tsc --noEmit -p tsconfig.typecheck.json`, and `git diff --check`.

Complete-loop runtime evidence: N/A for user-visible behavior; this is schema ownership/parity cleanup with preserved REST/MCP target validation semantics. PR checks will run the broader gates.

## Docs / Contracts

Updated `src/lib/AGENTS.md` to align the written architecture boundary with the enforced exception. Product contract JSON and OpenAPI output are unchanged.

## Risk Areas

REST/MCP validation shape for comment target identifiers. Focused tests cover valid public identifiers, malformed public identifiers with fallback `targetId`, and MCP read/mutation target schemas.

## Cleanup

No scratch artifacts, generated files, one-time probes, or unrelated rewrites are included.
