### PR TITLE
fix(audit): harden worker audit writes

### DIFF
--- a/src/features/admin/server/admin-api-service.ts
+++ b/src/features/admin/server/admin-api-service.ts
@@ -96,36 +96,50 @@ export async function updateAdminUser(
   const parsed = await buildAdminUserUpdateData(id, parsedBody);
   if (!parsed.ok) return parsed;
 
-  const updated = await runSerializableTransaction(async (tx) => {
-    const existingUser = await tx.user.findUnique({
-      where: { id },
-      select: { id: true, isAdmin: true },
-    });
-    if (!existingUser) {
-      return { ok: false as const, reason: "not_found" as const };
-    }
-
-    if (parsed.data.isAdmin === false && existingUser.isAdmin) {
-      if (id === adminUserId) {
-        return { ok: false as const, reason: "cannot_demote_self" as const };
+  const updateUser = () =>
+    runSerializableTransaction(async (tx) => {
+      const existingUser = await tx.user.findUnique({
+        where: { id },
+        select: { id: true, isAdmin: true },
+      });
+      if (!existingUser) {
+        return { ok: false as const, reason: "not_found" as const };
       }
 
-      const adminCount = await tx.user.count({ where: { isAdmin: true } });
-      if (adminCount <= 1) {
-        return {
-          ok: false as const,
-          reason: "cannot_remove_last_admin" as const,
-        };
-      }
-    }
+      if (parsed.data.isAdmin === false && existingUser.isAdmin) {
+        if (id === adminUserId) {
+          return { ok: false as const, reason: "cannot_demote_self" as const };
+        }
 
-    const updatedUser = await tx.user.update({
-      where: { id },
-      data: parsed.data,
-      select: { id: true },
-    });
-    return { id: updatedUser.id, ok: true as const };
-  }, "Failed to update admin user");
+        const adminCount = await tx.user.count({ where: { isAdmin: true } });
+        if (adminCount <= 1) {
+          return {
+            ok: false as const,
+            reason: "cannot_remove_last_admin" as const,
+          };
+        }
+      }
+
+      const updatedUser = await tx.user.update({
+        where: { id },
+        data: parsed.data,
+        select: { id: true },
+      });
+      return { id: updatedUser.id, ok: true as const };
+    }, "Failed to update admin user");
+
+  let updated: Awaited<ReturnType<typeof updateUser>>;
+  try {
+    updated = await updateUser();
+  } catch (error) {
+    if (
+      parsed.data.username === undefined ||
+      !isPrismaUniqueConstraintError(error)
+    ) {
+      throw error;
+    }
+    return { ok: false as const, reason: "username_taken" as const };
+  }
   if (!updated.ok) return updated;
 
   const user = await getAdminUserListItem(updated.id);

--- a/src/lib/audit/write-audit-log.ts
+++ b/src/lib/audit/write-audit-log.ts
@@ -2,7 +2,6 @@ import type { AuditAction, Prisma } from "@/generated/prisma/client";
 import { prisma } from "@/lib/db/prisma";
 import { logAppEvent } from "@/lib/log/app-logger";
 import { recordAuditWriteMetric } from "@/lib/metrics/observability-metrics";
-import { getRequestEvent } from "$app/server";
 
 export { getAuditRequestMetadata } from "@/lib/audit/request-metadata";
 
@@ -25,6 +24,14 @@ type AuditPlatform = {
   ctx?: unknown;
 };
 
+type AuditRequestEvent = {
+  platform?: AuditPlatform;
+};
+
+type AuditServerModule = {
+  getRequestEvent?: () => AuditRequestEvent;
+};
+
 function isWorkerWaitUntilContext(
   value: unknown,
 ): value is WorkerWaitUntilContext {
@@ -36,9 +43,20 @@ function isWorkerWaitUntilContext(
   );
 }
 
-function getAuditWaitUntil() {
+async function loadAuditServerModule() {
   try {
-    const platform = getRequestEvent().platform as AuditPlatform | undefined;
+    return (await import("$app/server")) as AuditServerModule;
+  } catch {
+    return undefined;
+  }
+}
+
+async function getAuditWaitUntil() {
+  try {
+    const getRequestEvent = (await loadAuditServerModule())?.getRequestEvent;
+    if (typeof getRequestEvent !== "function") return undefined;
+
+    const platform = getRequestEvent().platform;
     const context = platform?.ctx ?? platform?.context;
     if (!isWorkerWaitUntilContext(context)) return undefined;
 
@@ -94,17 +112,20 @@ export async function writeAuditLog(params: AuditLogParams) {
 /**
  * Fire-and-forget audit log that logs failures instead of swallowing them silently.
  * Use for non-critical audit trails where the route should not fail if logging errors.
- * In Worker requests, the write is scheduled with waitUntil; outside that
- * context, the logged write promise is returned so callers can await it.
+ * In Worker requests, the write is also scheduled with waitUntil when the
+ * SvelteKit request context is available. The logged write promise is returned
+ * so non-request callers and tests can await it.
  */
 export function fireAuditLog(params: AuditLogParams) {
-  const waitUntil = getAuditWaitUntil();
   const auditWrite = writeAuditLog(params).catch((error: unknown) => {
     logAuditWriteFailure(params, error);
   });
 
-  if (!waitUntil) return auditWrite;
+  void getAuditWaitUntil()
+    .then((waitUntil) => {
+      waitUntil?.(auditWrite);
+    })
+    .catch(() => undefined);
 
-  waitUntil(auditWrite);
-  return undefined;
+  return auditWrite;
 }

--- a/src/lib/audit/write-audit-log.ts
+++ b/src/lib/audit/write-audit-log.ts
@@ -2,10 +2,11 @@ import type { AuditAction, Prisma } from "@/generated/prisma/client";
 import { prisma } from "@/lib/db/prisma";
 import { logAppEvent } from "@/lib/log/app-logger";
 import { recordAuditWriteMetric } from "@/lib/metrics/observability-metrics";
+import { getRequestEvent } from "$app/server";
 
 export { getAuditRequestMetadata } from "@/lib/audit/request-metadata";
 
-export async function writeAuditLog(params: {
+type AuditLogParams = {
   action: AuditAction;
   userId: string;
   targetId?: string;
@@ -13,7 +14,57 @@ export async function writeAuditLog(params: {
   metadata?: Record<string, unknown>;
   ipAddress?: string;
   userAgent?: string;
-}) {
+};
+
+type WorkerWaitUntilContext = {
+  waitUntil(promise: Promise<unknown>): void;
+};
+
+type AuditPlatform = {
+  context?: unknown;
+  ctx?: unknown;
+};
+
+function isWorkerWaitUntilContext(
+  value: unknown,
+): value is WorkerWaitUntilContext {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "waitUntil" in value &&
+    typeof value.waitUntil === "function"
+  );
+}
+
+function getAuditWaitUntil() {
+  try {
+    const platform = getRequestEvent().platform as AuditPlatform | undefined;
+    const context = platform?.ctx ?? platform?.context;
+    if (!isWorkerWaitUntilContext(context)) return undefined;
+
+    return (promise: Promise<unknown>) => {
+      context.waitUntil(promise);
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function logAuditWriteFailure(params: AuditLogParams, error: unknown) {
+  logAppEvent(
+    "error",
+    "Audit log write failed",
+    {
+      source: "audit",
+      action: params.action,
+      userId: params.userId,
+      targetId: params.targetId,
+    },
+    error,
+  );
+}
+
+export async function writeAuditLog(params: AuditLogParams) {
   const { metadata, ...rest } = params;
   const start = Date.now();
   try {
@@ -43,27 +94,17 @@ export async function writeAuditLog(params: {
 /**
  * Fire-and-forget audit log that logs failures instead of swallowing them silently.
  * Use for non-critical audit trails where the route should not fail if logging errors.
+ * In Worker requests, the write is scheduled with waitUntil; outside that
+ * context, the logged write promise is returned so callers can await it.
  */
-export function fireAuditLog(params: {
-  action: AuditAction;
-  userId: string;
-  targetId?: string;
-  targetType?: string;
-  metadata?: Record<string, unknown>;
-  ipAddress?: string;
-  userAgent?: string;
-}) {
-  writeAuditLog(params).catch((error) => {
-    logAppEvent(
-      "error",
-      "Audit log write failed",
-      {
-        source: "audit",
-        action: params.action,
-        userId: params.userId,
-        targetId: params.targetId,
-      },
-      error,
-    );
+export function fireAuditLog(params: AuditLogParams) {
+  const waitUntil = getAuditWaitUntil();
+  const auditWrite = writeAuditLog(params).catch((error: unknown) => {
+    logAuditWriteFailure(params, error);
   });
+
+  if (!waitUntil) return auditWrite;
+
+  waitUntil(auditWrite);
+  return undefined;
 }

--- a/tests/unit/admin-api-service.test.ts
+++ b/tests/unit/admin-api-service.test.ts
@@ -158,6 +158,34 @@ describe("admin API service", () => {
     });
   });
 
+  it("maps username uniqueness races to username_taken", async () => {
+    const uniqueConflict = new Error("unique conflict");
+    isPrismaUniqueConstraintErrorMock.mockReturnValueOnce(true);
+    prismaMock.user.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "user-1",
+        isAdmin: false,
+      });
+    prismaMock.user.update.mockRejectedValueOnce(uniqueConflict);
+    const { updateAdminUser } = await import(
+      "@/features/admin/server/admin-api-service"
+    );
+
+    const result = await updateAdminUser("admin-1", "user-1", {
+      username: "taken-name",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "username_taken",
+    });
+    expect(isPrismaUniqueConstraintErrorMock).toHaveBeenCalledWith(
+      uniqueConflict,
+    );
+    expect(getAdminUserListItemMock).not.toHaveBeenCalled();
+  });
+
   it("rejects self-suspension before writing a suspension", async () => {
     const { createAdminSuspension } = await import(
       "@/features/admin/server/admin-api-service"

--- a/tests/unit/audit-write-log.test.ts
+++ b/tests/unit/audit-write-log.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getRequestEventMock,
+  logAppEventMock,
+  prismaMock,
+  recordAuditWriteMetricMock,
+} = vi.hoisted(() => ({
+  getRequestEventMock: vi.fn(),
+  logAppEventMock: vi.fn(),
+  prismaMock: {
+    auditLog: {
+      create: vi.fn(),
+    },
+  },
+  recordAuditWriteMetricMock: vi.fn(),
+}));
+
+vi.mock("$app/server", () => ({
+  getRequestEvent: getRequestEventMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/log/app-logger", () => ({
+  logAppEvent: logAppEventMock,
+}));
+
+vi.mock("@/lib/metrics/observability-metrics", () => ({
+  recordAuditWriteMetric: recordAuditWriteMetricMock,
+}));
+
+const auditParams = {
+  action: "comment_create" as const,
+  metadata: { source: "unit-test" },
+  targetId: "comment-1",
+  targetType: "comment",
+  userId: "user-1",
+};
+
+describe("fireAuditLog", () => {
+  beforeEach(() => {
+    getRequestEventMock.mockReset();
+    logAppEventMock.mockReset();
+    prismaMock.auditLog.create.mockReset();
+    recordAuditWriteMetricMock.mockReset();
+    vi.resetModules();
+  });
+
+  it("schedules audit writes on the active Worker request context", async () => {
+    const waitUntilMock = vi.fn();
+    getRequestEventMock.mockReturnValue({
+      platform: {
+        ctx: {
+          waitUntil: waitUntilMock,
+        },
+      },
+    });
+    prismaMock.auditLog.create.mockResolvedValue({});
+    const { fireAuditLog } = await import("@/lib/audit/write-audit-log");
+
+    const result = fireAuditLog(auditParams);
+
+    expect(result).toBeUndefined();
+    expect(waitUntilMock).toHaveBeenCalledTimes(1);
+    expect(prismaMock.auditLog.create).toHaveBeenCalledWith({
+      data: auditParams,
+    });
+
+    await waitUntilMock.mock.calls[0]?.[0];
+
+    expect(recordAuditWriteMetricMock).toHaveBeenCalledWith({
+      action: "comment_create",
+      durationMs: expect.any(Number),
+      status: "success",
+    });
+    expect(logAppEventMock).not.toHaveBeenCalled();
+  });
+
+  it("logs scheduled audit write failures", async () => {
+    const writeError = new Error("database unavailable");
+    const waitUntilMock = vi.fn();
+    getRequestEventMock.mockReturnValue({
+      platform: {
+        ctx: {
+          waitUntil: waitUntilMock,
+        },
+      },
+    });
+    prismaMock.auditLog.create.mockRejectedValueOnce(writeError);
+    const { fireAuditLog } = await import("@/lib/audit/write-audit-log");
+
+    fireAuditLog(auditParams);
+    await waitUntilMock.mock.calls[0]?.[0];
+
+    expect(recordAuditWriteMetricMock).toHaveBeenCalledWith({
+      action: "comment_create",
+      durationMs: expect.any(Number),
+      status: "error",
+    });
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "error",
+      "Audit log write failed",
+      {
+        action: "comment_create",
+        source: "audit",
+        targetId: "comment-1",
+        userId: "user-1",
+      },
+      writeError,
+    );
+  });
+
+  it("returns the audit write promise when waitUntil is unavailable", async () => {
+    getRequestEventMock.mockImplementation(() => {
+      throw new Error("outside request");
+    });
+    prismaMock.auditLog.create.mockResolvedValue({});
+    const { fireAuditLog } = await import("@/lib/audit/write-audit-log");
+
+    const result = fireAuditLog(auditParams);
+
+    expect(result).toHaveProperty("then");
+    await expect(result).resolves.toBeUndefined();
+    expect(logAppEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/audit-write-log.test.ts
+++ b/tests/unit/audit-write-log.test.ts
@@ -63,8 +63,9 @@ describe("fireAuditLog", () => {
 
     const result = fireAuditLog(auditParams);
 
-    expect(result).toBeUndefined();
-    expect(waitUntilMock).toHaveBeenCalledTimes(1);
+    expect(result).toHaveProperty("then");
+    await vi.dynamicImportSettled();
+    await vi.waitFor(() => expect(waitUntilMock).toHaveBeenCalledTimes(1));
     expect(prismaMock.auditLog.create).toHaveBeenCalledWith({
       data: auditParams,
     });
@@ -93,6 +94,8 @@ describe("fireAuditLog", () => {
     const { fireAuditLog } = await import("@/lib/audit/write-audit-log");
 
     fireAuditLog(auditParams);
+    await vi.dynamicImportSettled();
+    await vi.waitFor(() => expect(waitUntilMock).toHaveBeenCalledTimes(1));
     await waitUntilMock.mock.calls[0]?.[0];
 
     expect(recordAuditWriteMetricMock).toHaveBeenCalledWith({


### PR DESCRIPTION
## Goal

Close #229 and #236 by making audit-log writes durable in Worker request contexts and mapping admin username uniqueness races to the existing username-taken result.

## Changed Surfaces

- `src/lib/audit/write-audit-log.ts`: schedules fire-and-forget audit writes with active Worker/SvelteKit `waitUntil` when available; outside request context it returns the logged write promise so callers can await it.
- `src/features/admin/server/admin-api-service.ts`: catches Prisma unique conflicts during admin user updates and returns `username_taken`.
- Focused unit coverage for audit scheduling/failure logging and admin username race mapping.

## Evidence

- Focused behavior: `bun run vitest run tests/unit/audit-write-log.test.ts tests/unit/admin-api-service.test.ts`
- Formatting/lint: `bunx biome check src/lib/audit/write-audit-log.ts src/features/admin/server/admin-api-service.ts tests/unit/audit-write-log.test.ts tests/unit/admin-api-service.test.ts`
- Worker reported broader local check: `DATABASE_URL=... bun run verify:types`

## Docs / Contracts

No docs/contracts changed. The public API shape is unchanged; this hardens durability/error mapping for already-contracted behavior.

## Risk Areas

- Worker runtime audit durability: uses `getRequestEvent().platform.ctx/context.waitUntil` when present.
- Admin writes: only maps Prisma unique conflicts when a username update was attempted; other errors still throw.

## Cleanup

Diff reviewed for unrelated edits. No scratch artifacts, probes, generated files, or upload-service changes are included.