### PR TITLE
fix(upload): harden completion and filenames

### DIFF
--- a/docs/contracts/upload.json
+++ b/docs/contracts/upload.json
@@ -12,6 +12,7 @@
     "three-step-upload": "Web comment attachment uploads follow a three-step flow — create upload session on-site → browser PUT to an on-site Cloudflare Workers upload object route backed by R2 → confirm completion on-site.",
     "r2-backend": "Upload object create/read/head/delete operations use the Cloudflare R2 binding. The app runtime does not use S3-compatible signed URL fallbacks.",
     "storage-observability": "Shared storage helpers record production-safe bounded metrics for storage operation status and duration; metrics identify operation type but do not include bucket names, object keys, signed URLs, filenames, or user IDs.",
+    "safe-filenames": "Upload create, completion, and rename requests reject ASCII control characters in filenames; download responses use a safe Content-Disposition filename fallback with an encoded UTF-8 filename parameter.",
     "e2e-r2": "E2E upload coverage should exercise the same Workers upload object route used in production.",
     "one-upload-one-comment": "A completed upload can be attached to at most one comment. Reusing an upload id across comments is rejected instead of treated as implicit file sharing.",
     "download-auth-required": "Downloads must not bypass authorization by obtaining a direct link.",

--- a/src/features/uploads/lib/upload-utils.ts
+++ b/src/features/uploads/lib/upload-utils.ts
@@ -2,6 +2,8 @@
  * Shared upload helper functions extracted from route files to avoid duplication.
  */
 
+import { isAsciiControlCharacter } from "@/lib/text/ascii-control-characters";
+
 export function normalizeContentType(value: unknown) {
   if (typeof value !== "string") return "application/octet-stream";
   const trimmed = value.trim();
@@ -10,17 +12,12 @@ export function normalizeContentType(value: unknown) {
 
 const HEADER_UNSAFE_FILENAME_CHARACTERS = /[^\x20-\x7e]|["\\]/gu;
 
-function isControlCharacter(character: string) {
-  const code = character.charCodeAt(0);
-  return code < 32 || code === 127;
-}
-
 export function sanitizeFilename(filename: string) {
   let sanitized = "";
   let previousWasReplacement = false;
 
   for (const character of filename) {
-    if (isControlCharacter(character)) {
+    if (isAsciiControlCharacter(character)) {
       if (!previousWasReplacement) {
         sanitized += " ";
         previousWasReplacement = true;
@@ -33,10 +30,6 @@ export function sanitizeFilename(filename: string) {
   }
 
   return sanitized.trim();
-}
-
-export function hasFilenameControlCharacters(filename: string) {
-  return Array.from(filename).some(isControlCharacter);
 }
 
 export function buildContentDisposition(filename: string) {

--- a/src/features/uploads/lib/upload-utils.ts
+++ b/src/features/uploads/lib/upload-utils.ts
@@ -8,11 +8,45 @@ export function normalizeContentType(value: unknown) {
   return trimmed.length > 0 ? trimmed : "application/octet-stream";
 }
 
+const HEADER_UNSAFE_FILENAME_CHARACTERS = /[^\x20-\x7e]|["\\]/gu;
+
+function isControlCharacter(character: string) {
+  const code = character.charCodeAt(0);
+  return code < 32 || code === 127;
+}
+
 export function sanitizeFilename(filename: string) {
-  return filename.trim();
+  let sanitized = "";
+  let previousWasReplacement = false;
+
+  for (const character of filename) {
+    if (isControlCharacter(character)) {
+      if (!previousWasReplacement) {
+        sanitized += " ";
+        previousWasReplacement = true;
+      }
+      continue;
+    }
+
+    sanitized += character;
+    previousWasReplacement = false;
+  }
+
+  return sanitized.trim();
+}
+
+export function hasFilenameControlCharacters(filename: string) {
+  return Array.from(filename).some(isControlCharacter);
 }
 
 export function buildContentDisposition(filename: string) {
-  const safeName = filename.replace(/"/g, "'");
-  return `attachment; filename="${safeName}"`;
+  const safeName = sanitizeFilename(filename) || "download";
+  const fallbackName =
+    safeName.replace(HEADER_UNSAFE_FILENAME_CHARACTERS, "_") || "download";
+  const encodedName = encodeURIComponent(safeName).replace(
+    /['()*]/g,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+
+  return `attachment; filename="${fallbackName}"; filename*=UTF-8''${encodedName}`;
 }

--- a/src/features/uploads/server/upload-service.ts
+++ b/src/features/uploads/server/upload-service.ts
@@ -67,6 +67,12 @@ type PublicUpload = {
   size: number;
 };
 
+type UploadCompletionFailureCode = "Quota exceeded" | "Upload session expired";
+
+type UploadCompletionResult =
+  | { ok: true; upload: PublicUpload; usedBytes: number }
+  | { ok: false; code: UploadCompletionFailureCode };
+
 export function publicUploadPayload(upload: PublicUpload) {
   return {
     id: upload.id,
@@ -138,60 +144,122 @@ export async function completeUploadSession(
     throw new UploadError("Upload session expired");
   }
 
-  const existing = await prisma.upload.findUnique({
-    where: { key: input.key },
-  });
-  if (existing) {
-    if (existing.userId !== userId) {
-      throw new UploadError("Upload session expired");
-    }
-    await prisma.uploadPending.deleteMany({
-      where: { key: input.key, userId },
+  const existing = await findExistingUploadUsagePayload(input.key, userId, now);
+  if (existing) return existing;
+
+  try {
+    await assertActivePendingUpload({
+      key: input.key,
+      now,
+      userId,
     });
-    const usedBytes = await getUploadUsedBytes({ prisma, userId, now });
-    return uploadUsagePayload(existing, usedBytes || existing.size);
+  } catch (error) {
+    if (error instanceof UploadError) {
+      const completed = await findExistingUploadUsagePayload(
+        input.key,
+        userId,
+        new Date(),
+      );
+      if (completed) return completed;
+    }
+    throw error;
+  }
+
+  let uploadedObject: Awaited<ReturnType<typeof validateUploadedObject>>;
+  try {
+    uploadedObject = await validateUploadedObject(input);
+  } catch (error) {
+    if (error instanceof UploadError) {
+      await deletePendingUpload(input.key, userId);
+    }
+    throw error;
   }
 
   const reservation = await runUploadSerializableTransaction(async (tx) => {
+    const completed = await tx.upload.findUnique({
+      where: { key: input.key },
+    });
+    if (completed) {
+      if (completed.userId !== userId) {
+        return {
+          ok: false,
+          code: "Upload session expired",
+        } satisfies UploadCompletionResult;
+      }
+      await tx.uploadPending.deleteMany({
+        where: { key: input.key, userId },
+      });
+      const usedBytes = await getUploadUsedBytes({
+        prisma: tx,
+        userId,
+        now: new Date(),
+      });
+      return {
+        ok: true,
+        upload: completed,
+        usedBytes: usedBytes || completed.size,
+      } satisfies UploadCompletionResult;
+    }
+
     const pending = await tx.uploadPending.findUnique({
       where: { key: input.key },
     });
     if (!pending || pending.userId !== userId) {
-      throw new UploadError("Upload session expired");
+      return {
+        ok: false,
+        code: "Upload session expired",
+      } satisfies UploadCompletionResult;
     }
 
-    if (pending.expiresAt < now) {
-      await tx.uploadPending.delete({ where: { key: input.key } });
-      throw new UploadError("Upload session expired");
+    const transactionNow = new Date();
+    if (pending.expiresAt < transactionNow) {
+      await tx.uploadPending.deleteMany({
+        where: { key: input.key, userId },
+      });
+      return {
+        ok: false,
+        code: "Upload session expired",
+      } satisfies UploadCompletionResult;
     }
-
-    const { contentType, size } = await validateUploadedObject(input);
 
     const usedBytes = await getUploadUsedBytes({
       excludePendingKey: input.key,
       prisma: tx,
       userId,
-      now,
+      now: transactionNow,
     });
-    if (usedBytes + size > uploadConfig.totalQuotaBytes) {
-      await tx.uploadPending.delete({ where: { key: input.key } });
-      throw new UploadError("Quota exceeded");
+    if (usedBytes + uploadedObject.size > uploadConfig.totalQuotaBytes) {
+      await tx.uploadPending.deleteMany({
+        where: { key: input.key, userId },
+      });
+      return {
+        ok: false,
+        code: "Quota exceeded",
+      } satisfies UploadCompletionResult;
     }
 
     const upload = await tx.upload.create({
       data: {
-        contentType,
+        contentType: uploadedObject.contentType,
         filename: input.filename,
         key: input.key,
-        size,
+        size: uploadedObject.size,
         userId,
       },
     });
 
-    await tx.uploadPending.delete({ where: { key: input.key } });
+    await tx.uploadPending.deleteMany({ where: { key: input.key, userId } });
 
-    return { upload, usedBytes: usedBytes + size };
+    return {
+      ok: true,
+      upload,
+      usedBytes: usedBytes + uploadedObject.size,
+    } satisfies UploadCompletionResult;
   }, "Failed to finalize upload quota");
+
+  if (!reservation.ok) {
+    throw new UploadError(reservation.code);
+  }
 
   return uploadUsagePayload(reservation.upload, reservation.usedBytes);
 }
@@ -437,6 +505,53 @@ async function deleteExpiredPendingUploads(
   await uploadPrisma.uploadPending.deleteMany({
     where: { userId, expiresAt: { lt: now } },
   });
+}
+
+async function deletePendingUpload(key: string, userId: string) {
+  await prisma.uploadPending.deleteMany({
+    where: { key, userId },
+  });
+}
+
+async function findExistingUploadUsagePayload(
+  key: string,
+  userId: string,
+  now: Date,
+) {
+  const existing = await prisma.upload.findUnique({
+    where: { key },
+  });
+  if (!existing) return null;
+  if (existing.userId !== userId) {
+    throw new UploadError("Upload session expired");
+  }
+
+  await deletePendingUpload(key, userId);
+  const usedBytes = await getUploadUsedBytes({ prisma, userId, now });
+  return uploadUsagePayload(existing, usedBytes || existing.size);
+}
+
+async function assertActivePendingUpload(input: {
+  key: string;
+  now: Date;
+  userId: string;
+}) {
+  const pending = await prisma.uploadPending.findUnique({
+    where: { key: input.key },
+    select: {
+      expiresAt: true,
+      userId: true,
+    },
+  });
+
+  if (!pending || pending.userId !== input.userId) {
+    throw new UploadError("Upload session expired");
+  }
+
+  if (pending.expiresAt < input.now) {
+    await deletePendingUpload(input.key, input.userId);
+    throw new UploadError("Upload session expired");
+  }
 }
 
 async function getUploadUsedBytes(input: {

--- a/src/lib/AGENTS.md
+++ b/src/lib/AGENTS.md
@@ -15,6 +15,7 @@ oauth/     OAuth provider, tokens
 storage/   Cloudflare R2 object helpers
 security/  CSP, content security
 time/      Date parsing, serialization
+text/      Pure string/text helpers
 log/       Structured logging
 ```
 

--- a/src/lib/api/schemas/request-upload-mutation-schemas.ts
+++ b/src/lib/api/schemas/request-upload-mutation-schemas.ts
@@ -1,17 +1,38 @@
 import * as z from "zod";
+import { hasFilenameControlCharacters } from "@/features/uploads/lib/upload-utils";
+
+const filenameControlCharacterMessage =
+  "Filename contains unsupported control characters";
+
+const uploadFilenameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((filename) => !hasFilenameControlCharacters(filename), {
+    message: filenameControlCharacterMessage,
+  });
+
+const uploadRenameFilenameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(255)
+  .refine((filename) => !hasFilenameControlCharacters(filename), {
+    message: filenameControlCharacterMessage,
+  });
 
 export const uploadCreateRequestSchema = z.object({
-  filename: z.string().trim().min(1),
+  filename: uploadFilenameSchema,
   contentType: z.string().optional(),
   size: z.union([z.string(), z.number()]),
 });
 
 export const uploadCompleteRequestSchema = z.object({
   key: z.string().trim().min(1),
-  filename: z.string().trim().min(1),
+  filename: uploadFilenameSchema,
   contentType: z.string().optional(),
 });
 
 export const uploadRenameRequestSchema = z.object({
-  filename: z.string().trim().min(1).max(255),
+  filename: uploadRenameFilenameSchema,
 });

--- a/src/lib/api/schemas/request-upload-mutation-schemas.ts
+++ b/src/lib/api/schemas/request-upload-mutation-schemas.ts
@@ -1,5 +1,5 @@
 import * as z from "zod";
-import { hasFilenameControlCharacters } from "@/features/uploads/lib/upload-utils";
+import { hasAsciiControlCharacters } from "@/lib/text/ascii-control-characters";
 
 const filenameControlCharacterMessage =
   "Filename contains unsupported control characters";
@@ -8,7 +8,7 @@ const uploadFilenameSchema = z
   .string()
   .trim()
   .min(1)
-  .refine((filename) => !hasFilenameControlCharacters(filename), {
+  .refine((filename) => !hasAsciiControlCharacters(filename), {
     message: filenameControlCharacterMessage,
   });
 
@@ -17,7 +17,7 @@ const uploadRenameFilenameSchema = z
   .trim()
   .min(1)
   .max(255)
-  .refine((filename) => !hasFilenameControlCharacters(filename), {
+  .refine((filename) => !hasAsciiControlCharacters(filename), {
     message: filenameControlCharacterMessage,
   });
 

--- a/src/lib/text/ascii-control-characters.ts
+++ b/src/lib/text/ascii-control-characters.ts
@@ -1,0 +1,8 @@
+export function isAsciiControlCharacter(character: string) {
+  const code = character.charCodeAt(0);
+  return code < 32 || code === 127;
+}
+
+export function hasAsciiControlCharacters(value: string) {
+  return Array.from(value).some(isAsciiControlCharacter);
+}

--- a/tests/unit/api-schemas.test.ts
+++ b/tests/unit/api-schemas.test.ts
@@ -21,7 +21,9 @@ import {
   sectionsQuerySchema,
   todoCreateRequestSchema,
   todosQuerySchema,
+  uploadCompleteRequestSchema,
   uploadCreateRequestSchema,
+  uploadRenameRequestSchema,
 } from "@/lib/api/schemas/request-schemas";
 import {
   meResponseSchema,
@@ -192,6 +194,26 @@ describe("other request schemas", () => {
       size: "123",
     });
     expect(valid.success).toBe(true);
+  });
+
+  it("rejects upload filenames with control characters", () => {
+    expect(
+      uploadCreateRequestSchema.safeParse({
+        filename: "a\nb.txt",
+        size: "123",
+      }).success,
+    ).toBe(false);
+    expect(
+      uploadCompleteRequestSchema.safeParse({
+        key: "uploads/user-1/a.txt",
+        filename: "a\rb.txt",
+      }).success,
+    ).toBe(false);
+    expect(
+      uploadRenameRequestSchema.safeParse({
+        filename: "a\u0000b.txt",
+      }).success,
+    ).toBe(false);
   });
 
   it("validates comment list public target identifiers", () => {

--- a/tests/unit/upload-completion-service.test.ts
+++ b/tests/unit/upload-completion-service.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { uploadConfig } from "@/features/uploads/lib/upload-config";
+import { completeUploadSession } from "@/features/uploads/server/upload-service";
+
+const {
+  deleteStorageObjectMock,
+  headStorageObjectMock,
+  pendingAggregateMock,
+  pendingDeleteManyMock,
+  pendingFindUniqueMock,
+  runSerializableTransactionMock,
+  txPendingAggregateMock,
+  txPendingDeleteManyMock,
+  txPendingFindUniqueMock,
+  txUploadAggregateMock,
+  txUploadCreateMock,
+  txUploadFindUniqueMock,
+  uploadAggregateMock,
+  uploadFindUniqueMock,
+} = vi.hoisted(() => ({
+  deleteStorageObjectMock: vi.fn(),
+  headStorageObjectMock: vi.fn(),
+  pendingAggregateMock: vi.fn(),
+  pendingDeleteManyMock: vi.fn(),
+  pendingFindUniqueMock: vi.fn(),
+  runSerializableTransactionMock: vi.fn(),
+  txPendingAggregateMock: vi.fn(),
+  txPendingDeleteManyMock: vi.fn(),
+  txPendingFindUniqueMock: vi.fn(),
+  txUploadAggregateMock: vi.fn(),
+  txUploadCreateMock: vi.fn(),
+  txUploadFindUniqueMock: vi.fn(),
+  uploadAggregateMock: vi.fn(),
+  uploadFindUniqueMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    upload: {
+      aggregate: uploadAggregateMock,
+      findUnique: uploadFindUniqueMock,
+    },
+    uploadPending: {
+      aggregate: pendingAggregateMock,
+      deleteMany: pendingDeleteManyMock,
+      findUnique: pendingFindUniqueMock,
+    },
+  },
+}));
+
+vi.mock("@/lib/db/serializable-transaction", () => ({
+  runSerializableTransaction: runSerializableTransactionMock,
+}));
+
+vi.mock("@/lib/storage/r2-object", () => ({
+  deleteStorageObject: deleteStorageObjectMock,
+  headStorageObject: headStorageObjectMock,
+}));
+
+vi.mock("@/lib/audit/write-audit-log", () => ({
+  fireAuditLog: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/viewer-context", () => ({
+  getViewerContext: vi.fn(),
+}));
+
+vi.mock("@/lib/log/app-logger", () => ({
+  logAppEvent: vi.fn(),
+}));
+
+const FIXED_NOW = new Date("2026-01-15T00:00:00.000Z");
+const KEY = "uploads/user-1/test.txt";
+const USER_ID = "user-1";
+
+const validPending = {
+  expiresAt: new Date(FIXED_NOW.getTime() + 60_000),
+  userId: USER_ID,
+};
+
+const createdUpload = {
+  createdAt: FIXED_NOW,
+  filename: "test.txt",
+  id: "upload-1",
+  key: KEY,
+  size: 10,
+  userId: USER_ID,
+};
+
+const txPrisma = {
+  upload: {
+    aggregate: txUploadAggregateMock,
+    create: txUploadCreateMock,
+    findUnique: txUploadFindUniqueMock,
+  },
+  uploadPending: {
+    aggregate: txPendingAggregateMock,
+    deleteMany: txPendingDeleteManyMock,
+    findUnique: txPendingFindUniqueMock,
+  },
+};
+
+describe("completeUploadSession", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+
+    pendingDeleteManyMock.mockResolvedValue({ count: 0 });
+    pendingFindUniqueMock.mockResolvedValue(validPending);
+    uploadFindUniqueMock.mockResolvedValue(null);
+
+    headStorageObjectMock.mockResolvedValue({
+      contentType: "text/plain",
+      size: 10,
+    });
+    deleteStorageObjectMock.mockResolvedValue(undefined);
+
+    txUploadFindUniqueMock.mockResolvedValue(null);
+    txPendingFindUniqueMock.mockResolvedValue(validPending);
+    txUploadAggregateMock.mockResolvedValue({ _sum: { size: 0 } });
+    txPendingAggregateMock.mockResolvedValue({ _sum: { size: 0 } });
+    txUploadCreateMock.mockResolvedValue(createdUpload);
+    txPendingDeleteManyMock.mockResolvedValue({ count: 1 });
+    runSerializableTransactionMock.mockImplementation(async (action) =>
+      action(txPrisma),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("validates the uploaded object before opening the serializable transaction", async () => {
+    const calls: string[] = [];
+    headStorageObjectMock.mockImplementation(async () => {
+      calls.push("head");
+      return { contentType: "text/plain", size: 10 };
+    });
+    runSerializableTransactionMock.mockImplementation(async (action) => {
+      calls.push("transaction");
+      return action(txPrisma);
+    });
+
+    await expect(
+      completeUploadSession(USER_ID, {
+        filename: "test.txt",
+        key: KEY,
+      }),
+    ).resolves.toMatchObject({
+      upload: { id: "upload-1", key: KEY },
+      usedBytes: 10,
+    });
+
+    expect(calls).toEqual(["head", "transaction"]);
+    expect(txUploadCreateMock).toHaveBeenCalledWith({
+      data: {
+        contentType: "application/octet-stream",
+        filename: "test.txt",
+        key: KEY,
+        size: 10,
+        userId: USER_ID,
+      },
+    });
+  });
+
+  it("deletes pending quota outside the transaction when object validation fails", async () => {
+    headStorageObjectMock.mockResolvedValue({ size: 0 });
+
+    await expect(
+      completeUploadSession(USER_ID, {
+        filename: "test.txt",
+        key: KEY,
+      }),
+    ).rejects.toMatchObject({ code: "Uploaded object missing" });
+
+    expect(runSerializableTransactionMock).not.toHaveBeenCalled();
+    expect(pendingDeleteManyMock).toHaveBeenLastCalledWith({
+      where: { key: KEY, userId: USER_ID },
+    });
+  });
+
+  it("returns a concurrently completed upload instead of validating storage again", async () => {
+    pendingFindUniqueMock.mockResolvedValue(null);
+    uploadFindUniqueMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(createdUpload);
+    uploadAggregateMock.mockResolvedValue({ _sum: { size: 10 } });
+    pendingAggregateMock.mockResolvedValue({ _sum: { size: 0 } });
+
+    await expect(
+      completeUploadSession(USER_ID, {
+        filename: "test.txt",
+        key: KEY,
+      }),
+    ).resolves.toMatchObject({
+      upload: { id: "upload-1", key: KEY },
+      usedBytes: 10,
+    });
+
+    expect(headStorageObjectMock).not.toHaveBeenCalled();
+    expect(runSerializableTransactionMock).not.toHaveBeenCalled();
+    expect(pendingDeleteManyMock).toHaveBeenLastCalledWith({
+      where: { key: KEY, userId: USER_ID },
+    });
+  });
+
+  it("commits pending cleanup when the reservation expires before the transaction recheck", async () => {
+    const expiringPending = {
+      expiresAt: new Date(FIXED_NOW.getTime() + 1_000),
+      userId: USER_ID,
+    };
+    pendingFindUniqueMock.mockResolvedValue(expiringPending);
+    txPendingFindUniqueMock.mockResolvedValue(expiringPending);
+    headStorageObjectMock.mockImplementation(async () => {
+      vi.setSystemTime(new Date(FIXED_NOW.getTime() + 2_000));
+      return { contentType: "text/plain", size: 10 };
+    });
+    let transactionActionCompleted = false;
+    runSerializableTransactionMock.mockImplementation(async (action) => {
+      const result = await action(txPrisma);
+      transactionActionCompleted = true;
+      return result;
+    });
+
+    await expect(
+      completeUploadSession(USER_ID, {
+        filename: "test.txt",
+        key: KEY,
+      }),
+    ).rejects.toMatchObject({ code: "Upload session expired" });
+
+    expect(transactionActionCompleted).toBe(true);
+    expect(txPendingDeleteManyMock).toHaveBeenCalledWith({
+      where: { key: KEY, userId: USER_ID },
+    });
+    expect(txUploadCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("commits pending cleanup when quota validation fails in the transaction", async () => {
+    txUploadAggregateMock.mockResolvedValue({
+      _sum: { size: uploadConfig.totalQuotaBytes },
+    });
+
+    await expect(
+      completeUploadSession(USER_ID, {
+        filename: "test.txt",
+        key: KEY,
+      }),
+    ).rejects.toMatchObject({ code: "Quota exceeded" });
+
+    expect(txPendingDeleteManyMock).toHaveBeenCalledWith({
+      where: { key: KEY, userId: USER_ID },
+    });
+    expect(txUploadCreateMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/upload-utils.test.ts
+++ b/tests/unit/upload-utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildContentDisposition,
+  hasFilenameControlCharacters,
+  sanitizeFilename,
+} from "@/features/uploads/lib/upload-utils";
+
+function hasHeaderControlCharacters(value: string) {
+  return Array.from(value).some((character) => {
+    const code = character.charCodeAt(0);
+    return code < 32 || code === 127;
+  });
+}
+
+describe("upload filename utilities", () => {
+  it("detects and normalizes filename control characters", () => {
+    expect(hasFilenameControlCharacters("report\nfinal.txt")).toBe(true);
+    expect(hasFilenameControlCharacters("report-final.txt")).toBe(false);
+    expect(sanitizeFilename(" report\r\nfinal\u0000.txt ")).toBe(
+      "report final .txt",
+    );
+  });
+
+  it("builds Content-Disposition without invalid header characters", () => {
+    const header = buildContentDisposition('课程\r\n"final".txt');
+
+    expect(header).toContain('filename="__ _final_.txt"');
+    expect(header).toContain(
+      "filename*=UTF-8''%E8%AF%BE%E7%A8%8B%20%22final%22.txt",
+    );
+    expect(hasHeaderControlCharacters(header)).toBe(false);
+    expect(() => {
+      new Headers({ "Content-Disposition": header });
+    }).not.toThrow();
+  });
+});

--- a/tests/unit/upload-utils.test.ts
+++ b/tests/unit/upload-utils.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   buildContentDisposition,
-  hasFilenameControlCharacters,
   sanitizeFilename,
 } from "@/features/uploads/lib/upload-utils";
+import { hasAsciiControlCharacters } from "@/lib/text/ascii-control-characters";
 
 function hasHeaderControlCharacters(value: string) {
   return Array.from(value).some((character) => {
@@ -14,8 +14,8 @@ function hasHeaderControlCharacters(value: string) {
 
 describe("upload filename utilities", () => {
   it("detects and normalizes filename control characters", () => {
-    expect(hasFilenameControlCharacters("report\nfinal.txt")).toBe(true);
-    expect(hasFilenameControlCharacters("report-final.txt")).toBe(false);
+    expect(hasAsciiControlCharacters("report\nfinal.txt")).toBe(true);
+    expect(hasAsciiControlCharacters("report-final.txt")).toBe(false);
     expect(sanitizeFilename(" report\r\nfinal\u0000.txt ")).toBe(
       "report final .txt",
     );


### PR DESCRIPTION
## Goal

Close #230 and #233 by keeping R2 validation outside the serializable upload transaction, committing failed pending cleanup, and preventing unsafe filenames from reaching download headers.

## Changed Surfaces

- `src/features/uploads/server/upload-service.ts`: preflights pending state, validates R2 object metadata before opening the serializable transaction, rechecks pending/completed state inside the transaction, and returns transaction results so cleanup can commit before throwing route-level errors.
- `src/features/uploads/lib/upload-utils.ts`: rejects/normalizes filename control characters and builds encoded `Content-Disposition` values.
- `src/lib/api/schemas/request-upload-mutation-schemas.ts`: upload create/complete/rename schemas reject filename control characters.
- `docs/contracts/upload.json`: records safe filename behavior.
- Focused upload schema/helper/service tests.

## Evidence

- Focused behavior: `bun run test -- tests/unit/upload-utils.test.ts tests/unit/api-schemas.test.ts tests/unit/upload-completion-service.test.ts tests/unit/upload-object-put-route.test.ts tests/unit/upload-download-permissions.test.ts`
- Formatting/lint: `bunx biome check docs/contracts/upload.json src/features/uploads/lib/upload-utils.ts src/features/uploads/server/upload-service.ts src/lib/api/schemas/request-upload-mutation-schemas.ts tests/unit/api-schemas.test.ts tests/unit/upload-completion-service.test.ts tests/unit/upload-utils.test.ts`
- Worker reported broader local checks: `bun run verify:conventions`; `DATABASE_URL=... bun run verify:types`

## Docs / Contracts

Updated `docs/contracts/upload.json` for safe filename validation/download header behavior. OpenAPI was regenerated by the worker during development and there is no committed generated OpenAPI diff in this PR.

## Risk Areas

- Upload transaction ordering and quota cleanup.
- R2 metadata validation still happens before DB write and route-level object cleanup remains responsible for deleting rejected objects where applicable.
- Filename behavior now rejects ASCII control characters at public request schemas.

## Cleanup

Diff reviewed for unrelated edits. No scratch artifacts or temporary probes are included.