### PR TITLE
fix(dashboard): sync calendar navigation and homework errors

### DIFF
--- a/src/features/dashboard/components/DashboardPageController.svelte
+++ b/src/features/dashboard/components/DashboardPageController.svelte
@@ -65,7 +65,7 @@ import {
   todoPriorityOptions as buildTodoPriorityOptions,
   todoPriorityClass,
 } from "@/features/dashboard/lib/todos";
-import { invalidateAll, replaceState } from "$app/navigation";
+import { goto, invalidateAll, replaceState } from "$app/navigation";
 import { page } from "$app/stores";
 import { Alert } from "$lib/components/ui/alert/index.js";
 import AnonymousDashboardView from "./AnonymousDashboardView.svelte";
@@ -113,6 +113,7 @@ let {
   examView,
   filteredExamRows,
   filteredTodos,
+  homeworkActionError,
   homeworkFilter,
   homeworkItems,
   homeworkReferenceDate,
@@ -369,6 +370,9 @@ const { toggleHomeworkCompletion } = createDashboardHomeworkStateActions({
   getHomeworkSavingById: () => homeworkSavingById,
   getHomeworksCopy: () => homeworksCopy,
   getSelectedHomework: () => selectedHomework,
+  setHomeworkActionError: (value) => {
+    homeworkActionError = value;
+  },
   setHomeworkItems: (value) => {
     homeworkItems = value;
   },
@@ -440,6 +444,9 @@ const {
   getCalendarSemesterId: () => calendarSemesterId,
   getCalendarView: () => calendarView,
   getCalendarWeekStart: () => calendarWeekStart,
+  navigateUrl: (href) => {
+    void goto(href, { noScroll: true, replaceState: true });
+  },
   replaceUrl: (href) => {
     window.history.replaceState({}, "", href);
   },
@@ -581,6 +588,7 @@ onMount(() => {
         {examView}
         {filteredExamRows}
         {filteredTodos}
+        {homeworkActionError}
         {homeworkCopy}
         {homeworkReferenceDate}
         {homeworksCopy}

--- a/src/features/dashboard/components/HomeworksTab.svelte
+++ b/src/features/dashboard/components/HomeworksTab.svelte
@@ -16,6 +16,7 @@ import type {
 import { filterDashboardHomeworks } from "@/features/dashboard/lib/dashboard-homework-filter";
 import { hasDashboardSubscriptions } from "@/features/dashboard/lib/dashboard-subscription-state";
 import { createHomeworkTabDisplayActions } from "@/features/dashboard/lib/homeworks-tab-display";
+import { Alert } from "$lib/components/ui/alert/index.js";
 import DashboardNoSubscriptionsState from "./DashboardNoSubscriptionsState.svelte";
 import type {
   DashboardHomeworkCreateSection,
@@ -42,6 +43,7 @@ export let homeworksCopy: HomeworksCopy;
 export let homeworkCopy: HomeworkCopy;
 export let commentsCopy: CommentsCopy;
 export let signedData: SignedDashboardData;
+export let homeworkActionError: string;
 
 export let locale: string;
 export let referenceDate: Date | string;
@@ -121,6 +123,10 @@ $: ({
       {openCreateHomeworkDialog}
       {setHomeworkView}
     />
+
+    {#if homeworkActionError}
+      <Alert variant="destructive">{homeworkActionError}</Alert>
+    {/if}
 
     {#if homeworkView === "list"}
       <HomeworksListView

--- a/src/features/dashboard/components/SignedDashboardHomeworksTaskBranch.svelte
+++ b/src/features/dashboard/components/SignedDashboardHomeworksTaskBranch.svelte
@@ -18,6 +18,7 @@ export let createHomeworkSubmissionDueAt: DashboardHomeworksTaskProps["createHom
 export let createHomeworkSubmissionStartAt: DashboardHomeworksTaskProps["createHomeworkSubmissionStartAt"];
 export let dashboardCopy: DashboardHomeworksTaskProps["dashboardCopy"];
 export let data: DashboardHomeworksTaskProps["data"];
+export let homeworkActionError: DashboardHomeworksTaskProps["homeworkActionError"];
 export let homeworkCopy: DashboardHomeworksTaskProps["homeworkCopy"];
 export let homeworkFilter: DashboardHomeworksTaskProps["homeworkFilter"];
 export let homeworkItems: DashboardHomeworksTaskProps["homeworkItems"];
@@ -42,6 +43,7 @@ export let toggleHomeworkCompletion: DashboardHomeworksTaskProps["toggleHomework
   {dashboardCopy}
   {sectionCopy}
   {homeworksCopy}
+  {homeworkActionError}
   {homeworkCopy}
   {commentsCopy}
   {signedData}

--- a/src/features/dashboard/components/SignedDashboardTaskTabs.svelte
+++ b/src/features/dashboard/components/SignedDashboardTaskTabs.svelte
@@ -38,6 +38,7 @@ export let examTimeLabel: DashboardTaskTabsProps["examTimeLabel"];
 export let examView: DashboardTaskTabsProps["examView"];
 export let filteredExamRows: DashboardTaskTabsProps["filteredExamRows"];
 export let filteredTodos: DashboardTaskTabsProps["filteredTodos"];
+export let homeworkActionError: string;
 export let homeworkCopy: DashboardTaskTabsProps["homeworkCopy"];
 export let homeworkFilter: DashboardTaskTabsProps["homeworkFilter"];
 export let homeworkItems: DashboardTaskTabsProps["homeworkItems"];
@@ -110,6 +111,7 @@ export let updateTodoAction: DashboardTaskTabsProps["updateTodoAction"];
     {sectionCopy}
     {homeworksCopy}
     {homeworkCopy}
+    {homeworkActionError}
     {commentsCopy}
     {data}
     {signedData}

--- a/src/features/dashboard/components/dashboard-task-component-types.ts
+++ b/src/features/dashboard/components/dashboard-task-component-types.ts
@@ -80,6 +80,7 @@ export type DashboardHomeworksTaskProps = DashboardTaskBaseProps & {
   createHomeworkSectionId: DashboardTaskStringDraft;
   createHomeworkSubmissionDueAt: DashboardTaskStringDraft;
   createHomeworkSubmissionStartAt: DashboardTaskStringDraft;
+  homeworkActionError: string;
   homeworkCopy: DashboardTaskHomeworkCopy;
   homeworkFilter: HomeworkFilter;
   homeworkItems: DashboardHomeworkItem[];

--- a/src/features/dashboard/lib/dashboard-controller-calendar-actions.ts
+++ b/src/features/dashboard/lib/dashboard-controller-calendar-actions.ts
@@ -19,6 +19,7 @@ export function createDashboardCalendarActions(input: {
   getCalendarSemesterId: () => number | null;
   getCalendarView: () => CalendarView;
   getCalendarWeekStart: () => string;
+  navigateUrl: (href: string) => void | Promise<void>;
   replaceUrl: (href: string) => void;
   setCalendarMonth: (value: string) => void;
   setCalendarSemesterId: (value: number | null) => void;
@@ -84,7 +85,7 @@ export function createDashboardCalendarActions(input: {
       tabHref: input.tabHref,
     });
     applyCalendarState(next.state);
-    input.replaceUrl(next.href);
+    void input.navigateUrl(next.href);
   }
 
   function calendarSemesterHref(calendar: CalendarData, offset: number) {

--- a/src/features/dashboard/lib/dashboard-controller-default-state.ts
+++ b/src/features/dashboard/lib/dashboard-controller-default-state.ts
@@ -50,6 +50,7 @@ export function createDashboardControllerDefaultState() {
     examView: "cards" as ExamView,
     filteredExamRows: [] as ExamRow[],
     filteredTodos: [] as TodoItem[],
+    homeworkActionError: "",
     homeworkFilter: "incomplete" as HomeworkFilter,
     homeworkItems: [] as HomeworkItem[],
     homeworkReferenceDate: new Date(),

--- a/src/features/dashboard/lib/dashboard-controller-homework-state-actions.ts
+++ b/src/features/dashboard/lib/dashboard-controller-homework-state-actions.ts
@@ -10,6 +10,7 @@ export function createDashboardHomeworkStateActions(input: {
   getHomeworkSavingById: () => Record<string, boolean>;
   getHomeworksCopy: () => HomeworkActionsCopy;
   getSelectedHomework: () => HomeworkItem | null;
+  setHomeworkActionError: (value: string) => void;
   setHomeworkItems: (value: HomeworkItem[]) => void;
   setHomeworkSavingById: (value: Record<string, boolean>) => void;
   setSelectedHomework: (value: HomeworkItem | null) => void;
@@ -23,6 +24,7 @@ export function createDashboardHomeworkStateActions(input: {
 
   async function toggleHomeworkCompletion(homework: HomeworkItem) {
     if (input.getHomeworkSavingById()[homework.id]) return;
+    input.setHomeworkActionError("");
     setHomeworkSaving(homework.id, true);
     try {
       const nextHomework = await toggleDashboardHomeworkCompletion({
@@ -37,12 +39,8 @@ export function createDashboardHomeworkStateActions(input: {
       if (input.getSelectedHomework()?.id === homework.id) {
         input.setSelectedHomework(nextHomework);
       }
-    } catch (error) {
-      console.error(
-        error instanceof Error
-          ? error.message
-          : input.getHomeworksCopy().completionFailed,
-      );
+    } catch {
+      input.setHomeworkActionError(input.getHomeworksCopy().completionFailed);
     } finally {
       setHomeworkSaving(homework.id, false);
     }

--- a/tests/e2e/src/app/dashboard/calendar/test.ts
+++ b/tests/e2e/src/app/dashboard/calendar/test.ts
@@ -112,7 +112,7 @@ test.describe("dashboard calendar", () => {
     await captureStepScreenshot(page, testInfo, "calendar/exam-link");
   });
 
-  test("semester navigation controls are present", async ({
+  test("semester navigation controls navigate to another semester", async ({
     page,
   }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/calendar");
@@ -123,10 +123,27 @@ test.describe("dashboard calendar", () => {
     });
 
     // calendar.yml: Previous/next semester controls
-    await expect(page.getByText(/上一学期|Previous semester/i)).toBeVisible();
-    await expect(page.getByText(/下一学期|Next semester/i)).toBeVisible();
+    const previousSemester = page.getByRole("button", {
+      name: /上一学期|Previous semester/i,
+    });
+    const nextSemester = page.getByRole("button", {
+      name: /下一学期|Next semester/i,
+    });
+    await expect(previousSemester).toBeVisible();
+    await expect(nextSemester).toBeVisible();
 
-    await captureStepScreenshot(page, testInfo, "calendar/navigation-controls");
+    const navigationButton = (await previousSemester.isEnabled())
+      ? previousSemester
+      : nextSemester;
+    await expect(navigationButton).toBeEnabled();
+
+    const beforeUrl = page.url();
+    await navigationButton.click();
+    await expect(page).toHaveURL(/calendarSemester=\d+/);
+    expect(page.url()).not.toBe(beforeUrl);
+    await expect(page.locator("#main-content")).toBeVisible();
+
+    await captureStepScreenshot(page, testInfo, "calendar/semester-navigation");
   });
 
   test("view toggle switches between semester/month/week", async ({

--- a/tests/e2e/src/app/dashboard/homeworks/test.ts
+++ b/tests/e2e/src/app/dashboard/homeworks/test.ts
@@ -257,6 +257,57 @@ test.describe("dashboard homeworks", () => {
     await expect(homeworksBadge).toHaveText(String(beforeBadge));
   });
 
+  test("completion failure shows localized dashboard error", async ({
+    page,
+  }, testInfo) => {
+    await signInAsDebugUser(page, "/dashboard/homeworks");
+    await ensureSeedSectionSubscription(page);
+    await page.route(/\/api\/homeworks\/[^/]+\/completion$/, async (route) => {
+      await route.fulfill({
+        body: JSON.stringify({ error: { message: "forced failure" } }),
+        contentType: "application/json",
+        status: 500,
+      });
+    });
+    await gotoAndWaitForReady(page, "/dashboard/homeworks", {
+      testInfo,
+      screenshotLabel: "homeworks",
+    });
+
+    await page
+      .getByRole("button", { name: /全部|All/i })
+      .first()
+      .click();
+
+    const card = page
+      .locator('[data-slot="card"]')
+      .filter({ hasText: DEV_SEED.homeworks.title })
+      .first();
+    await expect(card).toBeVisible();
+    await card.hover();
+
+    const completionButton = card
+      .getByRole("button", {
+        name: /标记为完成|取消完成|Mark as complete|Mark as incomplete/i,
+      })
+      .first();
+    await expect(completionButton).toHaveCSS("opacity", "1");
+
+    const completionResponse = page.waitForResponse(
+      (r) =>
+        r.url().includes("/api/homeworks/") &&
+        r.url().includes("/completion") &&
+        r.status() === 500,
+    );
+    await completionButton.click();
+    await completionResponse;
+
+    await expect(
+      page.getByText(/更新完成状态失败|Couldn't update completion/i),
+    ).toBeVisible();
+    await captureStepScreenshot(page, testInfo, "homeworks/completion-error");
+  });
+
   test("view details links to section page with homework anchor", async ({
     page,
   }, testInfo) => {

--- a/tests/unit/dashboard-calendar-actions.test.ts
+++ b/tests/unit/dashboard-calendar-actions.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CalendarView } from "@/features/dashboard/lib/calendar";
+import { createDashboardCalendarActions } from "@/features/dashboard/lib/dashboard-controller-calendar-actions";
+import { dashboardTabHref } from "@/features/dashboard/lib/dashboard-nav";
+
+describe("dashboard calendar actions", () => {
+  function calendarActions() {
+    const navigateUrl = vi.fn();
+    const replaceUrl = vi.fn();
+    let calendarMonth = "2026-02";
+    let calendarSemesterId: number | null = 1;
+    let calendarView: CalendarView = "semester";
+    let calendarWeekStart = "2026-02-22";
+
+    const actions = createDashboardCalendarActions({
+      getCalendarData: () => null,
+      getCalendarMonth: () => calendarMonth,
+      getCalendarSemesterId: () => calendarSemesterId,
+      getCalendarView: () => calendarView,
+      getCalendarWeekStart: () => calendarWeekStart,
+      navigateUrl,
+      replaceUrl,
+      setCalendarMonth: (value) => {
+        calendarMonth = value;
+      },
+      setCalendarSemesterId: (value) => {
+        calendarSemesterId = value;
+      },
+      setCalendarView: (value) => {
+        calendarView = value;
+      },
+      setCalendarWeekStart: (value) => {
+        calendarWeekStart = value;
+      },
+      tabHref: dashboardTabHref,
+    });
+
+    return {
+      actions,
+      navigateUrl,
+      replaceUrl,
+      state: () => ({
+        calendarMonth,
+        calendarSemesterId,
+        calendarView,
+        calendarWeekStart,
+      }),
+    };
+  }
+
+  it("uses navigation for semester changes so dashboard load reruns", () => {
+    const { actions, navigateUrl, replaceUrl, state } = calendarActions();
+
+    actions.setCalendarSemester(2);
+
+    expect(state()).toMatchObject({
+      calendarSemesterId: 2,
+      calendarView: "semester",
+    });
+    expect(navigateUrl).toHaveBeenCalledWith(
+      "/dashboard/calendar?calendarSemester=2",
+    );
+    expect(replaceUrl).not.toHaveBeenCalled();
+  });
+
+  it("keeps month changes as local URL replacements", () => {
+    const { actions, navigateUrl, replaceUrl, state } = calendarActions();
+
+    actions.setCalendarMonth("2026-03");
+
+    expect(state()).toMatchObject({
+      calendarMonth: "2026-03",
+      calendarView: "month",
+    });
+    expect(replaceUrl).toHaveBeenCalledWith(
+      "/dashboard/calendar?calendarView=month&calendarMonth=2026-03&calendarSemester=1",
+    );
+    expect(navigateUrl).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/dashboard-homework-actions.test.ts
+++ b/tests/unit/dashboard-homework-actions.test.ts
@@ -50,4 +50,52 @@ describe("dashboard homework actions", () => {
       homeworkId: "homework-1",
     });
   });
+
+  it("surfaces localized dashboard completion failures", async () => {
+    const homework = {
+      id: "homework-1",
+      completion: null,
+      submissionDueAt: null,
+      title: "Homework",
+    } as HomeworkItem;
+    let homeworkSavingById: Record<string, boolean> = {};
+    const setHomeworkActionError = vi.fn();
+    const setHomeworkItems = vi.fn();
+    const setSelectedHomework = vi.fn();
+    updateHomeworkCompletionMock.mockRejectedValue(
+      new Error("homework not found"),
+    );
+
+    const { createDashboardHomeworkStateActions } = await import(
+      "@/features/dashboard/lib/dashboard-controller-homework-state-actions"
+    );
+
+    const { toggleHomeworkCompletion } = createDashboardHomeworkStateActions({
+      getHomeworkItems: () => [homework],
+      getHomeworkSavingById: () => homeworkSavingById,
+      getHomeworksCopy: () => ({ completionFailed: "completion failed" }),
+      getSelectedHomework: () => homework,
+      setHomeworkActionError,
+      setHomeworkItems,
+      setHomeworkSavingById: (value) => {
+        homeworkSavingById = value;
+      },
+      setSelectedHomework,
+    });
+
+    await toggleHomeworkCompletion(homework);
+
+    expect(updateHomeworkCompletionMock).toHaveBeenCalledWith({
+      completed: true,
+      fallbackMessage: "completion failed",
+      homeworkId: "homework-1",
+    });
+    expect(setHomeworkActionError).toHaveBeenNthCalledWith(1, "");
+    expect(setHomeworkActionError).toHaveBeenLastCalledWith(
+      "completion failed",
+    );
+    expect(homeworkSavingById).toEqual({ "homework-1": false });
+    expect(setHomeworkItems).not.toHaveBeenCalled();
+    expect(setSelectedHomework).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Goal

Close #228 and #231 by making dashboard semester navigation refresh server-backed calendar data and showing visible homework completion errors.

## Changed Surfaces

- Dashboard calendar actions now use SvelteKit navigation for semester changes so the dashboard load reruns and `calendarData` matches the selected semester.
- Dashboard homework completion failures now set a localized visible alert in the homeworks tab instead of only logging to the console.
- Focused unit coverage and dashboard E2E coverage for the navigation/error paths.

## Evidence

- Focused unit behavior: `bun run test -- tests/unit/dashboard-calendar-actions.test.ts tests/unit/dashboard-homework-actions.test.ts`
- Formatting/lint: `bunx biome check` on touched dashboard source/tests
- Worker reported default gate: `DATABASE_URL=... bun run verify`
- Browser evidence: focused Chromium Playwright run passed (`16 passed`) covering dashboard calendar semester navigation and forced homework completion failure alert. It used local Postgres on `127.0.0.1:5432` and Playwright port `3100` because port `3000` was occupied.

## Docs / Contracts

No docs/contracts changed. This is UI behavior only and does not change REST/MCP or data contracts.

## Risk Areas

- Dashboard SvelteKit navigation: semester changes now call `goto(..., { replaceState: true, noScroll: true })`; month/week view URL updates remain local replacements.
- UI error state is intentionally scoped to dashboard homework completion.

## Cleanup

Diff reviewed for unrelated edits. No scratch screenshots, traces, probes, or generated files are included.