### PR TITLE
fix(ui): align accessible control semantics

### DIFF
--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -193,6 +193,7 @@
   "apiDocs": {
     "title": "API Documentation",
     "description": "Interactive API reference generated from the project OpenAPI schema.",
+    "navigationLabel": "API navigation",
     "rawSpecLink": "Open raw OpenAPI JSON"
   },
   "homepage": {

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -193,6 +193,7 @@
   "apiDocs": {
     "title": "API 文档",
     "description": "基于项目 OpenAPI 规范生成的交互式接口文档。",
+    "navigationLabel": "API 导航",
     "rawSpecLink": "打开 OpenAPI 原始 JSON"
   },
   "homepage": {

--- a/src/features/admin/components/AdminBusHeader.svelte
+++ b/src/features/admin/components/AdminBusHeader.svelte
@@ -18,7 +18,7 @@ export let onImport: () => void;
 
 <PageHeader title={copy.title} description={copy.subtitle} eyebrow={adminCopy.title}>
   {#snippet breadcrumb()}
-    <Breadcrumb.Root>
+    <Breadcrumb.Root label={commonCopy.breadcrumb}>
       <Breadcrumb.List>
         <Breadcrumb.Item><Breadcrumb.Link href="/">{commonCopy.home}</Breadcrumb.Link></Breadcrumb.Item>
         <Breadcrumb.Separator />

--- a/src/features/admin/components/AdminDashboardHeader.svelte
+++ b/src/features/admin/components/AdminDashboardHeader.svelte
@@ -14,7 +14,7 @@ export let openItems: number;
 
 <PageHeader title={copy.title} description={copy.subtitle} eyebrow={copy.title}>
   {#snippet breadcrumb()}
-    <Breadcrumb.Root>
+    <Breadcrumb.Root label={commonCopy.breadcrumb}>
       <Breadcrumb.List>
         <Breadcrumb.Item><Breadcrumb.Link href="/">{commonCopy.home}</Breadcrumb.Link></Breadcrumb.Item>
         <Breadcrumb.Separator />

--- a/src/features/admin/components/AdminModerationCommentSuspensionSection.svelte
+++ b/src/features/admin/components/AdminModerationCommentSuspensionSection.svelte
@@ -26,7 +26,11 @@ export let suspensionReason: string;
     <p class="text-base-content/60 text-sm">{copy.suspendAuthorDescription}</p>
   </div>
   <div class="grid gap-2 md:grid-cols-[160px_1fr]">
-    <Select bind:value={suspensionDuration} items={suspensionDurationOptions} />
+    <Select
+      aria-label={copy.suspendExpires}
+      bind:value={suspensionDuration}
+      items={suspensionDurationOptions}
+    />
     {#if suspensionDuration === "custom"}
       <DateTimePicker
         bind:value={customExpiresAt}

--- a/src/features/admin/components/AdminModerationFilters.svelte
+++ b/src/features/admin/components/AdminModerationFilters.svelte
@@ -16,11 +16,14 @@ type ModerationFilters = {
 };
 
 type ModerationFilterCopy = {
+  descriptionContent: string;
+  descriptionTarget: string;
   filterAction: string;
   filterQueue: string;
   filterQueueDescription: string;
   searchAllPlaceholder: string;
   searchPlaceholder: string;
+  status: string;
 };
 
 export let copy: ModerationFilterCopy;
@@ -44,11 +47,13 @@ export let tab: string;
       <input type="hidden" name="tab" value={tab} />
       {#if tab === "descriptions"}
         <Select
+          aria-label={copy.descriptionTarget}
           items={descriptionTargetOptions}
           name="descriptionTarget"
           value={filters.descriptionTarget ?? "all"}
         />
         <Select
+          aria-label={copy.descriptionContent}
           items={descriptionContentOptions}
           name="descriptionContent"
           value={filters.descriptionContent ?? "all"}
@@ -56,6 +61,7 @@ export let tab: string;
         <input type="hidden" name="status" value={filters.status ?? "all"} />
       {:else}
         <Select
+          aria-label={copy.status}
           items={statusFilterOptions}
           name="status"
           value={filters.status ?? "all"}

--- a/src/features/admin/components/AdminModerationHeader.svelte
+++ b/src/features/admin/components/AdminModerationHeader.svelte
@@ -27,7 +27,7 @@ $: currentTabLabel = tabs.find(([id]) => id === currentTab)?.[1] ?? currentTab;
 
 <PageHeader title={copy.title} description={copy.pageDescription} eyebrow={adminCopy.title}>
   {#snippet breadcrumb()}
-    <Breadcrumb.Root>
+    <Breadcrumb.Root label={commonCopy.breadcrumb}>
       <Breadcrumb.List>
         <Breadcrumb.Item><Breadcrumb.Link href="/">{commonCopy.home}</Breadcrumb.Link></Breadcrumb.Item>
         <Breadcrumb.Separator />

--- a/src/features/admin/components/AdminOAuthHeader.svelte
+++ b/src/features/admin/components/AdminOAuthHeader.svelte
@@ -21,7 +21,7 @@ export let onCreate: () => void;
 
 <PageHeader title={copy.adminTitle} description={copy.adminSubtitle} eyebrow={adminCopy.title}>
   {#snippet breadcrumb()}
-    <Breadcrumb.Root>
+    <Breadcrumb.Root label={commonCopy.breadcrumb}>
       <Breadcrumb.List>
         <Breadcrumb.Item><Breadcrumb.Link href="/">{commonCopy.home}</Breadcrumb.Link></Breadcrumb.Item>
         <Breadcrumb.Separator />

--- a/src/features/admin/components/AdminUserSuspensionSection.svelte
+++ b/src/features/admin/components/AdminUserSuspensionSection.svelte
@@ -44,6 +44,7 @@ export let suspensionLabel: AdminUserFormatter;
     <label class="grid gap-2">
       <span class="font-medium text-sm">{moderationCopy.durationLabel}</span>
       <Select
+        aria-label={moderationCopy.durationLabel}
         items={suspendDurationOptions}
         value={suspendDuration}
         onchange={(event) => (suspendDuration = event.currentTarget.value)}

--- a/src/features/admin/components/AdminUsersHeader.svelte
+++ b/src/features/admin/components/AdminUsersHeader.svelte
@@ -16,7 +16,7 @@ export let search: string;
 
 <PageHeader title={copy.title} description={copy.subtitle} eyebrow={adminCopy.title}>
   {#snippet breadcrumb()}
-    <Breadcrumb.Root>
+    <Breadcrumb.Root label={commonCopy.breadcrumb}>
       <Breadcrumb.List>
         <Breadcrumb.Item><Breadcrumb.Link href="/">{commonCopy.home}</Breadcrumb.Link></Breadcrumb.Item>
         <Breadcrumb.Separator />

--- a/src/features/admin/components/admin-bus-types.ts
+++ b/src/features/admin/components/admin-bus-types.ts
@@ -57,5 +57,6 @@ export type AdminBusHeaderAdminCopy = {
 };
 
 export type AdminBusHeaderCommonCopy = {
+  breadcrumb: string;
   home: string;
 };

--- a/src/features/admin/components/admin-moderation-page-types.ts
+++ b/src/features/admin/components/admin-moderation-page-types.ts
@@ -72,6 +72,7 @@ export type AdminModerationAdminCopy = {
 };
 
 export type AdminModerationCommonCopy = {
+  breadcrumb: string;
   home: string;
 };
 

--- a/src/features/admin/components/admin-oauth-client-types.ts
+++ b/src/features/admin/components/admin-oauth-client-types.ts
@@ -14,6 +14,7 @@ export type AdminOAuthAdminCopy = {
 };
 
 export type AdminOAuthCommonCopy = {
+  breadcrumb: string;
   home: string;
 };
 

--- a/src/features/admin/components/admin-user-types.ts
+++ b/src/features/admin/components/admin-user-types.ts
@@ -59,6 +59,7 @@ export type AdminUsersAdminCopy = {
 };
 
 export type AdminUsersCommonCopy = {
+  breadcrumb: string;
   clear: string;
   home: string;
   next: string;

--- a/src/features/admin/lib/admin-dashboard-card-data.ts
+++ b/src/features/admin/lib/admin-dashboard-card-data.ts
@@ -67,6 +67,7 @@ export type AdminDashboardCardData = {
 export type AdminDashboardCopy = AdminDashboardCardData["copy"];
 
 export type AdminDashboardCommonCopy = {
+  breadcrumb: string;
   home: string;
 };
 

--- a/src/features/api-docs/components/ApiDocsPage.svelte
+++ b/src/features/api-docs/components/ApiDocsPage.svelte
@@ -18,10 +18,12 @@ type PageData = {
   copy: {
     apiDocs: {
       description: string;
+      navigationLabel: string;
       rawSpecLink: string;
       title: string;
     };
     common: {
+      breadcrumb: string;
       home: string;
       loading: string;
     };
@@ -147,7 +149,7 @@ function scheduleReferenceRouteRestore() {
 <section class="grid gap-5">
   <PageHeader title={data.copy.apiDocs.title} description={data.copy.apiDocs.description}>
     {#snippet breadcrumb()}
-      <Breadcrumb.Root>
+      <Breadcrumb.Root label={data.copy.common.breadcrumb}>
         <Breadcrumb.List>
           <Breadcrumb.Item><Breadcrumb.Link href="/">{data.copy.common.home}</Breadcrumb.Link></Breadcrumb.Item>
           <Breadcrumb.Separator />
@@ -161,7 +163,7 @@ function scheduleReferenceRouteRestore() {
   </PageHeader>
 
   <div class="api-docs-shell">
-    <aside class="api-docs-sidebar" aria-label="API navigation">
+    <aside class="api-docs-sidebar" aria-label={data.copy.apiDocs.navigationLabel}>
       {#if selectedDocs}
         {#each selectedDocs.groups as group}
           <section class="api-docs-nav-group">

--- a/src/features/catalog/components/CatalogDetailTabs.svelte
+++ b/src/features/catalog/components/CatalogDetailTabs.svelte
@@ -4,19 +4,31 @@ import type { CatalogDetailTab } from "../lib/catalog-detail-navigation";
 
 export let activeTab: CatalogDetailTab;
 export let commentsLabel: string;
+export let idPrefix = "catalog-detail";
 export let sectionsLabel: string;
 export let setActiveTab: (tab: CatalogDetailTab) => void;
+
+$: sectionsTabId = `${idPrefix}-sections-tab`;
+$: commentsTabId = `${idPrefix}-comments-tab`;
+$: sectionsPanelId = `${idPrefix}-sections-panel`;
+$: commentsPanelId = `${idPrefix}-comments-panel`;
 </script>
 
 <Tabs.Root aria-label={sectionsLabel}>
-  <Tabs.List>
+  <Tabs.List semantic>
     <Tabs.Button
+      id={sectionsTabId}
+      panelId={sectionsPanelId}
+      semantic
       selected={activeTab === "sections"}
       onclick={() => setActiveTab("sections")}
     >
       {sectionsLabel}
     </Tabs.Button>
     <Tabs.Button
+      id={commentsTabId}
+      panelId={commentsPanelId}
+      semantic
       selected={activeTab === "comments"}
       onclick={() => setActiveTab("comments")}
     >

--- a/src/features/catalog/components/CatalogPageHeader.svelte
+++ b/src/features/catalog/components/CatalogPageHeader.svelte
@@ -4,6 +4,7 @@ import PageHeaderMeta from "$lib/components/PageHeaderMeta.svelte";
 import * as Breadcrumb from "$lib/components/ui/breadcrumb/index.js";
 
 export let currentLabel: string;
+export let breadcrumbLabel: string;
 export let description: string;
 export let homeLabel: string;
 export let metaLabel: string;
@@ -13,7 +14,7 @@ export let title: string;
 
 <PageHeader {title} {description}>
   {#snippet breadcrumb()}
-    <Breadcrumb.Root>
+    <Breadcrumb.Root label={breadcrumbLabel}>
       <Breadcrumb.List>
         <Breadcrumb.Item><Breadcrumb.Link href="/">{homeLabel}</Breadcrumb.Link></Breadcrumb.Item>
         <Breadcrumb.Separator />

--- a/src/features/catalog/components/CourseDetailPageController.svelte
+++ b/src/features/catalog/components/CourseDetailPageController.svelte
@@ -44,7 +44,7 @@ type CourseDetailData = CatalogNamed & {
 type PageData = {
   commentsData: CatalogDetailCommentsData;
   copy: {
-    common: { courses: string; home: string };
+    common: { breadcrumb: string; courses: string; home: string };
     course: CourseDetailCopy["course"];
     courseDetail: CourseDetailCopy["courseDetail"] & {
       basicInfoDescription: string;
@@ -101,7 +101,7 @@ onMount(() => {
 <section class="grid gap-5">
   <PageHeader title={displayName} description={secondaryDisplayName}>
     {#snippet breadcrumb()}
-      <Breadcrumb.Root>
+      <Breadcrumb.Root label={copy.common.breadcrumb}>
         <Breadcrumb.List>
           <Breadcrumb.Item><Breadcrumb.Link href="/">{copy.common.home}</Breadcrumb.Link></Breadcrumb.Item>
           <Breadcrumb.Separator />
@@ -147,26 +147,41 @@ onMount(() => {
       <CatalogDetailTabs
         {activeTab}
         commentsLabel={copy.courseDetail.tabs.comments}
+        idPrefix="course-detail"
         sectionsLabel={copy.courseDetail.tabs.sections}
         {setActiveTab}
       />
 
       {#if activeTab === "comments"}
-        {#key `comments:course:${data.course.id}`}
-          <CommentsPanel
-            initialData={data.commentsData}
-            targetType="course"
-            targetId={data.course.id}
-          />
-        {/key}
+        <div
+          aria-labelledby="course-detail-comments-tab"
+          id="course-detail-comments-panel"
+          role="tabpanel"
+          tabindex="0"
+        >
+          {#key `comments:course:${data.course.id}`}
+            <CommentsPanel
+              initialData={data.commentsData}
+              targetType="course"
+              targetId={data.course.id}
+            />
+          {/key}
+        </div>
       {:else}
-        <CourseDetailSections
-          copy={detailCopy}
-          course={data.course}
-          {notAvailable}
-          {primaryName}
-          {teacherNames}
-        />
+        <div
+          aria-labelledby="course-detail-sections-tab"
+          id="course-detail-sections-panel"
+          role="tabpanel"
+          tabindex="0"
+        >
+          <CourseDetailSections
+            copy={detailCopy}
+            course={data.course}
+            {notAvailable}
+            {primaryName}
+            {teacherNames}
+          />
+        </div>
       {/if}
     </div>
 

--- a/src/features/catalog/components/CoursesPageController.svelte
+++ b/src/features/catalog/components/CoursesPageController.svelte
@@ -89,6 +89,7 @@ function courseEmptyDescription() {
 
 <section class="grid gap-5">
   <CatalogPageHeader
+    breadcrumbLabel={commonLabels.breadcrumb}
     currentLabel={commonLabels.courses}
     description={courseLabels.subtitle}
     homeLabel={commonLabels.home}

--- a/src/features/catalog/components/SectionsFilters.svelte
+++ b/src/features/catalog/components/SectionsFilters.svelte
@@ -57,7 +57,7 @@ export let updateSectionFilter: SectionListFilterUpdater;
         <div class="flex shrink-0 flex-wrap gap-2">
           <Button class="min-w-28" size="lg" type="submit">{commonLabels.search}</Button>
           <Button
-            aria-label="Help"
+            aria-label={sectionLabels.searchHelpTitle}
             class="mt-auto"
             onclick={() => {
               isSearchHelpOpen = true;

--- a/src/features/catalog/components/SectionsPageController.svelte
+++ b/src/features/catalog/components/SectionsPageController.svelte
@@ -102,6 +102,7 @@ function sectionEmptyDescription() {
 
 <section class="grid gap-5">
   <CatalogPageHeader
+    breadcrumbLabel={commonLabels.breadcrumb}
     currentLabel={commonLabels.sections}
     description={sectionLabels.subtitle}
     homeLabel={commonLabels.home}

--- a/src/features/catalog/components/TeacherDetailPageController.svelte
+++ b/src/features/catalog/components/TeacherDetailPageController.svelte
@@ -44,7 +44,7 @@ type PageData = {
   commentsData: CatalogDetailCommentsData;
   copy: {
     comments: { title: string };
-    common: { home: string; teachers: string };
+    common: { breadcrumb: string; home: string; teachers: string };
     descriptions: CatalogDetailDescriptionCopy;
     metadata: { pages: { teacherDetail: string } };
     teacherDetail: TeacherDetailCopy["teacherDetail"] & {
@@ -92,7 +92,7 @@ onMount(() => {
 <section class="grid gap-5">
   <PageHeader title={displayName} description={data.teacher.department ? primaryName(data.teacher.department) : ""}>
     {#snippet breadcrumb()}
-      <Breadcrumb.Root>
+      <Breadcrumb.Root label={copy.common.breadcrumb}>
         <Breadcrumb.List>
           <Breadcrumb.Item><Breadcrumb.Link href="/">{copy.common.home}</Breadcrumb.Link></Breadcrumb.Item>
           <Breadcrumb.Separator />
@@ -124,26 +124,41 @@ onMount(() => {
       <CatalogDetailTabs
         {activeTab}
         commentsLabel={copy.comments.title}
+        idPrefix="teacher-detail"
         sectionsLabel={copy.teacherDetail.teachingSectionsTitle}
         {setActiveTab}
       />
 
       {#if activeTab === "comments"}
-        {#key `comments:teacher:${data.teacher.id}`}
-          <CommentsPanel
-            initialData={data.commentsData}
-            targetType="teacher"
-            targetId={data.teacher.id}
-          />
-        {/key}
+        <div
+          aria-labelledby="teacher-detail-comments-tab"
+          id="teacher-detail-comments-panel"
+          role="tabpanel"
+          tabindex="0"
+        >
+          {#key `comments:teacher:${data.teacher.id}`}
+            <CommentsPanel
+              initialData={data.commentsData}
+              targetType="teacher"
+              targetId={data.teacher.id}
+            />
+          {/key}
+        </div>
       {:else}
-        <TeacherDetailSections
-          copy={detailCopy}
-          {notAvailable}
-          {primaryName}
-          {secondaryName}
-          teacher={data.teacher}
-        />
+        <div
+          aria-labelledby="teacher-detail-sections-tab"
+          id="teacher-detail-sections-panel"
+          role="tabpanel"
+          tabindex="0"
+        >
+          <TeacherDetailSections
+            copy={detailCopy}
+            {notAvailable}
+            {primaryName}
+            {secondaryName}
+            teacher={data.teacher}
+          />
+        </div>
       {/if}
     </div>
 

--- a/src/features/catalog/components/TeachersPageController.svelte
+++ b/src/features/catalog/components/TeachersPageController.svelte
@@ -89,6 +89,7 @@ function updateTeacherFilter(overrides: Partial<TeacherListFilters>) {
 
 <section class="grid gap-5">
   <CatalogPageHeader
+    breadcrumbLabel={commonLabels.breadcrumb}
     currentLabel={commonLabels.teachers}
     description={teacherLabels.subtitle}
     homeLabel={commonLabels.home}

--- a/src/features/catalog/components/catalog-course-list-types.ts
+++ b/src/features/catalog/components/catalog-course-list-types.ts
@@ -4,6 +4,7 @@ export type CourseListCommonLabels = {
   allCategories: string;
   allClassTypes: string;
   allEducationLevels: string;
+  breadcrumb: string;
   clear: string;
   next: string;
   nextPage: string;

--- a/src/features/catalog/components/catalog-section-list-types.ts
+++ b/src/features/catalog/components/catalog-section-list-types.ts
@@ -1,6 +1,7 @@
 import type { CatalogNamed } from "@/features/catalog/lib/catalog-list-display";
 
 export type SectionListCommonLabels = {
+  breadcrumb: string;
   clear: string;
   next: string;
   nextPage: string;

--- a/src/features/catalog/components/catalog-teacher-list-types.ts
+++ b/src/features/catalog/components/catalog-teacher-list-types.ts
@@ -1,6 +1,7 @@
 import type { CatalogNamed } from "@/features/catalog/lib/catalog-list-display";
 
 export type TeacherListCommonLabels = {
+  breadcrumb: string;
   clear: string;
   next: string;
   nextPage: string;

--- a/src/features/comments/components/CommentComposerHeader.svelte
+++ b/src/features/comments/components/CommentComposerHeader.svelte
@@ -27,6 +27,7 @@ export let visibilityOptions: CommentSelectOption[];
         <span>{commentCopy.visibilityAnonymous}</span>
       </label>
       <Select
+        aria-label={commentCopy.visibilityLabel}
         bind:value={visibility}
         disabled={!viewer.isAuthenticated || viewer.isSuspended}
         items={visibilityOptions}

--- a/src/features/comments/components/CommentComposerTargetSelect.svelte
+++ b/src/features/comments/components/CommentComposerTargetSelect.svelte
@@ -18,6 +18,7 @@ export let viewer: ViewerContext;
       {commentCopy.commentTargetPlaceholder}
     </span>
     <Select
+      aria-label={commentCopy.commentTargetPlaceholder}
       bind:value={postTargetKey}
       disabled={!viewer.isAuthenticated || viewer.isSuspended}
       items={postTargetOptions}

--- a/src/features/comments/components/CommentReplyEditor.svelte
+++ b/src/features/comments/components/CommentReplyEditor.svelte
@@ -70,6 +70,7 @@ $: replyDisabled = !viewer.isAuthenticated || viewer.isSuspended;
       <span>{commentCopy.visibilityAnonymous}</span>
     </label>
     <Select
+      aria-label={commentCopy.visibilityLabel}
       bind:value={replyVisibility}
       disabled={replyDisabled}
       items={visibilityOptions}

--- a/src/features/comments/components/CommentThreadEditForm.svelte
+++ b/src/features/comments/components/CommentThreadEditForm.svelte
@@ -38,7 +38,11 @@ export let visibilityOptions: CommentSelectOption[];
       <Checkbox bind:checked={editIsAnonymous} />
       <span>{commentCopy.visibilityAnonymous}</span>
     </label>
-    <Select bind:value={editVisibility} items={visibilityOptions} />
+    <Select
+      aria-label={commentCopy.visibilityLabel}
+      bind:value={editVisibility}
+      items={visibilityOptions}
+    />
   </div>
   <MarkdownEditor
     bind:value={editDraft}

--- a/src/features/comments/components/comment-component-types.ts
+++ b/src/features/comments/components/comment-component-types.ts
@@ -62,6 +62,7 @@ export type CommentsCopy = {
   tabWrite: string;
   ustcVerified: string;
   visibilityAnonymous: string;
+  visibilityLabel: string;
   visibilityLoggedIn: string;
   visibilityPublic: string;
 };

--- a/src/features/descriptions/components/DescriptionReadPanel.svelte
+++ b/src/features/descriptions/components/DescriptionReadPanel.svelte
@@ -21,21 +21,47 @@ export let history: DescriptionHistoryItem[];
 </script>
 
 <Tabs.Root aria-label={copy.title}>
-  <Tabs.List>
-    <Tabs.Button selected={activePanelTab === "description"} onclick={() => (activePanelTab = "description")}>{copy.title}</Tabs.Button>
-    <Tabs.Button selected={activePanelTab === "history"} onclick={() => (activePanelTab = "history")}>
+  <Tabs.List semantic>
+    <Tabs.Button
+      id="description-content-tab"
+      panelId="description-content-panel"
+      semantic
+      selected={activePanelTab === "description"}
+      onclick={() => (activePanelTab = "description")}
+    >
+      {copy.title}
+    </Tabs.Button>
+    <Tabs.Button
+      id="description-history-tab"
+      panelId="description-history-panel"
+      semantic
+      selected={activePanelTab === "history"}
+      onclick={() => (activePanelTab = "history")}
+    >
       {formatDescriptionCopy(copy.historyTitle, { count: String(history.length) })}
     </Tabs.Button>
   </Tabs.List>
 
-  {#if activePanelTab === "history"}
+  <Tabs.Panel
+    active={activePanelTab === "history"}
+    id="description-history-panel"
+    labelledBy="description-history-tab"
+  >
     <DescriptionHistoryList {copy} {formatDate} {history} />
-  {:else if description.content}
-    <MarkdownPreview
-      content={description.content}
-      remarkPlugins={campusReferenceMarkdownPlugins}
-    />
-  {:else}
-    <Alert>{copy.empty}</Alert>
-  {/if}
+  </Tabs.Panel>
+
+  <Tabs.Panel
+    active={activePanelTab === "description"}
+    id="description-content-panel"
+    labelledBy="description-content-tab"
+  >
+    {#if description.content}
+      <MarkdownPreview
+        content={description.content}
+        remarkPlugins={campusReferenceMarkdownPlugins}
+      />
+    {:else}
+      <Alert>{copy.empty}</Alert>
+    {/if}
+  </Tabs.Panel>
 </Tabs.Root>

--- a/src/features/section-detail/components/SectionDetailHeader.svelte
+++ b/src/features/section-detail/components/SectionDetailHeader.svelte
@@ -15,6 +15,7 @@ import type {
 } from "./section-basic-info-types";
 
 type SectionHeaderCommonCopy = {
+  breadcrumb: string;
   home: string;
   sections: string;
 };
@@ -66,7 +67,7 @@ export let viewer: SectionHeaderViewer;
   eyebrow={sectionCopy.teachingSection}
 >
   {#snippet breadcrumb()}
-    <Breadcrumb.Root>
+    <Breadcrumb.Root label={commonCopy.breadcrumb}>
       <Breadcrumb.List>
         <Breadcrumb.Item><Breadcrumb.Link href="/">{commonCopy.home}</Breadcrumb.Link></Breadcrumb.Item>
         <Breadcrumb.Separator />

--- a/src/features/section-detail/components/section-detail-dialog-types.ts
+++ b/src/features/section-detail/components/section-detail-dialog-types.ts
@@ -42,6 +42,7 @@ import type {
 } from "./section-homework-tab-types";
 
 export type SectionDetailCommonCopy = SectionHomeworkCommonCopy & {
+  breadcrumb: string;
   home: string;
   sections: string;
   signIn?: string;

--- a/src/features/section-detail/lib/section-detail-controller-types.ts
+++ b/src/features/section-detail/lib/section-detail-controller-types.ts
@@ -111,6 +111,7 @@ export type SectionDetailCopy = {
     tabWrite: string;
   };
   common: Record<string, string> & {
+    breadcrumb: string;
     home: string;
     sections: string;
     signIn?: string;

--- a/src/features/settings/components/SettingsHeader.svelte
+++ b/src/features/settings/components/SettingsHeader.svelte
@@ -12,7 +12,7 @@ export let copy: SettingsCopy;
   eyebrow={copy.settings.workspaceBadge}
 >
   {#snippet breadcrumb()}
-    <Breadcrumb.Root>
+    <Breadcrumb.Root label={copy.common.breadcrumb}>
       <Breadcrumb.List>
         <Breadcrumb.Item><Breadcrumb.Link href="/">{copy.common.home}</Breadcrumb.Link></Breadcrumb.Item>
         <Breadcrumb.Separator />

--- a/src/features/settings/components/settings-component-types.ts
+++ b/src/features/settings/components/settings-component-types.ts
@@ -40,6 +40,7 @@ export type SettingsCopy = {
     avatarOption: string;
   };
   common: {
+    breadcrumb: string;
     home: string;
   };
   profile: SettingsProfileCopy;

--- a/src/lib/components/ui/breadcrumb/breadcrumb.svelte
+++ b/src/lib/components/ui/breadcrumb/breadcrumb.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 let className = "";
+export let label = "";
 
 export { className as class };
 </script>
 
-<nav aria-label="breadcrumb" class={className} data-slot="breadcrumb" {...$$restProps}>
+<nav aria-label={label || undefined} class={className} data-slot="breadcrumb" {...$$restProps}>
   <slot />
 </nav>

--- a/src/lib/components/ui/button/button-variants.ts
+++ b/src/lib/components/ui/button/button-variants.ts
@@ -6,7 +6,7 @@ import { tv, type VariantProps } from "tailwind-variants";
 import type { WithElementRef } from "$lib/utils.js";
 
 export const buttonVariants = tv({
-  base: "rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:border-primary focus-visible:ring-3 focus-visible:ring-primary/30 active:not-aria-[haspopup]:translate-y-px aria-invalid:border-error aria-invalid:ring-3 aria-invalid:ring-error/20 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  base: "rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:border-primary focus-visible:ring-3 focus-visible:ring-primary/30 active:not-aria-[haspopup]:translate-y-px aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-invalid:border-error aria-invalid:ring-3 aria-invalid:ring-error/20 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   variants: {
     variant: {
       default: "bg-primary text-primary-content hover:bg-primary/85",

--- a/src/lib/components/ui/button/button.svelte
+++ b/src/lib/components/ui/button/button.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { HTMLLabelAttributes } from "svelte/elements";
 import { cn } from "$lib/utils.js";
 import { type ButtonProps, buttonVariants } from "./button-variants.js";
 
@@ -14,6 +15,8 @@ let {
   children,
   ...restProps
 }: ButtonProps = $props();
+
+let labelProps = $derived(restProps as HTMLLabelAttributes);
 </script>
 
 {#if href}
@@ -36,19 +39,20 @@ let {
 			data-slot="button"
 			class={cn(buttonVariants({ variant, size }), className)}
 			aria-disabled={disabled}
+			{...labelProps}
 		>
 			{@render children?.()}
 		</label>
 	{:else}
-	<button
-		bind:this={ref}
-		data-slot="button"
-		class={cn(buttonVariants({ variant, size }), className)}
-		{type}
-		{disabled}
-		{...restProps}
-	>
-		{@render children?.()}
-	</button>
+		<button
+			bind:this={ref}
+			data-slot="button"
+			class={cn(buttonVariants({ variant, size }), className)}
+			{type}
+			{disabled}
+			{...restProps}
+		>
+			{@render children?.()}
+		</button>
 	{/if}
 {/if}

--- a/src/lib/components/ui/tabs/index.ts
+++ b/src/lib/components/ui/tabs/index.ts
@@ -2,3 +2,4 @@ export { default as Root } from "./tabs.svelte";
 export { default as Button } from "./tabs-button.svelte";
 export { default as Link } from "./tabs-link.svelte";
 export { default as List } from "./tabs-list.svelte";
+export { default as Panel } from "./tabs-panel.svelte";

--- a/src/lib/components/ui/tabs/tabs-button.svelte
+++ b/src/lib/components/ui/tabs/tabs-button.svelte
@@ -1,15 +1,23 @@
 <script lang="ts">
 export let selected = false;
 export let onclick: ((event: MouseEvent) => void) | undefined = undefined;
+export let semantic = false;
+export let panelId: string | undefined = undefined;
+export let id: string | undefined = undefined;
 let className = "";
 
 export { className as class };
 </script>
 
 <button
-  aria-pressed={selected}
+  aria-controls={semantic ? panelId : undefined}
+  aria-pressed={semantic ? undefined : selected}
+  aria-selected={semantic ? selected : undefined}
   class={`inline-flex h-9 shrink-0 items-center justify-center whitespace-nowrap rounded-md px-3 font-medium text-sm transition hover:bg-base-200 ${selected ? "bg-base-200 text-base-content shadow-sm" : "text-base-content/65"} ${className}`}
   data-slot="tabs-button"
+  {id}
+  role={semantic ? "tab" : undefined}
+  tabindex={semantic && !selected ? -1 : undefined}
   type="button"
   {...$$restProps}
   onclick={onclick}

--- a/src/lib/components/ui/tabs/tabs-list.svelte
+++ b/src/lib/components/ui/tabs/tabs-list.svelte
@@ -6,6 +6,7 @@ import {
 } from "./tabs-context";
 
 export let role = "group";
+export let semantic = false;
 let className = "";
 
 export { className as class };
@@ -20,6 +21,43 @@ function explicitListLabel() {
 }
 
 $: listLabel = explicitListLabel() ?? rootLabelContext?.getLabel();
+$: listRole = semantic ? "tablist" : role;
+
+function handleKeydown(event: KeyboardEvent) {
+  if (
+    !semantic ||
+    !["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)
+  ) {
+    return;
+  }
+
+  const list = event.currentTarget as HTMLDivElement;
+  const tabs = Array.from(
+    list.querySelectorAll<HTMLButtonElement>(
+      '[role="tab"]:not([aria-disabled="true"])',
+    ),
+  );
+  if (tabs.length === 0) return;
+
+  const currentIndex = tabs.indexOf(
+    document.activeElement as HTMLButtonElement,
+  );
+  const fallbackIndex = tabs.findIndex(
+    (tab) => tab.getAttribute("aria-selected") === "true",
+  );
+  const startIndex =
+    currentIndex >= 0 ? currentIndex : Math.max(fallbackIndex, 0);
+  const nextIndex =
+    event.key === "Home"
+      ? 0
+      : event.key === "End"
+        ? tabs.length - 1
+        : (startIndex + (event.key === "ArrowRight" ? 1 : -1) + tabs.length) %
+          tabs.length;
+
+  event.preventDefault();
+  tabs[nextIndex]?.focus();
+}
 </script>
 
 <div
@@ -27,7 +65,8 @@ $: listLabel = explicitListLabel() ?? rootLabelContext?.getLabel();
   data-slot="tabs-list"
   {...$$restProps}
   aria-label={listLabel}
-  {role}
+  role={listRole}
+  onkeydown={handleKeydown}
 >
   <slot />
 </div>

--- a/src/lib/components/ui/tabs/tabs-panel.svelte
+++ b/src/lib/components/ui/tabs/tabs-panel.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+export let active = false;
+export let id: string;
+export let labelledBy: string;
+let className = "";
+
+export { className as class };
+</script>
+
+<div
+  aria-labelledby={labelledBy}
+  class={className}
+  data-slot="tabs-panel"
+  hidden={!active}
+  {id}
+  role="tabpanel"
+  tabindex="0"
+  {...$$restProps}
+>
+  <slot />
+</div>

--- a/src/routes/guides/markdown-support/+page.svelte
+++ b/src/routes/guides/markdown-support/+page.svelte
@@ -17,7 +17,7 @@ $: sections = buildMarkdownGuideSections(guide);
 <section class="grid gap-6 pb-12">
   <PageHeader title={guide.title} description={guide.subtitle}>
     {#snippet breadcrumb()}
-      <Breadcrumb.Root>
+      <Breadcrumb.Root label={data.copy.common.breadcrumb}>
         <Breadcrumb.List>
           <Breadcrumb.Item><Breadcrumb.Link href="/">{data.copy.common.home}</Breadcrumb.Link></Breadcrumb.Item>
           <Breadcrumb.Separator />

--- a/tests/e2e/src/app/courses/[jwId]/test.ts
+++ b/tests/e2e/src/app/courses/[jwId]/test.ts
@@ -171,24 +171,19 @@ test.describe("/courses/[jwId]", () => {
   test("tab switching works", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, COURSE_URL);
 
-    const nextTab = page
-      .locator('[role="button"][aria-pressed="false"]')
-      .first();
-    if ((await nextTab.count()) > 0) {
-      const nextTabLabel = ((await nextTab.textContent()) ?? "").trim();
-      expect(nextTabLabel).toBeTruthy();
-      await expect(async () => {
-        const targetTab = page
-          .getByRole("button", { name: nextTabLabel })
-          .first();
-        await targetTab.click();
-        await expect(targetTab).toHaveAttribute("aria-pressed", "true");
-      }).toPass({
-        timeout: 10_000,
-        intervals: [250, 500, 1_000],
-      });
-      await captureStepScreenshot(page, testInfo, "course/tab-switch");
-    }
+    const tabList = page.getByRole("tablist").first();
+    await expect(tabList).toBeVisible();
+    const targetTab = tabList.getByRole("tab").nth(1);
+    const panelId = await targetTab.getAttribute("aria-controls");
+    expect(panelId).toBeTruthy();
+
+    await targetTab.click();
+    await expect(targetTab).toHaveAttribute("aria-selected", "true");
+    await expect(page.locator(`#${panelId}`)).toHaveAttribute(
+      "role",
+      "tabpanel",
+    );
+    await captureStepScreenshot(page, testInfo, "course/tab-switch");
   });
 
   test("breadcrumb navigates back to course list", async ({
@@ -274,7 +269,11 @@ test.describe("/courses/[jwId]", () => {
       );
       await descCard.getByRole("button", { name: /保存|Save/i }).click();
       await saveResponse;
-      await expect(page.getByText(content).first()).toBeVisible();
+      await expect(
+        descCard
+          .getByRole("tabpanel", { name: /简介|Description/i })
+          .getByText(content),
+      ).toBeVisible();
       await captureStepScreenshot(page, testInfo, "course/description-updated");
     } finally {
       if (snapshot.original) {
@@ -295,11 +294,11 @@ test.describe("/courses/[jwId]", () => {
 
     try {
       const commentsTab = page
-        .getByRole("button", { name: /评论|Comments/i })
+        .getByRole("tab", { name: /评论|Comments/i })
         .first();
       await expect(commentsTab).toBeVisible();
       await commentsTab.click();
-      await expect(commentsTab).toHaveAttribute("aria-pressed", "true");
+      await expect(commentsTab).toHaveAttribute("aria-selected", "true");
 
       const body = `e2e-course-comment-${Date.now()}`;
       const composer = page.locator("textarea").first();

--- a/tests/e2e/src/app/sections/test.ts
+++ b/tests/e2e/src/app/sections/test.ts
@@ -79,7 +79,7 @@ test.describe("/sections", () => {
     });
 
     await page
-      .getByRole("button", { name: /\?|帮助|Help/i })
+      .getByRole("button", { name: /高级搜索语法|Advanced Search Syntax/i })
       .first()
       .click();
     const sheet = page.getByRole("dialog");
@@ -92,7 +92,7 @@ test.describe("/sections", () => {
 
     const searchInput = page.getByPlaceholder(/搜索或使用高级语法|search/i);
     await searchInput.fill(DEV_SEED.section.code);
-    await page.getByRole("button", { name: /搜索|Search/i }).click();
+    await page.getByRole("button", { name: /^(搜索|Search)$/i }).click();
     await expect(page).toHaveURL(
       new RegExp(`search=${encodeURIComponent(DEV_SEED.section.code)}`),
     );

--- a/tests/e2e/src/app/teachers/[id]/test.ts
+++ b/tests/e2e/src/app/teachers/[id]/test.ts
@@ -180,15 +180,30 @@ test.describe("/teachers/[id]", () => {
 
   // ── Navigation ──────────────────────────────────────────────────────────────
 
+  test("tab switching works", async ({ page }, testInfo) => {
+    await navigateToSeedTeacher(page);
+
+    const tabList = page.getByRole("tablist").first();
+    await expect(tabList).toBeVisible();
+    const targetTab = tabList.getByRole("tab").nth(1);
+    const panelId = await targetTab.getAttribute("aria-controls");
+    expect(panelId).toBeTruthy();
+
+    await targetTab.click();
+    await expect(targetTab).toHaveAttribute("aria-selected", "true");
+    await expect(page.locator(`#${panelId}`)).toHaveAttribute(
+      "role",
+      "tabpanel",
+    );
+    await captureStepScreenshot(page, testInfo, "teacher/tab-switch");
+  });
+
   test("breadcrumb navigates back to teacher list", async ({
     page,
   }, testInfo) => {
     await navigateToSeedTeacher(page);
 
-    const breadcrumb = page
-      .getByRole("navigation", { name: "breadcrumb" })
-      .getByRole("link", { name: /^(教师|Teachers)$/i })
-      .first();
+    const breadcrumb = page.locator('a[href="/teachers"]').first();
     await expect(breadcrumb).toBeVisible();
     await breadcrumb.click();
     await expect(page).toHaveURL(/\/teachers(?:\?.*)?$/);
@@ -236,7 +251,11 @@ test.describe("/teachers/[id]", () => {
       await waitForUiSettled(page);
 
       // description.content rendered
-      await expect(page.getByText(content).first()).toBeVisible();
+      await expect(
+        descCard
+          .getByRole("tabpanel", { name: /简介|Description/i })
+          .getByText(content),
+      ).toBeVisible();
       // description.lastEditedBy.name
       await expect(
         page.getByText(DEV_SEED.debugName, { exact: false }).first(),
@@ -273,11 +292,11 @@ test.describe("/teachers/[id]", () => {
           await navigateToSeedTeacher(page);
         }
         const commentsTab = page
-          .getByRole("button", { name: /评论|Comments/i })
+          .getByRole("tab", { name: /评论|Comments/i })
           .first();
         await expect(commentsTab).toBeVisible();
         await commentsTab.click();
-        await expect(commentsTab).toHaveAttribute("aria-pressed", "true");
+        await expect(commentsTab).toHaveAttribute("aria-selected", "true");
       }).toPass({
         timeout: 10_000,
         intervals: [250, 500, 1_000],


### PR DESCRIPTION
## Goal

Close #232, #234, and #235 by aligning shared UI controls with accessible semantics and localized labels.

## Changed Surfaces

- Shared UI primitives: semantic tab mode with tab panels, label-button disabled styling, localized breadcrumb landmark labels.
- Catalog/detail UI: course and teacher tabs now expose `tablist`/`tab`/`tabpanel` semantics while preserving the existing sections/comments behavior.
- Description UI: read/history panels use real tab panels.
- Admin/comment/catalog controls: select controls and helper buttons get explicit accessible names.
- Messages and E2E tests updated for localized labels and semantic tab assertions.

## Evidence

- `bunx biome check ...` on touched UI/message/E2E files.
- `DATABASE_URL=postgresql://unused:unused@127.0.0.1:5432/life_ustc bun run verify:types`.
- `bun run check:i18n`.
- Browser loop: `bun run e2e:db:prepare`, `bun run e2e:build-artifacts`, `bun run seed`, then `PLAYWRIGHT_PORT=3102 bun run e2e:test -- 'tests/e2e/src/app/courses/\\[jwId\\]/test.ts' 'tests/e2e/src/app/teachers/\\[id\\]/test.ts'` passed 23/23 after artifact rebuild.
- Regression check for CI public-web failure: `PLAYWRIGHT_PORT=3102 bun run e2e:test -- tests/e2e/src/app/sections/test.ts` passed 5/5.

## Docs / Contracts

- Updated `messages/en-us.json` and `messages/zh-cn.json` for API docs navigation labels.
- No API/MCP contract changes; this is UI semantics and copy only.

## Risk Areas

- UI accessibility semantics and i18n copy typing.
- Catalog detail E2E assertions were updated from `aria-pressed` button groups to tab roles.

## Cleanup

- Removed local Playwright `test-results` output before commits.
- No generated OpenAPI/Prisma artifacts, scratch probes, or unrelated rewrites are included.
