### PR TITLE
fix: local setup bootstrap and static loader validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ contracts live in [docs/contracts/](./docs/contracts/).
 
 ```bash
 bun install --frozen-lockfile
+cp .env.example .env
 docker compose -f docker-compose.dev.yml up -d
 bun run dev
 ```
 
-本地数据库由 Docker Compose 管理；需要数据库时先启动本地 infra，再运行应用。上传存储使用 Cloudflare `R2_UPLOADS` 绑定，需通过 Wrangler 相关流程本地验证。生产应用由 Cloudflare Git integration 发布，Docker 只保留静态数据加载环境。
+首次本地启动前先从 `.env.example` 创建 `.env`，因为 `bun run dev` 会在启动 Vite 前运行 Prisma 迁移并读取 `DATABASE_URL`。本地数据库由 Docker Compose 管理；需要数据库时先启动本地 infra，再运行应用。上传存储使用 Cloudflare `R2_UPLOADS` 绑定，需通过 Wrangler 相关流程本地验证。生产应用由 Cloudflare Git integration 发布，Docker 只保留静态数据加载环境。
 
 开发期建议节奏：
 - 默认提交门禁：`bun run verify`

--- a/tests/unit/static-loader-options.test.ts
+++ b/tests/unit/static-loader-options.test.ts
@@ -35,6 +35,29 @@ describe("static loader options", () => {
     });
   });
 
+  it.each([
+    "1",
+    "401",
+    "2026",
+  ])("parses valid --min-semester value %s", (value) => {
+    expect(
+      parseStaticLoaderOptions(["--min-semester", value]).minSemesterJwId,
+    ).toBe(Number.parseInt(value, 10));
+  });
+
+  it.each([
+    "foo",
+    "NaN",
+    "2026abc",
+    "0",
+    "-1",
+    "1.5",
+  ])("rejects invalid --min-semester value %s", (value) => {
+    expect(() => parseStaticLoaderOptions(["--min-semester", value])).toThrow(
+      `Invalid --min-semester "${value}": expected a positive integer jwId.`,
+    );
+  });
+
   it("keeps the short help flag behavior", () => {
     expect(parseStaticLoaderOptions(["-h"]).help).toBe(true);
   });

--- a/tests/unit/static-loader-options.test.ts
+++ b/tests/unit/static-loader-options.test.ts
@@ -54,7 +54,17 @@ describe("static loader options", () => {
     "1.5",
   ])("rejects invalid --min-semester value %s", (value) => {
     expect(() => parseStaticLoaderOptions(["--min-semester", value])).toThrow(
-      `Invalid --min-semester "${value}": expected a positive integer jwId.`,
+      `Invalid --min-semester "${value}": expected a positive safe integer jwId.`,
+    );
+  });
+
+  it("rejects --min-semester values beyond Number.MAX_SAFE_INTEGER", () => {
+    const unsafeValue = "9007199254740992";
+
+    expect(() =>
+      parseStaticLoaderOptions(["--min-semester", unsafeValue]),
+    ).toThrow(
+      `Invalid --min-semester "${unsafeValue}": expected a positive safe integer jwId.`,
     );
   });
 

--- a/tools/load/static-loader-options.ts
+++ b/tools/load/static-loader-options.ts
@@ -23,11 +23,15 @@ Options:
 }
 
 function parseMinSemesterJwId(value: string) {
-  const minSemesterJwId = Number.parseInt(value, 10);
+  const minSemesterJwId = Number(value);
 
-  if (!/^\+?\d+$/.test(value) || minSemesterJwId <= 0) {
+  if (
+    !/^\+?\d+$/.test(value) ||
+    !Number.isSafeInteger(minSemesterJwId) ||
+    minSemesterJwId <= 0
+  ) {
     throw new Error(
-      `Invalid --min-semester "${value}": expected a positive integer jwId.`,
+      `Invalid --min-semester "${value}": expected a positive safe integer jwId.`,
     );
   }
 

--- a/tools/load/static-loader-options.ts
+++ b/tools/load/static-loader-options.ts
@@ -22,11 +22,42 @@ Options:
   -h, --help              Show this help message`;
 }
 
+function parseMinSemesterJwId(value: string) {
+  const minSemesterJwId = Number.parseInt(value, 10);
+
+  if (!/^\+?\d+$/.test(value) || minSemesterJwId <= 0) {
+    throw new Error(
+      `Invalid --min-semester "${value}": expected a positive integer jwId.`,
+    );
+  }
+
+  return minSemesterJwId;
+}
+
+function normalizeMinSemesterArgs(argv: string[]) {
+  const args: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const nextArg = argv[index + 1];
+
+    if (arg === "--min-semester" && /^-\d/.test(nextArg ?? "")) {
+      args.push(`--min-semester=${nextArg}`);
+      index += 1;
+      continue;
+    }
+
+    args.push(arg);
+  }
+
+  return args;
+}
+
 export function parseStaticLoaderOptions(
   argv = process.argv.slice(2),
 ): StaticLoaderOptions {
   const { values } = parseArgs({
-    args: argv,
+    args: normalizeMinSemesterArgs(argv),
     options: {
       "cache-dir": {
         type: "string",
@@ -43,12 +74,12 @@ export function parseStaticLoaderOptions(
     strict: true,
   });
 
+  const minSemesterValue =
+    values["min-semester"] ?? DEFAULT_STATIC_LOADER_MIN_SEMESTER;
+
   return {
     cacheDir: values["cache-dir"] ?? DEFAULT_STATIC_LOADER_CACHE_DIR,
-    minSemesterJwId: Number.parseInt(
-      values["min-semester"] ?? DEFAULT_STATIC_LOADER_MIN_SEMESTER,
-      10,
-    ),
+    minSemesterJwId: parseMinSemesterJwId(minSemesterValue),
     skipCourses: values["skip-courses"] ?? false,
     skipBus: values["skip-bus"] ?? false,
     help: values.help ?? false,


### PR DESCRIPTION
## Goal

Close #249 by documenting the required fresh-clone `.env` bootstrap before local Prisma migrations run.

Close #250 by rejecting invalid static-loader `--min-semester` values before import filtering starts, including values that cannot be represented exactly as JavaScript safe integers.

## Changed Surfaces

- `README.md` quick start now copies `.env.example` to `.env` before Docker/dev startup.
- `tools/load/static-loader-options.ts` now validates `--min-semester` as a positive safe integer and normalizes separated negative values so they produce the same clear validation error.
- `tests/unit/static-loader-options.test.ts` covers valid values, malformed values, non-positive values, and a value beyond `Number.MAX_SAFE_INTEGER`.

## Evidence

Local focused checks on current head:

- `bun run vitest run tests/unit/static-loader-options.test.ts`
- `bunx biome check README.md tools/load/static-loader-options.ts tests/unit/static-loader-options.test.ts`
- `bun run tsc --noEmit -p tsconfig.typecheck.operational.json`

Remote checks on current head `4970cf13`:

- CI `Check / run`, `Static Loader Image`, `Build E2E artifacts`, and all E2E shards passed.
- CodeQL checks passed.
- E2E Snapshot Artifacts capture/comment jobs passed.
- Cloudflare Workers Builds passed.

## Docs / Contracts

README local setup docs changed. No contracts, OpenAPI, MCP, messages, or generated files changed because this PR does not alter public API/MCP shape or user-visible app behavior.

## Risk Areas

Low. The loader now fails fast for malformed, non-positive, partial, or unsafe integer CLI input instead of silently filtering with `NaN` or an imprecise number; default and valid positive parsing remain covered by unit tests.

## Cleanup

No scratch artifacts or generated-file edits are included. The PR changes are limited to `README.md`, `tools/load/static-loader-options.ts`, and `tests/unit/static-loader-options.test.ts`.
