### PR TITLE
fix: upload delete durability and MCP rename validation

### DIFF
--- a/docs/contracts/upload.json
+++ b/docs/contracts/upload.json
@@ -134,7 +134,7 @@
             "method": "DELETE",
             "returns": "{ deletedId: String, deletedSize: Int }",
             "notes": [
-              "Deletes one upload owned by the current user and removes the object from storage."
+              "Deletes one upload owned by the current user. The backing storage object is deleted before metadata is removed; storage cleanup failure returns an error and leaves the upload metadata available for retry."
             ]
           }
         ]
@@ -154,7 +154,7 @@
             "returns": "{ success: Boolean, deletedId: String, deletedSize: Int }",
             "rest_equivalent": "DELETE /api/uploads/[id]",
             "notes": [
-              "Requires an unsuspended signed-in user, deletes only uploads owned by the current user, performs best-effort object cleanup, and writes metadata.source=mcp in the upload_delete audit log."
+              "Requires an unsuspended signed-in user, deletes only uploads owned by the current user, removes the backing storage object before metadata deletion, returns storage_delete_failed without deleting metadata when storage cleanup fails, and writes metadata.source=mcp in the upload_delete audit log only after successful deletion."
             ]
           }
         ]

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -6379,6 +6379,16 @@
                 }
               }
             }
+          },
+          "502": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/src/features/uploads/server/upload-service.ts
+++ b/src/features/uploads/server/upload-service.ts
@@ -328,7 +328,7 @@ export async function renameOwnedUpload(input: {
   return { ok: true as const, upload };
 }
 
-export async function deleteUploadRecord(input: {
+async function findUploadRecordForDeletion(input: {
   id: string;
   userId: string;
 }) {
@@ -338,8 +338,6 @@ export async function deleteUploadRecord(input: {
   });
 
   if (!upload) return null;
-
-  await prisma.upload.delete({ where: { id: upload.id } });
   return upload;
 }
 
@@ -355,13 +353,21 @@ export async function deleteOwnedUpload(input: {
   const writer = await requireActiveUploadWriter(input.userId);
   if (!writer.ok) return writer;
 
-  const upload = await deleteUploadRecord({
+  const upload = await findUploadRecordForDeletion({
     id: input.id,
     userId: input.userId,
   });
   if (!upload) return { ok: false as const, error: "not_found" as const };
 
-  await cleanupDeletedUploadObject(upload);
+  const storageDeleted = await deleteUploadStorageObject(upload);
+  if (!storageDeleted) {
+    return {
+      ok: false as const,
+      error: "storage_delete_failed" as const,
+    };
+  }
+
+  await prisma.upload.delete({ where: { id: upload.id } });
   writeUploadDeleteAuditLog({
     audit: input.audit,
     upload,
@@ -456,16 +462,18 @@ async function requireActiveUploadWriter(userId: string) {
   return { ok: true as const };
 }
 
-async function cleanupDeletedUploadObject(upload: { key: string }) {
+async function deleteUploadStorageObject(upload: { key: string }) {
   try {
     await deleteStorageObject(upload.key);
+    return true;
   } catch (error) {
     logAppEvent(
       "error",
-      "R2 object cleanup failed after upload deletion",
+      "R2 object deletion failed; upload record preserved",
       { source: "upload" },
       error,
     );
+    return false;
   }
 }
 

--- a/src/lib/api/routes/upload-management-routes.ts
+++ b/src/lib/api/routes/upload-management-routes.ts
@@ -6,6 +6,7 @@ import {
 } from "@/features/uploads/server/upload-service";
 import {
   badRequest,
+  errorResponse,
   handleRouteError,
   jsonResponse,
   notFound,
@@ -74,7 +75,12 @@ export async function deleteUploadRoute(request: Request, params: IdParams) {
         id: parsed.id,
         userId,
       });
-      if (!result.ok) return notFound();
+      if (!result.ok) {
+        if (result.error === "storage_delete_failed") {
+          return errorResponse("Failed to delete upload object", 502);
+        }
+        return notFound();
+      }
 
       return jsonResponse({
         deletedId: result.deletedId,

--- a/src/lib/mcp/tools/upload-tools.ts
+++ b/src/lib/mcp/tools/upload-tools.ts
@@ -12,12 +12,25 @@ import {
   mcpModeInputSchema,
   resolveMcpMode,
 } from "@/lib/mcp/tools/_helpers";
+import { hasAsciiControlCharacters } from "@/lib/text/ascii-control-characters";
 
 const uploadIdInputSchema = z.string().trim().min(1);
-const uploadFilenameInputSchema = z.string().trim().min(1).max(255);
+const filenameControlCharacterMessage =
+  "Filename contains unsupported control characters";
+const uploadFilenameInputSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(255)
+  .refine((filename) => !hasAsciiControlCharacters(filename), {
+    message: filenameControlCharacterMessage,
+  })
+  .refine((filename) => sanitizeFilename(filename).length > 0, {
+    message: "Filename required",
+  });
 
 type UploadMutationError = {
-  error: "forbidden" | "not_found" | "suspended";
+  error: "forbidden" | "not_found" | "storage_delete_failed" | "suspended";
   reason?: string | null;
 };
 
@@ -44,6 +57,18 @@ function uploadMutationErrorResult(
         error: "not_found",
         message: "Upload not found",
         hint: "Use list_my_uploads to confirm the upload id before changing it.",
+      },
+      { mode },
+    );
+  }
+
+  if (result.error === "storage_delete_failed") {
+    return jsonToolResult(
+      {
+        success: false,
+        error: "storage_delete_failed",
+        message: "Failed to delete upload object",
+        hint: "The upload metadata was kept so the deletion can be retried.",
       },
       { mode },
     );
@@ -113,7 +138,7 @@ export function registerUploadTools(server: McpServer) {
     "delete_my_upload",
     {
       description:
-        "Delete one upload owned by the current user and remove its backing object best-effort. Requires an unsuspended signed-in user.",
+        "Delete one upload owned by the current user after removing its backing object. Requires an unsuspended signed-in user.",
       inputSchema: {
         id: uploadIdInputSchema,
         mode: mcpModeInputSchema,

--- a/src/routes/api/uploads/[id]/+server.ts
+++ b/src/routes/api/uploads/[id]/+server.ts
@@ -20,6 +20,7 @@ export const PATCH: RequestHandler = ({ request, params }) =>
  * @response 200:uploadDeleteResponseSchema
  * @response 401:openApiErrorSchema
  * @response 404:openApiErrorSchema
+ * @response 502:openApiErrorSchema
  */
 export const DELETE: RequestHandler = ({ request, params }) =>
   observedApiRoute(() => deleteUploadRoute(request, { id: params.id }))(

--- a/tests/integration/mcp-02-comments.test.ts
+++ b/tests/integration/mcp-02-comments.test.ts
@@ -557,7 +557,7 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
     }
   });
 
-  it("upload metadata tools list, rename, delete, and audit MCP source", async () => {
+  it("upload metadata tools list, rename, and preserve retry state on delete storage failure", async () => {
     const filename = `mcp-upload-${Date.now()}.txt`;
     const upload = await fixtures.prisma.upload.create({
       data: {
@@ -603,34 +603,59 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
       });
 
       const deleted = await context.client.call<{
-        deletedId?: string;
-        deletedSize?: number;
+        error?: string;
+        hint?: string;
+        message?: string;
         success?: boolean;
       }>("delete_my_upload", { id: upload.id });
-      expect(deleted).toEqual({
-        success: true,
-        deletedId: upload.id,
-        deletedSize: upload.size,
+      expect(deleted).toMatchObject({
+        success: false,
+        error: "storage_delete_failed",
+        message: "Failed to delete upload object",
       });
 
-      const deletedUpload = await fixtures.prisma.upload.findUnique({
+      const retainedUpload = await fixtures.prisma.upload.findUnique({
         where: { id: upload.id },
+        select: { filename: true },
       });
-      expect(deletedUpload).toBeNull();
-
-      const audit = await fixtures.findUploadDeleteAuditLog({
-        uploadId: upload.id,
-        metadata: { source: "mcp", size: upload.size, key: upload.key },
-      });
-      expect(audit?.metadata).toMatchObject({
-        source: "mcp",
-        size: upload.size,
-        key: upload.key,
-      });
+      expect(retainedUpload?.filename).toBe(renamedFilename);
     } finally {
       await fixtures.prisma.auditLog.deleteMany({
         where: { targetId: upload.id, targetType: "upload" },
       });
+      await fixtures.prisma.upload.deleteMany({ where: { id: upload.id } });
+    }
+  });
+
+  it("upload rename rejects control-character filenames without sanitizing", async () => {
+    const filename = `mcp-upload-invalid-rename-${Date.now()}.txt`;
+    const upload = await fixtures.prisma.upload.create({
+      data: {
+        userId: context.devUserId,
+        key: `integration-test/${filename}`,
+        filename,
+        contentType: "text/plain",
+        size: 321,
+      },
+      select: { id: true },
+    });
+
+    try {
+      for (const invalidFilename of ["bad\u0000name.txt", "\u0000"]) {
+        await expect(
+          context.client.call("rename_my_upload", {
+            id: upload.id,
+            filename: invalidFilename,
+          }),
+        ).rejects.toThrow();
+      }
+
+      const unchanged = await fixtures.prisma.upload.findUnique({
+        where: { id: upload.id },
+        select: { filename: true },
+      });
+      expect(unchanged?.filename).toBe(filename);
+    } finally {
       await fixtures.prisma.upload.deleteMany({ where: { id: upload.id } });
     }
   });

--- a/tests/unit/upload-delete-service.test.ts
+++ b/tests/unit/upload-delete-service.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { deleteOwnedUpload } from "@/features/uploads/server/upload-service";
+
+const {
+  deleteStorageObjectMock,
+  fireAuditLogMock,
+  getViewerContextMock,
+  logAppEventMock,
+  uploadDeleteMock,
+  uploadFindFirstMock,
+} = vi.hoisted(() => ({
+  deleteStorageObjectMock: vi.fn(),
+  fireAuditLogMock: vi.fn(),
+  getViewerContextMock: vi.fn(),
+  logAppEventMock: vi.fn(),
+  uploadDeleteMock: vi.fn(),
+  uploadFindFirstMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    upload: {
+      delete: uploadDeleteMock,
+      findFirst: uploadFindFirstMock,
+    },
+  },
+}));
+
+vi.mock("@/lib/storage/r2-object", () => ({
+  deleteStorageObject: deleteStorageObjectMock,
+  headStorageObject: vi.fn(),
+}));
+
+vi.mock("@/lib/audit/write-audit-log", () => ({
+  fireAuditLog: fireAuditLogMock,
+}));
+
+vi.mock("@/lib/auth/viewer-context", () => ({
+  getViewerContext: getViewerContextMock,
+}));
+
+vi.mock("@/lib/log/app-logger", () => ({
+  logAppEvent: logAppEventMock,
+}));
+
+const upload = {
+  id: "upload-1",
+  key: "uploads/user-1/object.txt",
+  size: 42,
+};
+
+describe("deleteOwnedUpload", () => {
+  beforeEach(() => {
+    getViewerContextMock.mockResolvedValue({
+      isAuthenticated: true,
+      isSuspended: false,
+    });
+    uploadFindFirstMock.mockResolvedValue(upload);
+    deleteStorageObjectMock.mockResolvedValue(undefined);
+    uploadDeleteMock.mockResolvedValue(upload);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes the storage object before deleting upload metadata", async () => {
+    const result = await deleteOwnedUpload({
+      audit: { source: "mcp" },
+      id: upload.id,
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      deletedId: upload.id,
+      deletedSize: upload.size,
+    });
+    expect(deleteStorageObjectMock).toHaveBeenCalledWith(upload.key);
+    expect(uploadDeleteMock).toHaveBeenCalledWith({ where: { id: upload.id } });
+    expect(deleteStorageObjectMock.mock.invocationCallOrder[0]).toBeLessThan(
+      uploadDeleteMock.mock.invocationCallOrder[0],
+    );
+    expect(fireAuditLogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "upload_delete",
+        metadata: { key: upload.key, size: upload.size, source: "mcp" },
+        targetId: upload.id,
+        targetType: "upload",
+        userId: "user-1",
+      }),
+    );
+  });
+
+  it("preserves upload metadata when storage deletion fails", async () => {
+    const storageError = new Error("R2 unavailable");
+    deleteStorageObjectMock.mockRejectedValue(storageError);
+
+    const result = await deleteOwnedUpload({
+      id: upload.id,
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "storage_delete_failed",
+    });
+    expect(uploadDeleteMock).not.toHaveBeenCalled();
+    expect(fireAuditLogMock).not.toHaveBeenCalled();
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "error",
+      "R2 object deletion failed; upload record preserved",
+      { source: "upload" },
+      storageError,
+    );
+  });
+});

--- a/tests/unit/upload-management-routes.test.ts
+++ b/tests/unit/upload-management-routes.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  deleteOwnedUploadMock,
+  getAuditRequestMetadataMock,
+  listUploadsMock,
+  renameOwnedUploadMock,
+  requireAuthMock,
+  requireWriteAuthMock,
+} = vi.hoisted(() => ({
+  deleteOwnedUploadMock: vi.fn(),
+  getAuditRequestMetadataMock: vi.fn(),
+  listUploadsMock: vi.fn(),
+  renameOwnedUploadMock: vi.fn(),
+  requireAuthMock: vi.fn(),
+  requireWriteAuthMock: vi.fn(),
+}));
+
+vi.mock("@/features/uploads/server/upload-service", () => ({
+  deleteOwnedUpload: deleteOwnedUploadMock,
+  listUploads: listUploadsMock,
+  renameOwnedUpload: renameOwnedUploadMock,
+}));
+
+vi.mock("@/lib/auth/api-auth", () => ({
+  requireAuth: requireAuthMock,
+  requireWriteAuth: requireWriteAuthMock,
+}));
+
+vi.mock("@/lib/audit/write-audit-log", () => ({
+  getAuditRequestMetadata: getAuditRequestMetadataMock,
+}));
+
+describe("upload management routes", () => {
+  beforeEach(() => {
+    requireWriteAuthMock.mockResolvedValue({ userId: "user-1" });
+    getAuditRequestMetadataMock.mockReturnValue({
+      ipAddress: "127.0.0.1",
+      userAgent: "unit-test",
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("serializes storage cleanup failures without reporting delete success", async () => {
+    deleteOwnedUploadMock.mockResolvedValue({
+      ok: false,
+      error: "storage_delete_failed",
+    });
+    const { deleteUploadRoute } = await import(
+      "@/lib/api/routes/upload-management-routes"
+    );
+
+    const response = await deleteUploadRoute(
+      new Request("https://example.test/api/uploads/upload-1", {
+        method: "DELETE",
+      }),
+      { id: "upload-1" },
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to delete upload object",
+    });
+    expect(deleteOwnedUploadMock).toHaveBeenCalledWith({
+      audit: { ipAddress: "127.0.0.1", userAgent: "unit-test" },
+      id: "upload-1",
+      userId: "user-1",
+    });
+  });
+});

--- a/tests/unit/upload-tools.test.ts
+++ b/tests/unit/upload-tools.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerUploadTools } from "@/lib/mcp/tools/upload-tools";
+
+const { deleteOwnedUploadMock, listUploadsMock, renameOwnedUploadMock } =
+  vi.hoisted(() => ({
+    deleteOwnedUploadMock: vi.fn(),
+    listUploadsMock: vi.fn(),
+    renameOwnedUploadMock: vi.fn(),
+  }));
+
+vi.mock("@/features/uploads/server/upload-service", () => ({
+  deleteOwnedUpload: deleteOwnedUploadMock,
+  listUploads: listUploadsMock,
+  renameOwnedUpload: renameOwnedUploadMock,
+}));
+
+type RegisteredTool = {
+  handler: (
+    args: Record<string, unknown>,
+    extra: { authInfo: { extra: { userId: string } } },
+  ) => Promise<{ content: Array<{ text: string; type: "text" }> }>;
+};
+
+function createToolRegistry() {
+  const tools = new Map<string, RegisteredTool>();
+  const server = {
+    registerTool(
+      name: string,
+      _config: unknown,
+      handler: RegisteredTool["handler"],
+    ) {
+      tools.set(name, { handler });
+    },
+  };
+
+  registerUploadTools(
+    server as unknown as Parameters<typeof registerUploadTools>[0],
+  );
+  return tools;
+}
+
+function parseToolResult(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0]?.text ?? "{}");
+}
+
+describe("upload MCP tools", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("serializes storage cleanup failures without reporting delete success", async () => {
+    deleteOwnedUploadMock.mockResolvedValue({
+      ok: false,
+      error: "storage_delete_failed",
+    });
+    const tools = createToolRegistry();
+    const tool = tools.get("delete_my_upload");
+    expect(tool).toBeDefined();
+    if (!tool) return;
+
+    const result = await tool.handler(
+      { id: "upload-1" },
+      { authInfo: { extra: { userId: "user-1" } } },
+    );
+
+    expect(parseToolResult(result)).toEqual({
+      success: false,
+      error: "storage_delete_failed",
+      message: "Failed to delete upload object",
+      hint: "The upload metadata was kept so the deletion can be retried.",
+    });
+    expect(deleteOwnedUploadMock).toHaveBeenCalledWith({
+      audit: { source: "mcp" },
+      id: "upload-1",
+      userId: "user-1",
+    });
+  });
+});


### PR DESCRIPTION
## Goal

Fix upload durability and REST/MCP parity bugs.

Closes #241.
Closes #242.

Note: #243 is the separate audit waitUntil issue and is intentionally not addressed here.

## Changed Surfaces

- Upload delete service now deletes the R2 object before deleting upload metadata.
- REST `DELETE /api/uploads/[id]` returns a 502 JSON error when storage cleanup fails, leaving metadata available for retry.
- MCP `delete_my_upload` returns `{ success: false, error: "storage_delete_failed" }` when storage cleanup fails.
- MCP `rename_my_upload` rejects ASCII control characters and names that sanitize to empty, matching REST validation.
- Upload contract and generated OpenAPI spec are aligned with the new delete failure behavior.

## Evidence

- `bun run db:migrate:deploy && bun run seed && bun run vitest run --config vitest.integration.config.ts tests/integration/mcp-02-comments.test.ts`
- `bun run test -- tests/unit/upload-delete-service.test.ts tests/unit/upload-management-routes.test.ts tests/unit/upload-tools.test.ts tests/unit/api-schemas.test.ts`
- `bun run biome check docs/contracts/upload.json public/openapi.generated.json src/features/uploads/server/upload-service.ts src/lib/api/routes/upload-management-routes.ts src/lib/mcp/tools/upload-tools.ts 'src/routes/api/uploads/[id]/+server.ts' tests/unit/upload-delete-service.test.ts tests/unit/upload-management-routes.test.ts tests/unit/upload-tools.test.ts tests/integration/mcp-02-comments.test.ts`
- `bun run openapi:check`
- `bun run check:contracts`
- `bun run tsc --noEmit -p tsconfig.typecheck.tests.json`

Complete-loop evidence:

- API serialized output: unit route test asserts `DELETE /api/uploads/[id]` storage cleanup failure returns status `502` with `{ "error": "Failed to delete upload object" }`.
- MCP serialized output: unit MCP test asserts `delete_my_upload` returns `{ success: false, error: "storage_delete_failed", ... }`.
- MCP integration: in-process MCP harness verifies delete failure preserves the upload row for retry and `rename_my_upload` rejects control-character filenames without sanitizing them into persisted names.

## Docs / Contracts

- Updated `docs/contracts/upload.json` for storage-first delete and retry-state behavior.
- Updated `src/routes/api/uploads/[id]/+server.ts` OpenAPI annotation and regenerated `public/openapi.generated.json` through `bun run openapi:generate`.

## Risk Areas

- Upload delete now fails visibly if R2 deletion fails. The upload row remains so users/tools can retry instead of leaving an orphaned storage object with no DB state.
- If R2 deletion succeeds and a later DB delete fails, retrying delete should still be safe because object deletion is expected to be idempotent.
- MCP rename validation now rejects inputs that were previously sanitized and accepted.

## Cleanup

- No scratch artifacts or one-off probes were added.
- PR branch was pushed from a clean worktree and includes only upload-scoped files.
