### PR TITLE
fix: audit scheduling and profile username races

### DIFF
--- a/src/features/admin/server/admin-api-service.ts
+++ b/src/features/admin/server/admin-api-service.ts
@@ -215,7 +215,7 @@ export async function createAdminSuspension(
   }
   if (!result.ok) return result;
 
-  fireAuditLog({
+  await fireAuditLog({
     action: "admin_user_suspend",
     userId: adminUserId,
     targetId: userId,
@@ -257,7 +257,7 @@ export async function liftAdminSuspension(adminUserId: string, id: string) {
   }, "Failed to lift admin suspension");
   if (!result.ok) return result;
 
-  fireAuditLog({
+  await fireAuditLog({
     action: "admin_user_unsuspend",
     userId: adminUserId,
     targetId: result.suspension.userId,
@@ -291,7 +291,7 @@ export async function moderateComment(
     },
   });
 
-  fireAuditLog({
+  await fireAuditLog({
     action: "admin_comment_moderate",
     userId: adminUserId,
     targetId: id,
@@ -339,7 +339,7 @@ export async function moderateDescription(
     return updated;
   });
 
-  fireAuditLog({
+  await fireAuditLog({
     action: "admin_description_moderate",
     userId: adminUserId,
     targetId: id,

--- a/src/features/comments/server/comment-audit.ts
+++ b/src/features/comments/server/comment-audit.ts
@@ -7,7 +7,7 @@ type CommentAuditRequestMetadata = {
 
 type CommentAuditMetadata = Record<string, unknown>;
 
-export function writeCommentCreateAuditLog({
+export async function writeCommentCreateAuditLog({
   auditMetadata,
   body,
   commentId,
@@ -20,7 +20,7 @@ export function writeCommentCreateAuditLog({
   requestMetadata?: CommentAuditRequestMetadata;
   userId: string;
 }) {
-  fireAuditLog({
+  await fireAuditLog({
     action: "comment_create",
     userId,
     targetId: commentId,
@@ -30,7 +30,7 @@ export function writeCommentCreateAuditLog({
   });
 }
 
-export function writeCommentEditAuditLog({
+export async function writeCommentEditAuditLog({
   auditMetadata,
   body,
   commentId,
@@ -43,7 +43,7 @@ export function writeCommentEditAuditLog({
   requestMetadata?: CommentAuditRequestMetadata;
   userId: string;
 }) {
-  fireAuditLog({
+  await fireAuditLog({
     action: "comment_edit",
     userId,
     targetId: commentId,
@@ -56,7 +56,7 @@ export function writeCommentEditAuditLog({
   });
 }
 
-export function writeCommentDeleteAuditLog({
+export async function writeCommentDeleteAuditLog({
   auditMetadata,
   commentId,
   requestMetadata,
@@ -67,7 +67,7 @@ export function writeCommentDeleteAuditLog({
   requestMetadata?: CommentAuditRequestMetadata;
   userId: string;
 }) {
-  fireAuditLog({
+  await fireAuditLog({
     action: "comment_delete",
     userId,
     targetId: commentId,
@@ -77,7 +77,7 @@ export function writeCommentDeleteAuditLog({
   });
 }
 
-export function writeCommentReactionAuditLog({
+export async function writeCommentReactionAuditLog({
   auditMetadata,
   commentId,
   operation,
@@ -92,7 +92,7 @@ export function writeCommentReactionAuditLog({
   type: string;
   userId: string;
 }) {
-  fireAuditLog({
+  await fireAuditLog({
     action: "comment_react",
     userId,
     targetId: commentId,

--- a/src/features/descriptions/server/description-upsert.ts
+++ b/src/features/descriptions/server/description-upsert.ts
@@ -104,7 +104,7 @@ export async function upsertDescriptionContent({
   }
 
   if (result.updated) {
-    writeDescriptionEditAuditLog({
+    await writeDescriptionEditAuditLog({
       content,
       descriptionId: result.id,
       metadata: auditMetadata,
@@ -116,7 +116,7 @@ export async function upsertDescriptionContent({
   return { ok: true as const, ...result };
 }
 
-function writeDescriptionEditAuditLog({
+async function writeDescriptionEditAuditLog({
   content,
   descriptionId,
   metadata,
@@ -130,7 +130,7 @@ function writeDescriptionEditAuditLog({
   userId: string;
 }) {
   const { source, ...requestMetadata } = metadata ?? {};
-  fireAuditLog({
+  await fireAuditLog({
     action: "description_edit",
     userId,
     targetId: descriptionId,

--- a/src/features/profile/server/profile-update-service.ts
+++ b/src/features/profile/server/profile-update-service.ts
@@ -1,5 +1,6 @@
 import { authApi } from "@/lib/auth/core";
 import { prisma } from "@/lib/db/prisma";
+import { isPrismaUniqueConstraintError } from "@/lib/db/prisma-errors";
 import { isValidProfileUsername } from "../lib/profile-username";
 
 type ProfileUpdateInput = {
@@ -59,11 +60,15 @@ export async function updateOwnProfile(
     updateBody.image = input.image;
   }
 
-  const response = await authApi.updateUser({
-    body: updateBody,
-    headers: input.headers,
-    returnHeaders: true,
-  });
-
-  return { headers: response.headers, ok: true };
+  try {
+    const response = await authApi.updateUser({
+      body: updateBody,
+      headers: input.headers,
+      returnHeaders: true,
+    });
+    return { headers: response.headers, ok: true };
+  } catch (error) {
+    if (!isPrismaUniqueConstraintError(error)) throw error;
+    return { ok: false, reason: "username_taken" };
+  }
 }

--- a/src/features/uploads/server/upload-service.ts
+++ b/src/features/uploads/server/upload-service.ts
@@ -362,7 +362,7 @@ export async function deleteOwnedUpload(input: {
   if (!upload) return { ok: false as const, error: "not_found" as const };
 
   await cleanupDeletedUploadObject(upload);
-  writeUploadDeleteAuditLog({
+  await writeUploadDeleteAuditLog({
     audit: input.audit,
     upload,
     userId: input.userId,
@@ -469,7 +469,7 @@ async function cleanupDeletedUploadObject(upload: { key: string }) {
   }
 }
 
-function writeUploadDeleteAuditLog({
+async function writeUploadDeleteAuditLog({
   audit,
   upload,
   userId,
@@ -482,7 +482,7 @@ function writeUploadDeleteAuditLog({
   upload: { id: string; key: string; size: number };
   userId: string;
 }) {
-  fireAuditLog({
+  await fireAuditLog({
     action: "upload_delete",
     userId,
     targetId: upload.id,

--- a/src/lib/api/routes/comment-delete-action.ts
+++ b/src/lib/api/routes/comment-delete-action.ts
@@ -22,7 +22,7 @@ export async function deleteOwnCommentAction(input: {
     return result.error === "not_found" ? notFound() : forbidden();
   }
 
-  writeCommentDeleteAuditLog({
+  await writeCommentDeleteAuditLog({
     commentId: input.commentId,
     requestMetadata: getAuditRequestMetadata(input.request),
     userId: input.userId,

--- a/src/lib/api/routes/comment-reaction-actions.ts
+++ b/src/lib/api/routes/comment-reaction-actions.ts
@@ -23,7 +23,7 @@ export async function createCommentReactionAction(input: {
   }
 
   if (result.changed) {
-    writeCommentReactionAuditLog({
+    await writeCommentReactionAuditLog({
       commentId: input.commentId,
       operation: "add",
       requestMetadata: getAuditRequestMetadata(input.request),

--- a/src/lib/api/routes/comment-reaction-delete-route.ts
+++ b/src/lib/api/routes/comment-reaction-delete-route.ts
@@ -56,7 +56,7 @@ export async function deleteCommentReactionRoute(
     }
 
     if (result.changed) {
-      writeCommentReactionAuditLog({
+      await writeCommentReactionAuditLog({
         commentId: id,
         operation: "remove",
         requestMetadata: getAuditRequestMetadata(request),

--- a/src/lib/api/routes/comments-create-route.ts
+++ b/src/lib/api/routes/comments-create-route.ts
@@ -73,7 +73,7 @@ export async function postCommentRoute(request: Request) {
       return forbidden();
     }
 
-    writeCommentCreateAuditLog({
+    await writeCommentCreateAuditLog({
       body: content,
       commentId: result.comment.id,
       requestMetadata: getAuditRequestMetadata(request),

--- a/src/lib/api/routes/comments-update-action.ts
+++ b/src/lib/api/routes/comments-update-action.ts
@@ -49,7 +49,7 @@ export async function updateCommentAction(
     return forbidden();
   }
 
-  writeCommentEditAuditLog({
+  await writeCommentEditAuditLog({
     body: content,
     requestMetadata: getAuditRequestMetadata(request),
     userId,

--- a/src/lib/audit/write-audit-log.ts
+++ b/src/lib/audit/write-audit-log.ts
@@ -113,19 +113,20 @@ export async function writeAuditLog(params: AuditLogParams) {
  * Fire-and-forget audit log that logs failures instead of swallowing them silently.
  * Use for non-critical audit trails where the route should not fail if logging errors.
  * In Worker requests, the write is also scheduled with waitUntil when the
- * SvelteKit request context is available. The logged write promise is returned
- * so non-request callers and tests can await it.
+ * SvelteKit request context is available. Awaiting this function guarantees
+ * Worker waitUntil registration without waiting for the DB write. Outside a
+ * Worker request, awaiting it waits for the logged write.
  */
-export function fireAuditLog(params: AuditLogParams) {
+export async function fireAuditLog(params: AuditLogParams) {
   const auditWrite = writeAuditLog(params).catch((error: unknown) => {
     logAuditWriteFailure(params, error);
   });
 
-  void getAuditWaitUntil()
-    .then((waitUntil) => {
-      waitUntil?.(auditWrite);
-    })
-    .catch(() => undefined);
+  const waitUntil = await getAuditWaitUntil();
+  if (waitUntil) {
+    waitUntil(auditWrite);
+    return;
+  }
 
-  return auditWrite;
+  await auditWrite;
 }

--- a/src/lib/mcp/tools/comment-write-tool-handlers.ts
+++ b/src/lib/mcp/tools/comment-write-tool-handlers.ts
@@ -77,7 +77,7 @@ export async function createCommentTool(
     return jsonToolResult(commentMutationErrorPayload(result), { mode });
   }
 
-  writeCommentCreateAuditLog({
+  await writeCommentCreateAuditLog({
     auditMetadata: { source: "mcp" },
     body: args.body,
     commentId: result.comment.id,
@@ -108,7 +108,7 @@ export async function updateOwnCommentTool(
     return jsonToolResult(commentMutationErrorPayload(result), { mode });
   }
 
-  writeCommentEditAuditLog({
+  await writeCommentEditAuditLog({
     auditMetadata: { source: "mcp" },
     body: args.body,
     commentId: args.commentId,
@@ -132,7 +132,7 @@ export async function deleteOwnCommentTool(
     });
   }
 
-  writeCommentDeleteAuditLog({
+  await writeCommentDeleteAuditLog({
     auditMetadata: { source: "mcp" },
     commentId,
     userId,
@@ -156,7 +156,7 @@ export async function addCommentReactionTool(
   }
 
   if (result.changed) {
-    writeCommentReactionAuditLog({
+    await writeCommentReactionAuditLog({
       auditMetadata: { source: "mcp" },
       commentId,
       operation: "add",
@@ -186,7 +186,7 @@ export async function removeCommentReactionTool(
   }
 
   if (result.changed) {
-    writeCommentReactionAuditLog({
+    await writeCommentReactionAuditLog({
       auditMetadata: { source: "mcp" },
       commentId,
       operation: "remove",

--- a/tests/unit/audit-write-log.test.ts
+++ b/tests/unit/audit-write-log.test.ts
@@ -40,6 +40,16 @@ const auditParams = {
   userId: "user-1",
 };
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
 describe("fireAuditLog", () => {
   beforeEach(() => {
     getRequestEventMock.mockReset();
@@ -49,7 +59,7 @@ describe("fireAuditLog", () => {
     vi.resetModules();
   });
 
-  it("schedules audit writes on the active Worker request context", async () => {
+  it("resolves after scheduling Worker waitUntil without waiting for the audit write", async () => {
     const waitUntilMock = vi.fn();
     getRequestEventMock.mockReturnValue({
       platform: {
@@ -58,18 +68,25 @@ describe("fireAuditLog", () => {
         },
       },
     });
-    prismaMock.auditLog.create.mockResolvedValue({});
+    const auditWrite = deferred<unknown>();
+    prismaMock.auditLog.create.mockReturnValue(auditWrite.promise);
     const { fireAuditLog } = await import("@/lib/audit/write-audit-log");
 
     const result = fireAuditLog(auditParams);
+    let schedulingResolved = false;
+    void result.then(() => {
+      schedulingResolved = true;
+    });
 
     expect(result).toHaveProperty("then");
-    await vi.dynamicImportSettled();
     await vi.waitFor(() => expect(waitUntilMock).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
+    expect(schedulingResolved).toBe(true);
     expect(prismaMock.auditLog.create).toHaveBeenCalledWith({
       data: auditParams,
     });
 
+    auditWrite.resolve({});
     await waitUntilMock.mock.calls[0]?.[0];
 
     expect(recordAuditWriteMetricMock).toHaveBeenCalledWith({
@@ -116,16 +133,26 @@ describe("fireAuditLog", () => {
     );
   });
 
-  it("returns the audit write promise when waitUntil is unavailable", async () => {
+  it("awaits the audit write when waitUntil is unavailable", async () => {
     getRequestEventMock.mockImplementation(() => {
       throw new Error("outside request");
     });
-    prismaMock.auditLog.create.mockResolvedValue({});
+    const auditWrite = deferred<unknown>();
+    prismaMock.auditLog.create.mockReturnValue(auditWrite.promise);
     const { fireAuditLog } = await import("@/lib/audit/write-audit-log");
 
     const result = fireAuditLog(auditParams);
+    let writeResolved = false;
+    void result.then(() => {
+      writeResolved = true;
+    });
 
     expect(result).toHaveProperty("then");
+    await vi.dynamicImportSettled();
+    await Promise.resolve();
+    expect(writeResolved).toBe(false);
+
+    auditWrite.resolve({});
     await expect(result).resolves.toBeUndefined();
     expect(logAppEventMock).not.toHaveBeenCalled();
   });

--- a/tests/unit/profile-update-service.test.ts
+++ b/tests/unit/profile-update-service.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authApiMock, isPrismaUniqueConstraintErrorMock, prismaMock } =
+  vi.hoisted(() => ({
+    authApiMock: {
+      updateUser: vi.fn(),
+    },
+    isPrismaUniqueConstraintErrorMock: vi.fn(),
+    prismaMock: {
+      user: {
+        findUnique: vi.fn(),
+      },
+    },
+  }));
+
+vi.mock("@/lib/auth/core", () => ({
+  authApi: authApiMock,
+}));
+
+vi.mock("@/lib/db/prisma-errors", () => ({
+  isPrismaUniqueConstraintError: isPrismaUniqueConstraintErrorMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+const profileInput = {
+  headers: new Headers(),
+  image: null,
+  name: "Test User",
+  userId: "user-1",
+  username: "race-name",
+};
+
+describe("updateOwnProfile", () => {
+  beforeEach(() => {
+    authApiMock.updateUser.mockReset();
+    isPrismaUniqueConstraintErrorMock.mockReset();
+    isPrismaUniqueConstraintErrorMock.mockReturnValue(false);
+    prismaMock.user.findUnique.mockReset();
+    vi.resetModules();
+  });
+
+  it("maps username uniqueness races to username_taken", async () => {
+    const uniqueConflict = new Error("unique conflict");
+    isPrismaUniqueConstraintErrorMock.mockReturnValueOnce(true);
+    prismaMock.user.findUnique
+      .mockResolvedValueOnce({
+        id: "user-1",
+        image: null,
+        profilePictures: [],
+      })
+      .mockResolvedValueOnce(null);
+    authApiMock.updateUser.mockRejectedValueOnce(uniqueConflict);
+    const { updateOwnProfile } = await import(
+      "@/features/profile/server/profile-update-service"
+    );
+
+    const result = await updateOwnProfile(profileInput);
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "username_taken",
+    });
+    expect(isPrismaUniqueConstraintErrorMock).toHaveBeenCalledWith(
+      uniqueConflict,
+    );
+  });
+});

--- a/tests/unit/upload-completion-service.test.ts
+++ b/tests/unit/upload-completion-service.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { uploadConfig } from "@/features/uploads/lib/upload-config";
-import { completeUploadSession } from "@/features/uploads/server/upload-service";
+import {
+  completeUploadSession,
+  deleteOwnedUpload,
+} from "@/features/uploads/server/upload-service";
 
 const {
   deleteStorageObjectMock,
+  fireAuditLogMock,
+  getViewerContextMock,
   headStorageObjectMock,
   pendingAggregateMock,
   pendingDeleteManyMock,
@@ -16,9 +21,13 @@ const {
   txUploadCreateMock,
   txUploadFindUniqueMock,
   uploadAggregateMock,
+  uploadDeleteMock,
+  uploadFindFirstMock,
   uploadFindUniqueMock,
 } = vi.hoisted(() => ({
   deleteStorageObjectMock: vi.fn(),
+  fireAuditLogMock: vi.fn(),
+  getViewerContextMock: vi.fn(),
   headStorageObjectMock: vi.fn(),
   pendingAggregateMock: vi.fn(),
   pendingDeleteManyMock: vi.fn(),
@@ -31,6 +40,8 @@ const {
   txUploadCreateMock: vi.fn(),
   txUploadFindUniqueMock: vi.fn(),
   uploadAggregateMock: vi.fn(),
+  uploadDeleteMock: vi.fn(),
+  uploadFindFirstMock: vi.fn(),
   uploadFindUniqueMock: vi.fn(),
 }));
 
@@ -38,6 +49,8 @@ vi.mock("@/lib/db/prisma", () => ({
   prisma: {
     upload: {
       aggregate: uploadAggregateMock,
+      delete: uploadDeleteMock,
+      findFirst: uploadFindFirstMock,
       findUnique: uploadFindUniqueMock,
     },
     uploadPending: {
@@ -58,11 +71,11 @@ vi.mock("@/lib/storage/r2-object", () => ({
 }));
 
 vi.mock("@/lib/audit/write-audit-log", () => ({
-  fireAuditLog: vi.fn(),
+  fireAuditLog: fireAuditLogMock,
 }));
 
 vi.mock("@/lib/auth/viewer-context", () => ({
-  getViewerContext: vi.fn(),
+  getViewerContext: getViewerContextMock,
 }));
 
 vi.mock("@/lib/log/app-logger", () => ({
@@ -99,6 +112,16 @@ const txPrisma = {
     findUnique: txPendingFindUniqueMock,
   },
 };
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
+}
 
 describe("completeUploadSession", () => {
   beforeEach(() => {
@@ -253,5 +276,53 @@ describe("completeUploadSession", () => {
       where: { key: KEY, userId: USER_ID },
     });
     expect(txUploadCreateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteOwnedUpload", () => {
+  beforeEach(() => {
+    getViewerContextMock.mockResolvedValue({
+      isAuthenticated: true,
+      isSuspended: false,
+    });
+    uploadFindFirstMock.mockResolvedValue({
+      id: "upload-1",
+      key: KEY,
+      size: 10,
+    });
+    uploadDeleteMock.mockResolvedValue({});
+    deleteStorageObjectMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("waits for upload delete audit scheduling before returning", async () => {
+    const auditWrite = deferred<void>();
+    fireAuditLogMock.mockReturnValue(auditWrite.promise);
+    const settled = vi.fn();
+
+    const result = deleteOwnedUpload({
+      id: "upload-1",
+      userId: USER_ID,
+    });
+    result.then(settled);
+
+    await vi.waitFor(() => expect(fireAuditLogMock).toHaveBeenCalled());
+    expect(settled).not.toHaveBeenCalled();
+
+    auditWrite.resolve();
+
+    await expect(result).resolves.toEqual({
+      ok: true,
+      deletedId: "upload-1",
+      deletedSize: 10,
+    });
+    expect(settled).toHaveBeenCalledWith({
+      ok: true,
+      deletedId: "upload-1",
+      deletedSize: 10,
+    });
   });
 });


### PR DESCRIPTION
## Goal

Fix audit `waitUntil` registration races and profile self-update username uniqueness races.

Closes #243.
Closes #244.

## Changed Surfaces

- `src/lib/audit/write-audit-log.ts`: make `fireAuditLog` await request-context lookup before returning, register Worker `waitUntil` before fast route responses finish, and preserve awaited/logged non-Worker behavior.
- Audit call sites: await `fireAuditLog` through admin, description, comment REST/MCP, and upload delete audit paths so the scheduling barrier is observed everywhere in source.
- `src/features/profile/server/profile-update-service.ts`: map Prisma unique conflicts from self-service username updates to the existing `username_taken` result.
- Focused unit coverage for audit scheduling, profile update races, and upload delete audit ordering.

## Evidence

- `rg 'fireAuditLog\\(' src tests` shows all production source call sites awaited; only direct unit-test calls are unawaited.
- `bun run test -- tests/unit/audit-write-log.test.ts tests/unit/profile-update-service.test.ts tests/unit/admin-api-service.test.ts tests/unit/protected-write-auth-order.test.ts tests/unit/upload-completion-service.test.ts tests/unit/upload-delete-service.test.ts` passed: 6 files, 26 tests.
- `bunx biome check src/lib/audit/write-audit-log.ts src/features/comments/server/comment-audit.ts src/lib/api/routes/comments-create-route.ts src/lib/api/routes/comments-update-action.ts src/lib/api/routes/comment-delete-action.ts src/lib/api/routes/comment-reaction-actions.ts src/lib/api/routes/comment-reaction-delete-route.ts src/lib/mcp/tools/comment-write-tool-handlers.ts src/features/admin/server/admin-api-service.ts src/features/descriptions/server/description-upsert.ts src/features/profile/server/profile-update-service.ts src/features/uploads/server/upload-service.ts tests/unit/audit-write-log.test.ts tests/unit/profile-update-service.test.ts tests/unit/upload-completion-service.test.ts` passed.
- `DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev" bun run verify` passed on current head: type checks, conventions, and 139 unit files / 644 tests.
- GitHub checks passed on `cb31b02`: CI check, Static Loader Image, E2E build, E2E admin-comments/api-mcp/public-web/signed-in shards, E2E snapshot artifact capture/comment, CodeQL, and Cloudflare Workers build.

## Docs / Contracts

No docs, contracts, OpenAPI, or message changes. This fixes internal race behavior and preserves existing API/result shapes.

## Risk Areas

- Audit logging: all source `fireAuditLog` call sites are now awaited so Worker scheduling can complete before route return.
- Profile auth: self-update unique races now align with existing admin username conflict handling.
- Uploads: this only awaits the existing upload delete audit log after current `origin/main` upload-delete changes; no upload behavior or contract changes are introduced here.

## Cleanup

No scratch artifacts or generated-file edits are committed. Changes are limited to focused source paths and unit tests; the local PR worktree is clean.
