### PR TITLE
fix(e2e): use copied worker entrypoint

### DIFF
--- a/tests/unit/playwright-runtime.test.ts
+++ b/tests/unit/playwright-runtime.test.ts
@@ -299,7 +299,7 @@ describe("playwright runtime", () => {
       };
       expect(config.routes).toBeUndefined();
       expect(config.main).toBe(
-        path.join(root, E2E_WORKER_ARTIFACT_DIR, "_worker.js"),
+        path.join(root, E2E_WORKER_ARTIFACT_DIR, "cloudflare", "_worker.js"),
       );
       expect(config.assets?.directory).toBe(
         path.join(root, E2E_WORKER_ARTIFACT_DIR, "cloudflare"),
@@ -371,7 +371,7 @@ describe("playwright runtime", () => {
       expect(() => validatePlaywrightWorkerRuntime(root)).not.toThrow();
       expect(
         existsSync(path.join(root, E2E_WORKER_ARTIFACT_DIR, "_worker.js")),
-      ).toBe(true);
+      ).toBe(false);
       expect(
         existsSync(
           path.join(root, E2E_WORKER_ARTIFACT_DIR, "cloudflare", "_worker.js"),
@@ -379,16 +379,16 @@ describe("playwright runtime", () => {
       ).toBe(true);
       expect(
         readFileSync(
-          path.join(root, E2E_WORKER_ARTIFACT_DIR, "_worker.js"),
+          path.join(root, E2E_WORKER_ARTIFACT_DIR, "cloudflare", "_worker.js"),
           "utf8",
         ),
-      ).toContain('from "./output/server/index.js"');
+      ).toContain('from "./../output/server/index.js"');
       expect(
         readFileSync(
-          path.join(root, E2E_WORKER_ARTIFACT_DIR, "_worker.js"),
+          path.join(root, E2E_WORKER_ARTIFACT_DIR, "cloudflare", "_worker.js"),
           "utf8",
         ),
-      ).toContain('from "./cloudflare-tmp/manifest.js"');
+      ).toContain('from "./../cloudflare-tmp/manifest.js"');
       expect(
         existsSync(
           path.join(
@@ -415,7 +415,7 @@ describe("playwright runtime", () => {
     const root = mkdtempSync(path.join(tmpdir(), "life-ustc-playwright-"));
     try {
       expect(() => validatePlaywrightWorkerRuntime(root)).toThrow(
-        /Missing E2E Worker artifact file: build\/e2e-worker\/_worker\.js/,
+        /Missing E2E Worker artifact file: build\/e2e-worker\/cloudflare\/_worker\.js/,
       );
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/tools/dev/e2e.ts
+++ b/tools/dev/e2e.ts
@@ -23,6 +23,7 @@ const WRANGLER_E2E_CONFIG_PATH = path.join(
 );
 const WRANGLER_E2E_PERSIST_PATH = path.join(".wrangler", "e2e", "state");
 export const E2E_WORKER_ARTIFACT_DIR = path.join("build", "e2e-worker");
+const E2E_WORKER_ENTRYPOINT = path.join("cloudflare", "_worker.js");
 const E2E_WORKER_SOURCE_ENTRIES = [
   {
     source: path.join(".svelte-kit", "cloudflare"),
@@ -41,7 +42,7 @@ const E2E_WORKER_SOURCE_ENTRIES = [
   },
 ] as const;
 const E2E_WORKER_CONTRACT_FILES = [
-  "_worker.js",
+  E2E_WORKER_ENTRYPOINT,
   path.join("cloudflare-tmp", "manifest.js"),
   path.join("output", "server", "index.js"),
 ] as const;
@@ -246,22 +247,6 @@ function copyE2EWorkerArtifact(root: string) {
       fs.copyFileSync(sourcePath, targetPath);
     }
   }
-
-  writeE2EWorkerEntrypoint(root);
-}
-
-function writeE2EWorkerEntrypoint(root: string) {
-  const sourcePath = e2eWorkerArtifactPath(
-    root,
-    path.join("cloudflare", "_worker.js"),
-  );
-  const targetPath = e2eWorkerArtifactPath(root, "_worker.js");
-  const source = fs.readFileSync(sourcePath, "utf8");
-  const rewritten = source
-    .replaceAll("./../output/", "./output/")
-    .replaceAll("./../cloudflare-tmp/", "./cloudflare-tmp/");
-
-  fs.writeFileSync(targetPath, rewritten);
 }
 
 export function validatePlaywrightWorkerRuntime(
@@ -365,7 +350,7 @@ export function writePlaywrightWranglerConfig(
 
   delete config.routes;
   const artifactRoot = e2eWorkerArtifactPath(root);
-  config.main = path.resolve(artifactRoot, "_worker.js");
+  config.main = path.resolve(artifactRoot, E2E_WORKER_ENTRYPOINT);
   config.assets = {
     ...config.assets,
     directory: path.resolve(artifactRoot, "cloudflare"),


### PR DESCRIPTION
## Goal

Close #267 by stopping the E2E staging helper from rewriting SvelteKit Cloudflare adapter output and using the copied adapter entrypoint directly.

## Changed Surfaces

- `tools/dev/e2e.ts`: validates `build/e2e-worker/cloudflare/_worker.js`, removes synthetic root `_worker.js`, and points generated Wrangler config at the copied adapter entrypoint.
- `tests/unit/playwright-runtime.test.ts`: updates runtime helper coverage to require the copied adapter entrypoint and assert the synthetic root file is absent.
- No workflows, package scripts, API/contracts, snapshots, UI, comments, bus, audit, or admin files changed.

## Evidence

- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run test -- tests/unit/playwright-runtime.test.ts`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev AUTH_SECRET=e2e-local-auth-secret WEBHOOK_SECRET=e2e-local-webhook-secret OAUTH_PROXY_SECRET=e2e-local-oauth-proxy-secret METRICS_BEARER_TOKEN=e2e-local-metrics-token bun run e2e:build-artifacts`
- `bun run e2e:prepare`
- `bun run check:e2e`
- `bunx biome check tools/dev/e2e.ts tests/unit/playwright-runtime.test.ts`
- Artifact checks: `build/e2e-worker/cloudflare/_worker.js` present, `build/e2e-worker/output/server/index.js` present, `build/e2e-worker/_worker.js` absent.

## Docs / Contracts

No docs/contracts change needed; this only changes the internal E2E artifact staging contract covered by the runtime helper tests.

## Risk Areas

Wrangler local E2E startup now depends on the copied adapter entrypoint path. The build/prepare check verifies the current SvelteKit Cloudflare adapter layout produces that file.

## Cleanup

`git status` shows only the committed source/test changes; generated build outputs remain ignored and no scratch artifacts were added.

Closes #267