### PR TITLE
fix(api): align REST/MCP query validation contracts

### DIFF
--- a/docs/contracts/admin.json
+++ b/docs/contracts/admin.json
@@ -14,6 +14,7 @@
     "admin-rest-session-only": "Admin REST endpoints require the in-site Better Auth session cookie and do not accept OAuth bearer tokens.",
     "suspension-expiration-validation": "Suspension expiration accepts omitted, null, or empty input as permanent and rejects invalid non-empty date strings.",
     "single-open-suspension": "Each user can have at most one open suspension. Creating a new suspension closes any previous open suspension for that user while retaining history; lifting an open suspension clears the user's open suspension state.",
+    "admin-mutation-not-found": "PATCH /api/admin/comments/[id], POST /api/admin/suspensions, and PATCH /api/admin/users/[id] return 404 when the target record is not found.",
     "suspension-retention": "Suspension history is retained when an admin account is deleted; creator and lifter actor references may be null after account deletion."
   },
   "capabilities": {
@@ -112,7 +113,8 @@
           {
             "path": "/api/admin/users/[id]",
             "method": "PATCH",
-            "returns": "{ user: User }"
+            "returns": "{ user: User }",
+            "notes": ["Returns 404 when the target user is not found."]
           }
         ]
       },

--- a/docs/contracts/bus.json
+++ b/docs/contracts/bus.json
@@ -161,6 +161,7 @@
             "notes": [
               "Requires originCampusId and destinationCampusId.",
               "Supports atTime, dayType, includeDeparted, limit, versionKey, and locale query parameters.",
+              "REST and MCP share the same limit bounds: 1-50.",
               "Departures include status and minutesUntilDeparture so clients can mark departed rows and the next upcoming trip."
             ]
           }
@@ -174,7 +175,7 @@
             "rest_equivalent": "GET /api/bus/next",
             "notes": [
               "Task-oriented convenience tool for 'when is the next bus?' prompts.",
-              "Default parameters: dayType=auto, includeDeparted=false, limit=5.",
+              "Default parameters: dayType=auto, includeDeparted=false, limit=5; REST and MCP share limit bounds 1-50.",
               "When a route exists but no remaining departures are available for the requested window, return guidance describing the situation and, when possible, the next available service time.",
               "Default/summary responses should avoid repeating the same originCampus/destinationCampus object inside every departure item when they already appear at the top level."
             ]

--- a/docs/contracts/course.json
+++ b/docs/contracts/course.json
@@ -27,7 +27,10 @@
         "routes": [
           {
             "path": "/api/courses",
-            "returns": "PaginatedResponse<Course>"
+            "returns": "PaginatedResponse<Course>",
+            "notes": [
+              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+            ]
           }
         ]
       },
@@ -36,7 +39,10 @@
           {
             "name": "search_courses",
             "returns": "PaginatedResponse<Course>",
-            "rest_equivalent": "GET /api/courses"
+            "rest_equivalent": "GET /api/courses",
+            "notes": [
+              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+            ]
           }
         ]
       },

--- a/docs/contracts/schedule.json
+++ b/docs/contracts/schedule.json
@@ -29,6 +29,7 @@
             "notes": [
               "Resolves the current user's subscribed sections server-side.",
               "Supports dateFrom/dateTo, weekday, limit, and locale filters.",
+              "weekday accepts 1-7 and limit accepts 1-300 on both REST and MCP.",
               "Use /api/schedules for public schedule queries without personal subscription scope."
             ]
           }
@@ -41,7 +42,8 @@
             "returns": "{ schedules: ScheduleEntry[] }",
             "rest_equivalent": "GET /api/me/subscriptions/schedules",
             "notes": [
-              "Returns schedules[]; each item contains date, weekday, startTime, endTime, section.course.namePrimary, section.code, room, teachers[], and scheduleGroup."
+              "Returns schedules[]; each item contains date, weekday, startTime, endTime, section.course.namePrimary, section.code, room, teachers[], and scheduleGroup.",
+              "weekday accepts 1-7 and limit accepts 1-300 on both REST and MCP."
             ]
           }
         ]
@@ -74,6 +76,7 @@
             "notes": [
               "Supports filtering by section, teacher, room, date range, and day of week.",
               "REST/MCP both accept exact JW/code-style filters for schedules so callers do not need to resolve internal numeric IDs first.",
+              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping.",
               "REST localizes nested schedule labels from the request locale; MCP accepts an explicit locale input."
             ]
           }
@@ -84,7 +87,10 @@
           {
             "name": "query_schedules",
             "returns": "PaginatedResponse<ScheduleEntry>",
-            "rest_equivalent": "GET /api/schedules"
+            "rest_equivalent": "GET /api/schedules",
+            "notes": [
+              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+            ]
           }
         ]
       },

--- a/docs/contracts/section.json
+++ b/docs/contracts/section.json
@@ -27,7 +27,10 @@
         "routes": [
           {
             "path": "/api/sections",
-            "returns": "PaginatedResponse<SectionSummary>"
+            "returns": "PaginatedResponse<SectionSummary>",
+            "notes": [
+              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+            ]
           }
         ]
       },
@@ -36,7 +39,10 @@
           {
             "name": "search_sections",
             "returns": "PaginatedResponse<SectionSummary>",
-            "rest_equivalent": "GET /api/sections"
+            "rest_equivalent": "GET /api/sections",
+            "notes": [
+              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+            ]
           }
         ]
       },

--- a/docs/contracts/semester.json
+++ b/docs/contracts/semester.json
@@ -23,7 +23,10 @@
         "routes": [
           {
             "path": "/api/semesters",
-            "returns": "PaginatedResponse<SemesterSummary>"
+            "returns": "PaginatedResponse<SemesterSummary>",
+            "notes": [
+              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+            ]
           }
         ]
       },
@@ -32,7 +35,10 @@
           {
             "name": "list_semesters",
             "returns": "PaginatedResponse<SemesterSummary>",
-            "rest_equivalent": "GET /api/semesters"
+            "rest_equivalent": "GET /api/semesters",
+            "notes": [
+              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+            ]
           }
         ]
       },

--- a/docs/contracts/teacher.json
+++ b/docs/contracts/teacher.json
@@ -26,7 +26,10 @@
         "routes": [
           {
             "path": "/api/teachers",
-            "returns": "PaginatedResponse<TeacherSummary>"
+            "returns": "PaginatedResponse<TeacherSummary>",
+            "notes": [
+              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+            ]
           }
         ]
       },
@@ -35,7 +38,10 @@
           {
             "name": "search_teachers",
             "returns": "PaginatedResponse<TeacherSummary>",
-            "rest_equivalent": "GET /api/teachers"
+            "rest_equivalent": "GET /api/teachers",
+            "notes": [
+              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+            ]
           }
         ]
       },

--- a/docs/contracts/todo.json
+++ b/docs/contracts/todo.json
@@ -28,7 +28,8 @@
             "returns": "{ counts: { incomplete: Int, completed: Int, overdue: Int }, todos: TodoItem[] }",
             "notes": [
               "Returns the same count summary as list_my_todos plus todos[]; each item contains id, title, content, completed, priority, dueAt, createdAt, and updatedAt.",
-              "Supports completed, priority, dueBefore, dueAfter, and limit query parameters."
+              "Supports completed, priority, dueBefore, dueAfter, and limit query parameters.",
+              "REST and MCP share the same limit bounds: 1-200."
             ]
           }
         ]
@@ -41,6 +42,7 @@
             "rest_equivalent": "GET /api/todos?completed=false&limit=50",
             "notes": [
               "Default parameters: includeCompleted=false, limit=50.",
+              "REST and MCP share the same limit bounds: 1-200.",
               "Incomplete items are returned first; completed items are excluded unless includeCompleted=true."
             ]
           }

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -429,6 +429,16 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
           }
         },
         "x-auth-role": "admin",
@@ -833,6 +843,16 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
           }
         },
         "x-auth-role": "admin",
@@ -1023,6 +1043,16 @@
             }
           },
           "401": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "404": {
             "description": "Error response",
             "content": {
               "application/json": {
@@ -1293,7 +1323,9 @@
             "name": "limit",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 50
             }
           },
           {
@@ -2453,7 +2485,9 @@
             "name": "limit",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 100
             },
             "example": 20
           }
@@ -3992,7 +4026,9 @@
             "name": "weekday",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 7
             }
           },
           {
@@ -4000,7 +4036,9 @@
             "name": "limit",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 300
             }
           },
           {
@@ -4343,7 +4381,9 @@
             "name": "limit",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 100
             }
           }
         ],
@@ -4481,7 +4521,9 @@
             "name": "limit",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 100
             },
             "example": 20
           }
@@ -5435,7 +5477,9 @@
             "name": "limit",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 100
             },
             "example": 20
           }
@@ -5567,7 +5611,9 @@
             "name": "limit",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 100
             },
             "example": 20
           }
@@ -5896,7 +5942,9 @@
             "name": "limit",
             "schema": {
               "type": "integer",
-              "format": "int64"
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 200
             }
           }
         ],
@@ -5907,6 +5955,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/todosListResponseSchema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
                 }
               }
             }

--- a/src/lib/api/schemas/catalog-query-schemas.ts
+++ b/src/lib/api/schemas/catalog-query-schemas.ts
@@ -1,8 +1,15 @@
 import * as z from "zod";
 import {
   dateInputStringSchema,
+  integerStringRangeSchema,
   integerStringSchema,
 } from "./request-schema-primitives";
+
+const catalogPaginationLimitSchema = integerStringRangeSchema({
+  minimum: 1,
+  maximum: 100,
+  message: "Limit must be between 1 and 100",
+});
 
 const weekdayStringSchema = integerStringSchema
   .refine(
@@ -41,7 +48,7 @@ export const sectionsQuerySchema = z.object({
   ids: z.string().trim().optional(),
   jwIds: z.string().trim().optional(),
   page: integerStringSchema.optional(),
-  limit: integerStringSchema.optional(),
+  limit: catalogPaginationLimitSchema.optional(),
 });
 
 export const schedulesQuerySchema = z.object({
@@ -56,7 +63,7 @@ export const schedulesQuerySchema = z.object({
   dateFrom: dateInputStringSchema.optional(),
   dateTo: dateInputStringSchema.optional(),
   page: integerStringSchema.optional(),
-  limit: integerStringSchema.optional(),
+  limit: catalogPaginationLimitSchema.optional(),
 });
 
 export const sectionSchedulesQuerySchema = z.object({
@@ -69,7 +76,7 @@ export const teachersQuerySchema = z.object({
   departmentId: integerStringSchema.optional(),
   search: z.string().trim().optional(),
   page: integerStringSchema.optional(),
-  limit: integerStringSchema.optional(),
+  limit: catalogPaginationLimitSchema.optional(),
 });
 
 export const coursesQuerySchema = z.object({
@@ -78,5 +85,5 @@ export const coursesQuerySchema = z.object({
   categoryId: integerStringSchema.optional(),
   classTypeId: integerStringSchema.optional(),
   page: integerStringSchema.optional(),
-  limit: integerStringSchema.optional(),
+  limit: catalogPaginationLimitSchema.optional(),
 });

--- a/src/lib/api/schemas/misc-query-schemas.ts
+++ b/src/lib/api/schemas/misc-query-schemas.ts
@@ -2,9 +2,40 @@ import * as z from "zod";
 import { APP_LOCALES } from "@/i18n/config";
 import {
   dateInputStringSchema,
+  integerStringRangeSchema,
   integerStringSchema,
   todoPrioritySchema,
 } from "./request-schema-primitives";
+
+const busNextDeparturesLimitSchema = integerStringRangeSchema({
+  minimum: 1,
+  maximum: 50,
+  message: "limit must be between 1 and 50",
+});
+
+const publicPaginationLimitSchema = integerStringRangeSchema({
+  minimum: 1,
+  maximum: 100,
+  message: "limit must be between 1 and 100",
+});
+
+const subscribedSchedulesWeekdaySchema = integerStringRangeSchema({
+  minimum: 1,
+  maximum: 7,
+  message: "weekday must be between 1 and 7",
+});
+
+const subscribedSchedulesLimitSchema = integerStringRangeSchema({
+  minimum: 1,
+  maximum: 300,
+  message: "limit must be between 1 and 300",
+});
+
+const todoLimitSchema = integerStringRangeSchema({
+  minimum: 1,
+  maximum: 200,
+  message: "limit must be between 1 and 200",
+});
 
 const overviewHomeworkWindowDaysSchema = integerStringSchema
   .refine(
@@ -47,7 +78,7 @@ export const busNextDeparturesQuerySchema = z.object({
   atTime: z.string().trim().min(1).optional(),
   dayType: z.enum(["auto", "weekday", "weekend"]).optional(),
   includeDeparted: z.enum(["true", "false"]).optional(),
-  limit: integerStringSchema.optional(),
+  limit: busNextDeparturesLimitSchema.optional(),
   versionKey: z.string().trim().min(1).optional(),
   locale: z.enum(APP_LOCALES).optional(),
 });
@@ -69,14 +100,14 @@ export const dashboardLinkVisitQuerySchema = z.object({
 
 export const semestersQuerySchema = z.object({
   page: integerStringSchema.optional(),
-  limit: integerStringSchema.optional(),
+  limit: publicPaginationLimitSchema.optional(),
 });
 
 export const subscribedSchedulesQuerySchema = z.object({
   dateFrom: dateInputStringSchema.optional(),
   dateTo: dateInputStringSchema.optional(),
-  weekday: integerStringSchema.optional(),
-  limit: integerStringSchema.optional(),
+  weekday: subscribedSchedulesWeekdaySchema.optional(),
+  limit: subscribedSchedulesLimitSchema.optional(),
   locale: z.enum(APP_LOCALES).optional(),
 });
 
@@ -116,7 +147,7 @@ export const todosQuerySchema = z.object({
   priority: todoPrioritySchema.optional(),
   dueBefore: dateInputStringSchema.optional(),
   dueAfter: dateInputStringSchema.optional(),
-  limit: integerStringSchema.optional(),
+  limit: todoLimitSchema.optional(),
 });
 
 export const uploadObjectQuerySchema = z.object({

--- a/src/lib/api/schemas/request-schema-primitives.ts
+++ b/src/lib/api/schemas/request-schema-primitives.ts
@@ -34,6 +34,33 @@ export const integerStringSchema = z
   })
   .meta({ override: { type: "integer", format: "int64" } });
 
+export function integerStringRangeSchema({
+  maximum,
+  message,
+  minimum,
+}: {
+  maximum: number;
+  message: string;
+  minimum: number;
+}) {
+  return integerStringSchema
+    .refine(
+      (value) => {
+        const parsed = parseInteger(value);
+        return parsed !== null && parsed >= minimum && parsed <= maximum;
+      },
+      { message },
+    )
+    .meta({
+      override: {
+        type: "integer",
+        format: "int64",
+        minimum,
+        maximum,
+      },
+    });
+}
+
 export const dateInputStringSchema = z
   .string()
   .trim()

--- a/src/lib/mcp/tools/bus-tools.ts
+++ b/src/lib/mcp/tools/bus-tools.ts
@@ -123,7 +123,7 @@ export function registerBusTools(server: McpServer) {
           ),
         dayType: busDayTypeSchema,
         includeDeparted: z.boolean().default(false),
-        limit: z.number().int().min(1).max(20).default(5),
+        limit: z.number().int().min(1).max(50).default(5),
         versionKey: z.string().trim().min(1).optional(),
         locale: mcpLocaleInputSchema,
         mode: mcpModeInputSchema,

--- a/src/routes/api/admin/comments/[id]/+server.ts
+++ b/src/routes/api/admin/comments/[id]/+server.ts
@@ -9,6 +9,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  * @response adminModeratedCommentResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
+ * @response 404:openApiErrorSchema
  */
 export const PATCH: RequestHandler = ({ request, params }) =>
   observedApiRoute(() => patchAdminCommentRoute(request, { id: params.id }))(

--- a/src/routes/api/admin/suspensions/+server.ts
+++ b/src/routes/api/admin/suspensions/+server.ts
@@ -19,6 +19,7 @@ export const GET = svelteRequestHandler(
  * @response adminSuspensionResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
+ * @response 404:openApiErrorSchema
  */
 export const POST = svelteRequestHandler(
   observedApiRoute(postAdminSuspensionRoute),

--- a/src/routes/api/admin/users/[id]/+server.ts
+++ b/src/routes/api/admin/users/[id]/+server.ts
@@ -9,6 +9,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  * @response adminUserResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
+ * @response 404:openApiErrorSchema
  */
 export const PATCH: RequestHandler = ({ request, params }) =>
   observedApiRoute(() => patchAdminUserRoute(request, { id: params.id }))(

--- a/src/routes/api/todos/+server.ts
+++ b/src/routes/api/todos/+server.ts
@@ -6,6 +6,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  * List todos.
  * @params todosQuerySchema
  * @response todosListResponseSchema
+ * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
  */
 export const GET = svelteRequestHandler(observedApiRoute(getTodosRoute));

--- a/tests/integration/mcp-11-bus.test.ts
+++ b/tests/integration/mcp-11-bus.test.ts
@@ -21,10 +21,22 @@ describe("get_next_buses — default mode drops repeated campus objects", () => 
         originCampusId: fixtures.DEV_SEED.bus.originCampusId,
         destinationCampusId: fixtures.DEV_SEED.bus.destinationCampusId,
         atTime: fixtures.SEED_DATE,
+        limit: 50,
       },
     );
 
     expect(result.totalRoutes).toBeGreaterThan(0);
+  });
+
+  it("rejects limits above the shared REST/MCP cap", async () => {
+    await expect(
+      context.client.call("get_next_buses", {
+        locale: "zh-cn",
+        originCampusId: fixtures.DEV_SEED.bus.originCampusId,
+        destinationCampusId: fixtures.DEV_SEED.bus.destinationCampusId,
+        limit: 51,
+      }),
+    ).rejects.toThrow();
   });
 
   it("rejects invalid atTime with the shared MCP date message", async () => {

--- a/tests/unit/api-route-query-validation.test.ts
+++ b/tests/unit/api-route-query-validation.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { getCoursesRoute } from "@/lib/api/routes/academic-course-routes";
+import { getSchedulesRoute } from "@/lib/api/routes/academic-schedule-routes";
+import { getBusNextDeparturesRoute } from "@/lib/api/routes/bus";
+import { parseTodosQuery } from "@/lib/api/routes/todo-route-request";
+
+async function expectInvalidQueryResponse(
+  result: Response | Promise<Response>,
+  message: string,
+) {
+  const response = await result;
+  expect(response.status).toBe(400);
+  expect(await response.json()).toEqual({ error: message });
+}
+
+describe("API route query validation", () => {
+  it("rejects oversized public pagination limits before clamping", async () => {
+    await expectInvalidQueryResponse(
+      getCoursesRoute(
+        new Request("https://example.test/api/courses?limit=101"),
+      ),
+      "Invalid course query",
+    );
+
+    await expectInvalidQueryResponse(
+      getSchedulesRoute(
+        new Request("https://example.test/api/schedules?limit=101"),
+      ),
+      "Invalid schedule query",
+    );
+  });
+
+  it("serializes next-bus and todo limit validation failures", async () => {
+    await expectInvalidQueryResponse(
+      getBusNextDeparturesRoute(
+        new Request(
+          "https://example.test/api/bus/next?originCampusId=1&destinationCampusId=2&limit=51",
+        ),
+      ),
+      "Invalid bus next-departures query",
+    );
+
+    const todosQuery = parseTodosQuery(
+      new Request("https://example.test/api/todos?limit=201"),
+    );
+    expect(todosQuery).toBeInstanceOf(Response);
+    await expectInvalidQueryResponse(
+      todosQuery as Response,
+      "Invalid todo query",
+    );
+  });
+});

--- a/tests/unit/api-schemas.test.ts
+++ b/tests/unit/api-schemas.test.ts
@@ -6,6 +6,7 @@ import {
 import { HOMEWORK_DESCRIPTION_MAX_LENGTH } from "@/features/homeworks/lib/homework-limits";
 import { TODO_CONTENT_MAX_LENGTH } from "@/features/todos/lib/todo-limits";
 import {
+  busNextDeparturesQuerySchema,
   calendarSubscriptionAppendRequestSchema,
   calendarSubscriptionCreateRequestSchema,
   commentCreateRequestSchema,
@@ -19,6 +20,9 @@ import {
   matchSectionCodesRequestSchema,
   schedulesQuerySchema,
   sectionsQuerySchema,
+  semestersQuerySchema,
+  subscribedSchedulesQuerySchema,
+  teachersQuerySchema,
   todoCreateRequestSchema,
   todosQuerySchema,
   uploadCompleteRequestSchema,
@@ -429,6 +433,47 @@ describe("other request schemas", () => {
     expect(todosQuerySchema.safeParse({ dueBefore: "" }).success).toBe(false);
     expect(
       todosQuerySchema.safeParse({ dueBefore: "not-a-date" }).success,
+    ).toBe(false);
+  });
+
+  it("validates documented query limit bounds", () => {
+    for (const schema of [
+      coursesQuerySchema,
+      sectionsQuerySchema,
+      schedulesQuerySchema,
+      teachersQuerySchema,
+      semestersQuerySchema,
+    ]) {
+      expect(schema.safeParse({ limit: "100" }).success).toBe(true);
+      expect(schema.safeParse({ limit: "101" }).success).toBe(false);
+      expect(schema.safeParse({ limit: "0" }).success).toBe(false);
+    }
+
+    const validBusNextQuery = {
+      destinationCampusId: "2",
+      limit: "50",
+      originCampusId: "1",
+    };
+    expect(
+      busNextDeparturesQuerySchema.safeParse(validBusNextQuery).success,
+    ).toBe(true);
+    expect(
+      busNextDeparturesQuerySchema.safeParse({
+        ...validBusNextQuery,
+        limit: "51",
+      }).success,
+    ).toBe(false);
+    expect(todosQuerySchema.safeParse({ limit: "200" }).success).toBe(true);
+    expect(todosQuerySchema.safeParse({ limit: "201" }).success).toBe(false);
+    expect(
+      subscribedSchedulesQuerySchema.safeParse({ weekday: "7", limit: "300" })
+        .success,
+    ).toBe(true);
+    expect(
+      subscribedSchedulesQuerySchema.safeParse({ weekday: "8" }).success,
+    ).toBe(false);
+    expect(
+      subscribedSchedulesQuerySchema.safeParse({ limit: "301" }).success,
     ).toBe(false);
   });
 

--- a/tests/unit/openapi-scenario-examples.test.ts
+++ b/tests/unit/openapi-scenario-examples.test.ts
@@ -56,6 +56,8 @@ type GeneratedMediaType = {
 type GeneratedSchema = {
   $ref?: string;
   format?: string;
+  maximum?: number;
+  minimum?: number;
   properties?: Record<string, unknown>;
   required?: string[];
   type?: string;
@@ -80,6 +82,13 @@ function resolveGeneratedSchema(
   if (!ref) return schema;
   const schemaName = ref.match(/^#\/components\/schemas\/(.+)$/)?.[1];
   return schemaName ? spec.components?.schemas?.[schemaName] : undefined;
+}
+
+function queryParameter(
+  operation: GeneratedOperation | undefined,
+  name: string,
+) {
+  return operation?.parameters?.find((parameter) => parameter.name === name);
 }
 
 describe("buildScenarioOpenApiExamples", () => {
@@ -241,6 +250,52 @@ describe("buildScenarioOpenApiExamples", () => {
       "Return OAuth device authorization CORS preflight headers",
     );
     expect(deviceAuthorizationOptions?.responses?.["204"]).toBeTruthy();
+  });
+
+  it("documents query bounds and implemented validation responses", () => {
+    const spec = generatedOpenApiDocument as GeneratedOpenApiDocument;
+
+    for (const path of [
+      "/api/courses",
+      "/api/sections",
+      "/api/schedules",
+      "/api/teachers",
+      "/api/semesters",
+    ]) {
+      expect(queryParameter(spec.paths[path]?.get, "limit")?.schema).toEqual(
+        expect.objectContaining({ minimum: 1, maximum: 100 }),
+      );
+    }
+
+    expect(
+      queryParameter(spec.paths["/api/bus/next"]?.get, "limit")?.schema,
+    ).toEqual(expect.objectContaining({ minimum: 1, maximum: 50 }));
+    expect(
+      queryParameter(spec.paths["/api/todos"]?.get, "limit")?.schema,
+    ).toEqual(expect.objectContaining({ minimum: 1, maximum: 200 }));
+    expect(
+      queryParameter(
+        spec.paths["/api/me/subscriptions/schedules"]?.get,
+        "weekday",
+      )?.schema,
+    ).toEqual(expect.objectContaining({ minimum: 1, maximum: 7 }));
+    expect(
+      queryParameter(
+        spec.paths["/api/me/subscriptions/schedules"]?.get,
+        "limit",
+      )?.schema,
+    ).toEqual(expect.objectContaining({ minimum: 1, maximum: 300 }));
+
+    expect(spec.paths["/api/todos"]?.get?.responses?.["400"]).toBeTruthy();
+    expect(
+      spec.paths["/api/admin/users/{id}"]?.patch?.responses?.["404"],
+    ).toBeTruthy();
+    expect(
+      spec.paths["/api/admin/comments/{id}"]?.patch?.responses?.["404"],
+    ).toBeTruthy();
+    expect(
+      spec.paths["/api/admin/suspensions"]?.post?.responses?.["404"],
+    ).toBeTruthy();
   });
 
   it("documents auth security for protected REST and MCP operations", () => {


### PR DESCRIPTION
## Goal

Close #256, #257, #258, and #259 by aligning REST/MCP query validation and generated API docs for the affected public API surfaces.

Closes #256
Closes #257
Closes #258
Closes #259

## Changed Surfaces

- REST query schemas: add bounded integer query metadata and reject out-of-range `limit` values for catalog/schedule, bus next, subscribed schedules, todos, and semesters.
- MCP tools: align `get_next_buses` with REST by using the shared `limit` cap of 50.
- OpenAPI: regenerate query bounds, add `GET /api/todos` 400, and document admin mutation 404 responses.
- Contracts/tests: update relevant contract modules and add focused schema, route serialization, generated OpenAPI, and MCP bus coverage.

## Evidence

- Focused unit: `bun run vitest run tests/unit/api-schemas.test.ts tests/unit/api-route-query-validation.test.ts tests/unit/openapi-scenario-examples.test.ts` — 39 tests passed.
- Focused MCP integration on an isolated temporary DB: migrations + seed + `bun run vitest run --config vitest.integration.config.ts tests/integration/mcp-11-bus.test.ts` — 6 tests passed.
- Default gate: `bun run verify` — typecheck, conventions, OpenAPI check, contracts/i18n/routes, and 651 unit tests passed.
- Complete-loop serialization: `tests/unit/api-route-query-validation.test.ts` inspects representative REST 400 JSON for oversized limits; generated OpenAPI snippets were checked for the new bounds and status responses.

## Docs / Contracts

Updated `docs/contracts/{admin,bus,course,schedule,section,semester,teacher,todo}.json` and regenerated `public/openapi.generated.json`.

## Risk Areas

- Intentional behavior change: affected REST list endpoints now reject out-of-range `limit` values instead of silently clamping them.
- Page normalization remains unchanged; these issues were scoped to limit cap/status documentation drift.
- The shared local dev DB seed has pre-existing enum drift, so focused MCP evidence used a fresh temporary DB instead of mutating shared dev state.

## Cleanup

No scratch artifacts, one-time probes, unrelated rewrites, or manual generated-file edits remain. The temporary verification DB was dropped by the command trap.
