### PR TITLE
fix(dashboard): dashboard bus SSR time and anonymous data

### DIFF
--- a/docs/contracts/bus.json
+++ b/docs/contracts/bus.json
@@ -8,7 +8,7 @@
   },
   "rules": {
     "public-no-signin": "Bus is public campus life information; sign-in should not be a prerequisite.",
-    "weekday-by-client-time": "The dashboard bus page determines weekday/weekend by the user's local time on the client side by default and allows manual switching.",
+    "weekday-by-shanghai-time": "The dashboard bus page determines weekday/weekend by Shanghai time by default and allows manual switching.",
     "shanghai-time-interpretation": "When calculating 'how long until departure', whether a trip has departed, and route ordering, the dashboard client interprets HH:mm times in the timetable uniformly as Shanghai Time, not changing with the browser's timezone.",
     "core-filters-only": "The dashboard bus page provides only core filters for departure stop, arrival stop, direction reversal, and 'show already-departed trips'; departure and arrival stops use a directly clickable vertical stop column to avoid secondary dropdowns, maintaining clear departure/arrival hierarchy.",
     "visual-priority": "The dashboard visual structure should prioritize 'quick scanning of the next trip and route differences'; selected stop, direction, next departure time, and route grouping must be more prominent than decorative cards.",

--- a/src/features/bus/lib/bus-client-time.ts
+++ b/src/features/bus/lib/bus-client-time.ts
@@ -3,7 +3,7 @@ import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
 export function resolveClientBusDayType(
   now = new Date(),
 ): "weekday" | "weekend" {
-  const day = now.getDay();
+  const day = shanghaiDayjs(now).day();
   return day === 0 || day === 6 ? "weekend" : "weekday";
 }
 

--- a/src/features/dashboard/components/AnonymousDashboardView.svelte
+++ b/src/features/dashboard/components/AnonymousDashboardView.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { onMount } from "svelte";
 import type { DashboardBusCopy } from "@/features/dashboard/lib/bus-tab-types";
 import type {
   AnonymousDashboardData,
@@ -7,7 +6,6 @@ import type {
   DashboardDashboardCopy,
   LinkView,
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
-import { Alert } from "$lib/components/ui/alert/index.js";
 import * as Tabs from "$lib/components/ui/tabs/index.js";
 import AnonymousLinksTab from "./AnonymousLinksTab.svelte";
 import BusTab from "./BusTab.svelte";
@@ -21,12 +19,6 @@ export let linkSearchInput: HTMLInputElement | null;
 export let linkSearchQuery: string;
 export let linkView: LinkView;
 export let setLinkView: (view: LinkView) => void;
-
-let mounted = false;
-
-onMount(() => {
-  mounted = true;
-});
 </script>
 
 <div class="flex flex-wrap justify-end gap-1">
@@ -52,11 +44,9 @@ onMount(() => {
     bind:linkSearchQuery
     bind:linkSearchInput
   />
-{:else if mounted}
+{:else}
   <BusTab
     {busCopy}
     bus={anonymousData.bus ?? null}
   />
-{:else}
-  <Alert>{busCopy.empty}</Alert>
 {/if}

--- a/src/features/dashboard/components/BusTab.svelte
+++ b/src/features/dashboard/components/BusTab.svelte
@@ -12,7 +12,6 @@ import type {
   DashboardBusData,
 } from "@/features/dashboard/lib/bus-tab-types";
 import { apiClient } from "@/lib/api/client";
-import { browser } from "$app/environment";
 import { Alert } from "$lib/components/ui/alert/index.js";
 import BusTabSettings from "./BusTabSettings.svelte";
 import BusTabTimetable from "./BusTabTimetable.svelte";
@@ -49,13 +48,11 @@ async function loadPublicBusData() {
   state.initializeWhenNeeded();
 }
 
-if (browser) {
-  onMount(() => {
-    const cleanup = state.actions.mount();
-    void loadPublicBusData();
-    return cleanup;
-  });
-}
+onMount(() => {
+  const cleanup = state.actions.mount();
+  void loadPublicBusData();
+  return cleanup;
+});
 
 $: {
   void busStateVersion;

--- a/src/features/dashboard/components/DashboardPageController.svelte
+++ b/src/features/dashboard/components/DashboardPageController.svelte
@@ -498,10 +498,7 @@ $: selectedImportCount = selectedImportSectionIds.length;
 $: canMatchImportSections =
   bulkImportText.trim().length > 0 && !isMatchingSections;
 
-let mounted = false;
-
 onMount(() => {
-  mounted = true;
   return mountDashboardController({
     applyViewState: applyDashboardViewState,
     clearPendingRemoveSection,
@@ -719,10 +716,6 @@ onMount(() => {
     {/if}
   {:else if data.signedIn && data.userMissing}
     <Alert variant="warning">{commonCopy.userNotFound}</Alert>
-  {:else if anonymousData?.tab === "bus" && !mounted}
-    <div class="rounded-xl border border-base-300 bg-base-100 p-4 text-base-content/70 text-sm">
-      {busCopy.empty}
-    </div>
   {:else if anonymousData}
     <AnonymousDashboardView
       {busCopy}

--- a/src/features/dashboard/lib/bus-tab-planner-controller.ts
+++ b/src/features/dashboard/lib/bus-tab-planner-controller.ts
@@ -8,6 +8,11 @@ import type { DashboardBusCopy, DashboardBusData } from "./bus-tab-types";
 
 export type BusDayType = "weekday" | "weekend";
 
+function busReferenceNow(bus: DashboardBusData) {
+  const fetchedAt = new Date(bus.fetchedAt);
+  return Number.isNaN(fetchedAt.getTime()) ? new Date(0) : fetchedAt;
+}
+
 type BusTabPlannerControllerInput = {
   getBus: () => DashboardBusData | null;
   getBusCopy: () => DashboardBusCopy;
@@ -41,12 +46,13 @@ export function createBusTabPlannerController(
   function initializeBusPlanner() {
     const bus = input.getBus();
     if (!bus) return;
+    const referenceNow = busReferenceNow(bus);
     const selection = getDefaultBusSelection(bus, bus.preferences);
-    input.setBusDayType(resolveClientBusDayType(new Date()));
+    input.setBusDayType(resolveClientBusDayType(referenceNow));
     input.setBusStartCampusId(selection.startCampusId);
     input.setBusEndCampusId(selection.endCampusId);
     input.setBusShowDepartedTrips(bus.preferences?.showDepartedTrips ?? false);
-    input.setBusNow(new Date());
+    input.setBusNow(referenceNow);
   }
 
   function selectBusStart(campusId: number) {
@@ -83,6 +89,9 @@ export function createBusTabPlannerController(
 
   function mount() {
     initializeBusPlanner();
+    const liveNow = new Date();
+    input.setBusDayType(resolveClientBusDayType(liveNow));
+    input.setBusNow(liveNow);
     input.setBusPlannerReady(true);
     const interval = window.setInterval(() => {
       input.setBusNow(new Date());

--- a/src/features/dashboard/lib/bus-tab-state.ts
+++ b/src/features/dashboard/lib/bus-tab-state.ts
@@ -23,7 +23,7 @@ export function createBusTabState({
   const values = {
     busDayType: "weekday" as BusDayType,
     busEndCampusId: null as number | null,
-    busNow: new Date(),
+    busNow: new Date(0),
     busPlannerReady: false,
     busPreferenceSaveError: "",
     busPreferenceSaveRun: 0,

--- a/src/features/dashboard/lib/bus-tab-types.ts
+++ b/src/features/dashboard/lib/bus-tab-types.ts
@@ -2,7 +2,13 @@ import type { BusTimetableData } from "@/features/bus/lib/bus-timetable-types";
 
 export type DashboardBusData = Pick<
   BusTimetableData,
-  "campuses" | "notice" | "preferences" | "routes" | "trips" | "version"
+  | "campuses"
+  | "fetchedAt"
+  | "notice"
+  | "preferences"
+  | "routes"
+  | "trips"
+  | "version"
 >;
 
 export type DashboardBusCopy = Record<string, unknown> & {

--- a/src/features/dashboard/server/dashboard-page-load-public.ts
+++ b/src/features/dashboard/server/dashboard-page-load-public.ts
@@ -2,6 +2,7 @@ import type {
   DashboardPageCopy,
   DashboardPublicCounts,
 } from "@/features/dashboard/server/dashboard-page-load-types";
+import { getBusTabData } from "@/features/dashboard/server/dashboard-tab-data";
 import type { DashboardLinkSummary } from "@/features/dashboard-links/server/dashboard-link-data";
 import type { AppLocale } from "@/i18n/config";
 
@@ -13,6 +14,9 @@ export async function loadAnonymousDashboardPageData(input: {
   publicLinks: DashboardLinkSummary[];
   tab: string;
 }) {
+  const bus =
+    input.tab === "bus" ? await getBusTabData(null, input.locale) : null;
+
   return {
     copy: input.pageCopy,
     locale: input.locale,
@@ -21,6 +25,6 @@ export async function loadAnonymousDashboardPageData(input: {
     counts: input.counts,
     publicLinks: input.publicLinks,
     overviewLinks: input.overviewLinks,
-    bus: null,
+    bus: bus?.data ?? null,
   };
 }

--- a/src/features/dashboard/server/dashboard-page-load.ts
+++ b/src/features/dashboard/server/dashboard-page-load.ts
@@ -73,7 +73,7 @@ export async function loadDashboardPage({
 
   if (!userId) {
     const publicSummary = await publicSummaryPromise;
-    const data = loadAnonymousDashboardPageData({
+    const data = await loadAnonymousDashboardPageData({
       counts: publicSummary.counts,
       locale,
       overviewLinks: publicSummary.links.overviewLinks,

--- a/src/features/dashboard/server/dashboard-tab-data.ts
+++ b/src/features/dashboard/server/dashboard-tab-data.ts
@@ -22,7 +22,7 @@ export type BusDashboardData = {
 };
 
 export async function getBusTabData(
-  userId: string,
+  userId: string | null,
   locale: AppLocale = DEFAULT_LOCALE,
 ): Promise<BusDashboardData> {
   const referenceNow = shanghaiDayjs();

--- a/tests/e2e/src/app/bus/test.ts
+++ b/tests/e2e/src/app/bus/test.ts
@@ -104,6 +104,42 @@ test.describe("bus dashboard tab", () => {
     );
   });
 
+  test("anonymous bus dashboard SSR renders public timetable data", async ({
+    page,
+  }) => {
+    const response = await page.request.get("/?tab=bus");
+    expect(response.status()).toBe(200);
+    const html = await response.text();
+
+    expect(html).toContain('href="/bus-map"');
+    expect(html).not.toMatch(
+      /data-slot="alert"[\s\S]{0,240}当前暂无可用的校车数据。/,
+    );
+    expect(html).not.toMatch(
+      /data-slot="alert"[\s\S]{0,240}No shuttle data is available right now\./,
+    );
+  });
+
+  test("public bus tab keeps planner controls usable on mobile", async ({
+    page,
+  }, testInfo) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await gotoAndWaitForReady(page, "/?tab=bus", {
+      testInfo,
+      screenshotLabel: "bus-mobile",
+    });
+
+    await expect(
+      page.getByRole("button", { name: /Weekday|工作日/ }).first(),
+    ).toBeVisible();
+    await expect(
+      page.locator("[data-testid='bus-start-stop-group']"),
+    ).toBeVisible();
+    await expect(page.locator("table").first()).toBeVisible();
+
+    await captureStepScreenshot(page, testInfo, "bus-planner-public-mobile");
+  });
+
   test("default stop pair shows every applicable route ordered by next available bus", async ({
     page,
   }, testInfo) => {

--- a/tests/unit/bus-client.test.ts
+++ b/tests/unit/bus-client.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   getApplicableBusRoutes,
   getShanghaiMinutesSinceMidnight,
+  resolveClientBusDayType,
 } from "@/features/bus/lib/bus-client";
 import { parseBusTimeMinutes } from "@/features/bus/lib/bus-time";
 import type {
@@ -138,6 +139,18 @@ describe("bus client timetable math", () => {
     expect(
       getShanghaiMinutesSinceMidnight(new Date("2026-04-22T13:10:00.000Z")),
     ).toBe(21 * 60 + 10);
+  });
+
+  test("resolves day type from the Shanghai calendar day", () => {
+    expect(resolveClientBusDayType(new Date("2026-04-24T15:59:00.000Z"))).toBe(
+      "weekday",
+    );
+    expect(resolveClientBusDayType(new Date("2026-04-24T16:00:00.000Z"))).toBe(
+      "weekend",
+    );
+    expect(resolveClientBusDayType(new Date("2026-04-26T16:00:00.000Z"))).toBe(
+      "weekday",
+    );
   });
 
   test("sorts routes by the next Shanghai departure time", () => {

--- a/tests/unit/bus-tab-state.test.ts
+++ b/tests/unit/bus-tab-state.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "vitest";
+import { parseBusTimeMinutes } from "@/features/bus/lib/bus-time";
+import type { BusTripSummary } from "@/features/bus/lib/bus-types";
+import { createBusTabState } from "@/features/dashboard/lib/bus-tab-state";
+import type {
+  DashboardBusCopy,
+  DashboardBusData,
+} from "@/features/dashboard/lib/bus-tab-types";
+
+function createTrip(input: {
+  id: number;
+  routeId: number;
+  dayType: "weekday" | "weekend";
+  position: number;
+  times: Array<
+    [stopOrder: number, campusId: number, campusName: string, time: string]
+  >;
+}): BusTripSummary {
+  const stopTimes = input.times.map(
+    ([stopOrder, campusId, campusName, time]) => ({
+      campusId,
+      campusName,
+      isPassThrough: false,
+      minutesSinceMidnight: parseBusTimeMinutes(time) ?? 0,
+      stopOrder,
+      time,
+    }),
+  );
+
+  return {
+    arrivalMinutes:
+      stopTimes[stopTimes.length - 1]?.minutesSinceMidnight ?? null,
+    arrivalTime: stopTimes[stopTimes.length - 1]?.time ?? null,
+    dayType: input.dayType,
+    departureMinutes: stopTimes[0]?.minutesSinceMidnight ?? null,
+    departureTime: stopTimes[0]?.time ?? null,
+    id: input.id,
+    position: input.position,
+    routeId: input.routeId,
+    stopTimes,
+  };
+}
+
+function createBusData(): DashboardBusData {
+  const east = {
+    id: 1,
+    latitude: 0,
+    longitude: 0,
+    nameCn: "东区",
+    nameEn: "East",
+    namePrimary: "东区",
+    nameSecondary: "East",
+  };
+  const west = {
+    id: 2,
+    latitude: 0,
+    longitude: 0,
+    nameCn: "西区",
+    nameEn: "West",
+    namePrimary: "西区",
+    nameSecondary: "West",
+  };
+
+  return {
+    campuses: [east, west],
+    fetchedAt: "2026-04-24T16:30:00.000Z",
+    notice: null,
+    preferences: null,
+    routes: [
+      {
+        descriptionPrimary: "东区 -> 西区",
+        descriptionSecondary: null,
+        id: 8,
+        nameCn: "东区 -> 西区",
+        nameEn: null,
+        stops: [
+          { campus: east, stopOrder: 1 },
+          { campus: west, stopOrder: 2 },
+        ],
+      },
+    ],
+    trips: [
+      createTrip({
+        dayType: "weekend",
+        id: 801,
+        position: 1,
+        routeId: 8,
+        times: [
+          [1, 1, "东区", "00:45"],
+          [2, 2, "西区", "01:05"],
+        ],
+      }),
+    ],
+    version: null,
+  };
+}
+
+describe("bus tab state", () => {
+  test("initializes planner time and day type from fetchedAt", () => {
+    const bus = createBusData();
+    const state = createBusTabState({
+      getBus: () => bus,
+      getBusCopy: () => ({}) as DashboardBusCopy,
+      getSavePreferences: () => false,
+      invalidate: () => {},
+    });
+
+    state.initializeWhenNeeded();
+
+    expect(state.values.busNow.toISOString()).toBe(bus.fetchedAt);
+    expect(state.values.busDayType).toBe("weekend");
+    expect(state.values.busStartCampusId).toBe(1);
+    expect(state.values.busEndCampusId).toBe(2);
+    expect(state.applicableRoutes()[0]?.nextTrip?.minutesUntilStart).toBe(15);
+  });
+});


### PR DESCRIPTION
## Goal

Fix dashboard bus first-render clock drift and anonymous bus SSR placeholders.

Closes #261.
Closes #262.

## Changed Surfaces

- Dashboard bus tab state/controller now seeds SSR and hydration from server bus `fetchedAt`, resolves default weekday/weekend using Shanghai time, and starts the live clock only after mount.
- Anonymous `/?tab=bus` now loads public bus data during server load instead of rendering an SSR empty placeholder and relying on mount-only fetch.
- Bus client day-type helper now uses the Shanghai calendar day.
- Focused unit and E2E coverage for fetched-time initialization, Shanghai day boundaries, anonymous SSR bus HTML, and mobile public bus controls.

## Evidence

- `bun run verify` passed on the rebased branch after loading the dev environment from the main worktree `.env`.
- `bun run test -- tests/unit/bus-client.test.ts tests/unit/bus-tab-state.test.ts` passed.
- `bun run check:contracts` passed.
- `PLAYWRIGHT_PORT=3303 bun run e2e:test -- tests/e2e/src/app/bus/test.ts` passed, 13/13.
- Browser evidence inspected before commit: desktop `1280x900` anonymous `/?tab=bus` and mobile `390x844` anonymous `/?tab=bus`; public bus planner controls/timetable rendered without the false empty placeholder. Screenshots were temporary and removed.
- `bun run verify:full` also passed before rebasing onto latest `origin/main`; after rebase, the focused E2E and default gate above were rerun.

## Docs / Contracts

- Updated `docs/contracts/bus.json` to state dashboard bus weekday/weekend defaults are based on Shanghai time.
- No OpenAPI or MCP contract changes; this is dashboard UI/server-load/client-time behavior only.

## Risk Areas

- Time-sensitive SSR/hydration behavior depends on `fetchedAt` being present in bus timetable data; invalid values fall back to epoch rather than browser-local time.
- Anonymous bus SSR now makes the same public bus data request during dashboard page load for `tab=bus`, which is intentional but adds that server-side query to the anonymous bus route path.

## Cleanup

- Removed temporary screenshots, Worker runtime output, and isolated database container after local checks.
- Worktree is clean; no generated OpenAPI/Prisma files or unrelated scopes were committed.
