### PR TITLE
fix(admin): make audit trails durable

### DIFF
--- a/docs/contracts/_audit.json
+++ b/docs/contracts/_audit.json
@@ -18,28 +18,28 @@
     },
     "description_edit": {
       "trigger": "POST /api/descriptions or MCP upsert_description",
-      "description": "User updates an object description (content changed)."
+      "description": "User updates an object description (content changed). The description row, edit history, and audit row are committed together."
     },
     "upload_delete": {
       "trigger": "DELETE /api/uploads/[id] or MCP delete_my_upload",
-      "description": "User deletes an upload they own. MCP-originated writes include metadata.source=mcp."
+      "description": "User deletes an upload they own. MCP-originated writes include metadata.source=mcp. After storage deletion succeeds, metadata deletion and the audit row are committed together."
     },
     "admin_user_suspend": {
       "trigger": "POST /api/admin/suspensions",
-      "description": "Admin suspends a user account."
+      "description": "Admin suspends a user account. The suspension change and audit row are committed together."
     },
     "admin_user_unsuspend": {
       "trigger": "PATCH /api/admin/suspensions/[id]",
-      "description": "Admin lifts a user suspension."
+      "description": "Admin lifts a user suspension. The suspension change and audit row are committed together."
     },
     "admin_comment_moderate": {
       "trigger": "PATCH /api/admin/comments/[id]",
-      "description": "Admin hides or moderates a comment."
+      "description": "Admin hides or moderates a comment. The moderation change and audit row are committed together."
     },
     "admin_description_moderate": {
       "trigger": "PATCH /api/admin/descriptions/[id] or /admin/moderation description action",
-      "description": "Admin updates description content from the moderation workflow."
+      "description": "Admin updates description content from the moderation workflow. The description row, edit history, and audit row are committed together."
     }
   },
-  "writer": "writeAuditLog in src/lib/audit/write-audit-log.ts writes a record and records bounded production-safe audit write metrics by action, status, and duration. fireAuditLog wraps writeAuditLog for non-critical audit trails, logs write failures, and keeps those failures from blocking the main request."
+  "writer": "writeAuditLog records audit rows and bounded write metrics. Required domain/security trails await writeAuditLog and use the same Prisma transaction as DB-only mutations where practical. fireAuditLog is reserved for non-critical telemetry and logs failures without blocking the request."
 }

--- a/docs/contracts/admin.json
+++ b/docs/contracts/admin.json
@@ -3,7 +3,7 @@
   "access": {
     "anon": "Cannot access the admin backend.",
     "user": "Cannot access the admin backend.",
-    "admin": "Can access governance pages for moderation, users, OAuth, bus, and more.",
+    "admin": "Can access governance pages for moderation, users, OAuth, bus, and more. Active suspensions block admin mutations but not read-only admin pages/list endpoints.",
     "agent": "No admin tools are currently provided."
   },
   "rules": {
@@ -12,6 +12,7 @@
     "high-risk-feedback": "High-risk admin actions such as delete, suspend, and hide must have clear feedback.",
     "admin-self-protection": "Admin user management must reject self-suspension, self-demotion, and removing the final remaining admin.",
     "admin-rest-session-only": "Admin REST endpoints require the in-site Better Auth session cookie and do not accept OAuth bearer tokens.",
+    "suspended-admin-write-gate": "Admins with an active suspension may load read-only admin pages and list endpoints, but admin REST mutations and page actions are blocked with the standard suspended 403 response until the suspension is lifted.",
     "suspension-expiration-validation": "Suspension expiration accepts omitted, null, or empty input as permanent and rejects invalid non-empty date strings.",
     "single-open-suspension": "Each user can have at most one open suspension. Creating a new suspension closes any previous open suspension for that user while retaining history; lifting an open suspension clears the user's open suspension state.",
     "suspension-retention": "Suspension history is retained when an admin account is deleted; creator and lifter actor references may be null after account deletion."

--- a/docs/contracts/comment.json
+++ b/docs/contracts/comment.json
@@ -3,7 +3,7 @@
   "access": {
     "anon": "Can read public comments but cannot create sign-in-required comments.",
     "user": "Can post, reply, react, edit, and delete their own comments; suspended users can read permitted comments but cannot use comment write actions or upload comment attachments.",
-    "admin": "Can hide, delete, and moderate comments through moderation surfaces, and handle suspensions.",
+    "admin": "Unsuspended admins can hide, delete, and moderate comments through moderation surfaces, and handle suspensions.",
     "agent": "Can read visible comment lists, focused threads, and ordinary signed-in user comment write actions through MCP with authenticated viewer context; no admin moderation capability is provided."
   },
   "rules": {
@@ -12,7 +12,7 @@
     "rich-content": "Supports Markdown, math formulas, emoji, tables, replies, and reactions.",
     "visibility-modes": "Supports public, signed-in-only, and anonymous posting; anonymous comments hide identity from regular users but are traceable by admins in governance scenarios.",
     "shared-read-policy": "Web, REST, and MCP comment reads share the same target resolution, thread serialization, visibility filtering, author masking, reaction, attachment, and viewer action-flag logic; read-only paths must not create durable comment targets and valid empty section-teacher targets load as empty threads.",
-    "interaction-gate": "Edits, deletes, replies, and reaction changes require an authenticated, unsuspended viewer and an active visible comment target; deleted or softbanned comments must not expose canEdit/canDelete/canReply/canReact or accept those write actions."
+    "interaction-gate": "Edits, deletes, replies, and reaction changes require an authenticated, unsuspended viewer and an active visible comment target; deleted or softbanned comments must not expose canEdit/canDelete/canReply/canReact or accept those write actions. Admin moderation affordances require an unsuspended admin."
   },
   "capabilities": {
     "object-comment-section": {

--- a/docs/contracts/description.json
+++ b/docs/contracts/description.json
@@ -87,7 +87,7 @@
             "method": "PATCH",
             "returns": "{ description: Description }",
             "notes": [
-              "Shares the same admin moderation service as /admin/moderation description edits and records DescriptionEdit plus admin_description_moderate audit entries."
+              "Shares the same admin moderation service as /admin/moderation description edits and commits DescriptionEdit plus admin_description_moderate audit entries with the content update."
             ]
           }
         ]

--- a/docs/contracts/upload.json
+++ b/docs/contracts/upload.json
@@ -154,7 +154,7 @@
             "returns": "{ success: Boolean, deletedId: String, deletedSize: Int }",
             "rest_equivalent": "DELETE /api/uploads/[id]",
             "notes": [
-              "Requires an unsuspended signed-in user, deletes only uploads owned by the current user, removes the backing storage object before metadata deletion, returns storage_delete_failed without deleting metadata when storage cleanup fails, and writes metadata.source=mcp in the upload_delete audit log only after successful deletion."
+              "Requires an unsuspended signed-in user, deletes only uploads owned by the current user, removes the backing storage object before metadata deletion, returns storage_delete_failed without deleting metadata when storage cleanup fails, and commits metadata deletion plus the upload_delete audit log together after successful storage deletion."
             ]
           }
         ]

--- a/src/features/admin/server/admin-api-service.ts
+++ b/src/features/admin/server/admin-api-service.ts
@@ -2,7 +2,7 @@ import { getAdminUserListItem } from "@/features/admin/server/admin-user-read-mo
 import { DESCRIPTION_CONTENT_MAX_LENGTH } from "@/features/descriptions/lib/description-limits";
 import { isValidProfileUsername } from "@/features/profile/lib/profile-username";
 import type { CommentStatus } from "@/generated/prisma/client";
-import { fireAuditLog } from "@/lib/audit/write-audit-log";
+import { writeAuditLog } from "@/lib/audit/write-audit-log";
 import { prisma } from "@/lib/db/prisma";
 import { isPrismaUniqueConstraintError } from "@/lib/db/prisma-errors";
 import { runSerializableTransaction } from "@/lib/db/serializable-transaction";
@@ -203,6 +203,17 @@ export async function createAdminSuspension(
         },
       });
 
+      await writeAuditLog(
+        {
+          action: "admin_user_suspend",
+          userId: adminUserId,
+          targetId: userId,
+          targetType: "user",
+          metadata: { reason: input.reason ?? null },
+        },
+        tx,
+      );
+
       return { ok: true as const, suspension };
     }, "Failed to create admin suspension");
 
@@ -214,14 +225,6 @@ export async function createAdminSuspension(
     result = await createSuspension();
   }
   if (!result.ok) return result;
-
-  await fireAuditLog({
-    action: "admin_user_suspend",
-    userId: adminUserId,
-    targetId: userId,
-    targetType: "user",
-    metadata: { reason: input.reason ?? null },
-  });
 
   return result;
 }
@@ -253,17 +256,20 @@ export async function liftAdminSuspension(adminUserId: string, id: string) {
       },
     });
 
+    await writeAuditLog(
+      {
+        action: "admin_user_unsuspend",
+        userId: adminUserId,
+        targetId: suspension.userId,
+        targetType: "user",
+        metadata: { suspensionId: id },
+      },
+      tx,
+    );
+
     return { ok: true as const, suspension };
   }, "Failed to lift admin suspension");
   if (!result.ok) return result;
-
-  await fireAuditLog({
-    action: "admin_user_unsuspend",
-    userId: adminUserId,
-    targetId: result.suspension.userId,
-    targetType: "user",
-    metadata: { suspensionId: id },
-  });
 
   return result;
 }
@@ -273,33 +279,41 @@ export async function moderateComment(
   id: string,
   input: AdminModerateCommentInput,
 ) {
-  const existing = await prisma.comment.findUnique({
-    where: { id },
-    select: { id: true },
-  });
-  if (!existing) return { ok: false as const, reason: "not_found" as const };
-
   const { status, moderationNote } = input;
-  const comment = await prisma.comment.update({
-    where: { id },
-    data: {
-      status,
-      moderationNote: moderationNote ?? null,
-      moderatedAt: new Date(),
-      moderatedById: adminUserId,
-      deletedAt: status === "deleted" ? new Date() : null,
-    },
+  const result = await prisma.$transaction(async (tx) => {
+    const existing = await tx.comment.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    if (!existing) return { ok: false as const, reason: "not_found" as const };
+
+    const now = new Date();
+    const comment = await tx.comment.update({
+      where: { id },
+      data: {
+        status,
+        moderationNote: moderationNote ?? null,
+        moderatedAt: now,
+        moderatedById: adminUserId,
+        deletedAt: status === "deleted" ? now : null,
+      },
+    });
+
+    await writeAuditLog(
+      {
+        action: "admin_comment_moderate",
+        userId: adminUserId,
+        targetId: id,
+        targetType: "comment",
+        metadata: { status, moderationNote: moderationNote ?? null },
+      },
+      tx,
+    );
+
+    return { comment, ok: true as const };
   });
 
-  await fireAuditLog({
-    action: "admin_comment_moderate",
-    userId: adminUserId,
-    targetId: id,
-    targetType: "comment",
-    metadata: { status, moderationNote: moderationNote ?? null },
-  });
-
-  return { comment, ok: true as const };
+  return result;
 }
 
 export async function moderateDescription(
@@ -307,16 +321,17 @@ export async function moderateDescription(
   id: string,
   input: AdminModerateDescriptionInput,
 ) {
-  const existing = await prisma.description.findUnique({
-    where: { id },
-    select: { id: true, content: true },
-  });
-  if (!existing) return { ok: false as const, reason: "not_found" as const };
   if (input.content.length > DESCRIPTION_CONTENT_MAX_LENGTH) {
     return { ok: false as const, reason: "invalid_content" as const };
   }
 
-  const description = await prisma.$transaction(async (tx) => {
+  const result = await prisma.$transaction(async (tx) => {
+    const existing = await tx.description.findUnique({
+      where: { id },
+      select: { id: true, content: true },
+    });
+    if (!existing) return { ok: false as const, reason: "not_found" as const };
+
     const updated = await tx.description.update({
       where: { id },
       data: {
@@ -336,19 +351,22 @@ export async function moderateDescription(
       },
     });
 
-    return updated;
+    await writeAuditLog(
+      {
+        action: "admin_description_moderate",
+        userId: adminUserId,
+        targetId: id,
+        targetType: "description",
+        metadata: {
+          previousContent: existing.content,
+          nextContent: input.content,
+        },
+      },
+      tx,
+    );
+
+    return { description: updated, ok: true as const };
   });
 
-  await fireAuditLog({
-    action: "admin_description_moderate",
-    userId: adminUserId,
-    targetId: id,
-    targetType: "description",
-    metadata: {
-      previousContent: existing.content,
-      nextContent: input.content,
-    },
-  });
-
-  return { description, ok: true as const };
+  return result;
 }

--- a/src/features/admin/server/admin-bus-page-server.ts
+++ b/src/features/admin/server/admin-bus-page-server.ts
@@ -42,7 +42,7 @@ export const loadAdminBusPage = async ({ locals, request }: AdminBusEvent) => {
 export const adminBusActions = {
   activateVersion: async ({ locals, request }: AdminBusEvent) => {
     const copy = getCopy(locals.locale).adminBus;
-    await requireAdminPage(request);
+    await requireAdminPage(request, { requireActive: true });
     const form = await request.formData();
     const id = parseAdminBusVersionId(form);
     if (id === null) return failure(copy.invalidVersionId);
@@ -65,7 +65,7 @@ export const adminBusActions = {
   },
   deleteVersion: async ({ locals, request }: AdminBusEvent) => {
     const copy = getCopy(locals.locale).adminBus;
-    await requireAdminPage(request);
+    await requireAdminPage(request, { requireActive: true });
     const form = await request.formData();
     const id = parseAdminBusVersionId(form);
     if (id === null) return failure(copy.invalidVersionId);
@@ -80,7 +80,7 @@ export const adminBusActions = {
   },
   importStatic: async ({ locals, request }: AdminBusEvent) => {
     const copy = getCopy(locals.locale).adminBus;
-    await requireAdminPage(request);
+    await requireAdminPage(request, { requireActive: true });
     let result: Awaited<ReturnType<typeof importBusStaticPayload>>;
     try {
       const payload = await loadBusStaticPayload();

--- a/src/features/admin/server/admin-moderation-action-context.ts
+++ b/src/features/admin/server/admin-moderation-action-context.ts
@@ -17,7 +17,7 @@ export async function getAdminModerationActionContext({
   const copy = getAdminModerationPageCopy(
     locals.locale as AppLocale,
   ).moderation;
-  const admin = await requireAdminPage(request);
+  const admin = await requireAdminPage(request, { requireActive: true });
   const form = await request.formData();
 
   return { admin, copy, form };

--- a/src/features/admin/server/admin-oauth-create-action.ts
+++ b/src/features/admin/server/admin-oauth-create-action.ts
@@ -17,7 +17,7 @@ export async function createAdminOAuthClientAction(
   locale: AppLocale,
 ) {
   const copy = getAdminOAuthCopy(locale).oauth;
-  await requireAdminPage(request);
+  await requireAdminPage(request, { requireActive: true });
   const parsed = await parseAdminOAuthCreateRequest(request, copy);
   if ("error" in parsed) return parsed.error;
   const { name, redirectUris, scopes, tokenEndpointAuthMethod } = parsed.value;

--- a/src/features/admin/server/admin-oauth-delete-action.ts
+++ b/src/features/admin/server/admin-oauth-delete-action.ts
@@ -9,7 +9,7 @@ export async function deleteAdminOAuthClientAction(
   locale: AppLocale,
 ) {
   const copy = getAdminOAuthCopy(locale).oauth;
-  await requireAdminPage(request);
+  await requireAdminPage(request, { requireActive: true });
   const form = await request.formData();
   const clientId = String(form.get("clientId") ?? "");
   if (!clientId) return fail(400, { message: copy.missingClientId });

--- a/src/features/admin/server/admin-page-auth.ts
+++ b/src/features/admin/server/admin-page-auth.ts
@@ -1,12 +1,20 @@
 import { error, redirect } from "@sveltejs/kit";
 import { buildSignInPageUrl } from "@/lib/auth/auth-routing";
+import { findActiveSuspension } from "@/lib/auth/viewer-context";
 import { prisma } from "@/lib/db/prisma";
 
 export async function getPrismaClient() {
   return prisma;
 }
 
-export async function requireAdminPage(request: Request) {
+type AdminPageGuardOptions = {
+  requireActive?: boolean;
+};
+
+export async function requireAdminPage(
+  request: Request,
+  options: AdminPageGuardOptions = {},
+) {
   const { getSessionFromHeaders } = await import("@/lib/auth/core");
   const session = await getSessionFromHeaders(request.headers);
   if (!session?.user?.id) {
@@ -21,5 +29,9 @@ export async function requireAdminPage(request: Request) {
   });
 
   if (!user?.isAdmin) error(404, "Not found");
+  if (options.requireActive) {
+    const suspension = await findActiveSuspension(user.id);
+    if (suspension) error(403, "Suspended");
+  }
   return user;
 }

--- a/src/features/comments/server/serialized-comment-node.ts
+++ b/src/features/comments/server/serialized-comment-node.ts
@@ -72,6 +72,6 @@ export function buildVisibleCommentNode({
     canReply: canInteract,
     canEdit: canInteract && isAuthor,
     canDelete: canInteract && isAuthor,
-    canModerate: viewer.isAdmin,
+    canModerate: viewer.isAdmin && !viewer.isSuspended,
   };
 }

--- a/src/features/descriptions/server/description-upsert.ts
+++ b/src/features/descriptions/server/description-upsert.ts
@@ -1,4 +1,4 @@
-import { fireAuditLog } from "@/lib/audit/write-audit-log";
+import { writeAuditLog } from "@/lib/audit/write-audit-log";
 import { getViewerContext } from "@/lib/auth/viewer-context";
 import { prisma } from "@/lib/db/prisma";
 import { isPrismaUniqueConstraintError } from "@/lib/db/prisma-errors";
@@ -92,6 +92,15 @@ export async function upsertDescriptionContent({
         },
       });
 
+      await writeDescriptionEditAuditLog({
+        client: tx,
+        content,
+        descriptionId: description.id,
+        metadata: auditMetadata,
+        targetType,
+        userId,
+      });
+
       return { id: description.id, updated: true };
     });
 
@@ -103,26 +112,18 @@ export async function upsertDescriptionContent({
     result = await writeDescription();
   }
 
-  if (result.updated) {
-    await writeDescriptionEditAuditLog({
-      content,
-      descriptionId: result.id,
-      metadata: auditMetadata,
-      targetType,
-      userId,
-    });
-  }
-
   return { ok: true as const, ...result };
 }
 
 async function writeDescriptionEditAuditLog({
+  client,
   content,
   descriptionId,
   metadata,
   targetType,
   userId,
 }: {
+  client: NonNullable<Parameters<typeof writeAuditLog>[1]>;
   content: string;
   descriptionId: string;
   metadata?: DescriptionEditAuditMetadata;
@@ -130,16 +131,19 @@ async function writeDescriptionEditAuditLog({
   userId: string;
 }) {
   const { source, ...requestMetadata } = metadata ?? {};
-  await fireAuditLog({
-    action: "description_edit",
-    userId,
-    targetId: descriptionId,
-    targetType: "description",
-    metadata: {
-      targetType,
-      content: content.slice(0, 200),
-      ...(source ? { source } : {}),
+  await writeAuditLog(
+    {
+      action: "description_edit",
+      userId,
+      targetId: descriptionId,
+      targetType: "description",
+      metadata: {
+        targetType,
+        content: content.slice(0, 200),
+        ...(source ? { source } : {}),
+      },
+      ...requestMetadata,
     },
-    ...requestMetadata,
-  });
+    client,
+  );
 }

--- a/src/features/uploads/server/upload-service.ts
+++ b/src/features/uploads/server/upload-service.ts
@@ -5,7 +5,7 @@ import {
   runUploadSerializableTransaction,
   UploadError,
 } from "@/features/uploads/server/upload-quota";
-import { fireAuditLog } from "@/lib/audit/write-audit-log";
+import { writeAuditLog } from "@/lib/audit/write-audit-log";
 import { getViewerContext } from "@/lib/auth/viewer-context";
 import { prisma } from "@/lib/db/prisma";
 import { logAppEvent } from "@/lib/log/app-logger";
@@ -367,11 +367,14 @@ export async function deleteOwnedUpload(input: {
     };
   }
 
-  await prisma.upload.delete({ where: { id: upload.id } });
-  await writeUploadDeleteAuditLog({
-    audit: input.audit,
-    upload,
-    userId: input.userId,
+  await prisma.$transaction(async (tx) => {
+    await tx.upload.delete({ where: { id: upload.id } });
+    await writeUploadDeleteAuditLog({
+      audit: input.audit,
+      client: tx,
+      upload,
+      userId: input.userId,
+    });
   });
 
   return {
@@ -479,6 +482,7 @@ async function deleteUploadStorageObject(upload: { key: string }) {
 
 async function writeUploadDeleteAuditLog({
   audit,
+  client,
   upload,
   userId,
 }: {
@@ -487,22 +491,26 @@ async function writeUploadDeleteAuditLog({
     source?: "mcp";
     userAgent?: string;
   };
+  client: NonNullable<Parameters<typeof writeAuditLog>[1]>;
   upload: { id: string; key: string; size: number };
   userId: string;
 }) {
-  await fireAuditLog({
-    action: "upload_delete",
-    userId,
-    targetId: upload.id,
-    targetType: "upload",
-    metadata: {
-      key: upload.key,
-      size: upload.size,
-      ...(audit?.source ? { source: audit.source } : {}),
+  await writeAuditLog(
+    {
+      action: "upload_delete",
+      userId,
+      targetId: upload.id,
+      targetType: "upload",
+      metadata: {
+        key: upload.key,
+        size: upload.size,
+        ...(audit?.source ? { source: audit.source } : {}),
+      },
+      ipAddress: audit?.ipAddress,
+      userAgent: audit?.userAgent,
     },
-    ipAddress: audit?.ipAddress,
-    userAgent: audit?.userAgent,
-  });
+    client,
+  );
 }
 
 async function deleteExpiredPendingUploads(

--- a/src/lib/api/routes/admin-comment-update-route.ts
+++ b/src/lib/api/routes/admin-comment-update-route.ts
@@ -30,5 +30,6 @@ export async function patchAdminCommentRoute(
 
       return jsonResponse({ comment: result.comment });
     },
+    { requireActive: true },
   );
 }

--- a/src/lib/api/routes/admin-description-update-route.ts
+++ b/src/lib/api/routes/admin-description-update-route.ts
@@ -37,5 +37,6 @@ export async function patchAdminDescriptionRoute(
 
       return jsonResponse({ description: result.description });
     },
+    { requireActive: true },
   );
 }

--- a/src/lib/api/routes/admin-homework-delete-route.ts
+++ b/src/lib/api/routes/admin-homework-delete-route.ts
@@ -25,5 +25,6 @@ export async function deleteAdminHomeworkRoute(
 
       return jsonResponse({ success: true });
     },
+    { requireActive: true },
   );
 }

--- a/src/lib/api/routes/admin-route-auth.ts
+++ b/src/lib/api/routes/admin-route-auth.ts
@@ -2,23 +2,43 @@ import {
   type AdminSession,
   resolveAdminByUserId,
 } from "@/features/admin/server/admin-api";
-import { handleRouteError, unauthorized } from "@/lib/api/helpers";
+import {
+  handleRouteError,
+  suspensionForbidden,
+  unauthorized,
+} from "@/lib/api/helpers";
 import { resolveSessionUserId } from "@/lib/auth/api-auth";
+import { findActiveSuspension } from "@/lib/auth/viewer-context";
 
-export async function requireAdminRequest(request: Request) {
+type AdminGuardOptions = {
+  requireActive?: boolean;
+};
+
+export async function requireAdminRequest(
+  request: Request,
+  options: AdminGuardOptions = {},
+) {
   const userId = await resolveSessionUserId(request);
   if (!userId) return unauthorized();
 
   const admin = await resolveAdminByUserId(userId);
-  return admin ?? unauthorized();
+  if (!admin) return unauthorized();
+
+  if (options.requireActive) {
+    const suspension = await findActiveSuspension(admin.userId);
+    if (suspension) return suspensionForbidden(suspension.reason);
+  }
+
+  return admin;
 }
 
 export async function withAdminApiRoute(
   request: Request,
   errorMessage: string,
   handler: (admin: AdminSession) => Promise<Response>,
+  options: AdminGuardOptions = {},
 ) {
-  const admin = await requireAdminRequest(request);
+  const admin = await requireAdminRequest(request, options);
   if (admin instanceof Response) {
     return admin;
   }

--- a/src/lib/api/routes/admin-suspensions.ts
+++ b/src/lib/api/routes/admin-suspensions.ts
@@ -21,27 +21,32 @@ export async function getAdminSuspensionsRoute(request: Request) {
 }
 
 export async function postAdminSuspensionRoute(request: Request) {
-  return withAdminApiRoute(request, "Failed to suspend user", async (admin) => {
-    const parsedBody = await parseRouteJsonBody(
-      request,
-      adminCreateSuspensionRequestSchema,
-      "Invalid suspension request",
-    );
-    if (parsedBody instanceof Response) return parsedBody;
+  return withAdminApiRoute(
+    request,
+    "Failed to suspend user",
+    async (admin) => {
+      const parsedBody = await parseRouteJsonBody(
+        request,
+        adminCreateSuspensionRequestSchema,
+        "Invalid suspension request",
+      );
+      if (parsedBody instanceof Response) return parsedBody;
 
-    const result = await createAdminSuspension(admin.userId, parsedBody);
-    if (!result.ok) {
-      if (result.reason === "invalid_expires_at") {
-        return badRequest("Invalid expiresAt");
+      const result = await createAdminSuspension(admin.userId, parsedBody);
+      if (!result.ok) {
+        if (result.reason === "invalid_expires_at") {
+          return badRequest("Invalid expiresAt");
+        }
+        if (result.reason === "cannot_suspend_self") {
+          return badRequest("Admins cannot suspend themselves");
+        }
+        return notFound("User not found");
       }
-      if (result.reason === "cannot_suspend_self") {
-        return badRequest("Admins cannot suspend themselves");
-      }
-      return notFound("User not found");
-    }
 
-    return jsonResponse({ suspension: result.suspension });
-  });
+      return jsonResponse({ suspension: result.suspension });
+    },
+    { requireActive: true },
+  );
 }
 
 export async function patchAdminSuspensionRoute(
@@ -61,5 +66,6 @@ export async function patchAdminSuspensionRoute(
 
       return jsonResponse({ suspension: result.suspension });
     },
+    { requireActive: true },
   );
 }

--- a/src/lib/api/routes/admin-users.ts
+++ b/src/lib/api/routes/admin-users.ts
@@ -46,32 +46,37 @@ export async function getAdminUsersRoute(request: Request) {
 }
 
 export async function patchAdminUserRoute(request: Request, params: IdParams) {
-  return withAdminApiRoute(request, "Failed to update user", async (admin) => {
-    const parsed = parseIdParam(params, "user");
-    if (parsed instanceof Response) return parsed;
-    const parsedBody = await parseRouteJsonBody(
-      request,
-      adminUpdateUserRequestSchema,
-      "Invalid update request",
-    );
-    if (parsedBody instanceof Response) return parsedBody;
+  return withAdminApiRoute(
+    request,
+    "Failed to update user",
+    async (admin) => {
+      const parsed = parseIdParam(params, "user");
+      if (parsed instanceof Response) return parsed;
+      const parsedBody = await parseRouteJsonBody(
+        request,
+        adminUpdateUserRequestSchema,
+        "Invalid update request",
+      );
+      if (parsedBody instanceof Response) return parsedBody;
 
-    const result = await updateAdminUser(admin.userId, parsed.id, parsedBody);
-    if (!result.ok) {
-      if (result.reason === "invalid_username")
-        return badRequest("Invalid username");
-      if (result.reason === "username_taken") {
-        return badRequest("Username already taken");
+      const result = await updateAdminUser(admin.userId, parsed.id, parsedBody);
+      if (!result.ok) {
+        if (result.reason === "invalid_username")
+          return badRequest("Invalid username");
+        if (result.reason === "username_taken") {
+          return badRequest("Username already taken");
+        }
+        if (result.reason === "cannot_demote_self") {
+          return badRequest("Admins cannot remove their own admin role");
+        }
+        if (result.reason === "cannot_remove_last_admin") {
+          return badRequest("At least one admin must remain");
+        }
+        return notFound("User not found");
       }
-      if (result.reason === "cannot_demote_self") {
-        return badRequest("Admins cannot remove their own admin role");
-      }
-      if (result.reason === "cannot_remove_last_admin") {
-        return badRequest("At least one admin must remain");
-      }
-      return notFound("User not found");
-    }
 
-    return jsonResponse({ user: result.user });
-  });
+      return jsonResponse({ user: result.user });
+    },
+    { requireActive: true },
+  );
 }

--- a/src/lib/audit/write-audit-log.ts
+++ b/src/lib/audit/write-audit-log.ts
@@ -15,6 +15,12 @@ type AuditLogParams = {
   userAgent?: string;
 };
 
+type AuditLogClient = {
+  auditLog: {
+    create(args: Prisma.AuditLogCreateArgs): Promise<unknown>;
+  };
+};
+
 type WorkerWaitUntilContext = {
   waitUntil(promise: Promise<unknown>): void;
 };
@@ -82,11 +88,14 @@ function logAuditWriteFailure(params: AuditLogParams, error: unknown) {
   );
 }
 
-export async function writeAuditLog(params: AuditLogParams) {
+export async function writeAuditLog(
+  params: AuditLogParams,
+  client: AuditLogClient = prisma,
+) {
   const { metadata, ...rest } = params;
   const start = Date.now();
   try {
-    await prisma.auditLog.create({
+    await client.auditLog.create({
       data: {
         ...rest,
         ...(metadata !== undefined && {

--- a/tests/unit/admin-api-service.test.ts
+++ b/tests/unit/admin-api-service.test.ts
@@ -1,16 +1,40 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
-  fireAuditLogMock,
+  auditLogCreateMock,
+  commentFindUniqueMock,
+  commentUpdateMock,
+  descriptionEditCreateMock,
+  descriptionFindUniqueMock,
+  descriptionUpdateMock,
   getAdminUserListItemMock,
   isPrismaUniqueConstraintErrorMock,
   prismaMock,
 } = vi.hoisted(() => ({
-  fireAuditLogMock: vi.fn(),
+  auditLogCreateMock: vi.fn(),
+  commentFindUniqueMock: vi.fn(),
+  commentUpdateMock: vi.fn(),
+  descriptionEditCreateMock: vi.fn(),
+  descriptionFindUniqueMock: vi.fn(),
+  descriptionUpdateMock: vi.fn(),
   getAdminUserListItemMock: vi.fn(),
   isPrismaUniqueConstraintErrorMock: vi.fn(),
   prismaMock: {
     $transaction: vi.fn(),
+    auditLog: {
+      create: vi.fn(),
+    },
+    comment: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    description: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    descriptionEdit: {
+      create: vi.fn(),
+    },
     user: {
       count: vi.fn(),
       findUnique: vi.fn(),
@@ -29,10 +53,6 @@ vi.mock("@/features/admin/server/admin-user-read-model", () => ({
   getAdminUserListItem: getAdminUserListItemMock,
 }));
 
-vi.mock("@/lib/audit/write-audit-log", () => ({
-  fireAuditLog: fireAuditLogMock,
-}));
-
 vi.mock("@/lib/db/prisma-errors", () => ({
   isPrismaUniqueConstraintError: isPrismaUniqueConstraintErrorMock,
 }));
@@ -41,19 +61,39 @@ vi.mock("@/lib/db/prisma", () => ({
   prisma: prismaMock,
 }));
 
+vi.mock("@/lib/metrics/observability-metrics", () => ({
+  recordAuditWriteMetric: vi.fn(),
+}));
+
 describe("admin API service", () => {
   beforeEach(() => {
-    fireAuditLogMock.mockReset();
+    auditLogCreateMock.mockReset();
+    commentFindUniqueMock.mockReset();
+    commentUpdateMock.mockReset();
+    descriptionEditCreateMock.mockReset();
+    descriptionFindUniqueMock.mockReset();
+    descriptionUpdateMock.mockReset();
     getAdminUserListItemMock.mockReset();
     isPrismaUniqueConstraintErrorMock.mockReset();
     isPrismaUniqueConstraintErrorMock.mockReturnValue(false);
+    prismaMock.auditLog.create = auditLogCreateMock;
+    prismaMock.comment.findUnique = commentFindUniqueMock;
+    prismaMock.comment.update = commentUpdateMock;
+    prismaMock.description.findUnique = descriptionFindUniqueMock;
+    prismaMock.description.update = descriptionUpdateMock;
+    prismaMock.descriptionEdit.create = descriptionEditCreateMock;
     prismaMock.$transaction.mockReset();
     prismaMock.$transaction.mockImplementation(async (action) =>
       action({
+        auditLog: prismaMock.auditLog,
+        comment: prismaMock.comment,
+        description: prismaMock.description,
+        descriptionEdit: prismaMock.descriptionEdit,
         user: prismaMock.user,
         userSuspension: prismaMock.userSuspension,
       }),
     );
+    auditLogCreateMock.mockResolvedValue({});
     prismaMock.user.count.mockReset();
     prismaMock.user.findUnique.mockReset();
     prismaMock.user.update.mockReset();
@@ -202,7 +242,7 @@ describe("admin API service", () => {
     expect(prismaMock.user.findUnique).not.toHaveBeenCalled();
     expect(prismaMock.userSuspension.create).not.toHaveBeenCalled();
     expect(prismaMock.userSuspension.updateMany).not.toHaveBeenCalled();
-    expect(fireAuditLogMock).not.toHaveBeenCalled();
+    expect(auditLogCreateMock).not.toHaveBeenCalled();
   });
 
   it("closes existing open suspensions before creating the current suspension", async () => {
@@ -242,12 +282,40 @@ describe("admin API service", () => {
         expiresAt: null,
       },
     });
-    expect(fireAuditLogMock).toHaveBeenCalledWith({
-      action: "admin_user_suspend",
-      userId: "admin-1",
-      targetId: "user-1",
-      targetType: "user",
-      metadata: { reason: " fresh reason " },
+    expect(auditLogCreateMock).toHaveBeenCalledWith({
+      data: {
+        action: "admin_user_suspend",
+        userId: "admin-1",
+        targetId: "user-1",
+        targetType: "user",
+        metadata: { reason: " fresh reason " },
+      },
+    });
+  });
+
+  it("rejects suspension creation when the required audit write fails", async () => {
+    const auditError = new Error("audit unavailable");
+    prismaMock.user.findUnique.mockResolvedValue({ id: "user-1" });
+    prismaMock.userSuspension.create.mockResolvedValue({
+      id: "suspension-1",
+      userId: "user-1",
+    });
+    auditLogCreateMock.mockRejectedValueOnce(auditError);
+    const { createAdminSuspension } = await import(
+      "@/features/admin/server/admin-api-service"
+    );
+
+    await expect(
+      createAdminSuspension("admin-1", { userId: "user-1" }),
+    ).rejects.toThrow(auditError);
+
+    expect(auditLogCreateMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: "admin_user_suspend",
+        targetId: "user-1",
+        targetType: "user",
+        userId: "admin-1",
+      }),
     });
   });
 
@@ -262,6 +330,7 @@ describe("admin API service", () => {
       .mockRejectedValueOnce(uniqueConflict)
       .mockImplementationOnce(async (action) =>
         action({
+          auditLog: prismaMock.auditLog,
           user: prismaMock.user,
           userSuspension: prismaMock.userSuspension,
         }),
@@ -317,12 +386,88 @@ describe("admin API service", () => {
         liftedById: "admin-1",
       },
     });
-    expect(fireAuditLogMock).toHaveBeenCalledWith({
-      action: "admin_user_unsuspend",
-      userId: "admin-1",
-      targetId: "user-1",
-      targetType: "user",
-      metadata: { suspensionId: "suspension-1" },
+    expect(auditLogCreateMock).toHaveBeenCalledWith({
+      data: {
+        action: "admin_user_unsuspend",
+        userId: "admin-1",
+        targetId: "user-1",
+        targetType: "user",
+        metadata: { suspensionId: "suspension-1" },
+      },
+    });
+  });
+
+  it("rejects comment moderation when the required audit write fails", async () => {
+    const auditError = new Error("audit unavailable");
+    commentFindUniqueMock.mockResolvedValue({ id: "comment-1" });
+    commentUpdateMock.mockResolvedValue({ id: "comment-1", status: "deleted" });
+    auditLogCreateMock.mockRejectedValueOnce(auditError);
+    const { moderateComment } = await import(
+      "@/features/admin/server/admin-api-service"
+    );
+
+    await expect(
+      moderateComment("admin-1", "comment-1", {
+        moderationNote: "spam",
+        status: "deleted",
+      }),
+    ).rejects.toThrow(auditError);
+
+    expect(commentUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "comment-1" } }),
+    );
+    expect(auditLogCreateMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: "admin_comment_moderate",
+        metadata: { moderationNote: "spam", status: "deleted" },
+        targetId: "comment-1",
+        targetType: "comment",
+        userId: "admin-1",
+      }),
+    });
+  });
+
+  it("rejects description moderation when the required audit write fails", async () => {
+    const auditError = new Error("audit unavailable");
+    descriptionFindUniqueMock.mockResolvedValue({
+      id: "description-1",
+      content: "old content",
+    });
+    descriptionUpdateMock.mockResolvedValue({
+      id: "description-1",
+      content: "new content",
+    });
+    descriptionEditCreateMock.mockResolvedValue({});
+    auditLogCreateMock.mockRejectedValueOnce(auditError);
+    const { moderateDescription } = await import(
+      "@/features/admin/server/admin-api-service"
+    );
+
+    await expect(
+      moderateDescription("admin-1", "description-1", {
+        content: "new content",
+      }),
+    ).rejects.toThrow(auditError);
+
+    expect(descriptionEditCreateMock).toHaveBeenCalledWith({
+      data: {
+        descriptionId: "description-1",
+        editorId: "admin-1",
+        previousContent: "old content",
+        nextContent: "new content",
+      },
+    });
+    expect(auditLogCreateMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: "admin_description_moderate",
+        metadata: {
+          previousContent: "old content",
+          nextContent: "new content",
+        },
+        targetId: "description-1",
+        targetType: "description",
+        userId: "admin-1",
+      }),
     });
   });
 });

--- a/tests/unit/admin-page-auth.test.ts
+++ b/tests/unit/admin-page-auth.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  findActiveSuspensionMock,
+  getSessionFromHeadersMock,
+  userFindUniqueMock,
+} = vi.hoisted(() => ({
+  findActiveSuspensionMock: vi.fn(),
+  getSessionFromHeadersMock: vi.fn(),
+  userFindUniqueMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/core", () => ({
+  getSessionFromHeaders: getSessionFromHeadersMock,
+}));
+
+vi.mock("@/lib/auth/viewer-context", () => ({
+  findActiveSuspension: findActiveSuspensionMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: userFindUniqueMock,
+    },
+  },
+}));
+
+describe("admin page auth", () => {
+  afterEach(() => {
+    findActiveSuspensionMock.mockReset();
+    getSessionFromHeadersMock.mockReset();
+    userFindUniqueMock.mockReset();
+    vi.resetModules();
+  });
+
+  it("allows suspended admins to load read-only admin pages", async () => {
+    getSessionFromHeadersMock.mockResolvedValue({
+      user: { id: "admin-1" },
+    });
+    userFindUniqueMock.mockResolvedValue({
+      id: "admin-1",
+      isAdmin: true,
+      name: "Admin",
+      username: "admin",
+    });
+    const { requireAdminPage } = await import(
+      "@/features/admin/server/admin-page-auth"
+    );
+
+    const admin = await requireAdminPage(
+      new Request("https://example.test/admin/moderation", {
+        headers: {
+          cookie: "better-auth.session_token=session-token",
+        },
+      }),
+    );
+
+    expect(admin.id).toBe("admin-1");
+    expect(findActiveSuspensionMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks suspended admins from admin page actions", async () => {
+    getSessionFromHeadersMock.mockResolvedValue({
+      user: { id: "admin-1" },
+    });
+    userFindUniqueMock.mockResolvedValue({
+      id: "admin-1",
+      isAdmin: true,
+      name: "Admin",
+      username: "admin",
+    });
+    findActiveSuspensionMock.mockResolvedValue({
+      reason: "policy hold",
+    });
+    const { requireAdminPage } = await import(
+      "@/features/admin/server/admin-page-auth"
+    );
+
+    await expect(
+      requireAdminPage(
+        new Request("https://example.test/admin/moderation", {
+          headers: {
+            cookie: "better-auth.session_token=session-token",
+          },
+        }),
+        { requireActive: true },
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+});

--- a/tests/unit/admin-route-auth.test.ts
+++ b/tests/unit/admin-route-auth.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const {
+  findActiveSuspensionMock,
   getSessionFromHeadersMock,
   resolveAdminByUserIdMock,
   verifyAccessTokenMock,
 } = vi.hoisted(() => ({
+  findActiveSuspensionMock: vi.fn(),
   getSessionFromHeadersMock: vi.fn(),
   resolveAdminByUserIdMock: vi.fn(),
   verifyAccessTokenMock: vi.fn(),
@@ -16,6 +18,10 @@ vi.mock("@/features/admin/server/admin-api", () => ({
 
 vi.mock("@/lib/auth/core", () => ({
   getSessionFromHeaders: getSessionFromHeadersMock,
+}));
+
+vi.mock("@/lib/auth/viewer-context", () => ({
+  findActiveSuspension: findActiveSuspensionMock,
 }));
 
 vi.mock("better-auth/oauth2", () => ({
@@ -30,6 +36,7 @@ vi.mock("@/lib/mcp/urls", () => ({
 
 describe("admin route auth", () => {
   afterEach(() => {
+    findActiveSuspensionMock.mockReset();
     getSessionFromHeadersMock.mockReset();
     resolveAdminByUserIdMock.mockReset();
     verifyAccessTokenMock.mockReset();
@@ -121,5 +128,38 @@ describe("admin route auth", () => {
     expect(admin).toEqual({ userId: "admin-1" });
     expect(getSessionFromHeadersMock).toHaveBeenCalledWith(request.headers);
     expect(resolveAdminByUserIdMock).toHaveBeenCalledWith("admin-1");
+  });
+
+  it("returns 403 when an admin mutation requires an active admin but the admin is suspended", async () => {
+    getSessionFromHeadersMock.mockResolvedValue({
+      user: { id: "admin-1" },
+    });
+    resolveAdminByUserIdMock.mockResolvedValue({ userId: "admin-1" });
+    findActiveSuspensionMock.mockResolvedValue({
+      reason: "policy hold",
+    });
+    const { requireAdminRequest } = await import(
+      "@/lib/api/routes/admin-route-auth"
+    );
+    const request = new Request(
+      "https://example.test/api/admin/comments/comment-1",
+      {
+        headers: {
+          cookie: "better-auth.session_token=session-token",
+        },
+      },
+    );
+
+    const response = await requireAdminRequest(request, {
+      requireActive: true,
+    });
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(403);
+    await expect((response as Response).json()).resolves.toEqual({
+      error: "Suspended",
+      reason: "policy hold",
+    });
+    expect(findActiveSuspensionMock).toHaveBeenCalledWith("admin-1");
   });
 });

--- a/tests/unit/comment-serialization-permissions.test.ts
+++ b/tests/unit/comment-serialization-permissions.test.ts
@@ -87,7 +87,7 @@ describe("comment serialization permissions", () => {
     });
   });
 
-  it("preserves suspended admin moderation affordances", () => {
+  it("removes suspended admin moderation affordances", () => {
     const { roots } = buildCommentNodes(
       [comment({ userId: "user-1" })],
       viewer({
@@ -101,7 +101,7 @@ describe("comment serialization permissions", () => {
     expect(roots[0]).toMatchObject({
       canDelete: false,
       canEdit: false,
-      canModerate: true,
+      canModerate: false,
       canReact: false,
       canReply: false,
       isAuthor: false,

--- a/tests/unit/description-upsert-service.test.ts
+++ b/tests/unit/description-upsert-service.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  auditLogCreateMock,
+  descriptionCreateMock,
+  descriptionEditCreateMock,
+  descriptionFindFirstMock,
+  descriptionUpdateMock,
+  getViewerContextMock,
+  isPrismaUniqueConstraintErrorMock,
+  prismaMock,
+  sectionFindUniqueMock,
+} = vi.hoisted(() => ({
+  auditLogCreateMock: vi.fn(),
+  descriptionCreateMock: vi.fn(),
+  descriptionEditCreateMock: vi.fn(),
+  descriptionFindFirstMock: vi.fn(),
+  descriptionUpdateMock: vi.fn(),
+  getViewerContextMock: vi.fn(),
+  isPrismaUniqueConstraintErrorMock: vi.fn(),
+  prismaMock: {
+    $transaction: vi.fn(),
+    auditLog: {
+      create: vi.fn(),
+    },
+    description: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+    descriptionEdit: {
+      create: vi.fn(),
+    },
+    section: {
+      findUnique: vi.fn(),
+    },
+  },
+  sectionFindUniqueMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/viewer-context", () => ({
+  getViewerContext: getViewerContextMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/db/prisma-errors", () => ({
+  isPrismaUniqueConstraintError: isPrismaUniqueConstraintErrorMock,
+}));
+
+vi.mock("@/lib/metrics/observability-metrics", () => ({
+  recordAuditWriteMetric: vi.fn(),
+}));
+
+describe("upsertDescriptionContent", () => {
+  beforeEach(() => {
+    auditLogCreateMock.mockReset();
+    descriptionCreateMock.mockReset();
+    descriptionEditCreateMock.mockReset();
+    descriptionFindFirstMock.mockReset();
+    descriptionUpdateMock.mockReset();
+    getViewerContextMock.mockReset();
+    isPrismaUniqueConstraintErrorMock.mockReset();
+    sectionFindUniqueMock.mockReset();
+
+    prismaMock.auditLog.create = auditLogCreateMock;
+    prismaMock.description.create = descriptionCreateMock;
+    prismaMock.description.findFirst = descriptionFindFirstMock;
+    prismaMock.description.update = descriptionUpdateMock;
+    prismaMock.descriptionEdit.create = descriptionEditCreateMock;
+    prismaMock.section.findUnique = sectionFindUniqueMock;
+    prismaMock.$transaction.mockReset();
+    prismaMock.$transaction.mockImplementation(async (action) =>
+      action({
+        auditLog: prismaMock.auditLog,
+        description: prismaMock.description,
+        descriptionEdit: prismaMock.descriptionEdit,
+      }),
+    );
+
+    auditLogCreateMock.mockResolvedValue({});
+    descriptionEditCreateMock.mockResolvedValue({});
+    getViewerContextMock.mockResolvedValue({
+      isAuthenticated: true,
+      isSuspended: false,
+    });
+    isPrismaUniqueConstraintErrorMock.mockReturnValue(false);
+    sectionFindUniqueMock.mockResolvedValue({ id: 1 });
+  });
+
+  it("rejects changed content when the required audit write fails", async () => {
+    const auditError = new Error("audit unavailable");
+    descriptionFindFirstMock.mockResolvedValue({
+      id: "description-1",
+      content: "old content",
+    });
+    descriptionUpdateMock.mockResolvedValue({
+      id: "description-1",
+      content: "new content",
+    });
+    auditLogCreateMock.mockRejectedValueOnce(auditError);
+    const { upsertDescriptionContent } = await import(
+      "@/features/descriptions/server/description-upsert"
+    );
+
+    await expect(
+      upsertDescriptionContent({
+        content: "new content",
+        targetId: 1,
+        targetType: "section",
+        userId: "user-1",
+      }),
+    ).rejects.toThrow(auditError);
+
+    expect(descriptionEditCreateMock).toHaveBeenCalledWith({
+      data: {
+        descriptionId: "description-1",
+        editorId: "user-1",
+        previousContent: "old content",
+        nextContent: "new content",
+      },
+    });
+    expect(auditLogCreateMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: "description_edit",
+        metadata: {
+          targetType: "section",
+          content: "new content",
+        },
+        targetId: "description-1",
+        targetType: "description",
+        userId: "user-1",
+      }),
+    });
+  });
+
+  it("does not write edit history or audit rows for idempotent content", async () => {
+    descriptionFindFirstMock.mockResolvedValue({
+      id: "description-1",
+      content: "same content",
+    });
+    const { upsertDescriptionContent } = await import(
+      "@/features/descriptions/server/description-upsert"
+    );
+
+    const result = await upsertDescriptionContent({
+      content: "same content",
+      targetId: 1,
+      targetType: "section",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      id: "description-1",
+      ok: true,
+      updated: false,
+    });
+    expect(descriptionEditCreateMock).not.toHaveBeenCalled();
+    expect(auditLogCreateMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/upload-completion-service.test.ts
+++ b/tests/unit/upload-completion-service.test.ts
@@ -6,8 +6,8 @@ import {
 } from "@/features/uploads/server/upload-service";
 
 const {
+  auditLogCreateMock,
   deleteStorageObjectMock,
-  fireAuditLogMock,
   getViewerContextMock,
   headStorageObjectMock,
   pendingAggregateMock,
@@ -24,9 +24,10 @@ const {
   uploadDeleteMock,
   uploadFindFirstMock,
   uploadFindUniqueMock,
+  uploadTransactionMock,
 } = vi.hoisted(() => ({
+  auditLogCreateMock: vi.fn(),
   deleteStorageObjectMock: vi.fn(),
-  fireAuditLogMock: vi.fn(),
   getViewerContextMock: vi.fn(),
   headStorageObjectMock: vi.fn(),
   pendingAggregateMock: vi.fn(),
@@ -43,10 +44,15 @@ const {
   uploadDeleteMock: vi.fn(),
   uploadFindFirstMock: vi.fn(),
   uploadFindUniqueMock: vi.fn(),
+  uploadTransactionMock: vi.fn(),
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
   prisma: {
+    $transaction: uploadTransactionMock,
+    auditLog: {
+      create: auditLogCreateMock,
+    },
     upload: {
       aggregate: uploadAggregateMock,
       delete: uploadDeleteMock,
@@ -70,16 +76,16 @@ vi.mock("@/lib/storage/r2-object", () => ({
   headStorageObject: headStorageObjectMock,
 }));
 
-vi.mock("@/lib/audit/write-audit-log", () => ({
-  fireAuditLog: fireAuditLogMock,
-}));
-
 vi.mock("@/lib/auth/viewer-context", () => ({
   getViewerContext: getViewerContextMock,
 }));
 
 vi.mock("@/lib/log/app-logger", () => ({
   logAppEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/metrics/observability-metrics", () => ({
+  recordAuditWriteMetric: vi.fn(),
 }));
 
 const FIXED_NOW = new Date("2026-01-15T00:00:00.000Z");
@@ -292,15 +298,27 @@ describe("deleteOwnedUpload", () => {
     });
     uploadDeleteMock.mockResolvedValue({});
     deleteStorageObjectMock.mockResolvedValue(undefined);
+    auditLogCreateMock.mockResolvedValue({});
+    uploadTransactionMock.mockImplementation(async (action) =>
+      action({
+        auditLog: {
+          create: auditLogCreateMock,
+        },
+        upload: {
+          delete: uploadDeleteMock,
+          findFirst: uploadFindFirstMock,
+        },
+      }),
+    );
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it("waits for upload delete audit scheduling before returning", async () => {
+  it("waits for upload delete audit write before returning", async () => {
     const auditWrite = deferred<void>();
-    fireAuditLogMock.mockReturnValue(auditWrite.promise);
+    auditLogCreateMock.mockReturnValue(auditWrite.promise);
     const settled = vi.fn();
 
     const result = deleteOwnedUpload({
@@ -309,7 +327,7 @@ describe("deleteOwnedUpload", () => {
     });
     result.then(settled);
 
-    await vi.waitFor(() => expect(fireAuditLogMock).toHaveBeenCalled());
+    await vi.waitFor(() => expect(auditLogCreateMock).toHaveBeenCalled());
     expect(settled).not.toHaveBeenCalled();
 
     auditWrite.resolve();

--- a/tests/unit/upload-delete-service.test.ts
+++ b/tests/unit/upload-delete-service.test.ts
@@ -2,23 +2,29 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { deleteOwnedUpload } from "@/features/uploads/server/upload-service";
 
 const {
+  auditLogCreateMock,
   deleteStorageObjectMock,
-  fireAuditLogMock,
   getViewerContextMock,
   logAppEventMock,
   uploadDeleteMock,
   uploadFindFirstMock,
+  uploadTransactionMock,
 } = vi.hoisted(() => ({
+  auditLogCreateMock: vi.fn(),
   deleteStorageObjectMock: vi.fn(),
-  fireAuditLogMock: vi.fn(),
   getViewerContextMock: vi.fn(),
   logAppEventMock: vi.fn(),
   uploadDeleteMock: vi.fn(),
   uploadFindFirstMock: vi.fn(),
+  uploadTransactionMock: vi.fn(),
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
   prisma: {
+    $transaction: uploadTransactionMock,
+    auditLog: {
+      create: auditLogCreateMock,
+    },
     upload: {
       delete: uploadDeleteMock,
       findFirst: uploadFindFirstMock,
@@ -31,16 +37,16 @@ vi.mock("@/lib/storage/r2-object", () => ({
   headStorageObject: vi.fn(),
 }));
 
-vi.mock("@/lib/audit/write-audit-log", () => ({
-  fireAuditLog: fireAuditLogMock,
-}));
-
 vi.mock("@/lib/auth/viewer-context", () => ({
   getViewerContext: getViewerContextMock,
 }));
 
 vi.mock("@/lib/log/app-logger", () => ({
   logAppEvent: logAppEventMock,
+}));
+
+vi.mock("@/lib/metrics/observability-metrics", () => ({
+  recordAuditWriteMetric: vi.fn(),
 }));
 
 const upload = {
@@ -58,6 +64,18 @@ describe("deleteOwnedUpload", () => {
     uploadFindFirstMock.mockResolvedValue(upload);
     deleteStorageObjectMock.mockResolvedValue(undefined);
     uploadDeleteMock.mockResolvedValue(upload);
+    auditLogCreateMock.mockResolvedValue({});
+    uploadTransactionMock.mockImplementation(async (action) =>
+      action({
+        auditLog: {
+          create: auditLogCreateMock,
+        },
+        upload: {
+          delete: uploadDeleteMock,
+          findFirst: uploadFindFirstMock,
+        },
+      }),
+    );
   });
 
   afterEach(() => {
@@ -81,15 +99,38 @@ describe("deleteOwnedUpload", () => {
     expect(deleteStorageObjectMock.mock.invocationCallOrder[0]).toBeLessThan(
       uploadDeleteMock.mock.invocationCallOrder[0],
     );
-    expect(fireAuditLogMock).toHaveBeenCalledWith(
-      expect.objectContaining({
+    expect(auditLogCreateMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
         action: "upload_delete",
         metadata: { key: upload.key, size: upload.size, source: "mcp" },
         targetId: upload.id,
         targetType: "upload",
         userId: "user-1",
       }),
-    );
+    });
+  });
+
+  it("surfaces audit failures after storage deletion instead of dropping audit rows", async () => {
+    const auditError = new Error("audit unavailable");
+    auditLogCreateMock.mockRejectedValueOnce(auditError);
+
+    await expect(
+      deleteOwnedUpload({
+        id: upload.id,
+        userId: "user-1",
+      }),
+    ).rejects.toThrow(auditError);
+
+    expect(deleteStorageObjectMock).toHaveBeenCalledWith(upload.key);
+    expect(uploadDeleteMock).toHaveBeenCalledWith({ where: { id: upload.id } });
+    expect(auditLogCreateMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: "upload_delete",
+        targetId: upload.id,
+        targetType: "upload",
+        userId: "user-1",
+      }),
+    });
   });
 
   it("preserves upload metadata when storage deletion fails", async () => {
@@ -106,7 +147,7 @@ describe("deleteOwnedUpload", () => {
       error: "storage_delete_failed",
     });
     expect(uploadDeleteMock).not.toHaveBeenCalled();
-    expect(fireAuditLogMock).not.toHaveBeenCalled();
+    expect(auditLogCreateMock).not.toHaveBeenCalled();
     expect(logAppEventMock).toHaveBeenCalledWith(
       "error",
       "R2 object deletion failed; upload record preserved",


### PR DESCRIPTION
## Goal

Close #264 and #266 by making required domain/security audit trails durable and by documenting/enforcing a single suspended-admin write policy.

Closes #264
Closes #266

## Changed Surfaces

- Required audit writes for admin suspension/unsuspension, comment moderation, description moderation, description edits, and upload deletion now await `writeAuditLog`.
- DB-only mutations commit their domain change and audit row in the same Prisma transaction where practical.
- Upload deletion keeps storage deletion first; after storage deletion succeeds, upload metadata deletion and `upload_delete` audit insertion commit together.
- Admin API/page mutation guards now require an unsuspended admin; read-only admin pages/list endpoints remain available to admins by role.
- Comment serialization no longer exposes moderation affordances to suspended admins.
- Focused unit coverage added for audit durability/failure and suspended-admin behavior.

## Evidence

- `bun install --frozen-lockfile`
- `bun run test -- tests/unit/admin-api-service.test.ts tests/unit/admin-route-auth.test.ts tests/unit/admin-page-auth.test.ts tests/unit/comment-serialization-permissions.test.ts tests/unit/upload-delete-service.test.ts tests/unit/upload-completion-service.test.ts tests/unit/description-upsert-service.test.ts tests/unit/audit-write-log.test.ts`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run verify`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_audit_admin_policy AUTH_SECRET=local-dev-auth-secret WEBHOOK_SECRET=local-dev-webhook-secret PLAYWRIGHT_PORT=3010 bun run verify:full` passed locally, including 549 Playwright E2E tests.
- After merging the then-current `origin/main` into the published branch: `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run verify` passed again.
- GitHub PR checks are green on commit `f3595794`: CI check, build artifacts, static loader image, E2E matrix (`admin-comments`, `api-mcp`, `public-web`, `signed-in`), CodeQL, E2E snapshot artifact/comment jobs, and Cloudflare Workers build.

## Docs / Contracts

Updated `docs/contracts/_audit.json`, `admin.json`, `comment.json`, `description.json`, and `upload.json` to describe durable audit writes and the suspended-admin policy.

## Risk Areas

- Upload deletion still cannot make R2 object deletion and DB mutation atomic together; storage delete remains first to avoid metadata removal when object cleanup fails. If the following DB transaction fails, the caller now gets the audit/DB error rather than silently losing the audit row.
- Suspended admins may still read admin pages/list endpoints by policy, but all admin mutations/page actions covered here require an active admin.
- Other branches continued landing on `main` while this PR was in progress; the PR is mergeable/clean and checks are green on the latest pushed commit.

## Cleanup

No scratch artifacts, generated-file edits, or unrelated rewrites remain. The temporary verification database was dropped after `verify:full` completed.
