### PR TITLE
fix(comment): comment privacy and mutation race guards

### DIFF
--- a/docs/contracts/comment.json
+++ b/docs/contracts/comment.json
@@ -10,7 +10,7 @@
     "attached-to-object": "Comments must be attached to a specific object; no decontextualized public feed entry is provided.",
     "attached-object-types": "Attached objects include courses, sections, teachers, homework, and section-teacher relationships.",
     "rich-content": "Supports Markdown, math formulas, emoji, tables, replies, and reactions.",
-    "visibility-modes": "Supports public, signed-in-only, and anonymous posting; anonymous comments hide identity from regular users but are traceable by admins in governance scenarios.",
+    "visibility-modes": "Supports public and signed-in-only audience visibility; anonymous posting is represented by comment.isAnonymous and hides identity from regular users while remaining traceable by admins in governance scenarios.",
     "shared-read-policy": "Web, REST, and MCP comment reads share the same target resolution, thread serialization, visibility filtering, author masking, reaction, attachment, and viewer action-flag logic; read-only paths must not create durable comment targets and valid empty section-teacher targets load as empty threads.",
     "interaction-gate": "Edits, deletes, replies, and reaction changes require an authenticated, unsuspended viewer and an active visible comment target; deleted or softbanned comments must not expose canEdit/canDelete/canReply/canReact or accept those write actions."
   },
@@ -36,6 +36,7 @@
             "auth": "user",
             "notes": [
               "Accepts REST-compatible internal targetId plus public identifiers such as sectionJwId, courseJwId, teacherId, homeworkId, and sectionTeacherId.",
+              "visibility accepts only public or logged_in_only; use isAnonymous for identity hiding.",
               "Provided sectionJwId and courseJwId values must be valid positive integers; malformed values return 400 even when targetId is also supplied.",
               "Returns 400 Invalid attachments when any requested upload is missing, owned by another user, or already attached to a comment."
             ]
@@ -47,6 +48,7 @@
             "auth": "user",
             "notes": [
               "Only the comment owner may use the public edit endpoint; admins moderate through /api/admin/comments/[id].",
+              "visibility accepts only public or logged_in_only; use isAnonymous for identity hiding.",
               "Returns 400 Invalid attachments when any requested upload is missing, owned by another user, or already attached to a different comment."
             ]
           },
@@ -97,7 +99,7 @@
             "auth": "user",
             "rest_equivalent": "POST /api/comments",
             "notes": [
-              "Uses the same target resolution and attachment validation as REST; MCP audit metadata records source=mcp."
+              "Uses the same target resolution, visibility validation, isAnonymous identity-hiding flag, and attachment validation as REST; MCP audit metadata records source=mcp."
             ]
           },
           {
@@ -106,7 +108,7 @@
             "auth": "user",
             "rest_equivalent": "PATCH /api/comments/[id]",
             "notes": [
-              "Only the comment owner may edit through this ordinary-user MCP tool; moderation remains unavailable through MCP."
+              "Only the comment owner may edit through this ordinary-user MCP tool; visibility validation and isAnonymous match REST, and moderation remains unavailable through MCP."
             ]
           },
           {

--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -1532,7 +1532,6 @@
     "anonymousBadge": "Anonymous",
     "ustcVerified": "USTC verified",
     "softbannedBadge": "Private",
-    "reportAction": "Report",
     "deletedBadge": "Deleted",
     "deletedMessage": "This comment was deleted.",
     "replyAction": "Reply",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -1498,7 +1498,6 @@
     "anonymousBadge": "匿名",
     "ustcVerified": "USTC 认证",
     "softbannedBadge": "仅自己可见",
-    "reportAction": "举报",
     "deletedBadge": "已删除",
     "deletedMessage": "该评论已删除。",
     "replyAction": "回复",

--- a/prisma/migrations/20260627120000_remove_anonymous_comment_visibility/migration.sql
+++ b/prisma/migrations/20260627120000_remove_anonymous_comment_visibility/migration.sql
@@ -1,0 +1,19 @@
+ALTER TABLE "Comment" ALTER COLUMN "visibility" DROP DEFAULT;
+
+UPDATE "Comment"
+SET
+  "isAnonymous" = TRUE,
+  "visibility" = 'public'::"CommentVisibility"
+WHERE "visibility" = 'anonymous'::"CommentVisibility";
+
+CREATE TYPE "CommentVisibility_new" AS ENUM ('public', 'logged_in_only');
+
+ALTER TABLE "Comment"
+  ALTER COLUMN "visibility" TYPE "CommentVisibility_new"
+  USING ("visibility"::text::"CommentVisibility_new");
+
+ALTER TYPE "CommentVisibility" RENAME TO "CommentVisibility_old";
+ALTER TYPE "CommentVisibility_new" RENAME TO "CommentVisibility";
+DROP TYPE "CommentVisibility_old";
+
+ALTER TABLE "Comment" ALTER COLUMN "visibility" SET DEFAULT 'public';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,6 @@ datasource db {
 enum CommentVisibility {
   public
   logged_in_only
-  anonymous
 }
 
 enum CommentStatus {

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -7214,8 +7214,7 @@
             "type": "string",
             "enum": [
               "public",
-              "logged_in_only",
-              "anonymous"
+              "logged_in_only"
             ]
           },
           "isAnonymous": {
@@ -7249,8 +7248,7 @@
             "type": "string",
             "enum": [
               "public",
-              "logged_in_only",
-              "anonymous"
+              "logged_in_only"
             ]
           },
           "isAnonymous": {
@@ -7904,8 +7902,7 @@
                   "type": "string",
                   "enum": [
                     "public",
-                    "logged_in_only",
-                    "anonymous"
+                    "logged_in_only"
                   ]
                 },
                 "status": {
@@ -8251,8 +8248,7 @@
                 "type": "string",
                 "enum": [
                   "public",
-                  "logged_in_only",
-                  "anonymous"
+                  "logged_in_only"
                 ]
               },
               "status": {

--- a/src/features/AGENTS.md
+++ b/src/features/AGENTS.md
@@ -40,7 +40,7 @@ feature/
 
 ### comments/
 - Scoped to section/course/teacher/homework
-- Visibility: public, logged-in, anonymous
+- Audience visibility: public or logged-in-only; anonymous posting uses `isAnonymous`
 - Suspended can't create
 - Admin can moderate
 

--- a/src/features/comments/components/CommentThreadHeaderActions.svelte
+++ b/src/features/comments/components/CommentThreadHeaderActions.svelte
@@ -55,9 +55,6 @@ export let toggleReply: (comment: CommentNode) => void;
             {commentCopy.deleteAction}
           </Menu.Item>
         {/if}
-        <Menu.Item class="cursor-not-allowed opacity-60" disabled>
-          {commentCopy.reportAction}
-        </Menu.Item>
       </Menu.Content>
     </Menu.Root>
   </div>

--- a/src/features/comments/components/comment-component-types.ts
+++ b/src/features/comments/components/comment-component-types.ts
@@ -51,7 +51,6 @@ export type CommentsCopy = {
   removeAttachment: string;
   replyAction: string;
   replyPlaceholder: string;
-  reportAction: string;
   saveAction: string;
   softbannedBadge: string;
   subtitle: string;

--- a/src/features/comments/server/comment-attachment-access.ts
+++ b/src/features/comments/server/comment-attachment-access.ts
@@ -25,8 +25,6 @@ export function canViewerAccessCommentAttachment(
     return viewer.isAdmin || comment.userId === viewer.userId;
   }
   return (
-    comment.visibility === "public" ||
-    comment.visibility === "logged_in_only" ||
-    comment.visibility === "anonymous"
+    comment.visibility === "public" || comment.visibility === "logged_in_only"
   );
 }

--- a/src/features/comments/server/comment-mutations.ts
+++ b/src/features/comments/server/comment-mutations.ts
@@ -20,11 +20,6 @@ type CommentMutationFailure = {
   reason?: string | null;
 };
 
-type CreateCommentParent = {
-  parentId: string | null;
-  rootId: string | null;
-};
-
 type CreateCommentTarget = {
   whereTarget: Record<string, unknown>;
 };
@@ -105,15 +100,6 @@ export async function createComment(input: {
     };
   }
 
-  const parent = await resolveCreateCommentParent({
-    parentId: input.parentId,
-    viewer: actor.viewer,
-    whereTarget: target.whereTarget,
-  });
-  if (!parent.ok) {
-    return { ok: false as const, error: parent.error };
-  }
-
   const attachmentIds = input.attachmentIds ?? [];
   if (
     attachmentIds.length > 0 &&
@@ -125,15 +111,16 @@ export async function createComment(input: {
     };
   }
 
-  let comment: Awaited<ReturnType<typeof createCommentRecord>>;
+  let result: Awaited<ReturnType<typeof createCommentRecord>>;
   try {
-    comment = await createCommentRecord({
+    result = await createCommentRecord({
       attachmentIds,
       content: input.content,
       isAnonymous: input.isAnonymous,
-      parent,
+      parentId: input.parentId,
       target,
       userId: input.userId,
+      viewer: actor.viewer,
       visibility: input.visibility,
     });
   } catch (error) {
@@ -143,32 +130,43 @@ export async function createComment(input: {
       error: "invalid_attachments" as CreateCommentError,
     };
   }
+  if (!result.ok) return result;
 
-  return { ok: true as const, comment };
+  return { ok: true as const, comment: result.comment };
 }
 
 async function createCommentRecord({
   attachmentIds,
   content,
   isAnonymous,
-  parent,
+  parentId,
   target,
   userId,
+  viewer,
   visibility,
 }: {
   attachmentIds: string[];
   content: string;
   isAnonymous: boolean;
-  parent: CreateCommentParent;
+  parentId?: string | null;
   target: CreateCommentTarget;
   userId: string;
-  visibility: string;
+  viewer: ViewerInfo;
+  visibility: CommentVisibility;
 }) {
   return prisma.$transaction(async (tx) => {
+    const parent = await resolveCreateCommentParentForWrite({
+      parentId,
+      tx,
+      viewer,
+      whereTarget: target.whereTarget,
+    });
+    if (!parent.ok) return parent;
+
     const comment = await tx.comment.create({
       data: {
         body: content,
-        visibility: visibility as CommentVisibility,
+        visibility,
         status: "active",
         isAnonymous,
         authorName: null,
@@ -195,7 +193,7 @@ async function createCommentRecord({
       });
     }
 
-    return comment;
+    return { ok: true as const, comment };
   });
 }
 
@@ -230,16 +228,19 @@ export async function updateOwnComment({
     }
   }
 
+  let updated = false;
   try {
     await prisma.$transaction(async (tx) => {
-      await tx.comment.update({
-        where: { id },
+      const result = await tx.comment.updateMany({
+        where: { id, status: "active", userId },
         data: {
           body,
           visibility,
           isAnonymous,
         },
       });
+      if (result.count !== 1) return;
+      updated = true;
 
       if (hasAttachmentUpdate) {
         await syncCommentAttachments(tx, id, attachmentIds);
@@ -248,6 +249,9 @@ export async function updateOwnComment({
   } catch (error) {
     if (!isPrismaUniqueConstraintError(error)) throw error;
     return { ok: false as const, error: "invalid_attachments" as const };
+  }
+  if (!updated) {
+    return loadOwnActiveCommentFailure({ id, userId, viewer: context.viewer });
   }
 
   const comment = await loadCommentResponse(id, context.viewer);
@@ -282,13 +286,20 @@ export async function deleteOwnComment(input: {
     return { ok: false as const, error: "locked" as const };
   }
 
-  await prisma.comment.update({
-    where: { id: input.commentId },
+  const result = await prisma.comment.updateMany({
+    where: { id: input.commentId, status: "active", userId: input.userId },
     data: {
       status: "deleted",
       deletedAt: new Date(),
     },
   });
+  if (result.count !== 1) {
+    return loadOwnActiveCommentFailure({
+      id: input.commentId,
+      userId: input.userId,
+      viewer: actor.viewer,
+    });
+  }
 
   return { ok: true as const };
 }
@@ -387,12 +398,14 @@ export async function validateCommentAttachmentIds(
   );
 }
 
-async function resolveCreateCommentParent({
+async function resolveCreateCommentParentForWrite({
   parentId,
+  tx,
   viewer,
   whereTarget,
 }: {
   parentId: string | null | undefined;
+  tx: Prisma.TransactionClient;
   viewer: ViewerInfo;
   whereTarget: Record<string, unknown>;
 }) {
@@ -400,7 +413,14 @@ async function resolveCreateCommentParent({
     return { ok: true as const, parentId: null, rootId: null };
   }
 
-  const parent = await prisma.comment.findUnique({
+  const lockedParent = await tx.$queryRaw<Array<{ id: string }>>`
+    SELECT "id" FROM "Comment" WHERE "id" = ${parentId} FOR UPDATE
+  `;
+  if (lockedParent.length === 0) {
+    return { ok: false as const, error: "parent_not_found" as const };
+  }
+
+  const parent = await tx.comment.findUnique({
     where: { id: parentId },
   });
   if (!parent) {
@@ -422,6 +442,35 @@ async function resolveCreateCommentParent({
     parentId: parent.id,
     rootId: parent.rootId ?? parent.id,
   };
+}
+
+async function loadOwnActiveCommentFailure({
+  id,
+  userId,
+  viewer,
+}: {
+  id: string;
+  userId: string;
+  viewer: ViewerInfo;
+}): Promise<CommentMutationFailure> {
+  const comment = await prisma.comment.findUnique({
+    where: { id },
+    select: { id: true, status: true, userId: true, visibility: true },
+  });
+
+  if (!comment) {
+    return { ok: false, error: "not_found" };
+  }
+
+  if (comment.userId !== userId) {
+    return { ok: false, error: "forbidden" };
+  }
+
+  if (!canViewerWriteCommentInteraction(comment, viewer)) {
+    return { ok: false, error: "locked" };
+  }
+
+  return { ok: false, error: "locked" };
 }
 
 async function loadEditableCommentContext({

--- a/src/features/comments/server/comment-serialization-helpers.ts
+++ b/src/features/comments/server/comment-serialization-helpers.ts
@@ -82,9 +82,5 @@ export function shouldHideAuthor(
   viewer: ViewerInfo,
   isAuthor: boolean,
 ) {
-  return (
-    (comment.visibility === "anonymous" || Boolean(comment.isAnonymous)) &&
-    !viewer.isAdmin &&
-    !isAuthor
-  );
+  return Boolean(comment.isAnonymous) && !viewer.isAdmin && !isAuthor;
 }

--- a/src/lib/api/schemas/shared-enum-schemas.ts
+++ b/src/lib/api/schemas/shared-enum-schemas.ts
@@ -1,10 +1,6 @@
 import * as z from "zod";
 
-export const commentVisibilitySchema = z.enum([
-  "public",
-  "logged_in_only",
-  "anonymous",
-]);
+export const commentVisibilitySchema = z.enum(["public", "logged_in_only"]);
 
 export const commentStatusSchema = z.enum(["active", "softbanned", "deleted"]);
 

--- a/tests/e2e/src/app/api/comments/[id]/test.ts
+++ b/tests/e2e/src/app/api/comments/[id]/test.ts
@@ -155,6 +155,43 @@ test("/api/comments/[id] DELETE 未登录返回 401", async ({ request }) => {
   expect(response.status()).toBe(401);
 });
 
+test("/api/comments/[id] PATCH rejects anonymous visibility", async ({
+  page,
+}) => {
+  await signInAsDebugUser(page, "/");
+  const sectionId = await resolveSeedSectionId(page.request);
+  const content = `e2e-reject-edit-anonymous-visibility-${Date.now()}`;
+  const createResponse = await page.request.post("/api/comments", {
+    data: {
+      targetType: "section",
+      targetId: String(sectionId),
+      body: content,
+      visibility: "public",
+    },
+  });
+  expect(createResponse.status()).toBe(200);
+  const commentId = ((await createResponse.json()) as { id?: string }).id;
+  expect(commentId).toBeTruthy();
+
+  try {
+    const response = await page.request.patch(`/api/comments/${commentId}`, {
+      data: {
+        body: `${content}-edited`,
+        visibility: "anonymous",
+      },
+    });
+
+    expect(response.status()).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid comment update",
+    });
+  } finally {
+    if (commentId) {
+      await page.request.delete(`/api/comments/${commentId}`);
+    }
+  }
+});
+
 test("/api/comments/[id] PATCH 可修改评论并 DELETE 清理", async ({ page }) => {
   await signInAsDebugUser(page, "/");
   const sectionId = await resolveSeedSectionId(page.request);

--- a/tests/e2e/src/app/api/comments/test.ts
+++ b/tests/e2e/src/app/api/comments/test.ts
@@ -268,6 +268,34 @@ test("/api/comments POST 未登录返回 401", async ({ request }) => {
   expect(response.status()).toBe(401);
 });
 
+test("/api/comments POST rejects anonymous visibility", async ({ page }) => {
+  await signInAsDebugUser(page, "/");
+  const sectionId = await resolveSeedSectionId(page.request);
+  const content = `e2e-reject-anonymous-visibility-${Date.now()}`;
+
+  const response = await page.request.post("/api/comments", {
+    data: {
+      targetType: "section",
+      targetId: String(sectionId),
+      body: content,
+      visibility: "anonymous",
+    },
+  });
+
+  expect(response.status()).toBe(400);
+  await expect(response.json()).resolves.toEqual({
+    error: "Invalid comment request",
+  });
+
+  const created = await withE2ePrisma((prisma) =>
+    prisma.comment.findFirst({
+      where: { body: content },
+      select: { id: true },
+    }),
+  );
+  expect(created).toBeNull();
+});
+
 test("/api/comments POST 登录后可发布新评论并清理", async ({ page }) => {
   await signInAsDebugUser(page, "/");
   const sectionId = await resolveSeedSectionId(page.request);

--- a/tests/e2e/src/app/teachers/[id]/test.ts
+++ b/tests/e2e/src/app/teachers/[id]/test.ts
@@ -383,6 +383,9 @@ test.describe("/teachers/[id]", () => {
         .getByRole("button", { name: /更多操作|More actions/i })
         .first()
         .click();
+      await expect(
+        page.getByRole("menuitem", { name: /举报|Report/i }),
+      ).toHaveCount(0);
       const deleteResponse = page.waitForResponse(
         (r) =>
           r.url().includes("/api/comments/") &&

--- a/tests/integration/mcp-02-comments.test.ts
+++ b/tests/integration/mcp-02-comments.test.ts
@@ -364,6 +364,17 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
     }
   });
 
+  it("comment write tools reject unsupported anonymous visibility", async () => {
+    await expect(
+      context.client.call("create_comment", {
+        targetType: "section",
+        sectionJwId: fixtures.DEV_SEED.section.jwId,
+        body: `[integration-test] rejected anonymous visibility ${Date.now()}`,
+        visibility: "anonymous",
+      }),
+    ).rejects.toThrow();
+  });
+
   it("comment write create_comment returns a serialized invalid-target failure", async () => {
     const result = await context.client.call<{
       success?: boolean;

--- a/tests/unit/api-schemas.test.ts
+++ b/tests/unit/api-schemas.test.ts
@@ -12,6 +12,7 @@ import {
   commentCreateRequestSchema,
   commentReactionRequestSchema,
   commentsQuerySchema,
+  commentUpdateRequestSchema,
   coursesQuerySchema,
   descriptionUpsertRequestSchema,
   homeworkCompletionBatchRequestSchema,
@@ -306,6 +307,23 @@ describe("other request schemas", () => {
         targetId: "123",
         sectionTeacherId: 0,
         body: "hello",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects unsupported anonymous comment visibility", () => {
+    expect(
+      commentCreateRequestSchema.safeParse({
+        targetType: "section",
+        sectionJwId: "9902001",
+        body: "hello",
+        visibility: "anonymous",
+      }).success,
+    ).toBe(false);
+    expect(
+      commentUpdateRequestSchema.safeParse({
+        body: "hello",
+        visibility: "anonymous",
       }).success,
     ).toBe(false);
   });

--- a/tests/unit/comment-mutations.test.ts
+++ b/tests/unit/comment-mutations.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getViewerContextMock,
+  isPrismaUniqueConstraintErrorMock,
+  prismaMock,
+  resolveCommentMutationTargetReferenceMock,
+  resolveCommentTargetMock,
+  transactionMock,
+} = vi.hoisted(() => ({
+  getViewerContextMock: vi.fn(),
+  isPrismaUniqueConstraintErrorMock: vi.fn(),
+  prismaMock: {
+    $transaction: vi.fn(),
+    comment: {
+      findUnique: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    upload: {
+      findMany: vi.fn(),
+    },
+  },
+  resolveCommentMutationTargetReferenceMock: vi.fn(),
+  resolveCommentTargetMock: vi.fn(),
+  transactionMock: {
+    $queryRaw: vi.fn(),
+    comment: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    commentAttachment: {
+      createMany: vi.fn(),
+      deleteMany: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth/viewer-context", () => ({
+  getViewerContext: getViewerContextMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/db/prisma-errors", () => ({
+  isPrismaUniqueConstraintError: isPrismaUniqueConstraintErrorMock,
+}));
+
+vi.mock("@/features/comments/server/comment-target-resolution", () => ({
+  resolveCommentMutationTargetReference:
+    resolveCommentMutationTargetReferenceMock,
+}));
+
+vi.mock("@/features/comments/server/comment-utils", () => ({
+  resolveCommentTarget: resolveCommentTargetMock,
+}));
+
+const viewer = {
+  userId: "user-1",
+  name: "User",
+  image: null,
+  isAdmin: false,
+  isAuthenticated: true,
+  isSuspended: false,
+  suspensionReason: null,
+  suspensionExpiresAt: null,
+};
+
+function activeComment() {
+  return {
+    id: "comment-1",
+    status: "active",
+    userId: "user-1",
+    visibility: "public",
+  };
+}
+
+describe("comment mutation write guards", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    getViewerContextMock.mockResolvedValue(viewer);
+    isPrismaUniqueConstraintErrorMock.mockReturnValue(false);
+    prismaMock.$transaction.mockImplementation((callback) =>
+      callback(transactionMock),
+    );
+  });
+
+  it("locks the parent row inside the reply creation transaction", async () => {
+    resolveCommentMutationTargetReferenceMock.mockResolvedValue({
+      ok: true,
+      rawTargetId: 1,
+      sectionId: 1,
+      targetType: "section",
+    });
+    resolveCommentTargetMock.mockResolvedValue({
+      verified: true,
+      whereTarget: { sectionId: 1 },
+    });
+    transactionMock.$queryRaw.mockResolvedValue([{ id: "parent-1" }]);
+    transactionMock.comment.findUnique.mockResolvedValue({
+      ...activeComment(),
+      id: "parent-1",
+      rootId: "root-1",
+      sectionId: 1,
+    });
+    transactionMock.comment.create.mockResolvedValue({ id: "reply-1" });
+
+    const { createComment } = await import(
+      "@/features/comments/server/comment-mutations"
+    );
+    const result = await createComment({
+      content: "reply",
+      isAnonymous: false,
+      parentId: "parent-1",
+      rawTargetId: 1,
+      targetType: "section",
+      userId: "user-1",
+      visibility: "public",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      comment: { id: "reply-1" },
+    });
+    expect(transactionMock.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(transactionMock.$queryRaw.mock.invocationCallOrder[0]).toBeLessThan(
+      transactionMock.comment.create.mock.invocationCallOrder[0],
+    );
+    expect(transactionMock.comment.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        parentId: "parent-1",
+        rootId: "root-1",
+        sectionId: 1,
+      }),
+    });
+  });
+
+  it("does not sync edit attachments when the owner/status guard loses a race", async () => {
+    prismaMock.comment.findUnique
+      .mockResolvedValueOnce(activeComment())
+      .mockResolvedValueOnce({ ...activeComment(), status: "deleted" });
+    prismaMock.upload.findMany.mockResolvedValue([
+      {
+        id: "upload-1",
+        commentAttachments: [{ commentId: "comment-1" }],
+      },
+    ]);
+    transactionMock.comment.updateMany.mockResolvedValue({ count: 0 });
+
+    const { updateOwnComment } = await import(
+      "@/features/comments/server/comment-mutations"
+    );
+    const result = await updateOwnComment({
+      attachmentIds: ["upload-1"],
+      body: "edited",
+      hasAttachmentUpdate: true,
+      id: "comment-1",
+      isAnonymous: false,
+      userId: "user-1",
+      visibility: "public",
+    });
+
+    expect(result).toEqual({ ok: false, error: "locked" });
+    expect(transactionMock.comment.updateMany).toHaveBeenCalledWith({
+      where: { id: "comment-1", status: "active", userId: "user-1" },
+      data: {
+        body: "edited",
+        visibility: "public",
+        isAnonymous: false,
+      },
+    });
+    expect(transactionMock.commentAttachment.deleteMany).not.toHaveBeenCalled();
+    expect(transactionMock.commentAttachment.createMany).not.toHaveBeenCalled();
+  });
+
+  it("guards delete by owner and active status in the final write", async () => {
+    prismaMock.comment.findUnique
+      .mockResolvedValueOnce(activeComment())
+      .mockResolvedValueOnce({ ...activeComment(), status: "deleted" });
+    prismaMock.comment.updateMany.mockResolvedValue({ count: 0 });
+
+    const { deleteOwnComment } = await import(
+      "@/features/comments/server/comment-mutations"
+    );
+    const result = await deleteOwnComment({
+      commentId: "comment-1",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ ok: false, error: "locked" });
+    expect(prismaMock.comment.updateMany).toHaveBeenCalledWith({
+      where: { id: "comment-1", status: "active", userId: "user-1" },
+      data: {
+        status: "deleted",
+        deletedAt: expect.any(Date),
+      },
+    });
+  });
+});

--- a/tools/dev/seed/seed-dev-scenarios.ts
+++ b/tools/dev/seed/seed-dev-scenarios.ts
@@ -1214,7 +1214,7 @@ async function main() {
         userId: debugUser.id,
         courseId: courses[1].id,
         body: "课程难度中上，适合作为线代进阶。",
-        visibility: CommentVisibility.anonymous,
+        visibility: CommentVisibility.public,
         isAnonymous: true,
         authorName: "匿名同学",
       },


### PR DESCRIPTION
## Goal

Fix comment privacy drift and mutation race windows:

- Closes #260 by removing the unsupported `visibility=anonymous` state and using `isAnonymous` as the identity-hiding flag across REST/MCP/web.
- Closes #263 by removing the disabled Report menu affordance/copy instead of shipping a non-functional report flow.
- Closes #265 by binding comment parent checks to reply creation transactions and guarding edit/delete writes by owner + active status.

## Changed Surfaces

- Comment REST/MCP schema enum now accepts only `public` and `logged_in_only` visibility.
- Prisma `CommentVisibility` enum drops `anonymous`; migration maps existing anonymous rows to `visibility=public` + `isAnonymous=true`.
- Comment serialization/attachment access now treats anonymity only through `isAnonymous`.
- Comment create/edit/delete mutation flow adds transaction/conditional-write guards for parent/status/ownership races.
- Comment action menu no longer renders the disabled Report item; related i18n/type entries removed.
- Focused unit, MCP integration, and E2E coverage added for privacy validation, write guards, and removed Report UI.

## Evidence

- `bun run verify:full` passed before final rebases: type/convention/unit/integration plus `551 passed` Playwright tests.
- After rebasing onto current `origin/main`:
  - `bun run verify:types`
  - `bun run vitest run tests/unit/api-schemas.test.ts tests/unit/comment-mutations.test.ts` (`2 passed`, `31 passed` tests)
  - `bun run vitest run --config vitest.integration.config.ts tests/integration/mcp-02-comments.test.ts` (`17 passed`)
  - `bun run e2e:db:prepare`
  - `bun run e2e:build-artifacts`
  - `bun run seed`
  - `PLAYWRIGHT_PORT=3104 bun run e2e:test -- tests/e2e/src/app/api/comments/test.ts 'tests/e2e/src/app/api/comments/\\[id\\]/test.ts' 'tests/e2e/src/app/teachers/\\[id\\]/test.ts'` (`37 passed`)
- Browser evidence: inspected the comment actions menu locally and confirmed only Copy link/Delete render; the focused teacher E2E also asserts no Report menu item is present.

## Docs / Contracts

- Updated `docs/contracts/comment.json` to document audience visibility vs `isAnonymous` identity hiding.
- Regenerated `public/openapi.generated.json` so comment visibility enums match the schema.
- Updated comment messages by removing unused Report copy.

## Risk Areas

- Prisma migration intentionally normalizes legacy `visibility='anonymous'` rows to `visibility='public'` plus `isAnonymous=true`; this preserves hidden identity while removing the unsupported audience state.
- Comment write guards now return the existing locked/forbidden/not-found style failures after conditional-write races.

## Cleanup

- Worktree checked clean before push.
- Temporary browser screenshot/probe files were deleted; no scratch artifacts were committed.