### PR TITLE
fix(api): align REST auth parsing and OpenAPI docs

### DIFF
--- a/docs/contracts/upload.json
+++ b/docs/contracts/upload.json
@@ -9,6 +9,7 @@
   "rules": {
     "comment-attachments-only": "Uploads serve only comment attachments; they are not an independent file space.",
     "permission-and-quota": "Permission and quota checks are required before upload.",
+    "write-auth-unsuspended": "Upload write routes require an unsuspended signed-in user; suspended users receive 403 before upload metadata or object state changes.",
     "three-step-upload": "Web comment attachment uploads follow a three-step flow — create upload session on-site → browser PUT to an on-site Cloudflare Workers upload object route backed by R2 → confirm completion on-site.",
     "r2-backend": "Upload object create/read/head/delete operations use the Cloudflare R2 binding. The app runtime does not use S3-compatible signed URL fallbacks.",
     "storage-observability": "Shared storage helpers record production-safe bounded metrics for storage operation status and duration; metrics identify operation type but do not include bucket names, object keys, signed URLs, filenames, or user IDs.",
@@ -69,7 +70,8 @@
             "method": "POST",
             "returns": "{ key: String, url: String, maxFileSizeBytes: Int, quotaBytes: Int, usedBytes: Int }",
             "notes": [
-              "The returned upload URL points to the on-site Workers upload object route and writes through the R2 binding."
+              "The returned upload URL points to the on-site Workers upload object route and writes through the R2 binding.",
+              "Requires an unsuspended signed-in user; suspended users receive 403 before upload session creation."
             ]
           },
           {
@@ -127,14 +129,18 @@
             "path": "/api/uploads/[id]",
             "method": "PATCH",
             "returns": "{ upload: Upload }",
-            "notes": ["Renames one upload owned by the current user."]
+            "notes": [
+              "Renames one upload owned by the current user.",
+              "Requires an unsuspended signed-in user; suspended users receive 403 before upload metadata changes."
+            ]
           },
           {
             "path": "/api/uploads/[id]",
             "method": "DELETE",
             "returns": "{ deletedId: String, deletedSize: Int }",
             "notes": [
-              "Deletes one upload owned by the current user. The backing storage object is deleted before metadata is removed; storage cleanup failure returns an error and leaves the upload metadata available for retry."
+              "Deletes one upload owned by the current user. The backing storage object is deleted before metadata is removed; storage cleanup failure returns an error and leaves the upload metadata available for retry.",
+              "Requires an unsuspended signed-in user; suspended users receive 403 before upload metadata or object state changes."
             ]
           }
         ]

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -2764,6 +2764,16 @@
               }
             }
           },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Error response",
             "content": {
@@ -4889,6 +4899,16 @@
               }
             }
           },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Error response",
             "content": {
@@ -5736,8 +5756,8 @@
             "in": "path",
             "name": "id",
             "schema": {
-              "type": "string",
-              "minLength": 1
+              "type": "integer",
+              "format": "int64"
             },
             "required": true,
             "example": 8001
@@ -5871,6 +5891,16 @@
                   "_count": {
                     "sections": 1
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
                 }
               }
             }
@@ -6290,6 +6320,16 @@
               }
             }
           },
+          "403": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
           "413": {
             "description": "Error response",
             "content": {
@@ -6370,6 +6410,16 @@
               }
             }
           },
+          "403": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Error response",
             "content": {
@@ -6419,6 +6469,16 @@
             }
           },
           "401": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "403": {
             "description": "Error response",
             "content": {
               "application/json": {

--- a/src/lib/api/schemas/request-path-schemas.ts
+++ b/src/lib/api/schemas/request-path-schemas.ts
@@ -5,6 +5,10 @@ export const resourceIdPathParamsSchema = z.object({
   id: z.string().trim().min(1),
 });
 
+export const teacherIdPathParamsSchema = z.object({
+  id: integerStringSchema,
+});
+
 export const jwIdPathParamsSchema = z.object({
   jwId: integerStringSchema,
 });

--- a/src/lib/auth/api-auth.ts
+++ b/src/lib/auth/api-auth.ts
@@ -9,6 +9,7 @@ import {
   OAUTH_REST_READ_SCOPE,
   OAUTH_REST_WRITE_SCOPE,
 } from "@/lib/oauth/constants";
+import { parseBearerAuthorizationHeader } from "./authorization-header";
 import { hasRequestAuthSignal } from "./request-auth-signal";
 
 type RestBearerScopeRequirement = "read" | "write";
@@ -57,10 +58,9 @@ export async function resolveApiUserId(
   request: Request,
   options: { bearerScope?: RestBearerScopeRequirement } = {},
 ): Promise<string | null> {
-  const authHeader = request.headers.get("authorization");
-  const bearer = authHeader?.match(/^Bearer(?:\s+(.+))?$/);
+  const bearer = parseBearerAuthorizationHeader(request.headers);
   if (bearer) {
-    const token = bearer[1]?.trim() ?? "";
+    const token = bearer.token ?? "";
     if (!token) return null;
     try {
       const jwt = await verifyAccessToken(token, {
@@ -100,8 +100,7 @@ export async function resolveApiUserId(
 export async function resolveSessionUserId(
   request: Request,
 ): Promise<string | null> {
-  const authHeader = request.headers.get("authorization");
-  if (/^Bearer(?:\s|$)/i.test(authHeader?.trimStart() ?? "")) {
+  if (parseBearerAuthorizationHeader(request.headers)) {
     return null;
   }
   if (!hasRequestAuthSignal(request.headers)) return null;

--- a/src/lib/auth/authorization-header.ts
+++ b/src/lib/auth/authorization-header.ts
@@ -1,0 +1,22 @@
+const BEARER_AUTHORIZATION_PATTERN = /^Bearer(?:\s+(.*))?$/i;
+
+export type BearerAuthorization = {
+  token: string | null;
+};
+
+export function parseBearerAuthorizationHeader(
+  headers: Headers,
+): BearerAuthorization | null {
+  const value = headers.get("authorization")?.trimStart();
+  if (!value) return null;
+
+  const match = BEARER_AUTHORIZATION_PATTERN.exec(value);
+  if (!match) return null;
+
+  const token = match[1]?.trim() ?? "";
+  return { token: token.length > 0 ? token : null };
+}
+
+export function hasBearerAuthorizationHeader(headers: Headers) {
+  return parseBearerAuthorizationHeader(headers) !== null;
+}

--- a/src/lib/auth/request-auth-signal.ts
+++ b/src/lib/auth/request-auth-signal.ts
@@ -1,8 +1,10 @@
+import { hasBearerAuthorizationHeader } from "./authorization-header";
+
 const AUTH_COOKIE_NAME_PATTERN =
   /(?:^|;\s*)(?:__Secure-)?(?:better-auth\.|session(?:Token|_token)?=)/;
 
 export function hasRequestAuthSignal(headers: Headers) {
-  if (headers.get("authorization")?.startsWith("Bearer ")) {
+  if (hasBearerAuthorizationHeader(headers)) {
     return true;
   }
 

--- a/src/routes/api/courses/[jwId]/+server.ts
+++ b/src/routes/api/courses/[jwId]/+server.ts
@@ -6,6 +6,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  * Get course.
  * @pathParams jwIdPathParamsSchema
  * @response courseDetailSchema
+ * @response 400:openApiErrorSchema
  * @response 404:openApiErrorSchema
  */
 export const GET: RequestHandler = ({ request, params }) =>

--- a/src/routes/api/sections/[jwId]/+server.ts
+++ b/src/routes/api/sections/[jwId]/+server.ts
@@ -6,6 +6,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  * Get section.
  * @pathParams jwIdPathParamsSchema
  * @response sectionDetailSchema
+ * @response 400:openApiErrorSchema
  * @response 404:openApiErrorSchema
  */
 export const GET: RequestHandler = ({ request, params }) =>

--- a/src/routes/api/teachers/[id]/+server.ts
+++ b/src/routes/api/teachers/[id]/+server.ts
@@ -4,8 +4,9 @@ import { observedApiRoute } from "@/lib/log/api-observability";
 
 /**
  * Get teacher.
- * @pathParams resourceIdPathParamsSchema
+ * @pathParams teacherIdPathParamsSchema
  * @response teacherDetailSchema
+ * @response 400:openApiErrorSchema
  * @response 404:openApiErrorSchema
  */
 export const GET: RequestHandler = ({ request, params }) =>

--- a/src/routes/api/uploads/+server.ts
+++ b/src/routes/api/uploads/+server.ts
@@ -14,6 +14,7 @@ export const GET = svelteRequestHandler(observedApiRoute(getUploadsRoute));
  * @response uploadCreateResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
+ * @response 403:openApiErrorSchema
  * @response 413:openApiErrorSchema
  */
 export const POST = svelteRequestHandler(observedApiRoute(postUploadRoute));

--- a/src/routes/api/uploads/[id]/+server.ts
+++ b/src/routes/api/uploads/[id]/+server.ts
@@ -9,6 +9,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  * @response uploadRenameResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
+ * @response 403:openApiErrorSchema
  * @response 404:openApiErrorSchema
  */
 export const PATCH: RequestHandler = ({ request, params }) =>
@@ -19,6 +20,7 @@ export const PATCH: RequestHandler = ({ request, params }) =>
  * @pathParams resourceIdPathParamsSchema
  * @response 200:uploadDeleteResponseSchema
  * @response 401:openApiErrorSchema
+ * @response 403:openApiErrorSchema
  * @response 404:openApiErrorSchema
  * @response 502:openApiErrorSchema
  */

--- a/tests/unit/auth-helpers.test.ts
+++ b/tests/unit/auth-helpers.test.ts
@@ -83,6 +83,45 @@ describe("auth helpers", () => {
     );
   });
 
+  it.each([
+    "bearer",
+    "bEaReR",
+  ])("accepts a %s bearer access token", async (scheme) => {
+    verifyAccessTokenMock.mockResolvedValue({
+      scope: OAUTH_REST_READ_SCOPE,
+      sub: "user-from-token",
+    });
+    const { resolveApiUserId } = await import("@/lib/auth/api-auth");
+    const request = new Request("https://life.example/api/me", {
+      headers: {
+        authorization: `${scheme} access-token`,
+        cookie: "better-auth.session_token=session-token",
+      },
+    });
+
+    await expect(resolveApiUserId(request)).resolves.toBe("user-from-token");
+    expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
+    expect(verifyAccessTokenMock).toHaveBeenCalledWith(
+      "access-token",
+      expect.any(Object),
+    );
+  });
+
+  it.each([
+    "bearer",
+    "bEaReR",
+  ])("treats a %s authorization header as an auth signal", async (scheme) => {
+    const { hasRequestAuthSignal } = await import(
+      "@/lib/auth/request-auth-signal"
+    );
+
+    expect(
+      hasRequestAuthSignal(
+        new Headers({ authorization: `${scheme} access-token` }),
+      ),
+    ).toBe(true);
+  });
+
   it("rejects profile-only bearer access for protected REST reads", async () => {
     verifyAccessTokenMock.mockResolvedValue({
       scope: OAUTH_PROFILE_SCOPE,
@@ -210,6 +249,29 @@ describe("auth helpers", () => {
     });
 
     await expect(resolveApiUserId(request)).resolves.toBeNull();
+    expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 instead of falling back to session cookies when a lowercase bearer token is invalid", async () => {
+    verifyAccessTokenMock.mockRejectedValue(new Error("invalid token"));
+    getSessionFromHeadersMock.mockResolvedValue({
+      user: { id: "user-from-cookie" },
+    });
+    const { requireAuth } = await import("@/lib/auth/api-auth");
+    const request = new Request("https://life.example/api/me", {
+      headers: {
+        authorization: "bearer invalid-token",
+        cookie: "better-auth.session_token=session-token",
+      },
+    });
+
+    const result = await requireAuth(request);
+
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(401);
+    await expect((result as Response).json()).resolves.toEqual({
+      error: "Unauthorized",
+    });
     expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/openapi-scenario-examples.test.ts
+++ b/tests/unit/openapi-scenario-examples.test.ts
@@ -29,8 +29,10 @@ const OPENAPI_HTTP_METHODS = [
 type GeneratedOperation = {
   description?: string;
   parameters?: Array<{
+    in?: string;
     name?: string;
     example?: unknown;
+    required?: boolean;
     schema?: GeneratedSchema;
   }>;
   requestBody?: {
@@ -89,6 +91,15 @@ function queryParameter(
   name: string,
 ) {
   return operation?.parameters?.find((parameter) => parameter.name === name);
+}
+
+function pathParameter(
+  operation: GeneratedOperation | undefined,
+  name: string,
+) {
+  return operation?.parameters?.find(
+    (parameter) => parameter.in === "path" && parameter.name === name,
+  );
 }
 
 describe("buildScenarioOpenApiExamples", () => {
@@ -287,6 +298,23 @@ describe("buildScenarioOpenApiExamples", () => {
     ).toEqual(expect.objectContaining({ minimum: 1, maximum: 300 }));
 
     expect(spec.paths["/api/todos"]?.get?.responses?.["400"]).toBeTruthy();
+    for (const [path, parameterName] of [
+      ["/api/teachers/{id}", "id"],
+      ["/api/courses/{jwId}", "jwId"],
+      ["/api/sections/{jwId}", "jwId"],
+    ] as const) {
+      const operation = spec.paths[path]?.get;
+      expect(operation?.responses?.["400"]).toBeTruthy();
+      expect(pathParameter(operation, parameterName)).toEqual(
+        expect.objectContaining({
+          required: true,
+          schema: expect.objectContaining({
+            format: "int64",
+            type: "integer",
+          }),
+        }),
+      );
+    }
     expect(
       spec.paths["/api/admin/users/{id}"]?.patch?.responses?.["404"],
     ).toBeTruthy();
@@ -341,6 +369,13 @@ describe("buildScenarioOpenApiExamples", () => {
     ).toBeTruthy();
     expect(
       spec.paths["/api/dashboard-links/pin"]?.post?.responses?.["303"],
+    ).toBeTruthy();
+    expect(spec.paths["/api/uploads"]?.post?.responses?.["403"]).toBeTruthy();
+    expect(
+      spec.paths["/api/uploads/{id}"]?.patch?.responses?.["403"],
+    ).toBeTruthy();
+    expect(
+      spec.paths["/api/uploads/{id}"]?.delete?.responses?.["403"],
     ).toBeTruthy();
     expect(
       spec.paths["/api/users/{userId}/calendar.ics"]?.get?.security,


### PR DESCRIPTION
## Goal

Fix REST auth parsing and OpenAPI drift reported in #278, #279, and #280.

Closes #278.
Closes #279.
Closes #280.

## Changed Surfaces

- Centralized REST bearer Authorization parsing under `src/lib/auth/authorization-header.ts`.
- Updated REST auth/session signal handling to accept lowercase and mixed-case bearer schemes without falling back to cookies for invalid bearer-shaped headers.
- Added upload mutation suspended-user `403` OpenAPI responses for `POST /api/uploads`, `PATCH /api/uploads/{id}`, and `DELETE /api/uploads/{id}`.
- Added a numeric teacher detail path schema and `400` OpenAPI responses for teacher/course/section detail route path validation.
- Regenerated `public/openapi.generated.json` and added focused unit contract coverage.

## Evidence

- `bun run openapi:generate`
- `bun run openapi:check`
- `bun run test -- tests/unit/auth-helpers.test.ts tests/unit/openapi-scenario-examples.test.ts`
- `bun run test -- tests/unit/auth-helpers.test.ts`
- `bun run verify`
- Exercised malformed teacher/course/section detail route adapters and inspected serialized responses: each returned `400` with `{ error: "Invalid ... ID" }`.
- Inspected generated OpenAPI for integer detail path params, detail `400` responses, and upload mutation `403` responses.

## Docs / Contracts

- Updated `docs/contracts/upload.json` to document unsuspended-user upload write requirements and suspended-user `403` behavior.
- Updated route OpenAPI annotations and regenerated `public/openapi.generated.json`.
- MCP contracts/tools are unchanged because these issues target REST auth parsing and REST/OpenAPI documentation; existing MCP upload management notes already state unsuspended-user requirements.

## Risk Areas

- Auth/OAuth: bearer parsing is now case-insensitive for REST and request auth-signal detection.
- Uploads: documentation/OpenAPI only for suspended-user `403`; route behavior already came from `requireWriteAuth()`.
- Catalog detail routes: documentation/OpenAPI only for existing malformed path `400` behavior.

## Cleanup

- No scratch files, temporary probes, unrelated rewrites, or manual unverified generated edits remain.
- Worktree was clean before push.
