### PR TITLE
fix(docs): tooling docs and local defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,16 @@
 # Host-native dev (`bun run dev`) uses 127.0.0.1 endpoints below and auto-runs
 # `prisma generate` + `prisma migrate deploy` before starting SvelteKit.
 DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev"
+# Optional when running multiple worktrees at once: set a unique
+# COMPOSE_PROJECT_NAME, POSTGRES_PORT, POSTGRES_DB, DATABASE_URL, APP_DEV_PORT,
+# APP_HEALTH_URL, and PLAYWRIGHT_PORT per worktree.
+# COMPOSE_PROJECT_NAME="life-ustc-dev-main"
+# POSTGRES_PORT="5433"
+# POSTGRES_DB="life_ustc_dev_main"
+# DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5433/life_ustc_dev_main"
+# APP_DEV_PORT="3001"
+# APP_HEALTH_URL="http://127.0.0.1:3001/"
+# PLAYWRIGHT_PORT="3101"
 # Optional override for local Cloudflare Worker Hyperdrive emulation.
 # Defaults to the same value in wrangler.jsonc when running wrangler locally.
 # CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE="postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev"

--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -158,8 +158,8 @@ jobs:
             ci:e2e:test)
               run_e2e_test_phase
               ;;
-            ci:snapshot:capture)
-              bun run ci:snapshot:capture
+            ci:snapshot:verify)
+              bun run ci:snapshot:verify
               ;;
             *)
               echo "::error::Unknown DB-backed Bun job phase: $JOB_PHASE"

--- a/.github/workflows/e2e-snapshot-artifacts.yml
+++ b/.github/workflows/e2e-snapshot-artifacts.yml
@@ -20,7 +20,7 @@ jobs:
       auth-secret: e2e-snapshot-ci-secret
       extra-env: |
         NO_PROXY=127.0.0.1,localhost,::1
-      job-phase: ci:snapshot:capture
+      job-phase: ci:snapshot:verify
       upload-artifact-name: e2e-snapshot-artifacts-${{ github.sha }}
       upload-artifact-path: |
         test-results/snapshots

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,7 +17,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["package.json", "CHANGELOG.md"],
+        "assets": ["CHANGELOG.md"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,7 @@ buildPaginatedResponse(items, page, pageSize, total)
 
 **Generated - DO NOT EDIT**:
 - `src/generated/prisma/`
+- `src/generated/prisma-node/`
 - `public/openapi.generated.json`
 
 **Feature Changes**:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,11 +2,11 @@ services:
   postgres:
     image: postgres:16
     environment:
-      POSTGRES_DB: life_ustc_dev
+      POSTGRES_DB: ${POSTGRES_DB:-life_ustc_dev}
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "bun run app:prepare && bun run openapi:generate && bun run vite build",
-    "dev": "bun run app:prepare && bun run openapi:generate && bun run db:migrate:deploy && bun run vite dev --host 127.0.0.1 --port 3000 --strictPort",
+    "dev": "bun run app:prepare && bun run openapi:generate && bun run db:migrate:deploy && bun run vite dev --host 127.0.0.1 --port ${APP_DEV_PORT:-3000} --strictPort",
     "format": "biome format",
     "health": "bun run tools/dev/health.ts",
     "hooks:install": "git config core.hooksPath .githooks",
@@ -30,7 +30,7 @@
     "ci:verify": "bun run verify",
     "ci:e2e:build-artifacts": "bun run e2e:build-artifacts",
     "ci:e2e:test": "bun run app:prepare && bun run e2e:db:prepare && bun run seed && bun run e2e:test",
-    "ci:snapshot:capture": "bun run snapshot:verify",
+    "ci:snapshot:verify": "bun run snapshot:verify",
     "e2e:build-worker": "bun run app:prepare && bun run openapi:generate && bun run vite build",
     "e2e:build-artifacts": "bun run e2e:build-worker && bun run e2e:prepare",
     "e2e:db:prepare": "bun run db:migrate:deploy && bun run check:e2e",

--- a/tests/unit/health-runtime.test.ts
+++ b/tests/unit/health-runtime.test.ts
@@ -1,0 +1,27 @@
+import { resolveAppHealthUrl } from "@tools/dev/health";
+import { describe, expect, it } from "vitest";
+
+describe("app health runtime", () => {
+  it("defaults to the host-native dev server", () => {
+    expect(resolveAppHealthUrl({}).toString()).toBe("http://127.0.0.1:3000/");
+  });
+
+  it("uses APP_DEV_PORT without reading Playwright runtime settings", () => {
+    expect(
+      resolveAppHealthUrl({
+        APP_DEV_PORT: "3001",
+        PLAYWRIGHT_PORT: "3101",
+        PLAYWRIGHT_BASE_URL: "http://127.0.0.1:3102",
+      }).toString(),
+    ).toBe("http://127.0.0.1:3001/");
+  });
+
+  it("prefers APP_HEALTH_URL for explicit probes", () => {
+    expect(
+      resolveAppHealthUrl({
+        APP_DEV_PORT: "3001",
+        APP_HEALTH_URL: "http://127.0.0.1:3002/api/health",
+      }).toString(),
+    ).toBe("http://127.0.0.1:3002/api/health");
+  });
+});

--- a/tools/dev/health.ts
+++ b/tools/dev/health.ts
@@ -1,7 +1,27 @@
-import { resolvePlaywrightServerRuntime } from "./e2e";
+const DEFAULT_APP_DEV_PORT = "3000";
+const DEFAULT_APP_HEALTH_ORIGIN = "http://127.0.0.1";
 
-const response = await fetch(
-  new URL("/", resolvePlaywrightServerRuntime().baseUrl),
-).catch(() => null);
+export function resolveAppHealthUrl(env: NodeJS.ProcessEnv = process.env) {
+  const explicitUrl = env.APP_HEALTH_URL?.trim();
+  if (explicitUrl) return new URL(explicitUrl);
 
-process.exit(response?.ok ? 0 : 1);
+  const port = env.APP_DEV_PORT?.trim() || DEFAULT_APP_DEV_PORT;
+  return new URL("/", `${DEFAULT_APP_HEALTH_ORIGIN}:${port}`);
+}
+
+export async function checkAppHealth(
+  env: NodeJS.ProcessEnv = process.env,
+  fetchImpl: typeof fetch = fetch,
+) {
+  const response = await fetchImpl(resolveAppHealthUrl(env)).catch(() => null);
+  return response?.ok === true;
+}
+
+if (process.argv[1]?.endsWith("health.ts")) {
+  try {
+    process.exit((await checkAppHealth()) ? 0 : 1);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Goal

Fix the focused tooling/docs drift tracked in #286, #287, #288, #289, and #290.

Closes #286.
Closes #287.
Closes #288.
Closes #289.
Closes #290.

## Changed Surfaces

- Local dev/E2E defaults: `docker-compose.dev.yml`, `.env.example`, and `package.json` now support opt-in per-worktree DB/app/Playwright port isolation while preserving existing defaults.
- Health tooling: `bun run health` now resolves from `APP_HEALTH_URL` or `APP_DEV_PORT`, not Playwright runtime settings.
- CI/snapshot naming: the CI snapshot phase is now named `ci:snapshot:verify`, matching its full prepare/build/seed/capture behavior.
- Release config: `.releaserc.json` no longer lists `package.json` as a release asset because the configured release flow does not update its version.
- Agent guidance: root `AGENTS.md` now marks `src/generated/prisma-node/` as generated.

## Evidence

- Remote checks for `df9783fd8ad75b4c3a289eb308b6d514e433eb88`: CI, E2E Snapshot Artifacts, CodeQL, Copilot Setup Steps, and Cloudflare Workers Builds are green.
- `bun install --frozen-lockfile`
- `bun run test -- tests/unit/health-runtime.test.ts tests/unit/playwright-runtime.test.ts`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run verify`
- `COMPOSE_PROJECT_NAME=life-ustc-verify-286 POSTGRES_PORT=56543 POSTGRES_DB=life_ustc_verify_286 docker compose -f docker-compose.dev.yml config`
- `bunx playwright install chromium`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:56543/life_ustc_verify_286 AUTH_SECRET=... WEBHOOK_SECRET=... PLAYWRIGHT_PORT=33186 NO_PROXY=127.0.0.1,localhost,::1 bun run verify:full` completed default + integration, then E2E failed before tests because the selected local Playwright port was occupied.
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:56543/life_ustc_verify_286 AUTH_SECRET=... WEBHOOK_SECRET=... PLAYWRIGHT_PORT=46631 NO_PROXY=127.0.0.1,localhost,::1 bun run verify:e2e` passed 553 tests.
- Skipped checks: none.

## Docs / Contracts

Updated root `AGENTS.md` and `.env.example`. No product contract, OpenAPI, route, MCP, i18n, or user-facing docs change was needed because behavior changes are limited to local tooling, release config, and workflow phase naming.

## Risk Areas

- CI workflow dispatch now expects `ci:snapshot:verify` instead of `ci:snapshot:capture` for the snapshot artifact workflow.
- `bun run dev` now relies on shell environment expansion for `APP_DEV_PORT`; the default remains `3000`.
- Full local E2E produced expected negative-test route logs plus unrelated local DNS/workerd warnings, but completed successfully on the rerun.

## Cleanup

No scratch artifacts or generated files are staged. The isolated Docker verification project was stopped and removed with `docker compose down -v`.
