### PR TITLE
fix(section): navigate calendar Today to current month

### DIFF
--- a/src/features/section-detail/components/SectionCalendarMonthView.svelte
+++ b/src/features/section-detail/components/SectionCalendarMonthView.svelte
@@ -9,6 +9,7 @@ import type { SectionCalendarCopy } from "./section-calendar-tab-types";
 export let calendarGridWeeks: CalendarGridWeek[];
 export let calendarMonthLabel: string;
 export let calendarMonthOffset: number;
+export let todayCalendarMonthOffset: number;
 export let formatMessage: (
   template: string,
   values: Record<string, string>,
@@ -36,7 +37,7 @@ export let sectionCopy: SectionCalendarCopy;
         size="sm"
         type="button"
         variant="outline"
-        onclick={() => (calendarMonthOffset = 0)}
+        onclick={() => (calendarMonthOffset = todayCalendarMonthOffset)}
       >
         {sectionCopy.today}
       </Button>

--- a/src/features/section-detail/components/SectionCalendarTab.svelte
+++ b/src/features/section-detail/components/SectionCalendarTab.svelte
@@ -23,6 +23,7 @@ export let formatMessage: (
 export let openCalendarDialog: () => void;
 export let sectionCalendarEvents: SectionCalendarEvent[];
 export let sectionCopy: SectionCalendarCopy;
+export let todayCalendarMonthOffset: number;
 export let unscheduledCalendarEvents: SectionCalendarEvent[];
 </script>
 
@@ -45,6 +46,7 @@ export let unscheduledCalendarEvents: SectionCalendarEvent[];
       {calendarMonthLabel}
       {formatMessage}
       {sectionCopy}
+      {todayCalendarMonthOffset}
     />
 
     <section class="grid gap-3">

--- a/src/features/section-detail/components/SectionDetailMainContent.svelte
+++ b/src/features/section-detail/components/SectionDetailMainContent.svelte
@@ -48,6 +48,7 @@ export let setSelectedHomework: SectionDetailMainContentProps["setSelectedHomewo
 export let tabs: SectionDetailMainContentProps["tabs"];
 export let teacherName: SectionDetailMainContentProps["teacherName"];
 export let todayCalendarKey: SectionDetailMainContentProps["todayCalendarKey"];
+export let todayCalendarMonthOffset: number;
 export let unscheduledCalendarEvents: SectionDetailMainContentProps["unscheduledCalendarEvents"];
 export let viewer: SectionDetailMainContentProps["viewer"];
 export let visibleCalendarMonth: Date;
@@ -79,7 +80,7 @@ export let yesNo: SectionDetailMainContentProps["yesNo"];
     {#if activeTab === "calendar"}
       <SectionCalendarTab
         bind:calendarMonthOffset
-        calendarGridWeeks={sectionCalendarGridWeeks()}
+        calendarGridWeeks={sectionCalendarGridWeeks}
         {calendarMonthLabel}
         dateTimePlaceText={data.section.dateTimePlaceText}
         {fmtDate}
@@ -87,6 +88,7 @@ export let yesNo: SectionDetailMainContentProps["yesNo"];
         {openCalendarDialog}
         {sectionCalendarEvents}
         {sectionCopy}
+        {todayCalendarMonthOffset}
         {unscheduledCalendarEvents}
       />
     {:else if activeTab === "homework"}

--- a/src/features/section-detail/components/SectionDetailPageController.svelte
+++ b/src/features/section-detail/components/SectionDetailPageController.svelte
@@ -2,7 +2,11 @@
 // biome-ignore assist/source/organizeImports: keep Svelte template/action imports grouped with local suppressions.
 import { onMount } from "svelte";
 import { createSectionDetailDisplayActions } from "@/features/section-detail/lib/section-detail-display-actions";
-import { findCalendarBaseMonth } from "@/features/section-detail/lib/calendar";
+import {
+  buildSectionCalendarGridWeeks,
+  calendarMonthOffsetForDateKey,
+  findCalendarBaseMonth,
+} from "@/features/section-detail/lib/calendar";
 import { buildSectionDetailCalendarEvents } from "@/features/section-detail/lib/section-detail-calendar-events";
 import { createSectionDetailCalendarDisplayActions } from "@/features/section-detail/lib/section-detail-calendar-display-actions";
 import { createSectionCalendarClipboardActions } from "@/features/section-detail/lib/section-detail-calendar-clipboard-actions";
@@ -95,14 +99,9 @@ const {
   fmtDateTime: _fmtDateTime,
   fmtMonth: _fmtMonth,
   isSameMonth: _isSameMonth,
-  sectionCalendarGridWeeks: _sectionCalendarGridWeeks,
 } = createSectionDetailCalendarDisplayActions({
-  getCalendarMonthWeeks: () => calendarMonthWeeks,
   getNotAvailable: () => _notAvailable,
   getSectionCalendarEvents: () => sectionCalendarEvents,
-  getSemesterWeekLabel: _semesterWeekLabel,
-  getTodayCalendarKey: () => todayCalendarKey,
-  getVisibleCalendarMonth: () => visibleCalendarMonth,
 });
 
 $: _copy = data.copy;
@@ -133,11 +132,28 @@ $: sectionCalendarEvents = buildSectionDetailCalendarEvents({
   section: data.section,
   sectionCopy: _sectionCopy,
 });
-$: calendarBaseMonth = findCalendarBaseMonth(sectionCalendarEvents);
+$: todayCalendarKey = data.todayCalendarKey;
+$: calendarBaseMonth = findCalendarBaseMonth(
+  sectionCalendarEvents,
+  todayCalendarKey,
+);
 $: visibleCalendarMonth = _addMonths(calendarBaseMonth, _calendarMonthOffset);
+$: todayCalendarMonthOffset = calendarMonthOffsetForDateKey(
+  calendarBaseMonth,
+  todayCalendarKey,
+);
 $: calendarMonthDays = _calendarMonthDays(visibleCalendarMonth);
 $: calendarMonthWeeks = _calendarWeeks(calendarMonthDays);
 $: calendarMonthLabel = _fmtMonth(visibleCalendarMonth);
+$: sectionCalendarGridWeeks = buildSectionCalendarGridWeeks({
+  dateKey: _dateKey,
+  events: sectionCalendarEvents,
+  formatDate: _fmtDate,
+  monthWeeks: calendarMonthWeeks,
+  semesterWeekLabel: _semesterWeekLabel,
+  todayKey: todayCalendarKey,
+  visibleMonth: visibleCalendarMonth,
+});
 $: unscheduledCalendarEvents = sectionCalendarEvents.filter(
   (event) => !event.dateKey,
 );
@@ -151,7 +167,6 @@ $: calendarExamDateKeys = buildCalendarDateKeySet(
   (exam) => exam.examDate,
   _dateKey,
 );
-$: todayCalendarKey = _dateKey(new Date());
 
 const {
   cancelEditHomework: _cancelEditHomework,
@@ -391,7 +406,7 @@ onMount(() => {
     {periodDetailRows}
     primaryName={_primaryName}
     {sectionCalendarEvents}
-    sectionCalendarGridWeeks={_sectionCalendarGridWeeks}
+    {sectionCalendarGridWeeks}
     sectionCopy={_sectionCopy}
     sectionTeachersLabel={_sectionTeachersLabel}
     setActiveTab={_setActiveTab}
@@ -405,6 +420,7 @@ onMount(() => {
     tabs={_tabs}
     teacherName={_teacherName}
     {todayCalendarKey}
+    {todayCalendarMonthOffset}
     {unscheduledCalendarEvents}
     viewer={data.viewer}
     {visibleCalendarMonth}

--- a/src/features/section-detail/components/section-detail-dialog-types.ts
+++ b/src/features/section-detail/components/section-detail-dialog-types.ts
@@ -203,7 +203,7 @@ export type SectionDetailMainContentProps = {
     teachers?: Parameters<SectionTeacherName>[0][];
   };
   sectionCalendarEvents: SectionCalendarEvent[];
-  sectionCalendarGridWeeks: () => CalendarGridWeek[];
+  sectionCalendarGridWeeks: CalendarGridWeek[];
   sectionCopy: SectionDetailMainSectionCopy;
   sectionTeachersLabel: SectionTeachersLabel;
   setActiveTab: (tab: SectionDetailActiveTab) => void;
@@ -212,6 +212,7 @@ export type SectionDetailMainContentProps = {
   tabs: readonly SectionDetailTab[];
   teacherName: SectionTeacherName;
   todayCalendarKey: string | null;
+  todayCalendarMonthOffset: number;
   unscheduledCalendarEvents: SectionCalendarEvent[];
   viewer: { isAuthenticated?: boolean; signedIn?: boolean };
   visibleCalendarMonth: Date;

--- a/src/features/section-detail/lib/calendar.ts
+++ b/src/features/section-detail/lib/calendar.ts
@@ -25,14 +25,32 @@ type CalendarGridEvent = {
   tooltip: string;
 };
 
-export function findCalendarBaseMonth(events: SectionCalendarEvent[]) {
+function monthIndex(monthKey: string) {
+  const [year, month] = monthKey.split("-").map(Number);
+  return year * 12 + month - 1;
+}
+
+export function findCalendarBaseMonth(
+  events: SectionCalendarEvent[],
+  fallbackDateKey?: string | null,
+) {
   const firstDated = events.find((event) => event.date);
-  const baseKey = toCampusDateKey(firstDated?.date ?? new Date());
-  const monthKey = (baseKey ?? requireCampusDateKeyForValue(new Date())).slice(
-    0,
-    7,
-  );
+  const fallbackKey =
+    toCampusDateKey(fallbackDateKey) ??
+    requireCampusDateKeyForValue(new Date());
+  const baseKey = toCampusDateKey(firstDated?.date) ?? fallbackKey;
+  const monthKey = baseKey.slice(0, 7);
   return campusDateKeyToLocalDate(`${monthKey}-01`) ?? new Date();
+}
+
+export function calendarMonthOffsetForDateKey(
+  baseMonth: Date,
+  targetDateKey: string | null | undefined,
+) {
+  const baseMonthKey = toCampusDateKey(baseMonth)?.slice(0, 7);
+  const targetMonthKey = toCampusDateKey(targetDateKey)?.slice(0, 7);
+  if (!baseMonthKey || !targetMonthKey) return 0;
+  return monthIndex(targetMonthKey) - monthIndex(baseMonthKey);
 }
 
 export function calendarEventsForDay(

--- a/src/features/section-detail/lib/section-detail-calendar-display-actions.ts
+++ b/src/features/section-detail/lib/section-detail-calendar-display-actions.ts
@@ -1,8 +1,4 @@
-import {
-  buildSectionCalendarGridWeeks,
-  calendarEventsForDay,
-  type SectionCalendarEvent,
-} from "./calendar";
+import { calendarEventsForDay, type SectionCalendarEvent } from "./calendar";
 import {
   addMonths,
   calendarMonthDays,
@@ -15,12 +11,8 @@ import {
 } from "./date-display";
 
 export function createSectionDetailCalendarDisplayActions(input: {
-  getCalendarMonthWeeks: () => Date[][];
   getNotAvailable: () => string;
   getSectionCalendarEvents: () => SectionCalendarEvent[];
-  getSemesterWeekLabel: (weekStart: Date) => string;
-  getTodayCalendarKey: () => string | null;
-  getVisibleCalendarMonth: () => Date;
 }) {
   function fmtDate(value: string | Date | null | undefined) {
     return formatDate(value, input.getNotAvailable());
@@ -53,16 +45,5 @@ export function createSectionDetailCalendarDisplayActions(input: {
     fmtDateTime,
     fmtMonth,
     isSameMonth,
-    sectionCalendarGridWeeks() {
-      return buildSectionCalendarGridWeeks({
-        dateKey: dateKeyValue,
-        events: input.getSectionCalendarEvents(),
-        formatDate: fmtDate,
-        monthWeeks: input.getCalendarMonthWeeks(),
-        semesterWeekLabel: input.getSemesterWeekLabel,
-        todayKey: input.getTodayCalendarKey(),
-        visibleMonth: input.getVisibleCalendarMonth(),
-      });
-    },
   };
 }

--- a/src/features/section-detail/lib/section-detail-controller-types.ts
+++ b/src/features/section-detail/lib/section-detail-controller-types.ts
@@ -329,6 +329,7 @@ export type SectionDetailPageData = {
   section: SectionDetailSection;
   showSubscribeDialog: boolean;
   tab?: string | null;
+  todayCalendarKey: string;
   viewer: {
     isSubscribed?: boolean;
     signedIn?: boolean;

--- a/src/features/section-detail/server/section-detail-page-server.ts
+++ b/src/features/section-detail/server/section-detail-page-server.ts
@@ -1,5 +1,6 @@
 import { error } from "@sveltejs/kit";
 import { getSectionPage } from "@/features/section-detail/server/section-page-data";
+import { requireCampusDateKeyForValue } from "@/lib/time/campus-date";
 import { getSectionDetailDescriptionAndComments } from "./section-detail-comments-data";
 import { getSectionHomeworkData } from "./section-detail-homework-data";
 import {
@@ -43,6 +44,7 @@ export async function loadSectionDetailPage({
   return {
     section,
     locale: locals.locale,
+    todayCalendarKey: requireCampusDateKeyForValue(new Date()),
     copy: getSectionDetailPageCopy(locals.locale),
     descriptionData: descriptionAndComments.descriptionData,
     commentsData: descriptionAndComments.commentsData,

--- a/src/lib/components/calendar/CalendarGridDayCell.svelte
+++ b/src/lib/components/calendar/CalendarGridDayCell.svelte
@@ -13,6 +13,7 @@ export let variant: "week" | "month" = "week";
 </script>
 
 <div
+  aria-current={day.isToday ? "date" : undefined}
   class={`border-base-300 p-2 ${variant === "week" ? "min-h-56 border-r" : "min-h-32 border-r border-b"} ${isLastDay ? "border-r-0" : ""} ${day.isToday ? "ring-1 ring-primary ring-inset" : ""} ${day.isMuted ? "bg-base-200/40 text-base-content/45" : "bg-base-100"}`}
 >
   <div class="flex items-start justify-between gap-2">

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -59,6 +59,13 @@ function getSectionTab(page: Page, name: RegExp) {
     .first();
 }
 
+function getSectionCalendarMonthView(page: Page) {
+  return page
+    .locator("section")
+    .filter({ has: page.getByRole("button", { name: /今天|Today/i }) })
+    .first();
+}
+
 test.describe("/sections/[jwId]", () => {
   test("contract", async ({ page }, testInfo) => {
     await assertPageContract(page, {
@@ -284,6 +291,29 @@ test.describe("/sections/[jwId]", () => {
     ).toBeVisible();
 
     await captureStepScreenshot(page, testInfo, "section/schedule-calendar");
+  });
+
+  test("Today button navigates calendar to current day instead of section start", async ({
+    page,
+  }, testInfo) => {
+    await gotoAndWaitForReady(page, SECTION_URL);
+
+    const calendarTab = getSectionTab(page, /日历|Calendar/i);
+    await calendarTab.click();
+    await expect(calendarTab).toHaveAttribute("aria-pressed", "true");
+
+    const monthView = getSectionCalendarMonthView(page);
+    const monthHeading = monthView.locator("h3").first();
+    const initialMonthLabel = (await monthHeading.innerText()).trim();
+
+    await monthView.getByRole("button", { name: /下个月|Next month/i }).click();
+    await expect(monthHeading).not.toHaveText(initialMonthLabel);
+
+    await monthView.getByRole("button", { name: /今天|Today/i }).click();
+    await expect(monthView.locator('[aria-current="date"]')).toHaveCount(1);
+    await expect(monthHeading).not.toHaveText(initialMonthLabel);
+
+    await captureStepScreenshot(page, testInfo, "section/calendar-today");
   });
 
   test("displays exam info (examBatch, examRooms) in calendar tab", async ({

--- a/tests/unit/section-detail-date-display.test.ts
+++ b/tests/unit/section-detail-date-display.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { findCalendarBaseMonth } from "@/features/section-detail/lib/calendar";
 import {
+  calendarMonthOffsetForDateKey,
+  findCalendarBaseMonth,
+} from "@/features/section-detail/lib/calendar";
+import {
+  addMonths,
   calendarMonthDays,
   dateKey,
   formatDate,
@@ -48,5 +52,33 @@ describe("section detail date display", () => {
     expect(dateKey(lastDay)).toBe("2026-04-11");
     expect(isSameMonth(firstDay, monthStart)).toBe(true);
     expect(isSameMonth(lastDay, monthStart)).toBe(false);
+  });
+
+  it("computes the Today month offset from the section base month", () => {
+    const baseMonth = findCalendarBaseMonth([
+      {
+        badges: [],
+        date: "2026-04-29T00:00:00+08:00",
+        dateKey: "2026-04-29",
+        details: [],
+        id: "event-1",
+        kind: "class",
+        meta: "",
+        sortValue: 0,
+        title: "Class",
+      },
+    ]);
+
+    const offset = calendarMonthOffsetForDateKey(baseMonth, "2026-06-27");
+
+    expect(dateKey(baseMonth)).toBe("2026-04-01");
+    expect(offset).toBe(2);
+    expect(dateKey(addMonths(baseMonth, offset))).toBe("2026-06-01");
+  });
+
+  it("uses the provided today key as the empty-calendar base month", () => {
+    const monthStart = findCalendarBaseMonth([], "2026-06-27");
+
+    expect(dateKey(monthStart)).toBe("2026-06-01");
   });
 });


### PR DESCRIPTION
## Goal

Fix the section detail calendar Today button so it navigates to the actual current day/month instead of resetting to the section's first calendar month.

Closes #282

## Changed Surfaces

- Section detail calendar data now carries a server-derived campus date key for Today.
- Section calendar month navigation computes the Today month offset from the calendar base month.
- Calendar grid rendering now updates from explicit reactive inputs when the visible month changes.
- Calendar day cells expose `aria-current="date"` for the current date marker.
- Added focused unit and E2E coverage for Today navigation.

## Evidence

- `bun install --frozen-lockfile`
- `DATABASE_URL=... AUTH_SECRET=... WEBHOOK_SECRET=... bun run app:prepare`
- `DATABASE_URL=... AUTH_SECRET=... WEBHOOK_SECRET=... bun run test -- tests/unit/section-detail-date-display.test.ts`
- `bun run biome check src/features/section-detail/components/SectionCalendarMonthView.svelte src/features/section-detail/components/SectionCalendarTab.svelte src/features/section-detail/components/SectionDetailMainContent.svelte src/features/section-detail/components/SectionDetailPageController.svelte src/features/section-detail/components/section-detail-dialog-types.ts src/features/section-detail/lib/calendar.ts src/features/section-detail/lib/section-detail-calendar-display-actions.ts src/features/section-detail/lib/section-detail-controller-types.ts src/features/section-detail/server/section-detail-page-server.ts src/lib/components/calendar/CalendarGridDayCell.svelte 'tests/e2e/src/app/sections/[jwId]/test.ts' tests/unit/section-detail-date-display.test.ts`
- `bunx playwright install chromium`
- `DATABASE_URL=... AUTH_SECRET=... WEBHOOK_SECRET=... PLAYWRIGHT_PORT=3100 bun run e2e:db:prepare`
- `DATABASE_URL=... AUTH_SECRET=... WEBHOOK_SECRET=... PLAYWRIGHT_PORT=3100 bun run e2e:build-artifacts`
- `DATABASE_URL=... AUTH_SECRET=... WEBHOOK_SECRET=... PLAYWRIGHT_PORT=3100 bun run seed`
- `DATABASE_URL=... AUTH_SECRET=... WEBHOOK_SECRET=... PLAYWRIGHT_PORT=3100 bun run e2e:test -- 'tests/e2e/src/app/sections/\\[jwId\\]/test.ts' -g 'Today button navigates calendar to current day instead of section start'`
- Manual browser check against the built E2E app on port 3100: initial month `April 2026`, next month `May 2026`, Today moved to `June 2026`, with one `aria-current="date"` marker on June 27.
- `DATABASE_URL=... AUTH_SECRET=... WEBHOOK_SECRET=... bun run verify`
- `DATABASE_URL=... AUTH_SECRET=... WEBHOOK_SECRET=... PLAYWRIGHT_PORT=3100 bun run verify:full` (554 E2E tests passed)

## Docs / Contracts

No docs/contracts update. The section contract already specifies a current date marker (`todayKey`); this change aligns the UI behavior with that existing contract and does not change public REST/MCP/OpenAPI shape or user-visible copy.

## Risk Areas

- Date behavior: Today is derived on the server as a campus date key and passed to the client to avoid SSR/client date drift.
- UI behavior: The calendar grid computation moved to explicit Svelte reactive inputs so month navigation and Today recompute the visible cells together.
- No auth, Prisma/migration, upload, OAuth/MCP, or i18n changes.

## Cleanup

No screenshots, traces, scratch probes, generated files, or unrelated rewrites are committed. Local temporary database and screenshot artifacts were removed after verification.
