### PR TITLE
fix(ui): UI accessibility semantics

### DIFF
--- a/src/features/bus/components/BusMapActiveTripList.svelte
+++ b/src/features/bus/components/BusMapActiveTripList.svelte
@@ -42,22 +42,16 @@ function activeTripBadge(trip: BusMapActiveTrip) {
   <ul class="grid max-h-72 gap-2 overflow-y-auto">
     {#each mapData.activeTrips as trip}
       {@const route = routeById(trip.routeId)}
-      <li>
-        <button
-          class={`flex w-full items-center gap-2 rounded-md border border-base-300 bg-base-100 px-3 py-2 text-left transition hover:bg-base-200/50 focus:outline-none focus:ring-2 focus:ring-primary/30 ${hoveredRoute === trip.routeId ? "bg-base-200/70" : ""}`}
-          type="button"
-          onmouseenter={() => {
-            hoveredRoute = trip.routeId;
-          }}
-          onmouseleave={() => {
-            hoveredRoute = null;
-          }}
-          onfocus={() => {
-            hoveredRoute = trip.routeId;
-          }}
-          onblur={() => {
-            hoveredRoute = null;
-          }}
+      <li
+        onpointerenter={() => {
+          hoveredRoute = trip.routeId;
+        }}
+        onpointerleave={() => {
+          hoveredRoute = null;
+        }}
+      >
+        <div
+          class={`flex w-full items-center gap-2 rounded-md border border-base-300 bg-base-100 px-3 py-2 text-left transition hover:bg-base-200/50 ${hoveredRoute === trip.routeId ? "bg-base-200/70" : ""}`}
         >
           <span class="h-2.5 w-2.5 shrink-0 rounded-full" style={`background:${routeColor(trip.routeId, allRouteIds)}`}></span>
           <span class="min-w-0 flex-1">
@@ -71,7 +65,7 @@ function activeTripBadge(trip: BusMapActiveTrip) {
           <Badge variant={trip.status === "en-route" ? "secondary" : "outline"}>
             {activeTripBadge(trip)}
           </Badge>
-        </button>
+        </div>
       </li>
     {/each}
   </ul>

--- a/src/features/bus/components/BusMapLegendPanel.svelte
+++ b/src/features/bus/components/BusMapLegendPanel.svelte
@@ -25,27 +25,20 @@ function formatMessage(template: string, values: Record<string, string>) {
     </div>
     <ul class="grid max-h-[32rem] gap-1.5 overflow-y-auto">
       {#each mapData.routes as route}
-        <li class={`rounded-md border px-2 py-1.5 text-sm transition ${hoveredRoute === route.routeId ? "border-base-300 bg-base-200/60" : "border-transparent hover:border-base-300 hover:bg-base-200/50"}`}>
+        <li
+          class={`rounded-md border px-2 py-1.5 text-sm transition ${hoveredRoute === route.routeId ? "border-base-300 bg-base-200/60" : "border-transparent hover:border-base-300 hover:bg-base-200/50"}`}
+          onpointerenter={() => {
+            hoveredRoute = route.routeId;
+          }}
+          onpointerleave={() => {
+            hoveredRoute = null;
+          }}
+        >
           <div class="flex items-center gap-2">
             <span class="h-2 w-8 rounded-full" style={`background:${routeColor(route.routeId, allRouteIds)}`}></span>
-            <button
-              class="min-w-0 flex-1 truncate text-left font-medium focus:outline-none"
-              type="button"
-              onmouseenter={() => {
-                hoveredRoute = route.routeId;
-              }}
-              onmouseleave={() => {
-                hoveredRoute = null;
-              }}
-              onfocus={() => {
-                hoveredRoute = route.routeId;
-              }}
-              onblur={() => {
-                hoveredRoute = null;
-              }}
-            >
+            <span class="min-w-0 flex-1 truncate text-left font-medium">
               {route.descriptionPrimary}
-            </button>
+            </span>
             <Badge variant="ghost">
               {formatMessage(copy.tripCount[mapData.todayType], {
                 count: String(mapData.todayType === "weekday" ? route.weekdayTrips : route.weekendTrips),

--- a/src/features/dashboard/components/SubscriptionsBulkImportMatchedList.svelte
+++ b/src/features/dashboard/components/SubscriptionsBulkImportMatchedList.svelte
@@ -22,6 +22,8 @@ export let toggleImportSectionSelection: (sectionId: number) => void;
       <button
         class="flex w-full cursor-pointer items-start gap-3 rounded-md border border-base-300 bg-base-100 p-3 text-left transition hover:bg-base-200"
         type="button"
+        role="checkbox"
+        aria-checked={selectedImportSectionIdSet.has(section.id)}
         aria-label={formatMessage(subscriptionsCopy.bulkImport.selectSection, {
           code: section.code,
         })}

--- a/src/features/section-detail/components/SectionDetailMainContent.svelte
+++ b/src/features/section-detail/components/SectionDetailMainContent.svelte
@@ -53,6 +53,14 @@ export let unscheduledCalendarEvents: SectionDetailMainContentProps["unscheduled
 export let viewer: SectionDetailMainContentProps["viewer"];
 export let visibleCalendarMonth: Date;
 export let yesNo: SectionDetailMainContentProps["yesNo"];
+
+function sectionTabId(id: SectionDetailMainContentProps["activeTab"]) {
+  return `section-detail-${id}-tab`;
+}
+
+function sectionPanelId(id: SectionDetailMainContentProps["activeTab"]) {
+  return `section-detail-${id}-panel`;
+}
 </script>
 
 <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-start">
@@ -68,9 +76,15 @@ export let yesNo: SectionDetailMainContentProps["yesNo"];
     {/key}
 
     <Tabs.Root aria-label={sectionCopy.teachingSection}>
-      <Tabs.List>
+      <Tabs.List semantic>
         {#each tabs as [id, label]}
-          <Tabs.Button selected={activeTab === id} onclick={() => setActiveTab(id)}>
+          <Tabs.Button
+            id={sectionTabId(id)}
+            panelId={sectionPanelId(id)}
+            semantic
+            selected={activeTab === id}
+            onclick={() => setActiveTab(id)}
+          >
             {label}
           </Tabs.Button>
         {/each}
@@ -78,37 +92,54 @@ export let yesNo: SectionDetailMainContentProps["yesNo"];
     </Tabs.Root>
 
     {#if activeTab === "calendar"}
-      <SectionCalendarTab
-        bind:calendarMonthOffset
-        calendarGridWeeks={sectionCalendarGridWeeks}
-        {calendarMonthLabel}
-        dateTimePlaceText={data.section.dateTimePlaceText}
-        {fmtDate}
-        {formatMessage}
-        {openCalendarDialog}
-        {sectionCalendarEvents}
-        {sectionCopy}
-        {todayCalendarMonthOffset}
-        {unscheduledCalendarEvents}
-      />
+      <Tabs.Panel
+        active
+        id={sectionPanelId("calendar")}
+        labelledBy={sectionTabId("calendar")}
+      >
+        <SectionCalendarTab
+          bind:calendarMonthOffset
+          calendarGridWeeks={sectionCalendarGridWeeks}
+          {calendarMonthLabel}
+          dateTimePlaceText={data.section.dateTimePlaceText}
+          {fmtDate}
+          {formatMessage}
+          {openCalendarDialog}
+          {sectionCalendarEvents}
+          {sectionCopy}
+          {todayCalendarMonthOffset}
+          {unscheduledCalendarEvents}
+        />
+      </Tabs.Panel>
     {:else if activeTab === "homework"}
-      <SectionHomeworkTab
-        {canWriteHomework}
-        {fmtDateTime}
-        {homeworkCopy}
-        {homeworkStatus}
-        {homeworkView}
-        {homeworks}
-        isAuthenticated={viewer.isAuthenticated ?? viewer.signedIn === true}
-        openAuditDialog={() => setHomeworkAuditDialogOpen(true)}
-        {openCreateHomeworkDialog}
-        {sectionCopy}
-        sectionJwId={data.section.jwId}
-        selectHomework={setSelectedHomework}
-        {setHomeworkView}
-      />
+      <Tabs.Panel
+        active
+        id={sectionPanelId("homework")}
+        labelledBy={sectionTabId("homework")}
+      >
+        <SectionHomeworkTab
+          {canWriteHomework}
+          {fmtDateTime}
+          {homeworkCopy}
+          {homeworkStatus}
+          {homeworkView}
+          {homeworks}
+          isAuthenticated={viewer.isAuthenticated ?? viewer.signedIn === true}
+          openAuditDialog={() => setHomeworkAuditDialogOpen(true)}
+          {openCreateHomeworkDialog}
+          {sectionCopy}
+          sectionJwId={data.section.jwId}
+          selectHomework={setSelectedHomework}
+          {setHomeworkView}
+        />
+      </Tabs.Panel>
     {:else if activeTab === "comments"}
-      <section class="grid gap-3">
+      <Tabs.Panel
+        active
+        class="grid gap-3"
+        id={sectionPanelId("comments")}
+        labelledBy={sectionTabId("comments")}
+      >
         {#key `comments:section:${data.section.id}`}
           <CommentsPanel
             initialData={data.commentsData}
@@ -118,7 +149,7 @@ export let yesNo: SectionDetailMainContentProps["yesNo"];
             showAllTargets
           />
         {/key}
-      </section>
+      </Tabs.Panel>
     {/if}
   </div>
 

--- a/tests/e2e/src/app/admin/moderation/test.ts
+++ b/tests/e2e/src/app/admin/moderation/test.ts
@@ -199,9 +199,7 @@ test("/admin/moderation 目标链接可跳转到原页面锚点", async ({
   await signInAsDevAdmin(page, sectionPath);
   await gotoAndWaitForReady(page, sectionPath);
 
-  const commentsTab = page
-    .getByRole("button", { name: /评论|Comments/i })
-    .first();
+  const commentsTab = page.getByRole("tab", { name: /评论|Comments/i }).first();
   await expect(commentsTab).toBeVisible();
   await commentsTab.click();
 

--- a/tests/e2e/src/app/bus-map/test.ts
+++ b/tests/e2e/src/app/bus-map/test.ts
@@ -69,6 +69,11 @@ test.describe("bus transit map", () => {
     await expect(
       page.getByText(DEV_SEED.bus.recommendedRoute, { exact: false }).first(),
     ).toBeVisible();
+    await expect(
+      page.getByRole("button").filter({
+        hasText: DEV_SEED.bus.recommendedRoute,
+      }),
+    ).toHaveCount(0);
 
     // Status indicators in legend
     await expect(page.getByText(/En route|行驶中/).first()).toBeVisible();

--- a/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
+++ b/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
@@ -34,6 +34,10 @@ import {
 import { captureStepScreenshot } from "../../../../../utils/screenshot";
 import { ensureSeedSectionSubscription } from "../../../../../utils/subscriptions";
 
+function escapeForRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 test.describe("dashboard subscriptions", () => {
   test.describe.configure({ mode: "serial" });
 
@@ -288,6 +292,20 @@ test.describe("dashboard subscriptions", () => {
       .getByRole("dialog", { name: /确认关注|Confirm following/i })
       .first();
     await expect(dialog).toBeVisible({ timeout: 15_000 });
+
+    const matchedSectionCheckbox = dialog
+      .getByRole("checkbox", {
+        name: new RegExp(
+          `选择 ${escapeForRegExp(DEV_SEED.section.code)}|Select ${escapeForRegExp(DEV_SEED.section.code)}`,
+          "i",
+        ),
+      })
+      .first();
+    await expect(matchedSectionCheckbox).toBeChecked();
+    await matchedSectionCheckbox.click();
+    await expect(matchedSectionCheckbox).not.toBeChecked();
+    await matchedSectionCheckbox.click();
+    await expect(matchedSectionCheckbox).toBeChecked();
 
     await captureStepScreenshot(
       page,

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -54,8 +54,8 @@ function escapeForRegExp(value: string) {
 
 function getSectionTab(page: Page, name: RegExp) {
   return page
-    .locator('[data-slot="tabs-list"]')
-    .getByRole("button", { name })
+    .getByRole("tablist", { name: /授课班级|Teaching section/i })
+    .getByRole("tab", { name })
     .first();
 }
 
@@ -108,7 +108,7 @@ test.describe("/sections/[jwId]", () => {
     // section.code (monospace)
     await expect(page.getByText(DEV_SEED.section.code).first()).toBeVisible();
     await expect(
-      page.getByRole("group", { name: /授课班级|Teaching section/i }),
+      page.getByRole("tablist", { name: /授课班级|Teaching section/i }),
     ).toBeVisible();
 
     await captureStepScreenshot(page, testInfo, "section/heading");
@@ -249,7 +249,7 @@ test.describe("/sections/[jwId]", () => {
     await expect(async () => {
       const calendarTab = getSectionTab(page, /日历|Calendar/i);
       await calendarTab.click();
-      await expect(calendarTab).toHaveAttribute("aria-pressed", "true");
+      await expect(calendarTab).toHaveAttribute("aria-selected", "true");
     }).toPass({
       timeout: 10_000,
       intervals: [250, 500, 1_000],
@@ -300,7 +300,7 @@ test.describe("/sections/[jwId]", () => {
 
     const calendarTab = getSectionTab(page, /日历|Calendar/i);
     await calendarTab.click();
-    await expect(calendarTab).toHaveAttribute("aria-pressed", "true");
+    await expect(calendarTab).toHaveAttribute("aria-selected", "true");
 
     const monthView = getSectionCalendarMonthView(page);
     const monthHeading = monthView.locator("h3").first();
@@ -324,7 +324,7 @@ test.describe("/sections/[jwId]", () => {
     await expect(async () => {
       const calendarTab = getSectionTab(page, /日历|Calendar/i);
       await calendarTab.click();
-      await expect(calendarTab).toHaveAttribute("aria-pressed", "true");
+      await expect(calendarTab).toHaveAttribute("aria-selected", "true");
     }).toPass({
       timeout: 10_000,
       intervals: [250, 500, 1_000],
@@ -387,24 +387,25 @@ test.describe("/sections/[jwId]", () => {
   test("tab switching works", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
 
-    const nextTab = page
-      .locator('[role="button"][aria-pressed="false"]')
+    const tabList = page
+      .getByRole("tablist", { name: /授课班级|Teaching section/i })
       .first();
-    if ((await nextTab.count()) > 0) {
-      const nextTabLabel = ((await nextTab.textContent()) ?? "").trim();
-      expect(nextTabLabel).toBeTruthy();
-      await expect(async () => {
-        const targetTab = page
-          .getByRole("button", { name: nextTabLabel })
-          .first();
-        await targetTab.click();
-        await expect(targetTab).toHaveAttribute("aria-pressed", "true");
-      }).toPass({
-        timeout: 10_000,
-        intervals: [250, 500, 1_000],
-      });
-      await captureStepScreenshot(page, testInfo, "section/tab-switch");
+    await expect(tabList).toBeVisible();
+    const targetTab = tabList.getByRole("tab").nth(1);
+    const targetTabId = await targetTab.getAttribute("id");
+    const panelId = await targetTab.getAttribute("aria-controls");
+    expect(targetTabId).toBeTruthy();
+    expect(panelId).toBeTruthy();
+    if (!targetTabId || !panelId) {
+      throw new Error("Expected section tab id and aria-controls");
     }
+
+    await targetTab.click();
+    await expect(targetTab).toHaveAttribute("aria-selected", "true");
+    const targetPanel = page.locator(`#${panelId}`);
+    await expect(targetPanel).toHaveAttribute("role", "tabpanel");
+    await expect(targetPanel).toHaveAttribute("aria-labelledby", targetTabId);
+    await captureStepScreenshot(page, testInfo, "section/tab-switch");
   });
 
   test("breadcrumb navigates back to sections list", async ({
@@ -591,7 +592,7 @@ test.describe("/sections/[jwId]", () => {
     await gotoAndWaitForReady(page, SECTION_URL);
 
     const homeworksTab = page
-      .getByRole("button", { name: /作业|Homework/i })
+      .getByRole("tab", { name: /作业|Homework/i })
       .first();
     if ((await homeworksTab.count()) === 0) {
       await expect(page.locator("#main-content")).toBeVisible();
@@ -632,7 +633,7 @@ test.describe("/sections/[jwId]", () => {
 
     try {
       const homeworksTab = page
-        .getByRole("button", { name: /作业|Homework/i })
+        .getByRole("tab", { name: /作业|Homework/i })
         .first();
       if ((await homeworksTab.count()) === 0) {
         await expect(page.locator("#main-content")).toBeVisible();
@@ -746,10 +747,10 @@ test.describe("/sections/[jwId]", () => {
 
     try {
       const commentsTab = page
-        .getByRole("button", { name: /评论|Comments/i })
+        .getByRole("tab", { name: /评论|Comments/i })
         .first();
       await commentsTab.click();
-      await expect(commentsTab).toHaveAttribute("aria-pressed", "true");
+      await expect(commentsTab).toHaveAttribute("aria-selected", "true");
 
       // Post comment
       const body = `e2e-section-comment-${Date.now()}`;
@@ -918,10 +919,10 @@ test.describe("/sections/[jwId]", () => {
           await gotoAndWaitForReady(page, SECTION_URL);
         }
         const commentsTab = page
-          .getByRole("button", { name: /评论|Comments/i })
+          .getByRole("tab", { name: /评论|Comments/i })
           .first();
         await commentsTab.click();
-        await expect(commentsTab).toHaveAttribute("aria-pressed", "true");
+        await expect(commentsTab).toHaveAttribute("aria-selected", "true");
       }).toPass({
         timeout: 10_000,
         intervals: [250, 500, 1_000],

--- a/tools/dev/artifacts/snapshots/snapshot-capture.ts
+++ b/tools/dev/artifacts/snapshots/snapshot-capture.ts
@@ -611,13 +611,10 @@ async function waitForSnapshotReady(
 }
 
 async function openTab(page: Page, name: RegExp) {
-  const tab = page
-    .locator('[data-slot="tabs-list"]')
-    .getByRole("button", { name })
-    .first();
+  const tab = page.getByRole("tab", { name }).first();
   await expect(tab).toBeVisible({ timeout: 10_000 });
   await tab.click();
-  await expect(tab).toHaveAttribute("aria-pressed", "true");
+  await expect(tab).toHaveAttribute("aria-selected", "true");
 }
 
 async function performSnapshotAction(page: Page, action: PageSnapshotAction) {


### PR DESCRIPTION
## Goal

Close #281, close #283, close #284 by tightening UI accessibility semantics without changing the user-facing flow.

## Changed Surfaces

- Dashboard subscriptions bulk-import dialog: matched rows expose checked/unchecked selection state.
- Section detail context tabs: teaching-section tabs now use tab/tablist/tabpanel relationships.
- Bus map: route preview/legend rows no longer expose no-op button semantics.
- Snapshot tooling: section-detail action snapshots now target semantic tabs.
- E2E coverage: dashboard bulk import, section tabs, bus map route rows, and the admin moderation flow that opens section comments.

## Evidence

- `bun install --frozen-lockfile`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/life_ustc_dev ... bun run verify:types`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/life_ustc_dev ... bun run e2e:db:prepare`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/life_ustc_dev ... bun run e2e:build-artifacts`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/life_ustc_dev ... bun run seed`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/life_ustc_dev ... PLAYWRIGHT_PORT=3010 bun run e2e:test -- tests/e2e/src/app/dashboard/subscriptions/sections/test.ts tests/e2e/src/app/bus-map/test.ts` (dashboard/bus-map focused subset passed)
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/life_ustc_dev ... PLAYWRIGHT_PORT=3030 bun run e2e:test -- "tests/e2e/src/app/sections/\\[jwId\\]/test.ts" -g "tab switching works|displays schedule with room|displays exam info"`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/life_ustc_dev ... PLAYWRIGHT_PORT=3032 bun run e2e:test -- "tests/e2e/src/app/sections/\\[jwId\\]/test.ts" tests/e2e/src/app/admin/moderation/test.ts -g "displays course name as h1 and section code|目标链接可跳转到原页面锚点"`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/life_ustc_dev ... bun run verify`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/life_ustc_dev ... PLAYWRIGHT_PORT=3034 bun run verify:full` (553 E2E passed)
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/life_ustc_dev ... bun run verify` after snapshot helper update
- `git diff --check`
- Browser evidence inspected locally: bus map route previews, section tab panel, and dashboard import checkbox-state screenshots.
- GitHub checks on latest commit `5b6a1e60`: CI, all E2E shards, CodeQL, Cloudflare Workers build, static loader image, and E2E Snapshot Artifacts passed.

## Docs / Contracts

No docs/contracts/OpenAPI/message changes. This is a UI semantics/accessibility-only change with no REST/MCP shape, permissions, or user-visible workflow contract changes.

## Risk Areas

- Section detail tab controls now expose semantic `tab` roles instead of generic buttons, so tests and snapshot capture helpers that navigate to comments/homework were updated to target the new role.
- Bus map route preview rows remain hoverable for pointer highlighting but are intentionally non-focusable because they do not perform an action.
- No auth, Prisma, upload, MCP, or API changes.

## Cleanup

- Local screenshots and Playwright reports were removed after inspection.
- The isolated local Postgres container used on port 5433 was stopped after local verification.
- No generated files or unrelated worktree changes are included.
