### PR TITLE
fix(openapi): document admin 403 and calendar media

### DIFF
--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -430,6 +430,16 @@
               }
             }
           },
+          "403": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Error response",
             "content": {
@@ -589,6 +599,16 @@
             }
           },
           "401": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "403": {
             "description": "Error response",
             "content": {
               "application/json": {
@@ -844,6 +864,16 @@
               }
             }
           },
+          "403": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Error response",
             "content": {
@@ -893,6 +923,16 @@
             }
           },
           "401": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "403": {
             "description": "Error response",
             "content": {
               "application/json": {
@@ -1043,6 +1083,16 @@
             }
           },
           "401": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "403": {
             "description": "Error response",
             "content": {
               "application/json": {
@@ -4942,12 +4992,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Binary response",
+            "description": "Calendar response",
             "content": {
-              "application/octet-stream": {
+              "text/calendar": {
                 "schema": {
-                  "type": "string",
-                  "format": "binary"
+                  "type": "string"
                 }
               }
             }
@@ -5109,12 +5158,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Binary response",
+            "description": "Calendar response",
             "content": {
-              "application/octet-stream": {
+              "text/calendar": {
                 "schema": {
-                  "type": "string",
-                  "format": "binary"
+                  "type": "string"
                 }
               }
             }
@@ -6772,12 +6820,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Binary response",
+            "description": "Calendar response",
             "content": {
-              "application/octet-stream": {
+              "text/calendar": {
                 "schema": {
-                  "type": "string",
-                  "format": "binary"
+                  "type": "string"
                 }
               }
             }

--- a/src/routes/api/admin/comments/[id]/+server.ts
+++ b/src/routes/api/admin/comments/[id]/+server.ts
@@ -9,6 +9,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  * @response adminModeratedCommentResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
+ * @response 403:openApiErrorSchema
  * @response 404:openApiErrorSchema
  */
 export const PATCH: RequestHandler = ({ request, params }) =>

--- a/src/routes/api/admin/descriptions/[id]/+server.ts
+++ b/src/routes/api/admin/descriptions/[id]/+server.ts
@@ -9,6 +9,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  * @response adminModeratedDescriptionResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
+ * @response 403:openApiErrorSchema
  * @response 404:openApiErrorSchema
  */
 export const PATCH: RequestHandler = ({ request, params }) =>

--- a/src/routes/api/admin/suspensions/+server.ts
+++ b/src/routes/api/admin/suspensions/+server.ts
@@ -19,6 +19,7 @@ export const GET = svelteRequestHandler(
  * @response adminSuspensionResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
+ * @response 403:openApiErrorSchema
  * @response 404:openApiErrorSchema
  */
 export const POST = svelteRequestHandler(

--- a/src/routes/api/admin/suspensions/[id]/+server.ts
+++ b/src/routes/api/admin/suspensions/[id]/+server.ts
@@ -7,6 +7,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  * @pathParams resourceIdPathParamsSchema
  * @response adminSuspensionResponseSchema
  * @response 401:openApiErrorSchema
+ * @response 403:openApiErrorSchema
  * @response 404:openApiErrorSchema
  */
 export const PATCH: RequestHandler = ({ request, params }) =>

--- a/src/routes/api/admin/users/[id]/+server.ts
+++ b/src/routes/api/admin/users/[id]/+server.ts
@@ -9,6 +9,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  * @response adminUserResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
+ * @response 403:openApiErrorSchema
  * @response 404:openApiErrorSchema
  */
 export const PATCH: RequestHandler = ({ request, params }) =>

--- a/src/routes/api/sections/[jwId]/calendar.ics/+server.ts
+++ b/src/routes/api/sections/[jwId]/calendar.ics/+server.ts
@@ -5,7 +5,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
 /**
  * Generate section calendar.
  * @pathParams jwIdPathParamsSchema
- * @response 200:binary
+ * @response 200:calendar
  * @response 404:openApiErrorSchema
  */
 export const GET: RequestHandler = ({ request, params }) =>

--- a/src/routes/api/sections/calendar.ics/+server.ts
+++ b/src/routes/api/sections/calendar.ics/+server.ts
@@ -5,7 +5,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
 /**
  * Generate sections calendar.
  * @params sectionsCalendarQuerySchema
- * @response 200:binary
+ * @response 200:calendar
  * @response 400:openApiErrorSchema
  */
 export const GET = svelteRequestHandler(

--- a/src/routes/api/users/[userId]/calendar.ics/+server.ts
+++ b/src/routes/api/users/[userId]/calendar.ics/+server.ts
@@ -6,7 +6,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  * Generate user calendar.
  * @pathParams userCalendarPathParamsSchema
  * @params userCalendarQuerySchema
- * @response 200:binary
+ * @response 200:calendar
  * @response 401:openApiErrorSchema
  * @response 403:openApiErrorSchema
  * @response 404:openApiErrorSchema

--- a/tests/unit/openapi-scenario-examples.test.ts
+++ b/tests/unit/openapi-scenario-examples.test.ts
@@ -263,6 +263,28 @@ describe("buildScenarioOpenApiExamples", () => {
     expect(deviceAuthorizationOptions?.responses?.["204"]).toBeTruthy();
   });
 
+  it("documents calendar exports without changing true binary media", () => {
+    const spec = generatedOpenApiDocument as GeneratedOpenApiDocument;
+
+    for (const path of [
+      "/api/sections/calendar.ics",
+      "/api/sections/{jwId}/calendar.ics",
+      "/api/users/{userId}/calendar.ics",
+    ]) {
+      const content = spec.paths[path]?.get?.responses?.["200"]?.content;
+      expect(content?.["text/calendar"]?.schema).toEqual({ type: "string" });
+      expect(content?.["application/octet-stream"]).toBeUndefined();
+    }
+
+    expect(
+      spec.paths["/api/uploads/{id}/download"]?.get?.responses?.["200"]
+        ?.content?.["application/octet-stream"]?.schema,
+    ).toEqual({
+      type: "string",
+      format: "binary",
+    });
+  });
+
   it("documents query bounds and implemented validation responses", () => {
     const spec = generatedOpenApiDocument as GeneratedOpenApiDocument;
 
@@ -406,6 +428,23 @@ describe("buildScenarioOpenApiExamples", () => {
         expect.objectContaining({ in: "query", name: "token" }),
       ]),
     );
+  });
+
+  it("documents active-admin write gate failures on admin mutations", () => {
+    const spec = generatedOpenApiDocument as GeneratedOpenApiDocument;
+    const missing403: string[] = [];
+
+    for (const [path, pathItem] of Object.entries(spec.paths)) {
+      if (!path.startsWith("/api/admin/")) continue;
+      for (const method of ["post", "put", "patch", "delete"] as const) {
+        const operation = pathItem[method];
+        if (operation && !operation.responses?.["403"]) {
+          missing403.push(`${method.toUpperCase()} ${path}`);
+        }
+      }
+    }
+
+    expect(missing403).toEqual([]);
   });
 
   it("documents operational endpoint response shapes", () => {

--- a/tools/build/openapi/generate-spec.ts
+++ b/tools/build/openapi/generate-spec.ts
@@ -359,6 +359,16 @@ function buildResponses(
       continue;
     }
 
+    if (schemaName === "calendar") {
+      responses[String(code)] = {
+        description: "Calendar response",
+        content: {
+          "text/calendar": { schema: { type: "string" } },
+        },
+      };
+      continue;
+    }
+
     if (schemaName === "array") {
       responses[String(code)] = {
         description: "Array response",


### PR DESCRIPTION
## Goal

Fixes #298.
Fixes #299.

## Changed Surfaces

- Added missing OpenAPI `403` annotations for active-admin mutation endpoints.
- Added `@response 200:calendar` OpenAPI response support and used it for `.ics` routes.
- Regenerated `public/openapi.generated.json` through `bun run openapi:generate`.
- Added focused OpenAPI unit assertions for admin mutation 403s and calendar-vs-binary media types.

## Evidence

- `bun run openapi:check`
- `bun run vitest run tests/unit/openapi-scenario-examples.test.ts tests/unit/api-schemas.test.ts tests/unit/api-docs-navigation.test.ts`
- `bun run check:contracts`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc bun run verify`
- Inspected generated OpenAPI JSON: `.ics` routes now expose `text/calendar`; upload download remains `application/octet-stream` binary.

## Docs / Contracts

- Updated tracked generated OpenAPI only through the generator.
- No hand-maintained contract JSON change: runtime behavior and existing iCal contract already describe `text/calendar`; this PR fixes OpenAPI parity only.

## Risk Areas

- OpenAPI generator response kind handling.
- Admin suspended-account write-gate documentation.
- Upload/download binary media type regression, covered by focused assertion.

## Cleanup

- No scratch artifacts or unrelated rewrites are staged/committed.
- Work was isolated in a clean worktree based on `origin/main` at `f7f786e1`.