### PR TITLE
chore(infra): remove stale Vercel references

### DIFF
--- a/src/lib/adapters/cloudflare-env.ts
+++ b/src/lib/adapters/cloudflare-env.ts
@@ -89,7 +89,6 @@ export function getAuthEnv(input: NodeJS.ProcessEnv = getDefaultEnvInput()) {
       OAUTH_PROXY_SECRET: true,
       E2E_DEBUG_AUTH: true,
       NODE_ENV: true,
-      VERCEL: true,
     }),
     input,
     "Invalid auth environment variables",

--- a/src/lib/auth/auth-config.ts
+++ b/src/lib/auth/auth-config.ts
@@ -4,10 +4,7 @@ export function getAuthRuntimeConfig() {
   const authEnv = getAuthEnv();
   const isDevelopment = authEnv.NODE_ENV === "development";
   const allowE2EDebugAuth = authEnv.E2E_DEBUG_AUTH === "1";
-  if (
-    allowE2EDebugAuth &&
-    (authEnv.VERCEL === "1" || authEnv.NODE_ENV === "production")
-  ) {
+  if (allowE2EDebugAuth && authEnv.NODE_ENV === "production") {
     throw new Error("E2E_DEBUG_AUTH must not be set in production hosting");
   }
 

--- a/src/lib/env/env-schema.ts
+++ b/src/lib/env/env-schema.ts
@@ -22,7 +22,6 @@ export const commonEnvSchema = z.object({
     .default("development"),
   UPLOAD_TOTAL_QUOTA_MB: optionalPositiveInt,
   E2E_DEBUG_AUTH: optionalString,
-  VERCEL: optionalString,
 });
 
 export const runtimeRequiredEnvSchema = z.object({

--- a/tests/unit/auth-config.test.ts
+++ b/tests/unit/auth-config.test.ts
@@ -32,21 +32,9 @@ describe("auth config", () => {
     expect(allowDebugAuth()).toBe(true);
   });
 
-  it("rejects E2E debug auth on Vercel hosting", async () => {
+  it("rejects E2E debug auth in production", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("E2E_DEBUG_AUTH", "1");
-    vi.stubEnv("VERCEL", "1");
-
-    const { allowDebugAuth } = await import("@/lib/auth/auth-config");
-    expect(() => allowDebugAuth()).toThrow(
-      "E2E_DEBUG_AUTH must not be set in production hosting",
-    );
-  });
-
-  it("rejects E2E debug auth in production without Vercel", async () => {
-    vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("E2E_DEBUG_AUTH", "1");
-    vi.stubEnv("VERCEL", "");
 
     const { allowDebugAuth } = await import("@/lib/auth/auth-config");
     expect(() => allowDebugAuth()).toThrow(

--- a/tests/unit/auth-origins.test.ts
+++ b/tests/unit/auth-origins.test.ts
@@ -11,20 +11,20 @@ describe("auth origin helpers", () => {
   });
 
   it("includes public and pinned local origins", () => {
-    vi.stubEnv("APP_PUBLIC_ORIGIN", "https://preview-123.vercel.app");
+    vi.stubEnv("APP_PUBLIC_ORIGIN", "https://preview-123.example.com");
 
     expect(getAuthTrustedOrigins()).toEqual([
-      "https://preview-123.vercel.app",
+      "https://preview-123.example.com",
       "http://localhost:3000",
       "http://127.0.0.1:3000",
     ]);
   });
 
   it("returns Better Auth allowed hosts for dynamic base URL resolution", () => {
-    vi.stubEnv("APP_PUBLIC_ORIGIN", "https://preview-123.vercel.app");
+    vi.stubEnv("APP_PUBLIC_ORIGIN", "https://preview-123.example.com");
 
     expect(getAuthAllowedHosts()).toEqual([
-      "preview-123.vercel.app",
+      "preview-123.example.com",
       "localhost:3000",
       "127.0.0.1:3000",
     ]);
@@ -81,10 +81,10 @@ describe("isTrustedAuthOrigin", () => {
     expect(isTrustedAuthOrigin("http://localhost:3010")).toBe(true);
   });
 
-  it("rejects unconfigured Vercel origins", () => {
+  it("rejects unconfigured example origins", () => {
     withOrigin("https://preview.example.com");
-    expect(isTrustedAuthOrigin("https://vercel.app")).toBe(false);
-    expect(isTrustedAuthOrigin("https://myapp-abc123.vercel.app")).toBe(false);
+    expect(isTrustedAuthOrigin("https://example.com")).toBe(false);
+    expect(isTrustedAuthOrigin("https://myapp-abc123.example.com")).toBe(false);
   });
 
   it("rejects a different port on an exact-match trusted origin", () => {


### PR DESCRIPTION
## Inspection summary: Cloudflare Workers setup

The project is **fully Cloudflare Workers** today:

- Production runtime: SvelteKit builds a Worker via `@sveltejs/adapter-cloudflare` and deploys through Cloudflare Git integration using `wrangler.jsonc`.
- E2E / CI: Playwright runs against a local Worker via `wrangler dev --config wrangler.e2e.jsonc`.
- Bindings: Hyperdrive for PostgreSQL, `R2_UPLOADS` for object storage, `ASSETS` for static assets.
- Prisma client generated with `runtime = "cloudflare"` for the Worker.

Intentional non-Worker pieces:
- Docker static loader (ETL for data imports).
- Local Postgres for dev/tests.
- Prisma Node client for scripts/migrations.
- Vite dev server (`bun run dev`) for local development.

## Cleanup

This PR removes leftover Vercel-specific env handling from the previous hosting platform:

- Drop `VERCEL` from `commonEnvSchema` and `getAuthEnv`.
- Simplify the E2E debug-auth guard to only check `NODE_ENV === "production"`.
- Update unit tests to use `example.com` origins instead of `vercel.app`.

## Verification

- `bunx biome check` passed
- `bunx vitest run` passed (586 tests)
- `bunx tsc --noEmit` passed for `tsconfig.typecheck.json` and `tsconfig.typecheck.tests.json`