### PR TITLE
test(names): translate all test/checkpoint names to Chinese

### DIFF
--- a/tests/e2e/mobile-screenshots/screenshots.spec.ts
+++ b/tests/e2e/mobile-screenshots/screenshots.spec.ts
@@ -9,8 +9,8 @@ function screenshotRoute(name: string, path: string) {
   });
 }
 
-test.describe("mobile screenshots", () => {
-  test.describe("public pages", () => {
+test.describe("移动端截图", () => {
+  test.describe("公开页面", () => {
     for (const path of [
       "/",
       "/courses",
@@ -32,7 +32,7 @@ test.describe("mobile screenshots", () => {
     }
   });
 
-  test.describe("signed-in pages", () => {
+  test.describe("登录后页面", () => {
     test.beforeEach(async ({ page }) => {
       await signInAsDebugUser(page, "/");
     });
@@ -54,7 +54,7 @@ test.describe("mobile screenshots", () => {
       screenshotRoute(path, path);
     }
 
-    test(`/u/id/[uid]`, async ({ page }) => {
+    test(`/u/id/[uid] 页面截图`, async ({ page }) => {
       const sessionResponse = await page.request.get("/api/auth/get-session");
       const session = (await sessionResponse.json()) as {
         user?: { id?: string };
@@ -64,7 +64,7 @@ test.describe("mobile screenshots", () => {
     });
   });
 
-  test.describe("admin pages", () => {
+  test.describe("管理员页面", () => {
     test.beforeEach(async ({ page }) => {
       await signInAsDevAdmin(page, "/admin");
     });

--- a/tests/e2e/src/app/admin/bus/test.ts
+++ b/tests/e2e/src/app/admin/bus/test.ts
@@ -44,9 +44,7 @@ test("/admin/bus 普通用户访问返回 404", async ({ page }, testInfo) => {
   await captureStepScreenshot(page, testInfo, "admin-bus/404");
 });
 
-test("/admin/bus displays all required version fields", async ({
-  page,
-}, testInfo) => {
+test("/admin/bus 显示所有必需的版本字段", async ({ page }, testInfo) => {
   await signInAsDevAdmin(page, "/admin/bus");
 
   // Heading
@@ -67,7 +65,7 @@ test("/admin/bus displays all required version fields", async ({
   await captureStepScreenshot(page, testInfo, "admin-bus/version-fields");
 });
 
-test("/admin/bus version table has trip count", async ({ page }, testInfo) => {
+test("/admin/bus 版本表格包含班次数量", async ({ page }, testInfo) => {
   await signInAsDevAdmin(page, "/admin/bus");
 
   // tripCount — the page shows a plain number (e.g. "22") in the Trips column
@@ -77,9 +75,7 @@ test("/admin/bus version table has trip count", async ({ page }, testInfo) => {
   await captureStepScreenshot(page, testInfo, "admin-bus/trip-count");
 });
 
-test("/admin/bus card visible on admin home and navigates", async ({
-  page,
-}, testInfo) => {
+test("/admin/bus 管理首页入口可见且可跳转", async ({ page }, testInfo) => {
   await signInAsDevAdmin(page, "/admin");
 
   const busCard = page.getByRole("link", {
@@ -94,7 +90,7 @@ test("/admin/bus card visible on admin home and navigates", async ({
   await captureStepScreenshot(page, testInfo, "admin-bus/navigate-from-home");
 });
 
-test("/admin/bus active version is protected and import dialog opens", async ({
+test("/admin/bus 激活版本受保护且导入弹窗可打开", async ({
   page,
 }, testInfo) => {
   test.setTimeout(60_000);

--- a/tests/e2e/src/app/admin/moderation/test.ts
+++ b/tests/e2e/src/app/admin/moderation/test.ts
@@ -95,9 +95,7 @@ test("/admin/moderation 管理员访问成功", async ({ page }, testInfo) => {
   await captureStepScreenshot(page, testInfo, "admin-moderation-home");
 });
 
-test("/admin/moderation invalid tab falls back to comments", async ({
-  page,
-}) => {
+test("/admin/moderation 无效标签回退到评论", async ({ page }) => {
   await signInAsDevAdmin(page, "/admin/moderation?tab=bad");
   await expect(page.locator('input[type="hidden"][name="tab"]')).toHaveValue(
     "comments",
@@ -400,9 +398,7 @@ test("/admin/moderation 可从评论弹窗封禁并解除用户", async ({
 
 // ── Description governance ──────────────────────────────────────────────────
 
-test("/admin/moderation description governance table visible", async ({
-  page,
-}, testInfo) => {
+test("/admin/moderation 课程简介治理表格可见", async ({ page }, testInfo) => {
   await signInAsDevAdmin(page, "/admin/moderation");
 
   // admin.yml moderation.display.fields: Description moderation table
@@ -452,9 +448,7 @@ test("/admin/moderation 简介桌面行操作可用键盘打开管理弹窗", as
 
 // ── Homework governance ─────────────────────────────────────────────────────
 
-test("/admin/moderation homework governance accessible", async ({
-  page,
-}, testInfo) => {
+test("/admin/moderation 作业治理可访问", async ({ page }, testInfo) => {
   await signInAsDevAdmin(page, "/admin/moderation");
 
   // admin.yml moderation.display.fields (via homework.yml → homework-governance)

--- a/tests/e2e/src/app/admin/oauth/test.ts
+++ b/tests/e2e/src/app/admin/oauth/test.ts
@@ -129,7 +129,7 @@ test("/admin/oauth 管理员可创建并删除客户端", async ({ page }, testI
   }
 });
 
-test("/admin/oauth created client shows all required fields", async ({
+test("/admin/oauth 创建的客户端显示所有必需字段", async ({
   page,
 }, testInfo) => {
   test.setTimeout(60_000);

--- a/tests/e2e/src/app/api/admin/comments/[id]/test.ts
+++ b/tests/e2e/src/app/api/admin/comments/[id]/test.ts
@@ -20,19 +20,19 @@ import { assertApiContract } from "../../../../_shared/api-contract";
 
 const BASE = "/api/admin/comments";
 
-test.describe("PATCH /api/admin/comments/[id]", () => {
-  test("api contract", async ({ request }) => {
+test.describe("PATCH /api/admin/comments/[id] 评论管理", () => {
+  test("API 契约", async ({ request }) => {
     await assertApiContract(request, { routePath: `${BASE}/[id]` });
   });
 
-  test("unauthenticated PATCH returns 401", async ({ request }) => {
+  test("未认证 PATCH 返回 401", async ({ request }) => {
     const response = await request.patch(`${BASE}/nonexistent-id`, {
       data: { status: "softbanned" },
     });
     expect(response.status()).toBe(401);
   });
 
-  test("non-admin PATCH returns 401", async ({ page }) => {
+  test("非管理员 PATCH 返回 401", async ({ page }) => {
     await signInAsDebugUser(page, "/");
     const response = await page.request.patch(`${BASE}/nonexistent-id`, {
       data: { status: "softbanned" },
@@ -40,7 +40,7 @@ test.describe("PATCH /api/admin/comments/[id]", () => {
     expect(response.status()).toBe(401);
   });
 
-  test("empty request body returns 400", async ({ page }) => {
+  test("空请求体返回 400", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
     const listResponse = await page.request.get(`${BASE}?limit=1`);
     expect(listResponse.status()).toBe(200);
@@ -57,7 +57,7 @@ test.describe("PATCH /api/admin/comments/[id]", () => {
     expect(response.status()).toBe(400);
   });
 
-  test("admin can moderate a comment and restore it", async ({ page }) => {
+  test("管理员可管理评论并恢复状态", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
 
     // Find an active comment to moderate.

--- a/tests/e2e/src/app/api/admin/comments/test.ts
+++ b/tests/e2e/src/app/api/admin/comments/test.ts
@@ -16,23 +16,23 @@ import { assertApiContract } from "../../../_shared/api-contract";
 
 const BASE = "/api/admin/comments";
 
-test.describe("GET /api/admin/comments", () => {
-  test("api contract", async ({ request }) => {
+test.describe("GET /api/admin/comments 评论列表", () => {
+  test("API 契约", async ({ request }) => {
     await assertApiContract(request, { routePath: BASE });
   });
 
-  test("unauthenticated request returns 401", async ({ request }) => {
+  test("未认证请求返回 401", async ({ request }) => {
     const response = await request.get(BASE);
     expect(response.status()).toBe(401);
   });
 
-  test("non-admin authenticated user returns 401", async ({ page }) => {
+  test("非管理员认证用户返回 401", async ({ page }) => {
     await signInAsDebugUser(page, "/");
     const response = await page.request.get(BASE);
     expect(response.status()).toBe(401);
   });
 
-  test("admin can filter comments by status=softbanned", async ({ page }) => {
+  test("管理员可按 status=softbanned 筛选评论", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
     const response = await page.request.get(`${BASE}?status=softbanned`);
     expect(response.status()).toBe(200);
@@ -45,9 +45,7 @@ test.describe("GET /api/admin/comments", () => {
     );
   });
 
-  test("admin can list active comments without status filter", async ({
-    page,
-  }) => {
+  test("管理员可无状态筛选列出活跃评论", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
     const response = await page.request.get(`${BASE}?limit=5`);
     expect(response.status()).toBe(200);

--- a/tests/e2e/src/app/api/admin/descriptions/[id]/test.ts
+++ b/tests/e2e/src/app/api/admin/descriptions/[id]/test.ts
@@ -20,19 +20,19 @@ import { assertApiContract } from "../../../../_shared/api-contract";
 
 const BASE = "/api/admin/descriptions";
 
-test.describe("PATCH /api/admin/descriptions/[id]", () => {
-  test("api contract", async ({ request }) => {
+test.describe("PATCH /api/admin/descriptions/[id] 课程简介管理", () => {
+  test("API 契约", async ({ request }) => {
     await assertApiContract(request, { routePath: `${BASE}/[id]` });
   });
 
-  test("unauthenticated PATCH returns 401", async ({ request }) => {
+  test("未认证 PATCH 返回 401", async ({ request }) => {
     const response = await request.patch(`${BASE}/missing-id`, {
       data: { content: "should fail" },
     });
     expect(response.status()).toBe(401);
   });
 
-  test("non-admin PATCH returns 401", async ({ page }) => {
+  test("非管理员 PATCH 返回 401", async ({ page }) => {
     await signInAsDebugUser(page, "/");
     const response = await page.request.patch(`${BASE}/missing-id`, {
       data: { content: "should fail" },
@@ -40,7 +40,7 @@ test.describe("PATCH /api/admin/descriptions/[id]", () => {
     expect(response.status()).toBe(401);
   });
 
-  test("admin can update and restore a description", async ({ page }) => {
+  test("管理员可更新并恢复课程简介", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
 
     const listResponse = await page.request.get(`${BASE}?limit=1`);
@@ -81,7 +81,7 @@ test.describe("PATCH /api/admin/descriptions/[id]", () => {
     }
   });
 
-  test("admin PATCH rejects overlong description content", async ({ page }) => {
+  test("管理员 PATCH 拒绝过长的课程简介内容", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
 
     const listResponse = await page.request.get(`${BASE}?limit=1`);

--- a/tests/e2e/src/app/api/admin/suspensions/[id]/test.ts
+++ b/tests/e2e/src/app/api/admin/suspensions/[id]/test.ts
@@ -22,25 +22,25 @@ import { assertApiContract } from "../../../../_shared/api-contract";
 
 const BASE = "/api/admin/suspensions";
 
-test.describe("PATCH /api/admin/suspensions/[id]", () => {
-  test("api contract", async ({ request }) => {
+test.describe("PATCH /api/admin/suspensions/[id] 解除封禁", () => {
+  test("API 契约", async ({ request }) => {
     await assertApiContract(request, {
       routePath: `${BASE}/[id]`,
     });
   });
 
-  test("unauthenticated PATCH returns 401", async ({ request }) => {
+  test("未认证 PATCH 返回 401", async ({ request }) => {
     const response = await request.patch(`${BASE}/nonexistent-id`);
     expect(response.status()).toBe(401);
   });
 
-  test("non-admin PATCH returns 401", async ({ page }) => {
+  test("非管理员 PATCH 返回 401", async ({ page }) => {
     await signInAsDebugUser(page, "/");
     const response = await page.request.patch(`${BASE}/nonexistent-id`);
     expect(response.status()).toBe(401);
   });
 
-  test("admin can lift a temporary suspension", async ({ page }) => {
+  test("管理员可解除临时封禁", async ({ page }) => {
     const prefix = `e2e-lift-sus-${Date.now()}`;
     const { usernames } = await createTempUsersFixture({ prefix, count: 1 });
     await signInAsDevAdmin(page, "/admin");

--- a/tests/e2e/src/app/api/admin/suspensions/test.ts
+++ b/tests/e2e/src/app/api/admin/suspensions/test.ts
@@ -21,30 +21,30 @@ import { assertApiContract } from "../../../_shared/api-contract";
 
 const BASE = "/api/admin/suspensions";
 
-test.describe("GET/POST /api/admin/suspensions", () => {
-  test("api contract", async ({ request }) => {
+test.describe("GET/POST /api/admin/suspensions 封禁管理", () => {
+  test("API 契约", async ({ request }) => {
     await assertApiContract(request, { routePath: BASE });
   });
 
-  test("unauthenticated GET returns 401", async ({ request }) => {
+  test("未认证 GET 返回 401", async ({ request }) => {
     const response = await request.get(BASE);
     expect(response.status()).toBe(401);
   });
 
-  test("unauthenticated POST returns 401", async ({ request }) => {
+  test("未认证 POST 返回 401", async ({ request }) => {
     const response = await request.post(BASE, {
       data: { userId: "fake-id", reason: "test" },
     });
     expect(response.status()).toBe(401);
   });
 
-  test("non-admin GET returns 401", async ({ page }) => {
+  test("非管理员 GET 返回 401", async ({ page }) => {
     await signInAsDebugUser(page, "/");
     const response = await page.request.get(BASE);
     expect(response.status()).toBe(401);
   });
 
-  test("admin can list suspensions and find seed record", async ({ page }) => {
+  test("管理员可列出封禁并找到 seed 记录", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
 
     const response = await page.request.get(BASE);
@@ -59,7 +59,7 @@ test.describe("GET/POST /api/admin/suspensions", () => {
     ).toBe(true);
   });
 
-  test("POST with nonexistent userId returns 404", async ({ page }) => {
+  test("POST 不存在的 userId 返回 404", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
 
     const response = await page.request.post(BASE, {
@@ -68,9 +68,7 @@ test.describe("GET/POST /api/admin/suspensions", () => {
     expect(response.status()).toBe(404);
   });
 
-  test("POST with invalid expiresAt returns 400 and creates no suspension", async ({
-    page,
-  }) => {
+  test("POST 无效 expiresAt 返回 400 且不创建封禁", async ({ page }) => {
     const prefix = `e2e-sus-invalid-${Date.now()}`;
     const { usernames } = await createTempUsersFixture({ prefix, count: 1 });
 
@@ -119,7 +117,7 @@ test.describe("GET/POST /api/admin/suspensions", () => {
     }
   });
 
-  test("admin can create a suspension for a temp user", async ({ page }) => {
+  test("管理员可为临时用户创建封禁", async ({ page }) => {
     const prefix = `e2e-sus-${Date.now()}`;
     const { usernames } = await createTempUsersFixture({ prefix, count: 1 });
 

--- a/tests/e2e/src/app/api/admin/users/[id]/test.ts
+++ b/tests/e2e/src/app/api/admin/users/[id]/test.ts
@@ -19,19 +19,19 @@ import { assertApiContract } from "../../../../_shared/api-contract";
 
 const BASE = "/api/admin/users";
 
-test.describe("PATCH /api/admin/users/[id]", () => {
-  test("api contract", async ({ request }) => {
+test.describe("PATCH /api/admin/users/[id] 用户更新", () => {
+  test("API 契约", async ({ request }) => {
     await assertApiContract(request, { routePath: `${BASE}/[id]` });
   });
 
-  test("unauthenticated PATCH returns 401", async ({ request }) => {
+  test("未认证 PATCH 返回 401", async ({ request }) => {
     const response = await request.patch(`${BASE}/nonexistent-id`, {
       data: { name: "test" },
     });
     expect(response.status()).toBe(401);
   });
 
-  test("non-admin PATCH returns 401", async ({ page }) => {
+  test("非管理员 PATCH 返回 401", async ({ page }) => {
     await signInAsDebugUser(page, "/");
     const response = await page.request.patch(`${BASE}/nonexistent-id`, {
       data: { name: "test" },
@@ -39,7 +39,7 @@ test.describe("PATCH /api/admin/users/[id]", () => {
     expect(response.status()).toBe(401);
   });
 
-  test("invalid username format returns 400", async ({ page }) => {
+  test("无效用户名格式返回 400", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
     const listResponse = await page.request.get(`${BASE}?limit=1`);
     expect(listResponse.status()).toBe(200);

--- a/tests/e2e/src/app/api/admin/users/test.ts
+++ b/tests/e2e/src/app/api/admin/users/test.ts
@@ -17,23 +17,23 @@ import { assertApiContract } from "../../../_shared/api-contract";
 
 const BASE = "/api/admin/users";
 
-test.describe("GET /api/admin/users", () => {
-  test("api contract", async ({ request }) => {
+test.describe("GET /api/admin/users 用户列表", () => {
+  test("API 契约", async ({ request }) => {
     await assertApiContract(request, { routePath: BASE });
   });
 
-  test("unauthenticated request returns 401", async ({ request }) => {
+  test("未认证请求返回 401", async ({ request }) => {
     const response = await request.get(BASE);
     expect(response.status()).toBe(401);
   });
 
-  test("non-admin authenticated user returns 401", async ({ page }) => {
+  test("非管理员认证用户返回 401", async ({ page }) => {
     await signInAsDebugUser(page, "/");
     const response = await page.request.get(BASE);
     expect(response.status()).toBe(401);
   });
 
-  test("admin can search seed users by username", async ({ page }) => {
+  test("管理员可按用户名搜索 seed 用户", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
     const response = await page.request.get(
       `${BASE}?search=${DEV_SEED.debugUsername}`,
@@ -59,7 +59,7 @@ test.describe("GET /api/admin/users", () => {
     expect(typeof body.pagination?.total).toBe("number");
   });
 
-  test("admin can paginate users with limit=1", async ({ page }) => {
+  test("管理员可使用 limit=1 分页用户", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
     const response = await page.request.get(`${BASE}?page=1&limit=1`);
     expect(response.status()).toBe(200);

--- a/tests/e2e/src/app/api/auth/[...auth]/test.ts
+++ b/tests/e2e/src/app/api/auth/[...auth]/test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 import { signInAsDebugUser, signInAsDevAdmin } from "../../../../../utils/auth";
 import { assertApiContract } from "../../../_shared/api-contract";
 
-test("/api/auth/[...auth]", async ({ request }) => {
+test("/api/auth/[...auth] 契约检查", async ({ request }) => {
   await assertApiContract(request, { routePath: "/api/auth/[...auth]" });
 });
 

--- a/tests/e2e/src/app/api/bus/test.ts
+++ b/tests/e2e/src/app/api/bus/test.ts
@@ -92,10 +92,8 @@ async function saveBusPreference(
   expect(response.status()).toBe(200);
 }
 
-test.describe("GET /api/bus", () => {
-  test("returns raw timetable data with both weekday and weekend trips", async ({
-    request,
-  }) => {
+test.describe("GET /api/bus 校车时刻表", () => {
+  test("返回原始时刻表数据，包含工作日和周末班次", async ({ request }) => {
     const response = await request.get(`${BASE}?${SEED_VERSION}`);
     expect(response.status()).toBe(200);
     const body = (await response.json()) as BusResponse;
@@ -119,9 +117,7 @@ test.describe("GET /api/bus", () => {
     expect(body.preferences).toBeNull();
   });
 
-  test("authenticated callers receive their saved bus preferences", async ({
-    page,
-  }) => {
+  test("已认证调用者收到保存的校车偏好", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     try {
@@ -152,9 +148,7 @@ test.describe("GET /api/bus", () => {
     }
   });
 
-  test("route 8 raw trip times match the seed timetable", async ({
-    request,
-  }) => {
+  test("路线 8 原始班次时间与 seed 时刻表一致", async ({ request }) => {
     const response = await request.get(`${BASE}?${SEED_VERSION}`);
     expect(response.status()).toBe(200);
     const body = (await response.json()) as BusResponse;
@@ -168,7 +162,7 @@ test.describe("GET /api/bus", () => {
     expect(route8WeekdayDepartures).toEqual(["06:50", "12:50", "21:20"]);
   });
 
-  test("route topology matches the seed data", async ({ request }) => {
+  test("路线拓扑与 seed 数据一致", async ({ request }) => {
     const response = await request.get(`${BASE}?${SEED_VERSION}`);
     expect(response.status()).toBe(200);
     const body = (await response.json()) as BusResponse;
@@ -184,7 +178,7 @@ test.describe("GET /api/bus", () => {
     expect(route7StopIds).toEqual([6, 5, 2, 1]);
   });
 
-  test("unknown versionKey returns 404", async ({ request }) => {
+  test("未知 versionKey 返回 404", async ({ request }) => {
     const response = await request.get(
       `${BASE}?versionKey=missing-bus-version`,
     );
@@ -192,14 +186,12 @@ test.describe("GET /api/bus", () => {
   });
 });
 
-test.describe("GET /api/bus/routes", () => {
-  test("contract", async ({ request }) => {
+test.describe("GET /api/bus/routes 路线发现", () => {
+  test("契约", async ({ request }) => {
     await assertApiContract(request, { routePath: ROUTES_BASE });
   });
 
-  test("returns concrete route variants for an origin/destination", async ({
-    request,
-  }) => {
+  test("返回起点到终点的具体路线变体", async ({ request }) => {
     const response = await request.get(
       `${ROUTES_BASE}?originCampusId=${DEV_SEED.bus.originCampusId}&destinationCampusId=${DEV_SEED.bus.destinationCampusId}&${SEED_VERSION}`,
     );
@@ -220,14 +212,12 @@ test.describe("GET /api/bus/routes", () => {
   });
 });
 
-test.describe("GET /api/bus/next", () => {
-  test("contract", async ({ request }) => {
+test.describe("GET /api/bus/next 下一班车", () => {
+  test("契约", async ({ request }) => {
     await assertApiContract(request, { routePath: NEXT_BASE });
   });
 
-  test("returns ranked next departures with status metadata", async ({
-    request,
-  }) => {
+  test("返回带状态元数据的排序下一班车", async ({ request }) => {
     const response = await request.get(
       `${NEXT_BASE}?originCampusId=${DEV_SEED.bus.originCampusId}&destinationCampusId=${DEV_SEED.bus.destinationCampusId}&atTime=${encodeURIComponent(DEV_SEED_ANCHOR.recommendedAtTime)}&dayType=weekday&includeDeparted=true&limit=1&${SEED_VERSION}`,
     );
@@ -248,21 +238,21 @@ test.describe("GET /api/bus/next", () => {
     );
   });
 
-  test("missing required campus IDs returns 400", async ({ request }) => {
+  test("缺少必需的校区 ID 返回 400", async ({ request }) => {
     const response = await request.get(NEXT_BASE);
     expect(response.status()).toBe(400);
   });
 });
 
-test.describe("/api/bus/preferences", () => {
+test.describe("/api/bus/preferences 校车偏好", () => {
   test.describe.configure({ mode: "serial" });
 
-  test("GET without auth returns 401", async ({ request }) => {
+  test("未认证 GET 返回 401", async ({ request }) => {
     const response = await request.get(PREF_BASE);
     expect(response.status()).toBe(401);
   });
 
-  test("POST without auth returns 401", async ({ request }) => {
+  test("未认证 POST 返回 401", async ({ request }) => {
     const response = await request.post(PREF_BASE, {
       data: {
         preferredOriginCampusId: 1,
@@ -273,9 +263,7 @@ test.describe("/api/bus/preferences", () => {
     expect(response.status()).toBe(401);
   });
 
-  test("authenticated GET returns the saved planner defaults", async ({
-    page,
-  }) => {
+  test("已认证 GET 返回保存的规划默认值", async ({ page }) => {
     await signInAsDebugUser(page, "/");
     const originalResponse = await page.request.get(PREF_BASE);
     expect(originalResponse.status()).toBe(200);
@@ -306,9 +294,7 @@ test.describe("/api/bus/preferences", () => {
     }
   });
 
-  test("POST saves planner defaults and GET reads them back", async ({
-    page,
-  }) => {
+  test("POST 保存规划默认值且 GET 可读取", async ({ page }) => {
     await signInAsDebugUser(page, "/");
     const originalResponse = await page.request.get(PREF_BASE);
     expect(originalResponse.status()).toBe(200);
@@ -345,7 +331,7 @@ test.describe("/api/bus/preferences", () => {
     }
   });
 
-  test("POST with invalid body returns 400", async ({ page }) => {
+  test("POST 无效请求体返回 400", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.post(PREF_BASE, {

--- a/tests/e2e/src/app/api/calendar-subscriptions/current/test.ts
+++ b/tests/e2e/src/app/api/calendar-subscriptions/current/test.ts
@@ -23,21 +23,19 @@ import { assertApiContract } from "../../../_shared/api-contract";
 
 const BASE = "/api/calendar-subscriptions/current";
 
-test.describe("GET /api/calendar-subscriptions/current", () => {
+test.describe("GET /api/calendar-subscriptions/current 接口", () => {
   test.describe.configure({ mode: "serial" });
 
-  test("contract", async ({ request }) => {
+  test("接口契约", async ({ request }) => {
     await assertApiContract(request, { routePath: BASE });
   });
 
-  test("returns 401 when not authenticated", async ({ request }) => {
+  test("未登录时返回 401", async ({ request }) => {
     const response = await request.get(BASE);
     expect(response.status()).toBe(401);
   });
 
-  test("returns subscription with seed section for authenticated user", async ({
-    page,
-  }) => {
+  test("登录用户返回包含 seed 课程的订阅", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     // Resolve seed section ID
@@ -83,7 +81,7 @@ test.describe("GET /api/calendar-subscriptions/current", () => {
     expect(sub.calendarUrl as string).not.toContain("/api/auth/api/users/");
   });
 
-  test("reflects changes made via POST", async ({ page }) => {
+  test("反映 POST 修改后的状态", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     // Save original state

--- a/tests/e2e/src/app/api/calendar-subscriptions/test.ts
+++ b/tests/e2e/src/app/api/calendar-subscriptions/test.ts
@@ -33,54 +33,46 @@ import { assertApiContract } from "../../_shared/api-contract";
 const BASE = "/api/calendar-subscriptions";
 const IMPORT_BASE = "/api/calendar-subscriptions/import-codes";
 
-test.describe("calendar subscription API", () => {
+test.describe("日历订阅 API", () => {
   test.describe.configure({ mode: "serial" });
 
-  test("contract", async ({ request }) => {
+  test("接口契约", async ({ request }) => {
     await assertApiContract(request, { routePath: BASE });
   });
 
-  test("import-codes contract", async ({ request }) => {
+  test("import-codes 接口契约", async ({ request }) => {
     await assertApiContract(request, { routePath: IMPORT_BASE });
   });
 
-  test("returns 401 when not authenticated", async ({ request }) => {
+  test("未登录时返回 401", async ({ request }) => {
     const response = await request.post(BASE, {
       data: { sectionIds: [1] },
     });
     expect(response.status()).toBe(401);
   });
 
-  test("import-codes returns 401 when not authenticated", async ({
-    request,
-  }) => {
+  test("import-codes 未登录时返回 401", async ({ request }) => {
     const response = await request.post(IMPORT_BASE, {
       data: { codes: [DEV_SEED.section.code] },
     });
     expect(response.status()).toBe(401);
   });
 
-  test("append sections returns 401 when not authenticated", async ({
-    request,
-  }) => {
+  test("append sections 未登录时返回 401", async ({ request }) => {
     const response = await request.patch(BASE, {
       data: { sectionIds: [1] },
     });
     expect(response.status()).toBe(401);
   });
 
-  test("remove sections returns 401 when not authenticated", async ({
-    request,
-  }) => {
+  test("remove sections 未登录时返回 401", async ({ request }) => {
     const response = await request.delete(BASE, {
       data: { sectionIds: [1] },
     });
     expect(response.status()).toBe(401);
   });
 
-  test("append sections returns 400 for malformed section ids", async ({
-    page,
-  }) => {
+  test("append sections 格式错误的 section id 返回 400", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.patch(BASE, {
@@ -90,9 +82,7 @@ test.describe("calendar subscription API", () => {
     expect(response.status()).toBe(400);
   });
 
-  test("remove sections returns 400 for malformed section ids", async ({
-    page,
-  }) => {
+  test("remove sections 格式错误的 section id 返回 400", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.delete(BASE, {
@@ -102,9 +92,7 @@ test.describe("calendar subscription API", () => {
     expect(response.status()).toBe(400);
   });
 
-  test("import-codes appends matched section codes and reports repeats", async ({
-    page,
-  }) => {
+  test("import-codes 追加匹配的课程代码并报告重复", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const currentRes = await page.request.get(
@@ -166,9 +154,7 @@ test.describe("calendar subscription API", () => {
     }
   });
 
-  test("append sections adds selected ids without replacing existing subscriptions", async ({
-    page,
-  }) => {
+  test("append sections 添加指定 id 且不替换已有订阅", async ({ page }) => {
     await signInAsDebugUser(page, "/");
     const [firstSection, secondSection] = await resolveSeedSectionMatches(page);
     expect(firstSection?.id).toBeDefined();
@@ -223,9 +209,7 @@ test.describe("calendar subscription API", () => {
     }
   });
 
-  test("remove sections deletes selected ids without replacing concurrent additions", async ({
-    page,
-  }) => {
+  test("remove sections 删除指定 id 且不替换并发添加", async ({ page }) => {
     await signInAsDebugUser(page, "/");
     const [firstSection, secondSection] = await resolveSeedSectionMatches(page);
     expect(firstSection?.id).toBeDefined();
@@ -265,9 +249,7 @@ test.describe("calendar subscription API", () => {
     }
   });
 
-  test("subscribes to seed section and returns correct shape", async ({
-    page,
-  }) => {
+  test("订阅 seed 课程并返回正确结构", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const matchRes = await page.request.post("/api/sections/match-codes", {
@@ -320,7 +302,7 @@ test.describe("calendar subscription API", () => {
     }
   });
 
-  test("omitting sectionIds clears subscriptions", async ({ page }) => {
+  test("省略 sectionIds 清空订阅", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     // Save current subscriptions for restoration
@@ -348,7 +330,7 @@ test.describe("calendar subscription API", () => {
     }
   });
 
-  test("non-existent section IDs are silently dropped", async ({ page }) => {
+  test("不存在的 section ID 被静默忽略", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const matchRes = await page.request.post("/api/sections/match-codes", {
@@ -398,7 +380,7 @@ test.describe("calendar subscription API", () => {
     }
   });
 
-  test("returns 400 for malformed body", async ({ page }) => {
+  test("格式错误的请求体返回 400", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.post(BASE, {

--- a/tests/e2e/src/app/api/comments/[id]/reactions/test.ts
+++ b/tests/e2e/src/app/api/comments/[id]/reactions/test.ts
@@ -64,7 +64,7 @@ async function findSeedCommentId(
   return seed!.id!;
 }
 
-test("/api/comments/[id]/reactions", async ({ request }) => {
+test("/api/comments/[id]/reactions 接口契约", async ({ request }) => {
   await assertApiContract(request, {
     routePath: "/api/comments/[id]/reactions",
   });
@@ -148,7 +148,7 @@ test("/api/comments/[id]/reactions POST 不存在的评论返回 404", async ({
   expect(response.status()).toBe(404);
 });
 
-test("/api/comments/[id]/reactions POST refuses inactive comments", async ({
+test("/api/comments/[id]/reactions POST 对失效评论返回 403", async ({
   page,
 }) => {
   await signInAsDebugUser(page, "/");
@@ -203,7 +203,7 @@ test("/api/comments/[id]/reactions POST refuses inactive comments", async ({
   }
 });
 
-test("/api/comments/[id]/reactions DELETE refuses inactive comments", async ({
+test("/api/comments/[id]/reactions DELETE 对失效评论返回 403", async ({
   page,
 }) => {
   await signInAsDebugUser(page, "/");

--- a/tests/e2e/src/app/api/comments/[id]/test.ts
+++ b/tests/e2e/src/app/api/comments/[id]/test.ts
@@ -68,7 +68,7 @@ async function findSeedCommentId(
   return seed!.id!;
 }
 
-test("/api/comments/[id]", async ({ request }) => {
+test("/api/comments/[id] 接口契约", async ({ request }) => {
   await assertApiContract(request, { routePath: "/api/comments/[id]" });
 });
 
@@ -109,7 +109,7 @@ test("/api/comments/[id] GET 不存在的 ID 返回 404", async ({ request }) =>
   expect(response.status()).toBe(404);
 });
 
-test("/api/comments/[id] GET hidden focused thread returns 403", async ({
+test("/api/comments/[id] GET 隐藏聚焦线程返回 403", async ({
   page,
   request,
 }) => {
@@ -155,9 +155,7 @@ test("/api/comments/[id] DELETE 未登录返回 401", async ({ request }) => {
   expect(response.status()).toBe(401);
 });
 
-test("/api/comments/[id] PATCH rejects anonymous visibility", async ({
-  page,
-}) => {
+test("/api/comments/[id] PATCH 拒绝匿名可见性", async ({ page }) => {
   await signInAsDebugUser(page, "/");
   const sectionId = await resolveSeedSectionId(page.request);
   const content = `e2e-reject-edit-anonymous-visibility-${Date.now()}`;
@@ -249,9 +247,7 @@ test("/api/comments/[id] PATCH 可修改评论并 DELETE 清理", async ({ page 
   }
 });
 
-test("/api/comments/[id] PATCH rejects admin when admin is not owner", async ({
-  browser,
-}) => {
+test("/api/comments/[id] PATCH 非所有者管理员被拒绝", async ({ browser }) => {
   const debugContext = await browser.newContext();
   const debugPage = await debugContext.newPage();
   const adminContext = await browser.newContext();
@@ -294,7 +290,7 @@ test("/api/comments/[id] PATCH rejects admin when admin is not owner", async ({
   }
 });
 
-test("/api/comments/[id] PATCH rejects an upload attached to another comment", async ({
+test("/api/comments/[id] PATCH 拒绝绑定到其他评论的上传文件", async ({
   page,
 }) => {
   await signInAsDebugUser(page, "/");
@@ -355,7 +351,7 @@ test("/api/comments/[id] PATCH rejects an upload attached to another comment", a
   }
 });
 
-test("/api/comments/[id] PATCH refuses inactive comments", async ({ page }) => {
+test("/api/comments/[id] PATCH 对失效评论返回 403", async ({ page }) => {
   await signInAsDebugUser(page, "/");
   const sectionId = await resolveSeedSectionId(page.request);
 

--- a/tests/e2e/src/app/api/comments/test.ts
+++ b/tests/e2e/src/app/api/comments/test.ts
@@ -129,7 +129,7 @@ async function resolveSeedSectionId(
   return section!.id!;
 }
 
-test("/api/comments", async ({ request }) => {
+test("/api/comments 接口契约", async ({ request }) => {
   await assertApiContract(request, { routePath: "/api/comments" });
 });
 
@@ -158,7 +158,7 @@ test("/api/comments GET 返回 section 目标与 seed 评论", async ({ request 
   ).toBe(true);
 });
 
-test("/api/comments GET accepts public section JW id", async ({ request }) => {
+test("/api/comments GET 接受公开 section JW id", async ({ request }) => {
   const response = await request.get(
     `/api/comments?targetType=section&sectionJwId=${DEV_SEED.section.jwId}`,
   );
@@ -268,7 +268,7 @@ test("/api/comments POST 未登录返回 401", async ({ request }) => {
   expect(response.status()).toBe(401);
 });
 
-test("/api/comments POST rejects anonymous visibility", async ({ page }) => {
+test("/api/comments POST 拒绝匿名可见性", async ({ page }) => {
   await signInAsDebugUser(page, "/");
   const sectionId = await resolveSeedSectionId(page.request);
   const content = `e2e-reject-anonymous-visibility-${Date.now()}`;
@@ -331,7 +331,7 @@ test("/api/comments POST 登录后可发布新评论并清理", async ({ page })
   }
 });
 
-test("/api/comments POST accepts public section JW id", async ({ page }) => {
+test("/api/comments POST 接受公开 section JW id", async ({ page }) => {
   await signInAsDebugUser(page, "/");
 
   const content = `e2e-create-comment-section-jwid-${Date.now()}`;
@@ -365,7 +365,7 @@ test("/api/comments POST accepts public section JW id", async ({ page }) => {
   }
 });
 
-test("/api/comments POST rejects malformed public section JW id with fallback targetId", async ({
+test("/api/comments POST 拒绝格式错误的公开 section JW id 并回退 targetId", async ({
   page,
 }) => {
   await signInAsDebugUser(page, "/");
@@ -395,9 +395,7 @@ test("/api/comments POST rejects malformed public section JW id with fallback ta
   expect(created).toBeNull();
 });
 
-test("/api/comments POST rejects reusing an uploaded attachment", async ({
-  page,
-}) => {
+test("/api/comments POST 拒绝复用已上传附件", async ({ page }) => {
   await signInAsDebugUser(page, "/");
   const sectionId = await resolveSeedSectionId(page.request);
   const marker = `e2e-upload-reuse-${Date.now()}`;
@@ -499,9 +497,7 @@ test("/api/comments POST 可创建回复评论", async ({ page }) => {
   }
 });
 
-test("/api/comments POST refuses replies to inactive parent comments", async ({
-  page,
-}) => {
+test("/api/comments POST 拒绝对失效父评论回复", async ({ page }) => {
   await signInAsDebugUser(page, "/");
   const sectionId = await resolveSeedSectionId(page.request);
 

--- a/tests/e2e/src/app/api/courses/test.ts
+++ b/tests/e2e/src/app/api/courses/test.ts
@@ -24,16 +24,16 @@ import { expect, test } from "@playwright/test";
 import { DEV_SEED } from "../../../../utils/dev-seed";
 import { assertApiContract } from "../../_shared/api-contract";
 
-test.describe("GET /api/courses", () => {
-  test("contract", async ({ request }) => {
+test.describe("GET /api/courses 接口", () => {
+  test("接口契约", async ({ request }) => {
     await assertApiContract(request, { routePath: "/api/courses" });
   });
 
-  test("detail contract", async ({ request }) => {
+  test("详情接口契约", async ({ request }) => {
     await assertApiContract(request, { routePath: "/api/courses/[jwId]" });
   });
 
-  test("returns paginated response shape", async ({ request }) => {
+  test("返回分页响应结构", async ({ request }) => {
     const response = await request.get("/api/courses");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -54,7 +54,7 @@ test.describe("GET /api/courses", () => {
     expect(body.pagination?.totalPages).toBeGreaterThanOrEqual(1);
   });
 
-  test("search by course code returns seed course", async ({ request }) => {
+  test("按课程代码搜索返回 seed 课程", async ({ request }) => {
     const response = await request.get(
       `/api/courses?search=${encodeURIComponent(DEV_SEED.course.code)}`,
     );
@@ -70,7 +70,7 @@ test.describe("GET /api/courses", () => {
     expect(course?.nameCn).toBe(DEV_SEED.course.nameCn);
   });
 
-  test("search by Chinese name returns seed course", async ({ request }) => {
+  test("按中文名搜索返回 seed 课程", async ({ request }) => {
     const response = await request.get(
       `/api/courses?search=${encodeURIComponent(DEV_SEED.course.nameCn)}`,
     );
@@ -83,7 +83,7 @@ test.describe("GET /api/courses", () => {
     );
   });
 
-  test("non-matching search returns empty data", async ({ request }) => {
+  test("无匹配搜索返回空数据", async ({ request }) => {
     const response = await request.get(
       "/api/courses?search=ZZZZZ_NONEXISTENT_COURSE_99999",
     );
@@ -97,7 +97,7 @@ test.describe("GET /api/courses", () => {
     expect(body.pagination?.totalPages).toBe(1);
   });
 
-  test("course list items have all required fields", async ({ request }) => {
+  test("课程列表项包含所有必填字段", async ({ request }) => {
     const response = await request.get(
       `/api/courses?search=${encodeURIComponent(DEV_SEED.course.code)}`,
     );
@@ -128,7 +128,7 @@ test.describe("GET /api/courses", () => {
     expect(Object.hasOwn(course as object, "classType")).toBe(true);
   });
 
-  test("page param navigates results", async ({ request }) => {
+  test("page 参数切换结果页", async ({ request }) => {
     const response = await request.get("/api/courses?page=1");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -137,7 +137,7 @@ test.describe("GET /api/courses", () => {
     expect(body.pagination?.page).toBe(1);
   });
 
-  test("limit param controls page size", async ({ request }) => {
+  test("limit 参数控制分页大小", async ({ request }) => {
     const response = await request.get("/api/courses?limit=1");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -148,9 +148,7 @@ test.describe("GET /api/courses", () => {
     expect(body.pagination?.pageSize).toBe(1);
   });
 
-  test("detail route returns seed course with sections", async ({
-    request,
-  }) => {
+  test("详情路由返回 seed 课程及其开课班", async ({ request }) => {
     const response = await request.get(`/api/courses/${DEV_SEED.course.jwId}`);
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {

--- a/tests/e2e/src/app/api/dashboard-links/pin/test.ts
+++ b/tests/e2e/src/app/api/dashboard-links/pin/test.ts
@@ -38,8 +38,8 @@ type PinResponse = {
   error?: string | null;
 };
 
-test.describe("POST /api/dashboard-links/pin", () => {
-  test("returns 401 JSON when not authenticated", async ({ request }) => {
+test.describe("POST /api/dashboard-links/pin 接口", () => {
+  test("未登录时返回 401 JSON", async ({ request }) => {
     const response = await request.post(BASE, {
       form: { slug: "jw", action: "pin", returnTo: "/" },
       headers: JSON_HEADERS,
@@ -50,9 +50,7 @@ test.describe("POST /api/dashboard-links/pin", () => {
     expect(body.maxPinnedLinks).toBe(MAX_PINNED_LINKS);
   });
 
-  test("redirects when not authenticated in non-JSON mode", async ({
-    request,
-  }) => {
+  test("非 JSON 模式未登录时重定向", async ({ request }) => {
     const response = await request.post(BASE, {
       form: { slug: "jw", action: "pin", returnTo: "/?tab=links" },
       maxRedirects: 0,
@@ -60,7 +58,7 @@ test.describe("POST /api/dashboard-links/pin", () => {
     expect(response.status()).toBe(303);
   });
 
-  test("returns 400 JSON for missing slug", async ({ page }) => {
+  test("缺少 slug 时返回 400 JSON", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.post(BASE, {
@@ -70,7 +68,7 @@ test.describe("POST /api/dashboard-links/pin", () => {
     expect(response.status()).toBe(400);
   });
 
-  test("pin and unpin a link", async ({ page }) => {
+  test("置顶并取消置顶链接", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     // Use a less common slug to minimize interference with seeded state
@@ -110,7 +108,7 @@ test.describe("POST /api/dashboard-links/pin", () => {
     }
   });
 
-  test("unknown slug returns 200 with empty pinnedSlugs in JSON mode", async ({
+  test("未知 slug 在 JSON 模式下返回 200 且 pinnedSlugs 为空", async ({
     page,
   }) => {
     await signInAsDebugUser(page, "/");
@@ -124,7 +122,7 @@ test.describe("POST /api/dashboard-links/pin", () => {
     expect(body.maxPinnedLinks).toBe(MAX_PINNED_LINKS);
   });
 
-  test("redirect mode returns 303 for authenticated user", async ({ page }) => {
+  test("重定向模式下登录用户返回 303", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.post(BASE, {

--- a/tests/e2e/src/app/api/dashboard-links/visit/test.ts
+++ b/tests/e2e/src/app/api/dashboard-links/visit/test.ts
@@ -29,8 +29,8 @@ import { signInAsDebugUser } from "../../../../../utils/auth";
 
 const BASE = "/api/dashboard-links/visit";
 
-test.describe("GET & POST /api/dashboard-links/visit", () => {
-  test("GET redirects to target link URL", async ({ request }) => {
+test.describe("GET & POST /api/dashboard-links/visit 接口", () => {
+  test("GET 重定向到目标链接 URL", async ({ request }) => {
     const response = await request.get(`${BASE}?slug=jw`, {
       maxRedirects: 0,
     });
@@ -38,7 +38,7 @@ test.describe("GET & POST /api/dashboard-links/visit", () => {
     expect(response.headers().location).toBe("https://jw.ustc.edu.cn/");
   });
 
-  test("GET with invalid slug redirects to /", async ({ request }) => {
+  test("GET 无效 slug 重定向到 /", async ({ request }) => {
     const response = await request.get(`${BASE}?slug=nonexistent-e2e`, {
       maxRedirects: 0,
     });
@@ -46,7 +46,7 @@ test.describe("GET & POST /api/dashboard-links/visit", () => {
     expect(response.headers().location).toMatch(/\/$/);
   });
 
-  test("GET without slug redirects to /", async ({ request }) => {
+  test("GET 缺少 slug 重定向到 /", async ({ request }) => {
     const response = await request.get(BASE, {
       maxRedirects: 0,
     });
@@ -54,7 +54,7 @@ test.describe("GET & POST /api/dashboard-links/visit", () => {
     expect(response.headers().location).toMatch(/\/$/);
   });
 
-  test("POST with valid slug redirects to target URL", async ({ page }) => {
+  test("POST 有效 slug 重定向到目标 URL", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.post(BASE, {
@@ -65,7 +65,7 @@ test.describe("GET & POST /api/dashboard-links/visit", () => {
     expect(response.headers().location).toBe("https://jw.ustc.edu.cn/");
   });
 
-  test("POST with invalid slug redirects to /", async ({ page }) => {
+  test("POST 无效 slug 重定向到 /", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.post(BASE, {
@@ -76,7 +76,7 @@ test.describe("GET & POST /api/dashboard-links/visit", () => {
     expect(response.headers().location).toMatch(/\/$/);
   });
 
-  test("POST without auth still redirects", async ({ request }) => {
+  test("POST 未登录仍重定向", async ({ request }) => {
     const response = await request.post(BASE, {
       form: { slug: "jw" },
       maxRedirects: 0,

--- a/tests/e2e/src/app/api/descriptions/test.ts
+++ b/tests/e2e/src/app/api/descriptions/test.ts
@@ -139,7 +139,7 @@ async function resolveSeedSectionId(
   return section!.id!;
 }
 
-test("/api/descriptions", async ({ request }) => {
+test("/api/descriptions 接口契约", async ({ request }) => {
   await assertApiContract(request, { routePath: "/api/descriptions" });
 });
 
@@ -161,9 +161,7 @@ test("/api/descriptions GET 返回 seed 描述内容", async ({ request }) => {
   expect(body.viewer).toBeDefined();
 });
 
-test("/api/descriptions GET accepts public section JW id", async ({
-  request,
-}) => {
+test("/api/descriptions GET 接受公开 section JW id", async ({ request }) => {
   const response = await request.get(
     `/api/descriptions?targetType=section&sectionJwId=${DEV_SEED.section.jwId}`,
   );
@@ -281,7 +279,7 @@ test("/api/descriptions POST 登录后可更新描述并清理", async ({
   }
 });
 
-test("/api/descriptions POST accepts public section JW id", async ({
+test("/api/descriptions POST 接受公开 section JW id", async ({
   page,
 }, testInfo) => {
   await signInAsDebugUser(page, "/");

--- a/tests/e2e/src/app/api/docs/test.ts
+++ b/tests/e2e/src/app/api/docs/test.ts
@@ -5,22 +5,22 @@ import { expect, test } from "@playwright/test";
 import { gotoAndWaitForReady } from "../../../../utils/page-ready";
 import { assertPageContract } from "../../_shared/page-contract";
 
-test.describe("/api/docs", () => {
-  test("contract", async ({ page }, testInfo) => {
+test.describe("/api/docs 页面", () => {
+  test("接口契约", async ({ page }, testInfo) => {
     await assertPageContract(page, {
       routePath: "/api/docs/tag/sections",
       testInfo,
     });
   });
 
-  test("renders API reference container", async ({ page }) => {
+  test("渲染 API 参考容器", async ({ page }) => {
     await gotoAndWaitForReady(page, "/api/docs/tag/sections", {
       waitUntil: "load",
     });
     await expect(page.locator("#api-reference")).toBeVisible();
   });
 
-  test("uses path navigation instead of hash navigation", async ({ page }) => {
+  test("使用路径导航而非哈希导航", async ({ page }) => {
     await gotoAndWaitForReady(page, "/api/docs/tag/sections", {
       waitUntil: "load",
     });
@@ -32,14 +32,14 @@ test.describe("/api/docs", () => {
     );
   });
 
-  test("redirects root to first route group", async ({ page }) => {
+  test("根路径重定向到第一个路由分组", async ({ page }) => {
     await page.goto("/api/docs");
     await expect(page).toHaveURL(/\/api\/docs\/tag\/sections$/);
   });
 });
 
-test.describe("/api-docs", () => {
-  test("redirects to /api/docs", async ({ page }) => {
+test.describe("/api-docs 页面", () => {
+  test("重定向到 /api/docs", async ({ page }) => {
     await page.goto("/api-docs");
     await expect(page).toHaveURL(/\/api\/docs\/tag\/sections$/);
   });

--- a/tests/e2e/src/app/api/homeworks/[id]/completion/test.ts
+++ b/tests/e2e/src/app/api/homeworks/[id]/completion/test.ts
@@ -63,7 +63,7 @@ async function findSeedHomeworkId(
   return hw!.id!;
 }
 
-test("/api/homeworks/[id]/completion", async ({ request }) => {
+test("/api/homeworks/[id]/completion 接口契约", async ({ request }) => {
   await assertApiContract(request, {
     routePath: "/api/homeworks/[id]/completion",
   });

--- a/tests/e2e/src/app/api/homeworks/[id]/test.ts
+++ b/tests/e2e/src/app/api/homeworks/[id]/test.ts
@@ -70,7 +70,7 @@ async function createTempHomework(
   return { id: body.id, title };
 }
 
-test("/api/homeworks/[id]", async ({ request }) => {
+test("/api/homeworks/[id] 接口契约", async ({ request }) => {
   await assertApiContract(request, { routePath: "/api/homeworks/[id]" });
 });
 

--- a/tests/e2e/src/app/api/homeworks/completions/test.ts
+++ b/tests/e2e/src/app/api/homeworks/completions/test.ts
@@ -58,7 +58,7 @@ async function createTempHomework(
   return homework!.id!;
 }
 
-test("/api/homeworks/completions", async ({ request }) => {
+test("/api/homeworks/completions 接口契约", async ({ request }) => {
   await assertApiContract(request, {
     routePath: "/api/homeworks/completions",
   });

--- a/tests/e2e/src/app/api/homeworks/test.ts
+++ b/tests/e2e/src/app/api/homeworks/test.ts
@@ -42,7 +42,7 @@ async function resolveSeedSectionId(
   return section!.id!;
 }
 
-test("/api/homeworks", async ({ request }) => {
+test("/api/homeworks 接口契约", async ({ request }) => {
   await assertApiContract(request, { routePath: "/api/homeworks" });
 });
 

--- a/tests/e2e/src/app/api/locale/test.ts
+++ b/tests/e2e/src/app/api/locale/test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { assertApiContract } from "../../_shared/api-contract";
 
-test("/api/locale", async ({ request, baseURL }) => {
+test("/api/locale 接口契约", async ({ request, baseURL }) => {
   await assertApiContract(request, { routePath: "/api/locale", baseURL });
 });
 

--- a/tests/e2e/src/app/api/mcp/oauth-tokens.test.ts
+++ b/tests/e2e/src/app/api/mcp/oauth-tokens.test.ts
@@ -14,10 +14,10 @@ import {
   MCP_CLIENT_SCOPES,
 } from "./helpers";
 
-test.describe("/api/mcp - OAuth token resource binding", () => {
+test.describe("/api/mcp - OAuth token 资源绑定", () => {
   test.describe.configure({ mode: "serial" });
 
-  test("opaque access token (no resource on token exchange) is rejected by /api/mcp", async ({
+  test("不透明 access token（token exchange 未带 resource）被 /api/mcp 拒绝", async ({
     page,
     request,
   }) => {
@@ -64,7 +64,7 @@ test.describe("/api/mcp - OAuth token resource binding", () => {
     await expect(response.json()).resolves.toEqual({ error: "invalid_token" });
   });
 
-  test("opaque MCP access token is rejected by protected REST routes", async ({
+  test("不透明 MCP access token 被受保护 REST 路由拒绝", async ({
     page,
     request,
   }) => {
@@ -89,7 +89,7 @@ test.describe("/api/mcp - OAuth token resource binding", () => {
     expect(response.status()).toBe(401);
   });
 
-  test("MCP refresh token without resource refreshes to a usable MCP access token", async ({
+  test("无 resource 的 MCP refresh token 可刷新为可用的 MCP access token", async ({
     page,
     request,
   }) => {
@@ -144,7 +144,7 @@ test.describe("/api/mcp - OAuth token resource binding", () => {
     expect(response.status()).toBe(200);
   });
 
-  test("resource-less MCP refresh token cannot omit resource to mint an MCP access token", async ({
+  test("无 resource 的 MCP refresh token 不能省略 resource 来签发 MCP access token", async ({
     page,
     request,
   }) => {
@@ -179,7 +179,7 @@ test.describe("/api/mcp - OAuth token resource binding", () => {
     );
   });
 
-  test("REST-only refresh token cannot omit resource to mint an MCP access token", async ({
+  test("仅 REST 的 refresh token 不能省略 resource 来签发 MCP access token", async ({
     page,
     request,
   }) => {

--- a/tests/e2e/src/app/api/mcp/seeded-tools.test.ts
+++ b/tests/e2e/src/app/api/mcp/seeded-tools.test.ts
@@ -11,10 +11,10 @@ import {
   saveBusPreference,
 } from "./helpers";
 
-test.describe("/api/mcp - seeded tool coverage", () => {
+test.describe("/api/mcp - 种子工具覆盖", () => {
   test.describe.configure({ mode: "serial" });
 
-  test("OAuth PKCE token can connect to /api/mcp and call all seeded tools", async ({
+  test("OAuth PKCE token 可连接 /api/mcp 并调用全部种子工具", async ({
     page,
     request,
   }) => {

--- a/tests/e2e/src/app/api/mcp/transport.test.ts
+++ b/tests/e2e/src/app/api/mcp/transport.test.ts
@@ -14,7 +14,7 @@ import {
   TRUSTED_BROWSER_ORIGIN,
 } from "./helpers";
 
-test.describe("/api/mcp - transport and authorization", () => {
+test.describe("/api/mcp - 传输与授权", () => {
   test.describe.configure({ mode: "serial" });
 
   test("/api/mcp 未认证时返回 OAuth bearer challenge", async ({ request }) => {

--- a/tests/e2e/src/app/api/me/overview/test.ts
+++ b/tests/e2e/src/app/api/me/overview/test.ts
@@ -14,17 +14,17 @@ const BASE = "/api/me/overview";
 const PAST_SAME_DAY_EXAM_JW_ID = 88_051_001;
 const UNKNOWN_DATE_EXAM_JW_ID = 88_051_002;
 
-test.describe("GET /api/me/overview", () => {
-  test("contract", async ({ request }) => {
+test.describe("GET /api/me/overview - 个人概览", () => {
+  test("契约", async ({ request }) => {
     await assertApiContract(request, { routePath: BASE });
   });
 
-  test("returns 401 when not authenticated", async ({ request }) => {
+  test("未认证时返回 401", async ({ request }) => {
     const response = await request.get(BASE);
     expect(response.status()).toBe(401);
   });
 
-  test("returns compact counts and top items", async ({ page }) => {
+  test("返回精简计数与置顶项", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.get(
@@ -79,7 +79,7 @@ test.describe("GET /api/me/overview", () => {
     expect((body.exams?.items?.length ?? 0) > 0).toBe(true);
   });
 
-  test("excludes same-day exams that already ended", async ({ page }) => {
+  test("排除已结束的当日考试", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const atTime = "2026-04-29T12:00:00+08:00";
@@ -142,7 +142,7 @@ test.describe("GET /api/me/overview", () => {
     }
   });
 
-  test("excludes date-unknown exams from upcoming counts", async ({ page }) => {
+  test("upcoming 计数排除日期未知的考试", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const url = `${BASE}?atTime=${encodeURIComponent(DEV_SEED.seedAnchorAtTime)}&limit=30`;
@@ -204,7 +204,7 @@ test.describe("GET /api/me/overview", () => {
     }
   });
 
-  test("treats date-only atTime as Shanghai day start", async ({ page }) => {
+  test("仅日期的 atTime 视为上海当天起始", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.get(
@@ -218,7 +218,7 @@ test.describe("GET /api/me/overview", () => {
     expect(body.anchor?.atTime).toBe(DEV_SEED.seedAnchorAtTime);
   });
 
-  test("invalid atTime returns 400", async ({ page }) => {
+  test("无效 atTime 返回 400", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.get(`${BASE}?atTime=not-a-date`);

--- a/tests/e2e/src/app/api/me/subscriptions/schedules/test.ts
+++ b/tests/e2e/src/app/api/me/subscriptions/schedules/test.ts
@@ -11,19 +11,17 @@ import { assertApiContract } from "../../../../_shared/api-contract";
 
 const BASE = "/api/me/subscriptions/schedules";
 
-test.describe("GET /api/me/subscriptions/schedules", () => {
-  test("contract", async ({ request }) => {
+test.describe("GET /api/me/subscriptions/schedules - 订阅课表", () => {
+  test("契约", async ({ request }) => {
     await assertApiContract(request, { routePath: BASE });
   });
 
-  test("returns 401 when not authenticated", async ({ request }) => {
+  test("未认证时返回 401", async ({ request }) => {
     const response = await request.get(BASE);
     expect(response.status()).toBe(401);
   });
 
-  test("returns subscribed schedules in one authenticated response", async ({
-    page,
-  }) => {
+  test("一次认证响应返回已订阅课表", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.get(
@@ -52,7 +50,7 @@ test.describe("GET /api/me/subscriptions/schedules", () => {
     expect(seedSchedule?.endTime).toMatch(/^\d{2}:\d{2}$/);
   });
 
-  test("invalid date query returns 400", async ({ page }) => {
+  test("无效日期查询返回 400", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.get(`${BASE}?dateFrom=not-a-date`);

--- a/tests/e2e/src/app/api/me/test.ts
+++ b/tests/e2e/src/app/api/me/test.ts
@@ -10,13 +10,13 @@ import { DEV_SEED } from "../../../../utils/dev-seed";
 
 const BASE = "/api/me";
 
-test.describe("GET /api/me", () => {
-  test("returns 401 when not authenticated", async ({ request }) => {
+test.describe("GET /api/me - 当前用户", () => {
+  test("未认证时返回 401", async ({ request }) => {
     const response = await request.get(BASE);
     expect(response.status()).toBe(401);
   });
 
-  test("returns authenticated profile fields", async ({ page }) => {
+  test("返回已认证用户资料字段", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const sessionResponse = await page.request.get("/api/auth/get-session");

--- a/tests/e2e/src/app/api/metadata/test.ts
+++ b/tests/e2e/src/app/api/metadata/test.ts
@@ -35,12 +35,12 @@ const EXPECTED_KEYS = [
   "campuses",
 ] as const;
 
-test.describe("GET /api/metadata", () => {
-  test("contract", async ({ request }) => {
+test.describe("GET /api/metadata - 元数据字典", () => {
+  test("契约", async ({ request }) => {
     await assertApiContract(request, { routePath: "/api/metadata" });
   });
 
-  test("all dictionary keys exist and are arrays", async ({ request }) => {
+  test("所有字典键存在且为数组", async ({ request }) => {
     const response = await request.get("/api/metadata");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as Record<string, unknown>;
@@ -49,7 +49,7 @@ test.describe("GET /api/metadata", () => {
     }
   });
 
-  test("seed teachLanguage present", async ({ request }) => {
+  test("seed 授课语言存在", async ({ request }) => {
     const response = await request.get("/api/metadata");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -62,7 +62,7 @@ test.describe("GET /api/metadata", () => {
     ).toBe(true);
   });
 
-  test("seed courseClassify present", async ({ request }) => {
+  test("seed 课程分类存在", async ({ request }) => {
     const response = await request.get("/api/metadata");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -75,7 +75,7 @@ test.describe("GET /api/metadata", () => {
     ).toBe(true);
   });
 
-  test("seed campus with buildings present", async ({ request }) => {
+  test("seed 校区及楼栋存在", async ({ request }) => {
     const response = await request.get("/api/metadata");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {

--- a/tests/e2e/src/app/api/oauth/register/test.ts
+++ b/tests/e2e/src/app/api/oauth/register/test.ts
@@ -49,10 +49,8 @@ const DCR_CLIENT_SCOPE = [
   MCP_TOOLS_SCOPE,
 ].join(" ");
 
-test.describe("OAuth provider", () => {
-  test("canonical well-known endpoints are exposed and legacy aliases redirect", async ({
-    request,
-  }) => {
+test.describe("OAuth 提供者", () => {
+  test("暴露标准 well-known 端点且旧别名重定向", async ({ request }) => {
     const [
       authServer,
       openid,
@@ -148,7 +146,7 @@ test.describe("OAuth provider", () => {
     );
   });
 
-  test("dynamic registration + consent + code exchange + userinfo", async ({
+  test("动态注册 + 授权同意 + 授权码交换 + userinfo", async ({
     page,
     request,
   }) => {
@@ -253,7 +251,7 @@ test.describe("OAuth provider", () => {
     expect(typeof userinfoBody.sub).toBe("string");
   });
 
-  test("dynamic registration accepts device-only clients without redirect URIs", async ({
+  test("动态注册接受无 redirect URI 的纯 device 客户端", async ({
     request,
   }) => {
     const registrationResponse = await request.post(
@@ -281,7 +279,7 @@ test.describe("OAuth provider", () => {
     expect(registrationBody.redirect_uris).toEqual([]);
   });
 
-  test("loopback authorize accepts localhost alias for a 127.0.0.1 DCR client", async ({
+  test("loopback 授权接受 127.0.0.1 DCR 客户端的 localhost 别名", async ({
     page,
     request,
   }) => {

--- a/tests/e2e/src/app/api/openapi/test.ts
+++ b/tests/e2e/src/app/api/openapi/test.ts
@@ -20,12 +20,12 @@
 import { expect, test } from "@playwright/test";
 import { assertApiContract } from "../../_shared/api-contract";
 
-test.describe("GET /api/openapi", () => {
-  test("contract", async ({ request }) => {
+test.describe("GET /api/openapi - OpenAPI 规范", () => {
+  test("契约", async ({ request }) => {
     await assertApiContract(request, { routePath: "/api/openapi" });
   });
 
-  test("returns valid OpenAPI 3.0.0 spec", async ({ request }) => {
+  test("返回有效的 OpenAPI 3.0.0 规范", async ({ request }) => {
     const response = await request.get("/api/openapi");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -37,7 +37,7 @@ test.describe("GET /api/openapi", () => {
     expect(typeof body.info?.title).toBe("string");
   });
 
-  test("spec contains known API paths", async ({ request }) => {
+  test("规范包含已知 API 路径", async ({ request }) => {
     const response = await request.get("/api/openapi");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -53,9 +53,7 @@ test.describe("GET /api/openapi", () => {
     expect(body.paths?.["/.well-known/openid-configuration"]?.get).toBeTruthy();
   });
 
-  test("spec exposes concrete schemas for generated clients", async ({
-    request,
-  }) => {
+  test("规范暴露生成客户端所需的具体 schema", async ({ request }) => {
     const response = await request.get("/api/openapi");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -91,9 +89,7 @@ test.describe("GET /api/openapi", () => {
     });
   });
 
-  test("request bodies and redirect endpoints stay accurate in the spec", async ({
-    request,
-  }) => {
+  test("请求体与重定向端点在规范中保持准确", async ({ request }) => {
     const response = await request.get("/api/openapi");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -174,7 +170,7 @@ test.describe("GET /api/openapi", () => {
     ).toBeTruthy();
   });
 
-  test("spec exposes auth security metadata", async ({ request }) => {
+  test("规范暴露认证安全元数据", async ({ request }) => {
     const response = await request.get("/api/openapi");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -257,7 +253,7 @@ test.describe("GET /api/openapi", () => {
     );
   });
 
-  test("static openapi.generated.json is accessible", async ({ request }) => {
+  test("静态 openapi.generated.json 可访问", async ({ request }) => {
     const response = await request.get("/openapi.generated.json");
     expect(response.status()).toBe(200);
     expect(response.headers()["content-type"]).toContain("application/json");

--- a/tests/e2e/src/app/api/schedules/test.ts
+++ b/tests/e2e/src/app/api/schedules/test.ts
@@ -47,12 +47,12 @@ async function resolveSeedSectionId(
   return section!.id!;
 }
 
-test.describe("GET /api/schedules", () => {
-  test("contract", async ({ request }) => {
+test.describe("GET /api/schedules - 排课列表", () => {
+  test("契约", async ({ request }) => {
     await assertApiContract(request, { routePath: "/api/schedules" });
   });
 
-  test("returns paginated response shape", async ({ request }) => {
+  test("返回分页响应结构", async ({ request }) => {
     const response = await request.get("/api/schedules");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -72,7 +72,7 @@ test.describe("GET /api/schedules", () => {
     expect(typeof body.pagination?.totalPages).toBe("number");
   });
 
-  test("filter by sectionId returns seed schedules", async ({ request }) => {
+  test("按 sectionId 过滤返回 seed 排课", async ({ request }) => {
     const sectionId = await resolveSeedSectionId(request);
     const response = await request.get(
       `/api/schedules?sectionId=${sectionId}&limit=20`,
@@ -90,7 +90,7 @@ test.describe("GET /api/schedules", () => {
     ).toBe(true);
   });
 
-  test("schedules include nested relations", async ({ request }) => {
+  test("排课包含嵌套关联", async ({ request }) => {
     const sectionId = await resolveSeedSectionId(request);
     const response = await request.get(
       `/api/schedules?sectionId=${sectionId}&limit=5`,
@@ -150,7 +150,7 @@ test.describe("GET /api/schedules", () => {
     }
   });
 
-  test("non-matching sectionId returns empty data", async ({ request }) => {
+  test("不匹配的 sectionId 返回空数据", async ({ request }) => {
     const response = await request.get("/api/schedules?sectionId=999999999");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -161,12 +161,12 @@ test.describe("GET /api/schedules", () => {
     expect(body.pagination?.total).toBe(0);
   });
 
-  test("invalid dateFrom returns 400", async ({ request }) => {
+  test("无效 dateFrom 返回 400", async ({ request }) => {
     const response = await request.get("/api/schedules?dateFrom=not-a-date");
     expect(response.status()).toBe(400);
   });
 
-  test("limit param controls page size", async ({ request }) => {
+  test("limit 参数控制页大小", async ({ request }) => {
     const response = await request.get("/api/schedules?limit=1");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {

--- a/tests/e2e/src/app/api/sections/[jwId]/calendar.ics/test.ts
+++ b/tests/e2e/src/app/api/sections/[jwId]/calendar.ics/test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 import { DEV_SEED } from "../../../../../../utils/dev-seed";
 import { assertApiContract } from "../../../../_shared/api-contract";
 
-test("/api/sections/[jwId]/calendar.ics", async ({ request }) => {
+test("/api/sections/[jwId]/calendar.ics 契约", async ({ request }) => {
   await assertApiContract(request, {
     routePath: "/api/sections/[jwId]/calendar.ics",
   });

--- a/tests/e2e/src/app/api/sections/[jwId]/schedule-groups/test.ts
+++ b/tests/e2e/src/app/api/sections/[jwId]/schedule-groups/test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 import { DEV_SEED } from "../../../../../../utils/dev-seed";
 import { assertApiContract } from "../../../../_shared/api-contract";
 
-test("/api/sections/[jwId]/schedule-groups", async ({ request }) => {
+test("/api/sections/[jwId]/schedule-groups 契约", async ({ request }) => {
   await assertApiContract(request, {
     routePath: "/api/sections/[jwId]/schedule-groups",
   });

--- a/tests/e2e/src/app/api/sections/[jwId]/schedules/test.ts
+++ b/tests/e2e/src/app/api/sections/[jwId]/schedules/test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 import { DEV_SEED } from "../../../../../../utils/dev-seed";
 import { assertApiContract } from "../../../../_shared/api-contract";
 
-test("/api/sections/[jwId]/schedules", async ({ request }) => {
+test("/api/sections/[jwId]/schedules 契约", async ({ request }) => {
   await assertApiContract(request, {
     routePath: "/api/sections/[jwId]/schedules",
   });

--- a/tests/e2e/src/app/api/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/api/sections/[jwId]/test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 import { DEV_SEED } from "../../../../../utils/dev-seed";
 import { assertApiContract } from "../../../_shared/api-contract";
 
-test("/api/sections/[jwId]", async ({ request }) => {
+test("/api/sections/[jwId] 契约", async ({ request }) => {
   await assertApiContract(request, { routePath: "/api/sections/[jwId]" });
 });
 
@@ -21,7 +21,7 @@ test("/api/sections/[jwId] 返回 teacherAssignments 与 exams", async ({
   expect((body.exams?.length ?? 0) > 0).toBe(true);
 });
 
-test("section detail has all SectionDetail fields", async ({ request }) => {
+test("班级详情包含全部 SectionDetail 字段", async ({ request }) => {
   const response = await request.get(`/api/sections/${DEV_SEED.section.jwId}`);
   expect(response.status()).toBe(200);
   const body = (await response.json()) as {

--- a/tests/e2e/src/app/api/sections/calendar.ics/test.ts
+++ b/tests/e2e/src/app/api/sections/calendar.ics/test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 import { DEV_SEED } from "../../../../../utils/dev-seed";
 import { assertApiContract } from "../../../_shared/api-contract";
 
-test("/api/sections/calendar.ics", async ({ request }) => {
+test("/api/sections/calendar.ics 契约", async ({ request }) => {
   await assertApiContract(request, { routePath: "/api/sections/calendar.ics" });
 });
 

--- a/tests/e2e/src/app/api/sections/test.ts
+++ b/tests/e2e/src/app/api/sections/test.ts
@@ -6,9 +6,7 @@ test("/api/sections", async ({ request }) => {
   await assertApiContract(request, { routePath: "/api/sections" });
 });
 
-test("section list items have all required SectionSummary fields", async ({
-  request,
-}) => {
+test("班级列表项包含所有必需的 SectionSummary 字段", async ({ request }) => {
   const response = await request.get(
     `/api/sections?search=${encodeURIComponent(DEV_SEED.section.code)}&limit=20`,
   );
@@ -40,7 +38,7 @@ test("section list items have all required SectionSummary fields", async ({
   expect(typeof section?.limitCount).toBe("number");
 });
 
-test("section list item has teachers array", async ({ request }) => {
+test("班级列表项包含教师数组", async ({ request }) => {
   const response = await request.get(
     `/api/sections?search=${encodeURIComponent(DEV_SEED.section.code)}&limit=20`,
   );
@@ -55,7 +53,7 @@ test("section list item has teachers array", async ({ request }) => {
   expect(Array.isArray(section?.teachers)).toBe(true);
 });
 
-test("section limit param controls page size", async ({ request }) => {
+test("limit 参数控制班级列表页大小", async ({ request }) => {
   const response = await request.get("/api/sections?limit=1");
   expect(response.status()).toBe(200);
   const body = (await response.json()) as {

--- a/tests/e2e/src/app/api/semesters/current/test.ts
+++ b/tests/e2e/src/app/api/semesters/current/test.ts
@@ -23,11 +23,11 @@ import { DEV_SEED } from "../../../../../utils/dev-seed";
 import { assertApiContract } from "../../../_shared/api-contract";
 
 test.describe("GET /api/semesters/current", () => {
-  test("contract", async ({ request }) => {
+  test("契约", async ({ request }) => {
     await assertApiContract(request, { routePath: "/api/semesters/current" });
   });
 
-  test("returns seed semester", async ({ request }) => {
+  test("返回 seed 学期", async ({ request }) => {
     const response = await request.get("/api/semesters/current");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -39,7 +39,7 @@ test.describe("GET /api/semesters/current", () => {
     expect(typeof body.nameCn).toBe("string");
   });
 
-  test("response has expected fields", async ({ request }) => {
+  test("响应包含预期字段", async ({ request }) => {
     const response = await request.get("/api/semesters/current");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as Record<string, unknown>;

--- a/tests/e2e/src/app/api/semesters/test.ts
+++ b/tests/e2e/src/app/api/semesters/test.ts
@@ -23,11 +23,11 @@ import { DEV_SEED } from "../../../../utils/dev-seed";
 import { assertApiContract } from "../../_shared/api-contract";
 
 test.describe("GET /api/semesters", () => {
-  test("contract", async ({ request }) => {
+  test("契约", async ({ request }) => {
     await assertApiContract(request, { routePath: "/api/semesters" });
   });
 
-  test("returns paginated response shape", async ({ request }) => {
+  test("返回分页响应结构", async ({ request }) => {
     const response = await request.get("/api/semesters");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -48,7 +48,7 @@ test.describe("GET /api/semesters", () => {
     expect(body.pagination?.totalPages).toBeGreaterThanOrEqual(1);
   });
 
-  test("list contains seed semester", async ({ request }) => {
+  test("列表包含 seed 学期", async ({ request }) => {
     const response = await request.get("/api/semesters?limit=20");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -61,7 +61,7 @@ test.describe("GET /api/semesters", () => {
     expect(typeof semester?.nameCn).toBe("string");
   });
 
-  test("limit param controls page size", async ({ request }) => {
+  test("limit 参数控制页大小", async ({ request }) => {
     const response = await request.get("/api/semesters?limit=1");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -72,7 +72,7 @@ test.describe("GET /api/semesters", () => {
     expect(body.pagination?.pageSize).toBe(1);
   });
 
-  test("semester items have all required fields", async ({ request }) => {
+  test("学期项包含所有必需字段", async ({ request }) => {
     const response = await request.get("/api/semesters?limit=20");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -97,7 +97,7 @@ test.describe("GET /api/semesters", () => {
     expect(typeof semester?.endDate).toBe("string");
   });
 
-  test("page param navigates results", async ({ request }) => {
+  test("page 参数可翻页", async ({ request }) => {
     const response = await request.get("/api/semesters?page=1");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {

--- a/tests/e2e/src/app/api/teachers/test.ts
+++ b/tests/e2e/src/app/api/teachers/test.ts
@@ -26,15 +26,15 @@ import { DEV_SEED } from "../../../../utils/dev-seed";
 import { assertApiContract } from "../../_shared/api-contract";
 
 test.describe("GET /api/teachers", () => {
-  test("contract", async ({ request }) => {
+  test("契约", async ({ request }) => {
     await assertApiContract(request, { routePath: "/api/teachers" });
   });
 
-  test("detail contract", async ({ request }) => {
+  test("详情契约", async ({ request }) => {
     await assertApiContract(request, { routePath: "/api/teachers/[id]" });
   });
 
-  test("returns paginated response shape", async ({ request }) => {
+  test("返回分页响应结构", async ({ request }) => {
     const response = await request.get("/api/teachers");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -55,7 +55,7 @@ test.describe("GET /api/teachers", () => {
     expect(body.pagination?.totalPages).toBeGreaterThanOrEqual(1);
   });
 
-  test("search by teacher code returns seed teacher", async ({ request }) => {
+  test("按教师工号搜索返回 seed 教师", async ({ request }) => {
     const response = await request.get(
       `/api/teachers?search=${encodeURIComponent(DEV_SEED.teacher.code)}`,
     );
@@ -70,7 +70,7 @@ test.describe("GET /api/teachers", () => {
     expect(teacher?.nameCn).toBe(DEV_SEED.teacher.nameCn);
   });
 
-  test("search by Chinese name returns seed teacher", async ({ request }) => {
+  test("按中文名搜索返回 seed 教师", async ({ request }) => {
     const response = await request.get(
       `/api/teachers?search=${encodeURIComponent(DEV_SEED.teacher.nameCn)}`,
     );
@@ -83,7 +83,7 @@ test.describe("GET /api/teachers", () => {
     ).toBe(true);
   });
 
-  test("non-matching search returns empty data", async ({ request }) => {
+  test("无匹配搜索返回空数据", async ({ request }) => {
     const response = await request.get(
       "/api/teachers?search=ZZZZZ_NONEXISTENT_TEACHER_99999",
     );
@@ -97,7 +97,7 @@ test.describe("GET /api/teachers", () => {
     expect(body.pagination?.totalPages).toBe(1);
   });
 
-  test("page param navigates results", async ({ request }) => {
+  test("page 参数可翻页", async ({ request }) => {
     const response = await request.get("/api/teachers?page=1");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -106,7 +106,7 @@ test.describe("GET /api/teachers", () => {
     expect(body.pagination?.page).toBe(1);
   });
 
-  test("limit param controls page size", async ({ request }) => {
+  test("limit 参数控制页大小", async ({ request }) => {
     const response = await request.get("/api/teachers?limit=1");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
@@ -117,9 +117,7 @@ test.describe("GET /api/teachers", () => {
     expect(body.pagination?.pageSize).toBe(1);
   });
 
-  test("detail route returns seed teacher with sections", async ({
-    request,
-  }) => {
+  test("详情路由返回带班级的 seed 教师", async ({ request }) => {
     const cacheBust = `teacher-detail-${Date.now()}`;
     const teacherListResponse = await request.get(
       `/api/teachers?search=${encodeURIComponent(DEV_SEED.teacher.code)}&limit=5&cacheBust=${cacheBust}`,
@@ -171,9 +169,7 @@ test.describe("GET /api/teachers", () => {
     expect(Object.hasOwn(seedSection as object, "credits")).toBe(true);
   });
 
-  test("teacher list items have all required TeacherSummary fields", async ({
-    request,
-  }) => {
+  test("教师列表项包含所有必需的 TeacherSummary 字段", async ({ request }) => {
     const response = await request.get(
       `/api/teachers?search=${encodeURIComponent(DEV_SEED.teacher.code)}&limit=5`,
     );

--- a/tests/e2e/src/app/api/todos/test.ts
+++ b/tests/e2e/src/app/api/todos/test.ts
@@ -53,7 +53,7 @@ test("/api/todos GET 登录后返回 seed 待办", async ({ page }) => {
   ).toBe(true);
 });
 
-test("/api/todos GET supports completed filter and limit", async ({ page }) => {
+test("/api/todos GET 支持 completed 筛选与 limit", async ({ page }) => {
   await signInAsDebugUser(page, "/");
 
   const response = await page.request.get("/api/todos?completed=false&limit=1");
@@ -66,9 +66,7 @@ test("/api/todos GET supports completed filter and limit", async ({ page }) => {
   expect(body.todos?.every((todo) => todo.completed === false)).toBe(true);
 });
 
-test("/api/todos GET accepts bare date filters and rejects invalid dates", async ({
-  page,
-}) => {
+test("/api/todos GET 接受裸日期筛选并拒绝无效日期", async ({ page }) => {
   await signInAsDebugUser(page, "/");
 
   const response = await page.request.get(
@@ -94,14 +92,14 @@ test("/api/todos GET accepts bare date filters and rejects invalid dates", async
   expect(invalidResponse.status()).toBe(400);
 });
 
-test("/api/todos GET rejects invalid limit", async ({ page }) => {
+test("/api/todos GET 拒绝无效 limit", async ({ page }) => {
   await signInAsDebugUser(page, "/");
 
   const response = await page.request.get("/api/todos?limit=0");
   expect(response.status()).toBe(400);
 });
 
-test("todos have all required TodoItem fields", async ({ page }) => {
+test("待办包含所有必需的 TodoItem 字段", async ({ page }) => {
   await signInAsDebugUser(page, "/");
 
   const response = await page.request.get("/api/todos");

--- a/tests/e2e/src/app/api/uploads/[id]/download/test.ts
+++ b/tests/e2e/src/app/api/uploads/[id]/download/test.ts
@@ -92,7 +92,7 @@ test("/api/uploads/[id]/download GET 非本人返回 404", async ({ browser }) =
   }
 });
 
-test("/api/uploads/[id]/download GET allows visible comment attachments", async ({
+test("/api/uploads/[id]/download GET 允许下载可见评论附件", async ({
   browser,
 }) => {
   const userContext = await browser.newContext();
@@ -147,7 +147,7 @@ test("/api/uploads/[id]/download GET allows visible comment attachments", async 
   }
 });
 
-test("/api/uploads/[id]/download GET denies deleted comment attachments", async ({
+test("/api/uploads/[id]/download GET 拒绝下载已删除评论附件", async ({
   browser,
 }) => {
   const userContext = await browser.newContext();

--- a/tests/e2e/src/app/api/users/[userId]/calendar.ics/test.ts
+++ b/tests/e2e/src/app/api/users/[userId]/calendar.ics/test.ts
@@ -44,27 +44,23 @@ function unfoldICalendar(text: string) {
 test.describe("GET /api/users/[userId]/calendar.ics", () => {
   test.describe.configure({ mode: "serial" });
 
-  test("contract", async ({ request }) => {
+  test("契约", async ({ request }) => {
     await assertApiContract(request, { routePath: ROUTE_PATH });
   });
 
-  test("returns 401 when not authenticated and no token", async ({
-    request,
-  }) => {
+  test("未认证且无 token 时返回 401", async ({ request }) => {
     const response = await request.get("/api/users/invalid-e2e/calendar.ics");
     expect(response.status()).toBe(401);
   });
 
-  test("returns 403 with invalid token", async ({ request }) => {
+  test("无效 token 返回 403", async ({ request }) => {
     const response = await request.get(
       "/api/users/invalid-e2e/calendar.ics?token=invalid-token",
     );
     expect(response.status()).toBe(403);
   });
 
-  test("returns 403 when accessing another user's calendar", async ({
-    page,
-  }) => {
+  test("访问其他用户日历时返回 403", async ({ page }) => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.get(
@@ -73,9 +69,7 @@ test.describe("GET /api/users/[userId]/calendar.ics", () => {
     expect(response.status()).toBe(403);
   });
 
-  test("returns valid iCalendar for own calendar via session auth", async ({
-    page,
-  }) => {
+  test("通过 session 认证返回有效的个人 iCalendar", async ({ page }) => {
     await signInAsDebugUser(page, "/");
     const { id: userId } = await getCurrentSessionUser(page);
 
@@ -134,7 +128,7 @@ test.describe("GET /api/users/[userId]/calendar.ics", () => {
     }
   });
 
-  test("returns valid iCalendar via path token (anonymous)", async ({
+  test("通过 path token 返回有效的 iCalendar（匿名）", async ({
     page,
     request,
   }) => {
@@ -152,7 +146,7 @@ test.describe("GET /api/users/[userId]/calendar.ics", () => {
     expect(body).toContain("BEGIN:VCALENDAR");
   });
 
-  test("returns valid iCalendar via query token (anonymous)", async ({
+  test("通过 query token 返回有效的 iCalendar（匿名）", async ({
     page,
     request,
   }) => {
@@ -171,10 +165,7 @@ test.describe("GET /api/users/[userId]/calendar.ics", () => {
     expect(body).toContain("BEGIN:VCALENDAR");
   });
 
-  test("returns 403 with invalid token for existing user", async ({
-    page,
-    request,
-  }) => {
+  test("现有用户无效 token 返回 403", async ({ page, request }) => {
     await signInAsDebugUser(page, "/");
     const { id: userId } = await getCurrentSessionUser(page);
 

--- a/tests/e2e/src/app/api/users/profile/test.ts
+++ b/tests/e2e/src/app/api/users/profile/test.ts
@@ -10,11 +10,11 @@ import { assertApiContract } from "../../../_shared/api-contract";
 const BASE = "/api/users/profile";
 
 test.describe("GET /api/users/profile", () => {
-  test("contract", async ({ request }) => {
+  test("契约", async ({ request }) => {
     await assertApiContract(request, { routePath: BASE });
   });
 
-  test("returns public profile by username", async ({ request }) => {
+  test("按用户名返回公开资料", async ({ request }) => {
     const response = await request.get(
       `${BASE}?username=${DEV_SEED.debugUsername}`,
     );
@@ -41,7 +41,7 @@ test.describe("GET /api/users/profile", () => {
     expect(typeof body.totalContributions).toBe("number");
   });
 
-  test("returns the same user by userId", async ({ request }) => {
+  test("按 userId 返回同一用户", async ({ request }) => {
     const byUsername = await request.get(
       `${BASE}?username=${DEV_SEED.debugUsername}`,
     );
@@ -61,7 +61,7 @@ test.describe("GET /api/users/profile", () => {
     expect(idBody.user?.username).toBe(DEV_SEED.debugUsername);
   });
 
-  test("requires exactly one lookup key", async ({ request }) => {
+  test("需要且仅需一个查询键", async ({ request }) => {
     const missing = await request.get(BASE);
     expect(missing.status()).toBe(400);
 
@@ -71,7 +71,7 @@ test.describe("GET /api/users/profile", () => {
     expect(duplicate.status()).toBe(400);
   });
 
-  test("returns 404 for missing users", async ({ request }) => {
+  test("缺失用户返回 404", async ({ request }) => {
     const response = await request.get(`${BASE}?username=missing-e2e-user`);
     expect(response.status()).toBe(404);
   });

--- a/tests/e2e/src/app/bus-map/test.ts
+++ b/tests/e2e/src/app/bus-map/test.ts
@@ -21,10 +21,8 @@ import { DEV_SEED } from "../../../utils/dev-seed";
 import { gotoAndWaitForReady } from "../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../utils/screenshot";
 
-test.describe("bus transit map", () => {
-  test("renders campus nodes and route lines in SVG", async ({
-    page,
-  }, testInfo) => {
+test.describe("校车线路图", () => {
+  test("SVG 中渲染校区节点与线路", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/bus-map", {
       testInfo,
       screenshotLabel: "bus-map",
@@ -54,9 +52,7 @@ test.describe("bus transit map", () => {
     await captureStepScreenshot(page, testInfo, "bus-map-overview");
   });
 
-  test("legend shows route descriptions and status indicators", async ({
-    page,
-  }, testInfo) => {
+  test("图例显示线路说明与状态指示器", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/bus-map", {
       testInfo,
       screenshotLabel: "bus-map",
@@ -80,7 +76,7 @@ test.describe("bus transit map", () => {
     await expect(page.getByText(/Departing|即将发车/).first()).toBeVisible();
   });
 
-  test("back link navigates to bus tab", async ({ page }, testInfo) => {
+  test("返回链接导航到校车标签页", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/bus-map", {
       testInfo,
       screenshotLabel: "bus-map",
@@ -93,9 +89,7 @@ test.describe("bus transit map", () => {
     await expect(backLink).toHaveAttribute("href", "/dashboard/bus");
   });
 
-  test("day type and time info shown in sidebar", async ({
-    page,
-  }, testInfo) => {
+  test("侧边栏显示日期类型与时间信息", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/bus-map", {
       testInfo,
       screenshotLabel: "bus-map",
@@ -107,7 +101,7 @@ test.describe("bus transit map", () => {
     ).toBeVisible();
   });
 
-  test("refresh button is present", async ({ page }, testInfo) => {
+  test("刷新按钮存在", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/bus-map", {
       testInfo,
       screenshotLabel: "bus-map",

--- a/tests/e2e/src/app/bus/test.ts
+++ b/tests/e2e/src/app/bus/test.ts
@@ -36,15 +36,15 @@ function routeSectionRows(page: Page) {
   });
 }
 
-test.describe("bus dashboard tab", () => {
+test.describe("校车面板标签页", () => {
   test.describe.configure({ mode: "serial" });
 
-  test("/bus returns 404 (redirect removed)", async ({ page }) => {
+  test("/bus 返回 404（重定向已移除）", async ({ page }) => {
     const response = await page.goto("/bus");
     expect(response?.status()).toBe(404);
   });
 
-  test("legacy query tab still renders the bus planner", async ({ page }) => {
+  test("旧版查询标签页仍渲染校车规划器", async ({ page }) => {
     await gotoAndWaitForReady(page, "/?tab=bus", {
       screenshotLabel: "bus-legacy",
     });
@@ -54,9 +54,7 @@ test.describe("bus dashboard tab", () => {
     ).toHaveAttribute("href", "/bus-map");
   });
 
-  test("public bus tab shows the planner controls", async ({
-    page,
-  }, testInfo) => {
+  test("公共校车标签页显示规划器控件", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/?tab=bus", {
       testInfo,
       screenshotLabel: "bus",
@@ -86,9 +84,7 @@ test.describe("bus dashboard tab", () => {
     await captureStepScreenshot(page, testInfo, "bus-planner-public");
   });
 
-  test("signed bus dashboard SSR renders server timetable data", async ({
-    page,
-  }) => {
+  test("登录校车面板 SSR 渲染服务端时刻表数据", async ({ page }) => {
     await signInAsDebugUser(page, "/dashboard/bus");
 
     const response = await page.request.get("/dashboard/bus");
@@ -104,9 +100,7 @@ test.describe("bus dashboard tab", () => {
     );
   });
 
-  test("anonymous bus dashboard SSR renders public timetable data", async ({
-    page,
-  }) => {
+  test("匿名校车面板 SSR 渲染公共时刻表数据", async ({ page }) => {
     const response = await page.request.get("/?tab=bus");
     expect(response.status()).toBe(200);
     const html = await response.text();
@@ -120,7 +114,7 @@ test.describe("bus dashboard tab", () => {
     );
   });
 
-  test("public bus tab keeps planner controls usable on mobile", async ({
+  test("公共校车标签页在移动端保持规划器控件可用", async ({
     page,
   }, testInfo) => {
     await page.setViewportSize({ width: 390, height: 844 });
@@ -140,7 +134,7 @@ test.describe("bus dashboard tab", () => {
     await captureStepScreenshot(page, testInfo, "bus-planner-public-mobile");
   });
 
-  test("default stop pair shows every applicable route ordered by next available bus", async ({
+  test("默认站点对按下一班可用校车排序显示所有适用线路", async ({
     page,
   }, testInfo) => {
     await gotoAndWaitForReady(page, "/?tab=bus", {
@@ -160,9 +154,7 @@ test.describe("bus dashboard tab", () => {
     ).toBe(true);
   });
 
-  test("reverse swaps direction and recomputes applicable routes", async ({
-    page,
-  }, testInfo) => {
+  test("反向交换方向并重新计算适用线路", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/?tab=bus", {
       testInfo,
       screenshotLabel: "bus",
@@ -196,9 +188,7 @@ test.describe("bus dashboard tab", () => {
     await captureStepScreenshot(page, testInfo, "bus-planner-reverse");
   });
 
-  test("selecting 东区 to 南区 narrows the list to the direct route", async ({
-    page,
-  }, testInfo) => {
+  test("选择东区到南区缩小为直达线路", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/?tab=bus", {
       testInfo,
       screenshotLabel: "bus",
@@ -211,9 +201,7 @@ test.describe("bus dashboard tab", () => {
     await expect(page.locator("table")).toContainText("南区");
   });
 
-  test("departed toggle keeps the timetable visible and switchable", async ({
-    page,
-  }, testInfo) => {
+  test("已发车切换保持时刻表可见且可切换", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/?tab=bus", {
       testInfo,
       screenshotLabel: "bus",
@@ -232,9 +220,7 @@ test.describe("bus dashboard tab", () => {
     await expect(page.locator("table").first()).toBeVisible();
   });
 
-  test("weekday/weekend toggle updates the selected route timetable", async ({
-    page,
-  }, testInfo) => {
+  test("工作日/周末切换更新所选线路时刻表", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/?tab=bus", {
       testInfo,
       screenshotLabel: "bus",
@@ -263,9 +249,7 @@ test.describe("bus dashboard tab", () => {
     await captureStepScreenshot(page, testInfo, "bus-planner-daytype");
   });
 
-  test("signed-in planner changes auto-save to bus preferences", async ({
-    page,
-  }, testInfo) => {
+  test("登录规划器自动保存到校车偏好设置", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/bus");
     const originalResponse = await page.request.get("/api/bus/preferences");
     expect(originalResponse.status()).toBe(200);
@@ -343,9 +327,7 @@ test.describe("bus dashboard tab", () => {
     }
   });
 
-  test("signed-in planner shows preference save failures", async ({
-    page,
-  }, testInfo) => {
+  test("登录规划器显示偏好保存失败", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/bus");
     await page.route("**/api/bus/preferences", async (route) => {
       if (route.request().method() !== "POST") {

--- a/tests/e2e/src/app/comments/[id]/test.ts
+++ b/tests/e2e/src/app/comments/[id]/test.ts
@@ -4,7 +4,7 @@ import { gotoAndWaitForReady } from "../../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
 import { assertPageContract } from "../../_shared/page-contract";
 
-test("/comments/[id]", async ({ page }, testInfo) => {
+test("/comments/[id] 页面契约", async ({ page }, testInfo) => {
   await assertPageContract(page, { routePath: "/comments/[id]", testInfo });
 });
 

--- a/tests/e2e/src/app/comments/guide/test.ts
+++ b/tests/e2e/src/app/comments/guide/test.ts
@@ -1,9 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { gotoAndWaitForReady } from "../../../../utils/page-ready";
 
-test("/comments/guide redirects to the canonical markdown guide", async ({
-  page,
-}) => {
+test("/comments/guide 重定向到标准 Markdown 指南", async ({ page }) => {
   await gotoAndWaitForReady(page, "/comments/guide", {
     waitUntil: "load",
   });

--- a/tests/e2e/src/app/courses/[jwId]/test.ts
+++ b/tests/e2e/src/app/courses/[jwId]/test.ts
@@ -44,14 +44,14 @@ const COURSE_URL = `/courses/${DEV_SEED.course.jwId}`;
 const COURSE_WITH_DESCRIPTION_URL = `/courses/${scenarioData.courses[2].jwId}`;
 const COURSE_WITH_DESCRIPTION_TEXT = "实验课建议准备护目镜并提前完成预习问答。";
 
-test.describe("/courses/[jwId]", () => {
+test.describe("/courses/[jwId] 课程详情", () => {
   test.describe.configure({ mode: "serial" });
 
-  test("contract", async ({ page }, testInfo) => {
+  test("页面契约", async ({ page }, testInfo) => {
     await assertPageContract(page, { routePath: "/courses/[jwId]", testInfo });
   });
 
-  test("404 for invalid param", async ({ page }, testInfo) => {
+  test("无效参数返回 404", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/courses/999999999", {
       expectMainContent: false,
     });
@@ -64,9 +64,7 @@ test.describe("/courses/[jwId]", () => {
 
   // ── Display fields ──────────────────────────────────────────────────────────
 
-  test("displays course name (primary and secondary), code, and basic info", async ({
-    page,
-  }, testInfo) => {
+  test("显示课程名称、代码和基本信息", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, COURSE_URL);
 
     const heading = page.getByRole("heading", { level: 1 }).first();
@@ -88,9 +86,7 @@ test.describe("/courses/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "course/heading-and-code");
   });
 
-  test("displays education level, category, and class type in basic info", async ({
-    page,
-  }, testInfo) => {
+  test("显示培养层次、课程类别和教学班类型", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, COURSE_URL);
 
     // course.educationLevel.namePrimary (locale-dependent)
@@ -121,7 +117,7 @@ test.describe("/courses/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "course/basic-info");
   });
 
-  test("sections table shows semester, section code, teacher, campus, capacity", async ({
+  test("班级表格显示学期、班级代码、教师、校区和容量", async ({
     page,
   }, testInfo) => {
     await gotoAndWaitForReady(page, COURSE_URL);
@@ -157,9 +153,7 @@ test.describe("/courses/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "course/sections-table");
   });
 
-  test("jwId is NOT displayed in visible course UI (jwid-url-only rule)", async ({
-    page,
-  }) => {
+  test("jwId 不在课程可见界面中显示", async ({ page }) => {
     await gotoAndWaitForReady(page, COURSE_URL);
     const content = await page.locator("#main-content").innerText();
     // Raw jwId should not appear as visible text
@@ -168,7 +162,7 @@ test.describe("/courses/[jwId]", () => {
 
   // ── Navigation ──────────────────────────────────────────────────────────────
 
-  test("tab switching works", async ({ page }, testInfo) => {
+  test("标签切换正常工作", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, COURSE_URL);
 
     const tabList = page.getByRole("tablist").first();
@@ -186,9 +180,7 @@ test.describe("/courses/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "course/tab-switch");
   });
 
-  test("breadcrumb navigates back to course list", async ({
-    page,
-  }, testInfo) => {
+  test("面包屑可返回课程列表", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, COURSE_URL);
     const breadcrumb = page.locator('a[href="/courses"]').first();
     await expect(breadcrumb).toBeVisible();
@@ -197,7 +189,7 @@ test.describe("/courses/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "course/breadcrumb-back");
   });
 
-  test("section row links to section detail", async ({ page }, testInfo) => {
+  test("班级行链接到班级详情", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, COURSE_URL);
     const sectionLink = page
       .locator(`a[href="/sections/${DEV_SEED.section.jwId}"]:visible`)
@@ -211,9 +203,7 @@ test.describe("/courses/[jwId]", () => {
 
   // ── Description ─────────────────────────────────────────────────────────────
 
-  test("same-route navigation resets target-scoped description state", async ({
-    page,
-  }, testInfo) => {
+  test("同路由导航重置目标范围内的简介状态", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, COURSE_WITH_DESCRIPTION_URL);
     await expect(page.getByText(COURSE_WITH_DESCRIPTION_TEXT)).toBeVisible();
 
@@ -232,9 +222,7 @@ test.describe("/courses/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "course/same-route-reset");
   });
 
-  test("signed-in user can edit description (description.content)", async ({
-    page,
-  }, testInfo) => {
+  test("登录用户可以编辑课程简介", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, COURSE_URL);
     const snapshot = await snapshotDescriptionTargetForE2e(
@@ -285,9 +273,7 @@ test.describe("/courses/[jwId]", () => {
 
   // ── Comment CRUD ─────────────────────────────────────────────────────────────
 
-  test("signed-in user can post, edit, and delete comment", async ({
-    page,
-  }, testInfo) => {
+  test("登录用户可以发布、编辑和删除评论", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, COURSE_URL);
     let commentId: string | undefined;

--- a/tests/e2e/src/app/courses/test.ts
+++ b/tests/e2e/src/app/courses/test.ts
@@ -29,12 +29,12 @@ import { absoluteTestUrl } from "../../../utils/request-url";
 import { captureStepScreenshot } from "../../../utils/screenshot";
 import { assertPageContract } from "../_shared/page-contract";
 
-test.describe("/courses", () => {
-  test("contract", async ({ page }, testInfo) => {
+test.describe("/courses 课程目录", () => {
+  test("页面契约", async ({ page }, testInfo) => {
     await assertPageContract(page, { routePath: "/courses", testInfo });
   });
 
-  test("SSR output contains search query", async ({ baseURL }) => {
+  test("SSR 输出包含搜索查询", async ({ baseURL }) => {
     const response = await fetch(
       absoluteTestUrl(
         `/courses?search=${encodeURIComponent(DEV_SEED.course.code)}`,
@@ -47,7 +47,7 @@ test.describe("/courses", () => {
     expect(html).toContain(DEV_SEED.course.code);
   });
 
-  test("language switching works", async ({ page, baseURL }, testInfo) => {
+  test("语言切换正常工作", async ({ page, baseURL }, testInfo) => {
     await gotoAndWaitForReady(page, "/courses", {
       testInfo,
       screenshotLabel: "courses",
@@ -93,9 +93,7 @@ test.describe("/courses", () => {
     await captureStepScreenshot(page, testInfo, "courses-zh-cn");
   });
 
-  test("mobile cards stay tappable and navigate to detail", async ({
-    page,
-  }, testInfo) => {
+  test("移动端卡片可点击并导航到详情", async ({ page }, testInfo) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await gotoAndWaitForReady(
       page,
@@ -118,7 +116,7 @@ test.describe("/courses", () => {
     await captureStepScreenshot(page, testInfo, "courses-navigate-detail");
   });
 
-  test("search and clear button", async ({ page }, testInfo) => {
+  test("搜索和清除按钮", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/courses", {
       testInfo,
       screenshotLabel: "courses",
@@ -145,9 +143,7 @@ test.describe("/courses", () => {
     await captureStepScreenshot(page, testInfo, "courses-search-clear");
   });
 
-  test("filter by seed dimensions preserves results", async ({
-    page,
-  }, testInfo) => {
+  test("按种子维度筛选保留结果", async ({ page }, testInfo) => {
     const filters = await getSeedCourseFilterFixture(DEV_SEED.course.jwId);
     const params = new URLSearchParams();
     if (filters.educationLevelId) {

--- a/tests/e2e/src/app/dashboard/[tab]/test.ts
+++ b/tests/e2e/src/app/dashboard/[tab]/test.ts
@@ -9,16 +9,12 @@ import {
 import { gotoAndWaitForReady } from "../../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
 
-test("/dashboard aliases require authentication", async ({
-  page,
-}, testInfo) => {
+test("/dashboard 别名需要登录", async ({ page }, testInfo) => {
   await expectRequiresSignIn(page, "/dashboard/homeworks");
   await captureStepScreenshot(page, testInfo, "dashboard-homeworks-unauth");
 });
 
-test("/dashboard/homeworks loads authenticated tab", async ({
-  page,
-}, testInfo) => {
+test("/dashboard/homeworks 加载登录标签", async ({ page }, testInfo) => {
   await signInAsDebugUser(page, "/dashboard/homeworks");
   await gotoAndWaitForReady(page, "/dashboard/homeworks", {
     testInfo,

--- a/tests/e2e/src/app/dashboard/calendar/test.ts
+++ b/tests/e2e/src/app/dashboard/calendar/test.ts
@@ -26,10 +26,8 @@ import { gotoAndWaitForReady } from "../../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
 import { ensureSeedSectionSubscription } from "../../../../utils/subscriptions";
 
-test.describe("dashboard calendar", () => {
-  test("unauthenticated ?tab=calendar shows public view", async ({
-    page,
-  }, testInfo) => {
+test.describe("仪表盘日历", () => {
+  test("未登录 ?tab=calendar 显示公共视图", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/?tab=calendar", {
       testInfo,
       screenshotLabel: "calendar",
@@ -53,7 +51,7 @@ test.describe("dashboard calendar", () => {
     await captureStepScreenshot(page, testInfo, "calendar/unauthenticated");
   });
 
-  test("authenticated shows calendar with section event links and weekday labels", async ({
+  test("登录后显示日历，包含班级事件链接和星期标签", async ({
     page,
   }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/calendar");
@@ -79,9 +77,7 @@ test.describe("dashboard calendar", () => {
     await captureStepScreenshot(page, testInfo, "calendar/semester-view");
   });
 
-  test("section event link navigates to section detail", async ({
-    page,
-  }, testInfo) => {
+  test("班级事件链接导航到班级详情", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/calendar");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/calendar", {
@@ -97,7 +93,7 @@ test.describe("dashboard calendar", () => {
     await captureStepScreenshot(page, testInfo, "calendar/section-link");
   });
 
-  test("exam card links to exams tab", async ({ page }, testInfo) => {
+  test("考试卡片链接到考试标签", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/calendar");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/calendar", {
@@ -112,9 +108,7 @@ test.describe("dashboard calendar", () => {
     await captureStepScreenshot(page, testInfo, "calendar/exam-link");
   });
 
-  test("semester navigation controls navigate to another semester", async ({
-    page,
-  }, testInfo) => {
+  test("学期导航控件可切换到其他学期", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/calendar");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/calendar", {
@@ -146,9 +140,7 @@ test.describe("dashboard calendar", () => {
     await captureStepScreenshot(page, testInfo, "calendar/semester-navigation");
   });
 
-  test("view toggle switches between semester/month/week", async ({
-    page,
-  }, testInfo) => {
+  test("视图切换可在学期/月/周之间切换", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/calendar");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/calendar", {
@@ -177,7 +169,7 @@ test.describe("dashboard calendar", () => {
     await captureStepScreenshot(page, testInfo, "calendar/week-view");
   });
 
-  test("copy calendar link produces valid iCal URL", async ({ page }) => {
+  test("复制日历链接生成有效的 iCal URL", async ({ page }) => {
     await page
       .context()
       .grantPermissions(["clipboard-read", "clipboard-write"]);

--- a/tests/e2e/src/app/dashboard/comments/test.ts
+++ b/tests/e2e/src/app/dashboard/comments/test.ts
@@ -19,10 +19,8 @@ import { signInAsDebugUser } from "../../../../utils/auth";
 import { gotoAndWaitForReady } from "../../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
 
-test.describe("dashboard invalid tab (comments)", () => {
-  test("/dashboard/comments is not a routed dashboard page", async ({
-    page,
-  }, testInfo) => {
+test.describe("仪表盘无效标签（comments）", () => {
+  test("/dashboard/comments 不是仪表盘路由页面", async ({ page }, testInfo) => {
     const response = await gotoAndWaitForReady(page, "/dashboard/comments", {
       testInfo,
       screenshotLabel: "dashboard-invalid-comments-route",
@@ -32,7 +30,7 @@ test.describe("dashboard invalid tab (comments)", () => {
     await expect(page.getByText(/not found|找不到/i)).toBeVisible();
   });
 
-  test("unauthenticated ?tab=comments falls back to public bus view", async ({
+  test("未登录 ?tab=comments 回退到公共校车视图", async ({
     page,
   }, testInfo) => {
     await gotoAndWaitForReady(page, "/?tab=comments", {
@@ -59,9 +57,7 @@ test.describe("dashboard invalid tab (comments)", () => {
     await captureStepScreenshot(page, testInfo, "home-comments-public");
   });
 
-  test("authenticated ?tab=comments falls back to overview", async ({
-    page,
-  }, testInfo) => {
+  test("登录后 ?tab=comments 回退到总览", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/?tab=comments");
 
     await expect(page.locator("#main-content")).toBeVisible();

--- a/tests/e2e/src/app/dashboard/exams/test.ts
+++ b/tests/e2e/src/app/dashboard/exams/test.ts
@@ -26,8 +26,8 @@ import { gotoAndWaitForReady } from "../../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
 import { ensureSeedSectionSubscription } from "../../../../utils/subscriptions";
 
-test.describe("dashboard exams", () => {
-  test("unauthenticated ?tab=exams shows public view (no exams tab)", async ({
+test.describe("仪表盘考试", () => {
+  test("未登录 ?tab=exams 显示公共视图（无考试标签）", async ({
     page,
   }, testInfo) => {
     await gotoAndWaitForReady(page, "/?tab=exams", {
@@ -53,9 +53,7 @@ test.describe("dashboard exams", () => {
     await captureStepScreenshot(page, testInfo, "exams/unauthenticated");
   });
 
-  test("authenticated shows exam filter toolbar and cards", async ({
-    page,
-  }, testInfo) => {
+  test("登录后显示考试筛选工具栏和卡片", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/exams");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/exams", {
@@ -84,9 +82,7 @@ test.describe("dashboard exams", () => {
     await captureStepScreenshot(page, testInfo, "exams/filter-toolbar");
   });
 
-  test("exam cards display required fields (course name, date, times, mode, rooms)", async ({
-    page,
-  }, testInfo) => {
+  test("考试卡片显示必填字段", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/exams");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/exams", {
@@ -160,7 +156,7 @@ test.describe("dashboard exams", () => {
     await captureStepScreenshot(page, testInfo, "exams/card-fields");
   });
 
-  test("exam card links to section detail page", async ({ page }, testInfo) => {
+  test("考试卡片链接到班级详情页", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/exams");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/exams", {
@@ -181,7 +177,7 @@ test.describe("dashboard exams", () => {
     await captureStepScreenshot(page, testInfo, "exams/section-link");
   });
 
-  test("completed filter shows past exams, incomplete shows upcoming", async ({
+  test("已完成筛选显示过往考试，未完成显示即将到来", async ({
     page,
   }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/exams");

--- a/tests/e2e/src/app/dashboard/homeworks/test.ts
+++ b/tests/e2e/src/app/dashboard/homeworks/test.ts
@@ -28,12 +28,10 @@ import { gotoAndWaitForReady } from "../../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
 import { ensureSeedSectionSubscription } from "../../../../utils/subscriptions";
 
-test.describe("dashboard homeworks", () => {
+test.describe("仪表盘作业", () => {
   test.describe.configure({ mode: "serial" });
 
-  test("unauthenticated ?tab=homeworks falls back to public view", async ({
-    page,
-  }, testInfo) => {
+  test("未登录 ?tab=homeworks 回退到公共视图", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/?tab=homeworks", {
       testInfo,
       screenshotLabel: "homeworks",
@@ -57,9 +55,7 @@ test.describe("dashboard homeworks", () => {
     await captureStepScreenshot(page, testInfo, "homeworks/unauthenticated");
   });
 
-  test("authenticated shows seed homework with all required fields", async ({
-    page,
-  }, testInfo) => {
+  test("登录后显示种子作业及所有必填字段", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/homeworks");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/homeworks", {
@@ -94,9 +90,7 @@ test.describe("dashboard homeworks", () => {
     await captureStepScreenshot(page, testInfo, "homeworks/seed-card-fields");
   });
 
-  test("seeded collaborative homework shows major and team badges", async ({
-    page,
-  }, testInfo) => {
+  test("种子协作作业显示重要和团队徽章", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/homeworks");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/homeworks", {
@@ -120,7 +114,7 @@ test.describe("dashboard homeworks", () => {
     await captureStepScreenshot(page, testInfo, "homeworks/major-team-badges");
   });
 
-  test("can switch between filter tabs", async ({ page }, testInfo) => {
+  test("可在筛选标签之间切换", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/homeworks");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/homeworks", {
@@ -151,9 +145,7 @@ test.describe("dashboard homeworks", () => {
     await captureStepScreenshot(page, testInfo, "homeworks/filter-all");
   });
 
-  test("can switch to list view and persist preference", async ({
-    page,
-  }, testInfo) => {
+  test("可切换到列表视图并持久化偏好", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/homeworks");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/homeworks", {
@@ -188,7 +180,7 @@ test.describe("dashboard homeworks", () => {
     await captureStepScreenshot(page, testInfo, "homeworks/list-view");
   });
 
-  test("can toggle homework completion status", async ({ page }, testInfo) => {
+  test("可切换作业完成状态", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, "/dashboard/homeworks");
     await ensureSeedSectionSubscription(page);
@@ -257,9 +249,7 @@ test.describe("dashboard homeworks", () => {
     await expect(homeworksBadge).toHaveText(String(beforeBadge));
   });
 
-  test("completion failure shows localized dashboard error", async ({
-    page,
-  }, testInfo) => {
+  test("完成状态更新失败显示本地化仪表盘错误", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/homeworks");
     await ensureSeedSectionSubscription(page);
     await page.route(/\/api\/homeworks\/[^/]+\/completion$/, async (route) => {
@@ -308,9 +298,7 @@ test.describe("dashboard homeworks", () => {
     await captureStepScreenshot(page, testInfo, "homeworks/completion-error");
   });
 
-  test("view details links to section page with homework anchor", async ({
-    page,
-  }, testInfo) => {
+  test("查看详情链接到带作业锚点的班级页面", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/homeworks");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/homeworks", {
@@ -343,7 +331,7 @@ test.describe("dashboard homeworks", () => {
     await captureStepScreenshot(page, testInfo, "homeworks/view-details");
   });
 
-  test("can create a new homework", async ({ page }, testInfo) => {
+  test("可以创建新作业", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, "/dashboard/homeworks");
     await ensureSeedSectionSubscription(page);

--- a/tests/e2e/src/app/dashboard/links/test.ts
+++ b/tests/e2e/src/app/dashboard/links/test.ts
@@ -39,8 +39,8 @@ async function setLocale(page: Page, locale: "en-us" | "zh-cn") {
   expect(response.status()).toBe(200);
 }
 
-test.describe("dashboard links", () => {
-  test("public ?tab=links shows search and links without pin controls", async ({
+test.describe("仪表盘网站链接", () => {
+  test("公共 ?tab=links 显示搜索和链接，无置顶控件", async ({
     page,
   }, testInfo) => {
     await setLocale(page, "zh-cn");
@@ -62,9 +62,7 @@ test.describe("dashboard links", () => {
     await captureStepScreenshot(page, testInfo, "public-dashboard-links-tab");
   });
 
-  test("public English links tab uses localized titles in search", async ({
-    page,
-  }, testInfo) => {
+  test("公共英文链接标签在搜索中使用本地化标题", async ({ page }, testInfo) => {
     await setLocale(page, "en-us");
 
     await gotoAndWaitForReady(page, "/?tab=links");
@@ -99,9 +97,7 @@ test.describe("dashboard links", () => {
     );
   });
 
-  test("authenticated can navigate to links tab", async ({
-    page,
-  }, testInfo) => {
+  test("登录后可以导航到链接标签", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/");
 
     const linksTab = page.getByRole("link", { name: /网站|Websites/i }).first();
@@ -121,7 +117,7 @@ test.describe("dashboard links", () => {
     await captureStepScreenshot(page, testInfo, "dashboard-links-tab");
   });
 
-  test("search filters links", async ({ page }, testInfo) => {
+  test("搜索可筛选链接", async ({ page }, testInfo) => {
     await setLocale(page, "zh-cn");
     await signInAsDebugUser(page, "/dashboard/links");
 
@@ -151,9 +147,7 @@ test.describe("dashboard links", () => {
     await captureStepScreenshot(page, testInfo, "dashboard-links-search");
   });
 
-  test("can pin and unpin a link with state restoration", async ({
-    page,
-  }, testInfo) => {
+  test("可以置顶和取消置顶链接并恢复状态", async ({ page }, testInfo) => {
     await setLocale(page, "zh-cn");
     await signInAsDebugUser(page, "/dashboard/links");
     await page.request.post("/api/dashboard-links/pin", {
@@ -252,9 +246,7 @@ test.describe("dashboard links", () => {
     }
   });
 
-  test("keeps pin state when search recomputes links", async ({
-    page,
-  }, testInfo) => {
+  test("搜索重新计算链接时保持置顶状态", async ({ page }, testInfo) => {
     await setLocale(page, "zh-cn");
     await signInAsDebugUser(page, "/dashboard/links");
     await page.request.post("/api/dashboard-links/pin", {

--- a/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
+++ b/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
@@ -38,10 +38,10 @@ function escapeForRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-test.describe("dashboard subscriptions", () => {
+test.describe("仪表盘关注班级", () => {
   test.describe.configure({ mode: "serial" });
 
-  test("legacy /dashboard/subscriptions/sections redirects to subscriptions page", async ({
+  test("旧版 /dashboard/subscriptions/sections 重定向到关注班级页面", async ({
     page,
   }) => {
     await signInAsDebugUser(page, "/dashboard/subscriptions");
@@ -50,7 +50,7 @@ test.describe("dashboard subscriptions", () => {
     await expect(page).toHaveURL(/\/dashboard\/subscriptions(?:\?.*)?$/);
   });
 
-  test("unauthenticated ?tab=subscriptions falls back to public view", async ({
+  test("未登录 ?tab=subscriptions 回退到公共视图", async ({
     page,
   }, testInfo) => {
     await gotoAndWaitForReady(page, "/?tab=subscriptions");
@@ -72,9 +72,7 @@ test.describe("dashboard subscriptions", () => {
     );
   });
 
-  test("authenticated shows seed section subscription with all required fields", async ({
-    page,
-  }, testInfo) => {
+  test("登录后显示种子班级关注及所有必填字段", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/subscriptions");
     await expect(async () => {
       await ensureSeedSectionSubscription(page);
@@ -128,7 +126,7 @@ test.describe("dashboard subscriptions", () => {
     await captureStepScreenshot(page, testInfo, "subscriptions/seed-fields");
   });
 
-  test("empty state offers discovery actions", async ({ page }, testInfo) => {
+  test("空状态提供发现操作", async ({ page }, testInfo) => {
     test.setTimeout(60000);
     await signInAsDebugUser(page, "/dashboard/subscriptions");
     await gotoAndWaitForReady(page, "/dashboard/subscriptions");
@@ -177,9 +175,7 @@ test.describe("dashboard subscriptions", () => {
     );
   });
 
-  test("can navigate to section detail from subscription row", async ({
-    page,
-  }, testInfo) => {
+  test("可从关注行导航到班级详情", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/subscriptions");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/subscriptions");
@@ -196,7 +192,7 @@ test.describe("dashboard subscriptions", () => {
     );
   });
 
-  test("opt-out button enters confirm state", async ({ page }, testInfo) => {
+  test("退选按钮进入确认状态", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/subscriptions");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/subscriptions");
@@ -220,9 +216,7 @@ test.describe("dashboard subscriptions", () => {
     );
   });
 
-  test("copy calendar link produces valid iCal URL", async ({
-    page,
-  }, testInfo) => {
+  test("复制日历链接生成有效的 iCal URL", async ({ page }, testInfo) => {
     await page
       .context()
       .grantPermissions(["clipboard-read", "clipboard-write"]);
@@ -258,9 +252,7 @@ test.describe("dashboard subscriptions", () => {
     );
   });
 
-  test("bulk import opens confirm dialog and can cancel", async ({
-    page,
-  }, testInfo) => {
+  test("批量导入打开确认对话框并可取消", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, "/dashboard/subscriptions");
 
@@ -317,9 +309,7 @@ test.describe("dashboard subscriptions", () => {
     await expect(dialog).not.toBeVisible();
   });
 
-  test("bulk import can confirm and shows success", async ({
-    page,
-  }, testInfo) => {
+  test("批量导入可确认并显示成功", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, "/dashboard/subscriptions");
 

--- a/tests/e2e/src/app/dashboard/test.ts
+++ b/tests/e2e/src/app/dashboard/test.ts
@@ -26,10 +26,8 @@ import { gotoAndWaitForReady } from "../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../utils/screenshot";
 import { ensureSeedSectionSubscription } from "../../../utils/subscriptions";
 
-test.describe("dashboard", () => {
-  test("unauthenticated with ?tab=homeworks shows public bus view", async ({
-    page,
-  }, testInfo) => {
+test.describe("仪表盘", () => {
+  test("未登录 ?tab=homeworks 显示公共校车视图", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/?tab=homeworks", {
       testInfo,
       screenshotLabel: "dashboard",
@@ -54,9 +52,7 @@ test.describe("dashboard", () => {
     await captureStepScreenshot(page, testInfo, "home-public-with-tab");
   });
 
-  test("authenticated home shows overview with all tabs and seed data", async ({
-    page,
-  }, testInfo) => {
+  test("登录后首页显示总览、所有标签和种子数据", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/", {
@@ -97,9 +93,7 @@ test.describe("dashboard", () => {
     await captureStepScreenshot(page, testInfo, "dashboard-home");
   });
 
-  test("can navigate to homeworks tab via tab bar", async ({
-    page,
-  }, testInfo) => {
+  test("可通过标签栏导航到作业标签", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/");
 
     const homeworksTab = page
@@ -112,9 +106,7 @@ test.describe("dashboard", () => {
     await captureStepScreenshot(page, testInfo, "dashboard-navigate-homeworks");
   });
 
-  test("dashboard path aliases render the matching tabs", async ({
-    page,
-  }, testInfo) => {
+  test("仪表盘路径别名渲染匹配的标签", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/links");
     await gotoAndWaitForReady(page, "/dashboard/links", {
       testInfo,

--- a/tests/e2e/src/app/dashboard/todos/test.ts
+++ b/tests/e2e/src/app/dashboard/todos/test.ts
@@ -25,10 +25,8 @@ import { DEV_SEED } from "../../../../utils/dev-seed";
 import { gotoAndWaitForReady } from "../../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
 
-test.describe("dashboard todos", () => {
-  test("unauthenticated ?tab=todos falls back to public view", async ({
-    page,
-  }, testInfo) => {
+test.describe("仪表盘待办", () => {
+  test("未登录 ?tab=todos 回退到公共视图", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/?tab=todos", {
       testInfo,
       screenshotLabel: "todos",
@@ -47,7 +45,7 @@ test.describe("dashboard todos", () => {
     await captureStepScreenshot(page, testInfo, "dashboard-todos-unauthorized");
   });
 
-  test("authenticated shows seed todos", async ({ page }, testInfo) => {
+  test("登录后显示种子待办", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/todos");
 
     await expect(page.locator("#main-content")).toBeVisible();
@@ -74,9 +72,7 @@ test.describe("dashboard todos", () => {
     await captureStepScreenshot(page, testInfo, "dashboard-todos-seed");
   });
 
-  test("can toggle todo completion and filter updates", async ({
-    page,
-  }, testInfo) => {
+  test("可切换待办完成状态并更新筛选", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/todos");
 
     const card = page
@@ -124,7 +120,7 @@ test.describe("dashboard todos", () => {
     await captureStepScreenshot(page, testInfo, "dashboard-todos-toggle");
   });
 
-  test("completed filter shows completed todo", async ({ page }, testInfo) => {
+  test("已完成筛选显示已完成的待办", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/todos");
 
     const completedFilter = page
@@ -142,9 +138,7 @@ test.describe("dashboard todos", () => {
     await captureStepScreenshot(page, testInfo, "dashboard-todos-completed");
   });
 
-  test("server action errors render on nested todos route", async ({
-    page,
-  }, testInfo) => {
+  test("嵌套待办路由渲染服务端操作错误", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/dashboard/todos");
 
     const postResponse = page.waitForResponse(
@@ -168,7 +162,7 @@ test.describe("dashboard todos", () => {
     await captureStepScreenshot(page, testInfo, "dashboard-todos-action-error");
   });
 
-  test("can create and delete a todo", async ({ page }, testInfo) => {
+  test("可以创建和删除待办", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, "/dashboard/todos");
 

--- a/tests/e2e/src/app/e2e/oauth/callback/test.ts
+++ b/tests/e2e/src/app/e2e/oauth/callback/test.ts
@@ -5,15 +5,15 @@ import { expect, test } from "@playwright/test";
 import { gotoAndWaitForReady } from "../../../../../utils/page-ready";
 import { assertPageContract } from "../../../_shared/page-contract";
 
-test.describe("/e2e/oauth/callback", () => {
-  test("contract", async ({ page }, testInfo) => {
+test.describe("/e2e/oauth/callback 回调页", () => {
+  test("页面契约", async ({ page }, testInfo) => {
     await assertPageContract(page, {
       routePath: "/e2e/oauth/callback",
       testInfo,
     });
   });
 
-  test("captures callback query payload", async ({ page }, testInfo) => {
+  test("捕获回调查询参数", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(
       page,
       "/e2e/oauth/callback?code=abc123&state=state-xyz&error=some-error",

--- a/tests/e2e/src/app/error/test.ts
+++ b/tests/e2e/src/app/error/test.ts
@@ -5,14 +5,12 @@ import { expect, test } from "@playwright/test";
 import { gotoAndWaitForReady } from "../../../utils/page-ready";
 import { assertPageContract } from "../_shared/page-contract";
 
-test.describe("/error", () => {
-  test("contract", async ({ page }, testInfo) => {
+test.describe("/error 错误页", () => {
+  test("页面契约", async ({ page }, testInfo) => {
     await assertPageContract(page, { routePath: "/error", testInfo });
   });
 
-  test("displays authorization error message for consent failures", async ({
-    page,
-  }, testInfo) => {
+  test("授权被拒绝时显示授权错误信息", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/error?error=consent_failed", {
       testInfo,
       screenshotLabel: "error-consent-failed",

--- a/tests/e2e/src/app/guides/markdown-support/test.ts
+++ b/tests/e2e/src/app/guides/markdown-support/test.ts
@@ -10,17 +10,15 @@ import {
 } from "../../../../utils/page-ready";
 import { assertPageContract } from "../../_shared/page-contract";
 
-test.describe("/guides/markdown-support", () => {
-  test("contract", async ({ page }, testInfo) => {
+test.describe("/guides/markdown-support Markdown 支持页", () => {
+  test("页面契约", async ({ page }, testInfo) => {
     await assertPageContract(page, {
       routePath: "/guides/markdown-support",
       testInfo,
     });
   });
 
-  test("renders markdown guide with code blocks and tables", async ({
-    page,
-  }) => {
+  test("渲染 Markdown 指南，包含代码块与表格", async ({ page }) => {
     await gotoAndWaitForReady(page, "/guides/markdown-support", {
       waitUntil: "load",
     });

--- a/tests/e2e/src/app/mobile-app/test.ts
+++ b/tests/e2e/src/app/mobile-app/test.ts
@@ -3,7 +3,7 @@ import { gotoAndWaitForReady } from "../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../utils/screenshot";
 import { assertPageContract } from "../_shared/page-contract";
 
-test("/mobile-app", async ({ page }, testInfo) => {
+test("/mobile-app 页面契约", async ({ page }, testInfo) => {
   await assertPageContract(page, { routePath: "/mobile-app", testInfo });
 });
 

--- a/tests/e2e/src/app/oauth/device/test.ts
+++ b/tests/e2e/src/app/oauth/device/test.ts
@@ -200,9 +200,7 @@ async function exchangeDeviceToken(
   };
 }
 
-test("/oauth/device page renders user code entry form", async ({
-  page,
-}, testInfo) => {
+test("/oauth/device 页面渲染用户代码输入表单", async ({ page }, testInfo) => {
   await gotoAndWaitForReady(page, "/oauth/device");
 
   await expect(
@@ -217,9 +215,7 @@ test("/oauth/device page renders user code entry form", async ({
   await captureStepScreenshot(page, testInfo, "oauth/device/form");
 });
 
-test("/oauth/device invalid user code shows public error", async ({
-  page,
-}, testInfo) => {
+test("/oauth/device 无效用户代码显示公开错误", async ({ page }, testInfo) => {
   await gotoAndWaitForReady(page, "/oauth/device?code=NOPE-NOPE&step=approve");
 
   await expect(
@@ -229,9 +225,7 @@ test("/oauth/device invalid user code shows public error", async ({
   await captureStepScreenshot(page, testInfo, "oauth/device/invalid-code");
 });
 
-test("/oauth/device device-authorization endpoint returns required fields", async ({
-  request,
-}) => {
+test("/oauth/device 设备授权端点返回必要字段", async ({ request }) => {
   const clientName = `device-e2e-${Date.now()}`;
   try {
     const result = await requestDeviceCode(request, clientName);
@@ -249,9 +243,7 @@ test("/oauth/device device-authorization endpoint returns required fields", asyn
   }
 });
 
-test("/oauth/device rejects scopes outside the registered client allowance", async ({
-  request,
-}) => {
+test("/oauth/device 拒绝超出客户端允许范围的 scope", async ({ request }) => {
   const clientName = `device-e2e-invalid-scope-${Date.now()}`;
   try {
     const clientId = await registerDeviceClient(clientName);
@@ -279,9 +271,7 @@ test("/oauth/device rejects scopes outside the registered client allowance", asy
   }
 });
 
-test("/oauth/device rejects clients not registered for the device grant", async ({
-  request,
-}) => {
+test("/oauth/device 拒绝未注册设备授权类型的客户端", async ({ request }) => {
   const clientName = `device-e2e-unsupported-grant-${Date.now()}`;
   try {
     const clientId = await registerDeviceClient(clientName, {
@@ -311,7 +301,7 @@ test("/oauth/device rejects clients not registered for the device grant", async 
   }
 });
 
-test("/oauth/device unauthenticated pending approval redirects to sign-in", async ({
+test("/oauth/device 未登录的待批准请求重定向到登录页", async ({
   page,
   request,
 }, testInfo) => {
@@ -340,7 +330,7 @@ test("/oauth/device unauthenticated pending approval redirects to sign-in", asyn
   }
 });
 
-test("/oauth/device authenticated user sees approval screen", async ({
+test("/oauth/device 已登录用户看到批准界面", async ({
   page,
   request,
 }, testInfo) => {
@@ -366,7 +356,7 @@ test("/oauth/device authenticated user sees approval screen", async ({
   }
 });
 
-test("/oauth/device resource-bound token authenticates REST and MCP", async ({
+test("/oauth/device 资源绑定令牌可访问 REST 与 MCP", async ({
   page,
   request,
 }, testInfo) => {
@@ -426,7 +416,7 @@ test("/oauth/device resource-bound token authenticates REST and MCP", async ({
   }
 });
 
-test("/oauth/device profile-only REST token is rejected by protected REST", async ({
+test("/oauth/device 仅 profile 的 REST 令牌被受保护 REST 拒绝", async ({
   page,
   request,
 }) => {
@@ -462,7 +452,7 @@ test("/oauth/device profile-only REST token is rejected by protected REST", asyn
   }
 });
 
-test("/oauth/device MCP-scoped token without REST scope is rejected by protected REST", async ({
+test("/oauth/device 含 MCP scope 但无 REST scope 的令牌被受保护 REST 拒绝", async ({
   page,
   request,
 }) => {
@@ -502,7 +492,7 @@ test("/oauth/device MCP-scoped token without REST scope is rejected by protected
   }
 });
 
-test("/oauth/device disabled client code shows error instead of approval", async ({
+test("/oauth/device 已禁用客户端代码显示错误而非批准界面", async ({
   page,
   request,
 }, testInfo) => {
@@ -531,9 +521,7 @@ test("/oauth/device disabled client code shows error instead of approval", async
   }
 });
 
-test("/oauth/device well-known discovery includes device endpoint", async ({
-  request,
-}) => {
+test("/oauth/device 发现文档包含设备授权端点", async ({ request }) => {
   const discoveryResponse = await request.get(
     "/api/auth/.well-known/openid-configuration",
   );

--- a/tests/e2e/src/app/privacy/test.ts
+++ b/tests/e2e/src/app/privacy/test.ts
@@ -10,12 +10,12 @@ import {
 } from "../../../utils/page-ready";
 import { assertPageContract } from "../_shared/page-contract";
 
-test.describe("/privacy", () => {
-  test("contract", async ({ page }, testInfo) => {
+test.describe("/privacy 隐私政策页", () => {
+  test("页面契约", async ({ page }, testInfo) => {
     await assertPageContract(page, { routePath: "/privacy", testInfo });
   });
 
-  test("renders privacy policy with sections", async ({ page }, testInfo) => {
+  test("渲染带章节的隐私政策", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/privacy", {
       testInfo,
       screenshotLabel: "privacy",

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -66,15 +66,15 @@ function getSectionCalendarMonthView(page: Page) {
     .first();
 }
 
-test.describe("/sections/[jwId]", () => {
-  test("contract", async ({ page }, testInfo) => {
+test.describe("/sections/[jwId] 班级详情页", () => {
+  test("页面契约", async ({ page }, testInfo) => {
     await assertPageContract(page, {
       routePath: "/sections/[jwId]",
       testInfo,
     });
   });
 
-  test("404 for invalid param", async ({ page }, testInfo) => {
+  test("无效参数返回 404", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/sections/999999999", {
       expectMainContent: false,
     });
@@ -87,9 +87,7 @@ test.describe("/sections/[jwId]", () => {
 
   // ── Display fields (section.yml → section-detail) ──────────────────────────
 
-  test("displays course name as h1 and section code", async ({
-    page,
-  }, testInfo) => {
+  test("显示课程名称为 h1 与班级代码", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
 
     const heading = page.getByRole("heading", { level: 1 }).first();
@@ -114,9 +112,7 @@ test.describe("/sections/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "section/heading");
   });
 
-  test("displays semester, campus, and teacher info", async ({
-    page,
-  }, testInfo) => {
+  test("显示学期、校区与教师信息", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
 
     // section.semester.nameCn
@@ -143,9 +139,7 @@ test.describe("/sections/[jwId]", () => {
     );
   });
 
-  test("displays credits, exam mode, and remark", async ({
-    page,
-  }, testInfo) => {
+  test("显示学分、考试方式与备注", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
 
     const creditsValue = page
@@ -180,9 +174,7 @@ test.describe("/sections/[jwId]", () => {
     );
   });
 
-  test("displays teach language and room type in basic info", async ({
-    page,
-  }, testInfo) => {
+  test("基本信息中显示授课语言与教室类型", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
 
     // Expand "More Details" inner collapsible to reveal teachLanguage and roomType
@@ -219,7 +211,7 @@ test.describe("/sections/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "section/teach-lang-roomtype");
   });
 
-  test("displays admin classes (collapsible)", async ({ page }, testInfo) => {
+  test("显示行政班级（可折叠）", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
 
     // section.adminClasses[] — expand collapsible if needed
@@ -241,9 +233,7 @@ test.describe("/sections/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "section/admin-classes");
   });
 
-  test("displays schedule with room, building, teachers in calendar tab", async ({
-    page,
-  }, testInfo) => {
+  test("日历标签页显示课表、教室、教学楼与教师", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
 
     await expect(async () => {
@@ -293,7 +283,7 @@ test.describe("/sections/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "section/schedule-calendar");
   });
 
-  test("Today button navigates calendar to current day instead of section start", async ({
+  test("今天按钮将日历导航到当前日期而非班级开始日期", async ({
     page,
   }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
@@ -316,7 +306,7 @@ test.describe("/sections/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "section/calendar-today");
   });
 
-  test("displays exam info (examBatch, examRooms) in calendar tab", async ({
+  test("日历标签页显示考试信息（examBatch、examRooms）", async ({
     page,
   }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
@@ -345,9 +335,7 @@ test.describe("/sections/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "section/exam-calendar");
   });
 
-  test("jwId is NOT displayed in visible text (jwid-url-only rule)", async ({
-    page,
-  }) => {
+  test("可见文本中不显示 jwId（仅 URL 规则）", async ({ page }) => {
     await gotoAndWaitForReady(page, SECTION_URL);
     // The page content should not contain the raw jwId as visible text
     const content = await page.locator("#main-content").innerText();
@@ -355,9 +343,7 @@ test.describe("/sections/[jwId]", () => {
     expect(content).not.toMatch(new RegExp(`\\b${DEV_SEED.section.jwId}\\b`));
   });
 
-  test("subscribe button uses subscription language, not enrollment language", async ({
-    page,
-  }) => {
+  test("关注按钮使用订阅用语而非选课用语", async ({ page }) => {
     // section.yml subscription-not-enrollment rule:
     // Subscribe button must say "subscribe/follow", not "enroll".
     // Disclaimer text MAY reference enrollment to contrast subscription vs enrollment.
@@ -384,7 +370,7 @@ test.describe("/sections/[jwId]", () => {
 
   // ── Navigation ──────────────────────────────────────────────────────────────
 
-  test("tab switching works", async ({ page }, testInfo) => {
+  test("标签切换可用", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
 
     const tabList = page
@@ -408,9 +394,7 @@ test.describe("/sections/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "section/tab-switch");
   });
 
-  test("breadcrumb navigates back to sections list", async ({
-    page,
-  }, testInfo) => {
+  test("面包屑可返回班级列表", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
     const breadcrumb = page
       .getByRole("navigation", { name: "breadcrumb" })
@@ -422,9 +406,7 @@ test.describe("/sections/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "section/breadcrumb-back");
   });
 
-  test("non-enrollment disclaimer is visible in subscribe dialog", async ({
-    page,
-  }, testInfo) => {
+  test("关注弹窗显示非选课声明", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
 
     const subscribeButton = page
@@ -448,9 +430,7 @@ test.describe("/sections/[jwId]", () => {
 
   // ── Subscription ────────────────────────────────────────────────────────────
 
-  test("unauthenticated subscribe prompts login dialog", async ({
-    page,
-  }, testInfo) => {
+  test("未登录时关注弹出登录对话框", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
 
     const subscribeButton = page
@@ -474,9 +454,7 @@ test.describe("/sections/[jwId]", () => {
     );
   });
 
-  test("authenticated user can subscribe and unsubscribe", async ({
-    page,
-  }, testInfo) => {
+  test("已登录用户可关注与取消关注", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, SECTION_URL);
 
@@ -517,9 +495,7 @@ test.describe("/sections/[jwId]", () => {
 
   // ── Calendar export ─────────────────────────────────────────────────────────
 
-  test("calendar export dialog shows iCal URL and subscription URL", async ({
-    page,
-  }, testInfo) => {
+  test("日历导出弹窗显示 iCal URL 与订阅 URL", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     await page
       .context()
@@ -586,9 +562,7 @@ test.describe("/sections/[jwId]", () => {
 
   // ── Homework CRUD ───────────────────────────────────────────────────────────
 
-  test("can switch section homework tab to list view and persist preference", async ({
-    page,
-  }, testInfo) => {
+  test("可切换班级作业标签为列表视图并记住偏好", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
 
     const homeworksTab = page
@@ -624,7 +598,7 @@ test.describe("/sections/[jwId]", () => {
     await captureStepScreenshot(page, testInfo, "section/homework-list-view");
   });
 
-  test("signed-in user can create homework, inspect discussion, toggle completion, and delete", async ({
+  test("已登录用户可创建作业、查看讨论、切换完成状态并删除", async ({
     page,
   }, testInfo) => {
     test.setTimeout(60_000);
@@ -735,9 +709,7 @@ test.describe("/sections/[jwId]", () => {
     }
   });
 
-  test("homework comment permalink opens the target comment", async ({
-    page,
-  }, testInfo) => {
+  test("作业评论永久链接打开目标评论", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, SECTION_URL);
     let homeworkId: string | undefined;
@@ -802,7 +774,7 @@ test.describe("/sections/[jwId]", () => {
 
   // ── Comment CRUD ────────────────────────────────────────────────────────────
 
-  test("signed-in user can post, react, edit, reply, and delete comment", async ({
+  test("已登录用户可发布、回应、编辑、回复与删除评论", async ({
     page,
   }, testInfo) => {
     test.setTimeout(60_000);
@@ -966,9 +938,7 @@ test.describe("/sections/[jwId]", () => {
 
   // ── Attachment upload ────────────────────────────────────────────────────────
 
-  test("comment can upload attachment and open via signed download URL", async ({
-    page,
-  }, testInfo) => {
+  test("评论可上传附件并通过签名下载链接打开", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     const filename = `e2e-attachment-${Date.now()}.txt`;
     const body = `e2e-attachment-comment-${Date.now()}`;

--- a/tests/e2e/src/app/sections/test.ts
+++ b/tests/e2e/src/app/sections/test.ts
@@ -30,12 +30,12 @@ import { absoluteTestUrl } from "../../../utils/request-url";
 import { captureStepScreenshot } from "../../../utils/screenshot";
 import { assertPageContract } from "../_shared/page-contract";
 
-test.describe("/sections", () => {
-  test("contract", async ({ page }, testInfo) => {
+test.describe("/sections 班级搜索页", () => {
+  test("页面契约", async ({ page }, testInfo) => {
     await assertPageContract(page, { routePath: "/sections", testInfo });
   });
 
-  test("SSR output contains search query", async ({ baseURL }) => {
+  test("SSR 输出包含搜索查询", async ({ baseURL }) => {
     const response = await fetch(
       absoluteTestUrl(
         `/sections?search=${encodeURIComponent(DEV_SEED.section.code)}`,
@@ -48,9 +48,7 @@ test.describe("/sections", () => {
     expect(html).toContain(DEV_SEED.section.code);
   });
 
-  test("mobile cards stay tappable and navigate to detail", async ({
-    page,
-  }, testInfo) => {
+  test("移动端卡片可点击并导航到详情", async ({ page }, testInfo) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await gotoAndWaitForReady(
       page,
@@ -72,7 +70,7 @@ test.describe("/sections", () => {
     await captureStepScreenshot(page, testInfo, "sections-navigate-detail");
   });
 
-  test("search help and clear", async ({ page }, testInfo) => {
+  test("搜索帮助与清除", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/sections", {
       testInfo,
       screenshotLabel: "sections",
@@ -108,7 +106,7 @@ test.describe("/sections", () => {
     }
   });
 
-  test("semester filter preserves seed results", async ({ page }, testInfo) => {
+  test("学期筛选保留种子数据结果", async ({ page }, testInfo) => {
     const filter = await getSeedSectionSemesterFixture(DEV_SEED.section.jwId);
     if (!filter.semesterName) {
       await gotoAndWaitForReady(page, "/sections", {

--- a/tests/e2e/src/app/settings/[tab]/test.ts
+++ b/tests/e2e/src/app/settings/[tab]/test.ts
@@ -9,12 +9,12 @@ import {
 import { gotoAndWaitForReady } from "../../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
 
-test("/settings aliases require authentication", async ({ page }, testInfo) => {
+test("/settings 别名路由需要登录", async ({ page }, testInfo) => {
   await expectRequiresSignIn(page, "/settings/profile");
   await captureStepScreenshot(page, testInfo, "settings-profile-unauth");
 });
 
-test("/settings/profile alias is routed", async ({ page }, testInfo) => {
+test("/settings/profile 别名路由生效", async ({ page }, testInfo) => {
   await signInAsDebugUser(page, "/settings/profile");
   await gotoAndWaitForReady(page, "/settings/profile", {
     testInfo,
@@ -26,7 +26,7 @@ test("/settings/profile alias is routed", async ({ page }, testInfo) => {
   await captureStepScreenshot(page, testInfo, "settings-profile");
 });
 
-test("/settings invalid alias returns 404", async ({ page }) => {
+test("/settings 无效别名返回 404", async ({ page }) => {
   await signInAsDebugUser(page, "/settings/profile");
   await gotoAndWaitForReady(page, "/settings/not-a-tab", {
     expectMainContent: false,

--- a/tests/e2e/src/app/settings/accounts/test.ts
+++ b/tests/e2e/src/app/settings/accounts/test.ts
@@ -36,8 +36,8 @@ import {
 import { waitForUiSettled } from "../../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
 
-test.describe("/settings?tab=accounts", () => {
-  test("requires authentication", async ({ page }, testInfo) => {
+test.describe("/settings?tab=accounts 关联账号设置", () => {
+  test("需要登录", async ({ page }, testInfo) => {
     await expectRequiresSignIn(page, "/settings?tab=accounts");
     await captureStepScreenshot(
       page,
@@ -46,7 +46,7 @@ test.describe("/settings?tab=accounts", () => {
     );
   });
 
-  test("displays all provider cards", async ({ page }, testInfo) => {
+  test("显示所有提供商卡片", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/settings?tab=accounts");
 
     await expectPagePath(page, "/settings?tab=accounts");
@@ -56,9 +56,7 @@ test.describe("/settings?tab=accounts", () => {
     await captureStepScreenshot(page, testInfo, "settings-accounts-platforms");
   });
 
-  test("connect button initiates account-linking OAuth flow", async ({
-    page,
-  }, testInfo) => {
+  test("连接按钮启动账号关联 OAuth 流程", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/settings?tab=accounts");
 
     const providerCard = page
@@ -101,9 +99,7 @@ test.describe("/settings?tab=accounts", () => {
     }
   });
 
-  test("disconnect disabled when only one account linked", async ({
-    page,
-  }, testInfo) => {
+  test("仅关联一个账号时断开连接被禁用", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/settings?tab=accounts");
 
     const disconnectButton = page
@@ -125,9 +121,7 @@ test.describe("/settings?tab=accounts", () => {
     );
   });
 
-  test("multi-account: cancel and confirm unlink flow", async ({
-    page,
-  }, testInfo) => {
+  test("多账号：取消与确认解绑流程", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     const provider = "github";
     await signInAsDebugUser(page, "/settings?tab=accounts");

--- a/tests/e2e/src/app/settings/content/test.ts
+++ b/tests/e2e/src/app/settings/content/test.ts
@@ -23,8 +23,8 @@ import {
 import { gotoAndWaitForReady } from "../../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
 
-test.describe("/settings?tab=content", () => {
-  test("requires authentication", async ({ page }, testInfo) => {
+test.describe("/settings?tab=content 内容设置", () => {
+  test("需要登录", async ({ page }, testInfo) => {
     await expectRequiresSignIn(page, "/settings?tab=content");
     await captureStepScreenshot(
       page,
@@ -33,7 +33,7 @@ test.describe("/settings?tab=content", () => {
     );
   });
 
-  test("displays canonical content guidance", async ({ page }, testInfo) => {
+  test("显示标准内容引导", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/settings?tab=content");
 
     await expectPagePath(page, "/settings?tab=content");
@@ -51,7 +51,7 @@ test.describe("/settings?tab=content", () => {
     await captureStepScreenshot(page, testInfo, "settings-content-links");
   });
 
-  test("content links navigate correctly", async ({ page }, testInfo) => {
+  test("内容链接导航正确", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/settings?tab=content");
 
     const sectionsLink = page.getByRole("link", {

--- a/tests/e2e/src/app/settings/danger/test.ts
+++ b/tests/e2e/src/app/settings/danger/test.ts
@@ -30,13 +30,13 @@ import {
 } from "../../../../utils/auth";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
 
-test.describe("/settings?tab=danger", () => {
-  test("requires authentication", async ({ page }, testInfo) => {
+test.describe("/settings?tab=danger 危险区设置", () => {
+  test("需要登录", async ({ page }, testInfo) => {
     await expectRequiresSignIn(page, "/settings?tab=danger");
     await captureStepScreenshot(page, testInfo, "settings-danger-unauthorized");
   });
 
-  test("delete account confirmation flow", async ({ page }, testInfo) => {
+  test("删除账号确认流程", async ({ page }, testInfo) => {
     await signInAsDebugUser(
       page,
       "/settings?tab=danger",

--- a/tests/e2e/src/app/settings/profile/test.ts
+++ b/tests/e2e/src/app/settings/profile/test.ts
@@ -28,11 +28,11 @@ import {
 import { DEV_SEED } from "../../../../utils/dev-seed";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
 
-test.describe("/settings?tab=profile", () => {
+test.describe("/settings?tab=profile 个人资料设置", () => {
   // Serial mode avoids intra-file contention on the shared debug user profile.
   test.describe.configure({ mode: "serial" });
 
-  test("requires authentication", async ({ page }, testInfo) => {
+  test("需要登录", async ({ page }, testInfo) => {
     await expectRequiresSignIn(page, "/settings?tab=profile");
     await captureStepScreenshot(
       page,
@@ -41,7 +41,7 @@ test.describe("/settings?tab=profile", () => {
     );
   });
 
-  test("displays all required profile fields", async ({ page }, testInfo) => {
+  test("显示所有必填个人资料字段", async ({ page }, testInfo) => {
     test.setTimeout(300_000);
     await signInAsDebugUser(page, "/settings?tab=profile");
 
@@ -64,7 +64,7 @@ test.describe("/settings?tab=profile", () => {
     await captureStepScreenshot(page, testInfo, "settings/profile-fields");
   });
 
-  test("can save name and rollback", async ({ page }, testInfo) => {
+  test("可保存姓名并回滚", async ({ page }, testInfo) => {
     test.setTimeout(300_000);
     await signInAsDebugUser(page, "/settings?tab=profile");
 
@@ -104,7 +104,7 @@ test.describe("/settings?tab=profile", () => {
     });
   });
 
-  test("requires username before saving", async ({ page }, testInfo) => {
+  test("保存前要求填写用户名", async ({ page }, testInfo) => {
     test.setTimeout(300_000);
     await signInAsDebugUser(page, "/settings?tab=profile");
 

--- a/tests/e2e/src/app/settings/test.ts
+++ b/tests/e2e/src/app/settings/test.ts
@@ -24,15 +24,13 @@ import { DEV_SEED } from "../../../utils/dev-seed";
 import { gotoAndWaitForReady } from "../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../utils/screenshot";
 
-test.describe("/settings", () => {
-  test("requires authentication", async ({ page }, testInfo) => {
+test.describe("/settings 设置中心", () => {
+  test("需要登录", async ({ page }, testInfo) => {
     await expectRequiresSignIn(page, "/settings");
     await captureStepScreenshot(page, testInfo, "settings-unauthorized");
   });
 
-  test("defaults to profile tab with seed user data", async ({
-    page,
-  }, testInfo) => {
+  test("默认进入个人资料标签并显示种子用户数据", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/settings");
 
     await expect(page).toHaveURL(/\/settings(?:\?.*)?$/);
@@ -43,7 +41,7 @@ test.describe("/settings", () => {
     await captureStepScreenshot(page, testInfo, "settings-default-profile");
   });
 
-  test("tab navigation switches sections", async ({ page }, testInfo) => {
+  test("标签导航切换分区", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/settings");
 
     // Navigate to accounts tab
@@ -79,9 +77,7 @@ test.describe("/settings", () => {
     await captureStepScreenshot(page, testInfo, "settings-profile-tab");
   });
 
-  test("settings path aliases render the matching sections", async ({
-    page,
-  }, testInfo) => {
+  test("设置路径别名渲染对应分区", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/settings/accounts");
     await expect(page).toHaveURL(/\/settings\/accounts(?:\?.*)?$/);
     await expect(page.getByText("GitHub").first()).toBeVisible();

--- a/tests/e2e/src/app/signin/test.ts
+++ b/tests/e2e/src/app/signin/test.ts
@@ -53,11 +53,11 @@ async function expectSignedOutAfterMenuClick(page: Page) {
   ).toBeVisible();
 }
 
-test("/signin contract", async ({ page }, testInfo) => {
+test("/signin 页面契约", async ({ page }, testInfo) => {
   await assertPageContract(page, { routePath: "/signin", testInfo });
 });
 
-test("/signin displays all required fields", async ({ page }, testInfo) => {
+test("/signin 显示所有必填字段", async ({ page }, testInfo) => {
   await gotoAndWaitForReady(page, "/signin", {
     testInfo,
     screenshotLabel: "signin",
@@ -117,9 +117,7 @@ test("/signin 调试管理员可登出", async ({ page }, testInfo) => {
   await captureStepScreenshot(page, testInfo, "signin/admin-after-sign-out");
 });
 
-test("/signin post-login redirects to callbackUrl", async ({
-  page,
-}, testInfo) => {
+test("/signin 登录后重定向到 callbackUrl", async ({ page }, testInfo) => {
   // callbackUrl preserved through the sign-in flow (user.yml post-login-redirect)
   await gotoAndWaitForReady(page, "/signin?callbackUrl=%2Fsections", {
     testInfo,

--- a/tests/e2e/src/app/teachers/[id]/test.ts
+++ b/tests/e2e/src/app/teachers/[id]/test.ts
@@ -56,14 +56,14 @@ async function navigateToSeedTeacher(
   await waitForUiSettled(page);
 }
 
-test.describe("/teachers/[id]", () => {
+test.describe("/teachers/[id] 教师详情页", () => {
   test.describe.configure({ mode: "serial" });
 
-  test("contract", async ({ page }, testInfo) => {
+  test("页面契约", async ({ page }, testInfo) => {
     await assertPageContract(page, { routePath: "/teachers/[id]", testInfo });
   });
 
-  test("404 for invalid param", async ({ page }, testInfo) => {
+  test("无效参数返回 404", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/teachers/999999999", {
       expectMainContent: false,
     });
@@ -76,9 +76,7 @@ test.describe("/teachers/[id]", () => {
 
   // ── Display fields ──────────────────────────────────────────────────────────
 
-  test("displays teacher primary name in the heading", async ({
-    page,
-  }, testInfo) => {
+  test("标题中显示教师主名称", async ({ page }, testInfo) => {
     await navigateToSeedTeacher(page);
 
     // teacher.namePrimary (h1) (locale-dependent)
@@ -101,9 +99,7 @@ test.describe("/teachers/[id]", () => {
     await captureStepScreenshot(page, testInfo, "teacher/heading");
   });
 
-  test("does not display internal teacher id in ordinary UI", async ({
-    page,
-  }) => {
+  test("常规界面不显示内部教师 ID", async ({ page }) => {
     await navigateToSeedTeacher(page);
     const teacherId = new URL(page.url()).pathname.split("/").pop();
     expect(teacherId).toBeTruthy();
@@ -113,9 +109,7 @@ test.describe("/teachers/[id]", () => {
     );
   });
 
-  test("displays department, title, and email in basic info", async ({
-    page,
-  }, testInfo) => {
+  test("基本信息中显示院系、职称与邮箱", async ({ page }, testInfo) => {
     await navigateToSeedTeacher(page);
 
     // teacher.department.namePrimary (locale-dependent)
@@ -139,9 +133,7 @@ test.describe("/teachers/[id]", () => {
     await captureStepScreenshot(page, testInfo, "teacher/basic-info");
   });
 
-  test("sections table shows semester, course name, code, credits", async ({
-    page,
-  }, testInfo) => {
+  test("班级表格显示学期、课程名、代码与学分", async ({ page }, testInfo) => {
     await navigateToSeedTeacher(page);
 
     // section.semester.nameCn badge
@@ -164,9 +156,7 @@ test.describe("/teachers/[id]", () => {
     await captureStepScreenshot(page, testInfo, "teacher/sections-table");
   });
 
-  test("section links navigate to section detail", async ({
-    page,
-  }, testInfo) => {
+  test("班级链接导航到班级详情", async ({ page }, testInfo) => {
     await navigateToSeedTeacher(page);
 
     const sectionLink = page
@@ -180,7 +170,7 @@ test.describe("/teachers/[id]", () => {
 
   // ── Navigation ──────────────────────────────────────────────────────────────
 
-  test("tab switching works", async ({ page }, testInfo) => {
+  test("标签切换可用", async ({ page }, testInfo) => {
     await navigateToSeedTeacher(page);
 
     const tabList = page.getByRole("tablist").first();
@@ -198,9 +188,7 @@ test.describe("/teachers/[id]", () => {
     await captureStepScreenshot(page, testInfo, "teacher/tab-switch");
   });
 
-  test("breadcrumb navigates back to teacher list", async ({
-    page,
-  }, testInfo) => {
+  test("面包屑可返回教师列表", async ({ page }, testInfo) => {
     await navigateToSeedTeacher(page);
 
     const breadcrumb = page.locator('a[href="/teachers"]').first();
@@ -212,7 +200,7 @@ test.describe("/teachers/[id]", () => {
 
   // ── Description ─────────────────────────────────────────────────────────────
 
-  test("signed-in user can edit description (description.content, lastEditedBy, lastEditedAt)", async ({
+  test("已登录用户可编辑简介（content、lastEditedBy、lastEditedAt）", async ({
     page,
   }, testInfo) => {
     test.setTimeout(60_000);
@@ -278,9 +266,7 @@ test.describe("/teachers/[id]", () => {
 
   // ── Comment CRUD ─────────────────────────────────────────────────────────────
 
-  test("signed-in user can post, edit, and delete comment", async ({
-    page,
-  }, testInfo) => {
+  test("已登录用户可发布、编辑与删除评论", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
     await signInAsDebugUser(page, "/teachers");
     await navigateToSeedTeacher(page);

--- a/tests/e2e/src/app/teachers/test.ts
+++ b/tests/e2e/src/app/teachers/test.ts
@@ -28,11 +28,11 @@ import { captureStepScreenshot } from "../../../utils/screenshot";
 import { assertPageContract } from "../_shared/page-contract";
 
 test.describe("/teachers", () => {
-  test("contract", async ({ page }, testInfo) => {
+  test("页面契约", async ({ page }, testInfo) => {
     await assertPageContract(page, { routePath: "/teachers", testInfo });
   });
 
-  test("SSR output includes search params", async ({ baseURL }) => {
+  test("SSR 输出包含搜索参数", async ({ baseURL }) => {
     const response = await fetch(
       absoluteTestUrl(
         `/teachers?search=${encodeURIComponent(DEV_SEED.teacher.nameCn)}`,
@@ -45,9 +45,7 @@ test.describe("/teachers", () => {
     expect(html).toContain(DEV_SEED.teacher.nameCn);
   });
 
-  test("mobile cards stay tappable and navigate to detail", async ({
-    page,
-  }, testInfo) => {
+  test("移动端卡片可点击并导航到详情", async ({ page }, testInfo) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await gotoAndWaitForReady(
       page,
@@ -69,7 +67,7 @@ test.describe("/teachers", () => {
     await captureStepScreenshot(page, testInfo, "teachers-navigate-detail");
   });
 
-  test("search and clear buttons work", async ({ page }, testInfo) => {
+  test("搜索和清除按钮可用", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/teachers", {
       testInfo,
       screenshotLabel: "teachers",
@@ -95,9 +93,7 @@ test.describe("/teachers", () => {
     await captureStepScreenshot(page, testInfo, "teachers-search-clear");
   });
 
-  test("department filter preserves teacher results", async ({
-    page,
-  }, testInfo) => {
+  test("院系筛选保留教师结果", async ({ page }, testInfo) => {
     const filter = await getSeedTeacherDepartmentFixture(DEV_SEED.teacher.code);
     await gotoAndWaitForReady(
       page,

--- a/tests/e2e/src/app/terms/test.ts
+++ b/tests/e2e/src/app/terms/test.ts
@@ -11,11 +11,11 @@ import {
 import { assertPageContract } from "../_shared/page-contract";
 
 test.describe("/terms", () => {
-  test("contract", async ({ page }, testInfo) => {
+  test("页面契约", async ({ page }, testInfo) => {
     await assertPageContract(page, { routePath: "/terms", testInfo });
   });
 
-  test("renders terms of service with sections", async ({ page }, testInfo) => {
+  test("渲染服务条款及分节", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/terms", {
       testInfo,
       screenshotLabel: "terms",

--- a/tests/e2e/src/app/test.ts
+++ b/tests/e2e/src/app/test.ts
@@ -75,7 +75,7 @@ test("/ 主题切换可写入 localStorage", async ({ page }, testInfo) => {
   await captureStepScreenshot(page, testInfo, "theme-dark");
 });
 
-test("/ shell menus can switch in one click", async ({ page }) => {
+test("/ shell 菜单可一键切换", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 800 });
   await signInAsDebugUser(page, "/");
 
@@ -99,7 +99,7 @@ test("/ shell menus can switch in one click", async ({ page }) => {
   ).toHaveCount(0);
 });
 
-test("/ shell menus expose keyboard menu semantics", async ({ page }) => {
+test("/ shell 菜单支持键盘菜单语义", async ({ page }) => {
   await signInAsDebugUser(page, "/");
 
   const profileMenuButton = page.getByRole("button", {

--- a/tests/e2e/src/app/u/[username]/test.ts
+++ b/tests/e2e/src/app/u/[username]/test.ts
@@ -31,11 +31,11 @@ import { captureStepScreenshot } from "../../../../utils/screenshot";
 import { assertPageContract } from "../../_shared/page-contract";
 
 test.describe("/u/[username]", () => {
-  test("contract", async ({ page }, testInfo) => {
+  test("页面契约", async ({ page }, testInfo) => {
     await assertPageContract(page, { routePath: "/u/[username]", testInfo });
   });
 
-  test("displays all required profile fields", async ({ page }, testInfo) => {
+  test("显示所有必需的资料字段", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, `/u/${DEV_SEED.adminUsername}`);
 
     // user.name (display name)
@@ -56,7 +56,7 @@ test.describe("/u/[username]", () => {
     await captureStepScreenshot(page, testInfo, "u-username/profile-fields");
   });
 
-  test("displays stat counters grid", async ({ page }, testInfo) => {
+  test("显示统计计数器网格", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, `/u/${DEV_SEED.adminUsername}`);
 
     // sectionCount, _count.comments, _count.uploads, _count.homeworksCreated
@@ -75,9 +75,7 @@ test.describe("/u/[username]", () => {
     await captureStepScreenshot(page, testInfo, "u-username/stats-grid");
   });
 
-  test("displays contribution heatmap with totalContributions", async ({
-    page,
-  }, testInfo) => {
+  test("显示贡献热力图及 totalContributions", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, `/u/${DEV_SEED.debugUsername}`);
 
     // totalContributions label or heading
@@ -96,9 +94,7 @@ test.describe("/u/[username]", () => {
     );
   });
 
-  test("user internal ID is NOT visible on username page", async ({
-    baseURL,
-  }) => {
+  test("用户名页面不显示内部用户 ID", async ({ baseURL }) => {
     // user.yml: public-identity-display rule — internal ids hidden (permission.yml)
     const res = await fetch(
       absoluteTestUrl(`/u/${DEV_SEED.adminUsername}`, baseURL),
@@ -110,7 +106,7 @@ test.describe("/u/[username]", () => {
     expect(html).not.toMatch(/\/u\/id\/[a-z0-9]{15,}/);
   });
 
-  test("returns 404 for non-existent username", async ({ page }, testInfo) => {
+  test("不存在的用户名返回 404", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/u/non-existing-username", {
       expectMainContent: false,
     });
@@ -126,11 +122,11 @@ test.describe("/u/[username]", () => {
 });
 
 test.describe("/u/id/[uid]", () => {
-  test("contract", async ({ page }, testInfo) => {
+  test("页面契约", async ({ page }, testInfo) => {
     await assertPageContract(page, { routePath: "/u/id/[uid]", testInfo });
   });
 
-  test("shows profile by internal user ID", async ({ page }, testInfo) => {
+  test("通过内部用户 ID 显示资料", async ({ page }, testInfo) => {
     await signInAsDevAdmin(page, "/");
     const sessionResponse = await page.request.get("/api/auth/get-session");
     expect(sessionResponse.status()).toBe(200);
@@ -148,7 +144,7 @@ test.describe("/u/id/[uid]", () => {
     await captureStepScreenshot(page, testInfo, "u-id/profile");
   });
 
-  test("404 for non-existent uid", async ({ page }, testInfo) => {
+  test("不存在的 uid 返回 404", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/u/id/non-existent-uid-000000000", {
       expectMainContent: false,
     });

--- a/tests/e2e/src/app/u/id/[uid]/test.ts
+++ b/tests/e2e/src/app/u/id/[uid]/test.ts
@@ -26,13 +26,11 @@ import { captureStepScreenshot } from "../../../../../utils/screenshot";
 import { assertPageContract } from "../../../_shared/page-contract";
 
 test.describe("/u/id/[uid]", () => {
-  test("contract", async ({ page }, testInfo) => {
+  test("页面契约", async ({ page }, testInfo) => {
     await assertPageContract(page, { routePath: "/u/id/[uid]", testInfo });
   });
 
-  test("displays all required profile fields including user ID", async ({
-    page,
-  }, testInfo) => {
+  test("显示所有必需的资料字段，包括用户 ID", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/");
     const user = await getCurrentSessionUser(page);
 
@@ -54,9 +52,7 @@ test.describe("/u/id/[uid]", () => {
     await captureStepScreenshot(page, testInfo, "u-id/profile-fields");
   });
 
-  test("displays contribution heatmap and stat counters", async ({
-    page,
-  }, testInfo) => {
+  test("显示贡献热力图和统计计数器", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/");
     const user = await getCurrentSessionUser(page);
     const profileUrl = `/u/id/${user.id}`;
@@ -87,7 +83,7 @@ test.describe("/u/id/[uid]", () => {
     await captureStepScreenshot(page, testInfo, "u-id/stats-and-heatmap");
   });
 
-  test("returns 404 for non-existent user ID", async ({ page }, testInfo) => {
+  test("不存在的用户 ID 返回 404", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/u/id/non-existing-user-id", {
       expectMainContent: false,
     });

--- a/tests/e2e/src/app/welcome/test.ts
+++ b/tests/e2e/src/app/welcome/test.ts
@@ -39,7 +39,7 @@ test("/welcome 未登录重定向到登录页", async ({ page }, testInfo) => {
   await captureStepScreenshot(page, testInfo, "welcome/unauthorized");
 });
 
-test("/welcome displays required fields", async ({ page }, testInfo) => {
+test("/welcome 显示必填字段", async ({ page }, testInfo) => {
   test.setTimeout(300_000);
   await signInAsDebugUser(page, "/");
   const sessionUser = await getCurrentSessionUser(page);
@@ -98,9 +98,7 @@ test("/welcome displays required fields", async ({ page }, testInfo) => {
   }
 });
 
-test("incomplete signed-in users are redirected to /welcome from normal pages", async ({
-  page,
-}) => {
+test("资料不完整的登录用户从普通页面重定向到 /welcome", async ({ page }) => {
   test.setTimeout(300_000);
   await signInAsDebugUser(page, "/");
   const sessionUser = await getCurrentSessionUser(page);
@@ -129,9 +127,7 @@ test("incomplete signed-in users are redirected to /welcome from normal pages", 
   }
 });
 
-test("/welcome completion returns to the original callback page", async ({
-  page,
-}, testInfo) => {
+test("/welcome 完成后返回原回调页面", async ({ page }, testInfo) => {
   test.setTimeout(300_000);
   await signInAsDebugUser(page, "/");
   const sessionUser = await getCurrentSessionUser(page);

--- a/tests/integration/collaborative-invariants.test.ts
+++ b/tests/integration/collaborative-invariants.test.ts
@@ -22,8 +22,8 @@ afterAll(async () => {
   await prisma.$disconnect();
 });
 
-describe("collaborative data invariants", () => {
-  it("prevents direct duplicate open suspensions for one user", async () => {
+describe("协作数据不变量", () => {
+  it("阻止同一用户的直接重复开放封禁", async () => {
     const prefix = marker("suspension-unique");
     const user = await prisma.user.create({
       data: {
@@ -57,7 +57,7 @@ describe("collaborative data invariants", () => {
     }
   });
 
-  it("creates a replacement suspension while closing the previous open row", async () => {
+  it("创建替代封禁并关闭之前的开放记录", async () => {
     const prefix = marker("suspension-replace");
     const [admin, user] = await Promise.all([
       prisma.user.create({
@@ -121,7 +121,7 @@ describe("collaborative data invariants", () => {
     }
   });
 
-  it("deletes accounts while anonymizing audit rows and issued suspensions", async () => {
+  it("删除账户并匿名化审计行与已发出的封禁", async () => {
     const prefix = marker("account-delete");
     const [remainingAdmin, deletingAdmin, suspendedUser] = await Promise.all([
       prisma.user.create({
@@ -201,7 +201,7 @@ describe("collaborative data invariants", () => {
     }
   });
 
-  it("keeps concurrent first description writes stable and records edit history", async () => {
+  it("并发首次描述写入保持稳定并记录编辑历史", async () => {
     const prefix = marker("description-race");
     const user = await prisma.user.create({
       data: {

--- a/tests/integration/mcp-01-profile.test.ts
+++ b/tests/integration/mcp-01-profile.test.ts
@@ -4,7 +4,7 @@ import * as fixtures from "./utils/mcp-tool-test-utils";
 const context = fixtures.createMcpToolTestContext();
 
 describe("get_my_profile", () => {
-  it("returns the authenticated user's REST-equivalent profile fields", async () => {
+  it("返回认证用户的 REST 等价资料字段", async () => {
     const profile = await context.client.call<{
       id?: string;
       email?: string | null;
@@ -27,7 +27,7 @@ describe("get_my_profile", () => {
 });
 
 describe("get_public_user_profile", () => {
-  it("returns public profile hierarchy by username", async () => {
+  it("按用户名返回公开资料层级", async () => {
     const profile = await context.client.call<{
       found?: boolean;
       user?: {
@@ -63,7 +63,7 @@ describe("get_public_user_profile", () => {
     expect(typeof profile.user?._count?.subscribedSections).toBe("number");
   });
 
-  it("returns not_found for missing users", async () => {
+  it("缺失用户返回 not_found", async () => {
     const result = await context.client.call<{
       success?: boolean;
       found?: boolean;

--- a/tests/integration/mcp-02-comments.test.ts
+++ b/tests/integration/mcp-02-comments.test.ts
@@ -4,8 +4,8 @@ import * as fixtures from "./utils/mcp-tool-test-utils";
 
 const context = fixtures.createMcpToolTestContext();
 
-describe("comment read tools — MCP exposes the REST comment hierarchy", () => {
-  it("list_comments returns threaded section comments with viewer/action fields", async () => {
+describe("评论读取工具 — MCP 暴露 REST 评论层级", () => {
+  it("list_comments 返回带查看者/操作字段的班级串帖评论", async () => {
     const result = await context.client.call<{
       found?: boolean;
       comments?: Array<{
@@ -63,7 +63,7 @@ describe("comment read tools — MCP exposes the REST comment hierarchy", () => 
     ).toBe(true);
   });
 
-  it("get_comment_thread returns the focused thread and target metadata", async () => {
+  it("get_comment_thread 返回聚焦线程及目标元数据", async () => {
     const seedComment = await fixtures.prisma.comment.findFirst({
       where: { body: fixtures.DEV_SEED.comments.sectionRootBody },
       select: { id: true },
@@ -102,7 +102,7 @@ describe("comment read tools — MCP exposes the REST comment hierarchy", () => 
     expect(result.target?.courseName).toBe(fixtures.DEV_SEED.course.nameCn);
   });
 
-  it("list_comments reports missing targets instead of returning an empty success", async () => {
+  it("list_comments 报告缺失目标而非返回空成功", async () => {
     const result = await context.client.call<{
       success?: boolean;
       found?: boolean;
@@ -117,7 +117,7 @@ describe("comment read tools — MCP exposes the REST comment hierarchy", () => 
     expect(result.error).toBe("target_not_found");
   });
 
-  it("list_comments reports unattached section-teacher pairs as missing targets", async () => {
+  it("list_comments 将未关联的班级-教师对报告为缺失目标", async () => {
     const marker = `[integration-test] mcp-section-teacher-missing-${Date.now()}`;
     const teacher = await fixtures.prisma.teacher.create({
       data: {
@@ -146,7 +146,7 @@ describe("comment read tools — MCP exposes the REST comment hierarchy", () => 
     }
   });
 
-  it("list_comments does not create section-teacher targets while reading", async () => {
+  it("list_comments 读取时不创建班级-教师目标", async () => {
     const section = await fixtures.prisma.section.findUnique({
       where: { jwId: fixtures.DEV_SEED.section.jwId },
       select: { id: true },
@@ -231,8 +231,8 @@ describe("comment read tools — MCP exposes the REST comment hierarchy", () => 
   });
 });
 
-describe("comment write tools — MCP mirrors ordinary-user REST writes", () => {
-  it("comment write create/update/delete and reaction calls serialize success and audit source", async () => {
+describe("评论写入工具 — MCP 镜像普通用户 REST 写入", () => {
+  it("评论写入的创建/更新/删除及反应调用序列化成功与审计来源", async () => {
     const marker = `[integration-test] mcp-comment-write-${Date.now()}`;
     let commentId: string | undefined;
 
@@ -364,7 +364,7 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
     }
   });
 
-  it("comment write tools reject unsupported anonymous visibility", async () => {
+  it("评论写入工具拒绝不支持的匿名可见性", async () => {
     await expect(
       context.client.call("create_comment", {
         targetType: "section",
@@ -375,7 +375,7 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
     ).rejects.toThrow();
   });
 
-  it("comment write create_comment returns a serialized invalid-target failure", async () => {
+  it("评论写入 create_comment 返回序列化的无效目标失败", async () => {
     const result = await context.client.call<{
       success?: boolean;
       found?: boolean;
@@ -393,7 +393,7 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
     expect(result.message).toContain("section");
   });
 
-  it("comment write create_comment supports replies through the public MCP surface", async () => {
+  it("评论写入 create_comment 支持通过公共 MCP 接口回复", async () => {
     const marker = `[integration-test] mcp-comment-reply-${Date.now()}`;
     const commentIds: string[] = [];
 
@@ -439,7 +439,7 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
     }
   });
 
-  it("comment write tools deny non-owner edit and delete attempts", async () => {
+  it("评论写入工具拒绝非所有者编辑和删除尝试", async () => {
     const marker = `[integration-test] mcp-comment-non-owner-${Date.now()}`;
     const otherUser = await fixtures.prisma.user.create({
       data: {
@@ -491,7 +491,7 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
     }
   });
 
-  it("comment write tools validate existing upload attachments", async () => {
+  it("评论写入工具校验现有上传附件", async () => {
     const marker = `[integration-test] mcp-comment-attachments-${Date.now()}`;
     const filename = `mcp-comment-attachment-${Date.now()}.txt`;
     const upload = await fixtures.prisma.upload.create({
@@ -568,7 +568,7 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
     }
   });
 
-  it("upload metadata tools list, rename, and preserve retry state on delete storage failure", async () => {
+  it("上传元数据工具列出、重命名并在存储删除失败时保留重试状态", async () => {
     const filename = `mcp-upload-${Date.now()}.txt`;
     const upload = await fixtures.prisma.upload.create({
       data: {
@@ -638,7 +638,7 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
     }
   });
 
-  it("upload rename rejects control-character filenames without sanitizing", async () => {
+  it("上传重命名拒绝控制字符文件名且不做清洗", async () => {
     const filename = `mcp-upload-invalid-rename-${Date.now()}.txt`;
     const upload = await fixtures.prisma.upload.create({
       data: {
@@ -671,7 +671,7 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
     }
   });
 
-  it("upload metadata tools deny non-owner and suspended writes", async () => {
+  it("上传元数据工具拒绝非所有者及被禁用户写入", async () => {
     const otherUser = await fixtures.prisma.user.create({
       data: {
         email: fixtures.integrationUserEmail("mcp-upload-owner"),
@@ -762,7 +762,7 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
     }
   });
 
-  it("comment write create_comment checks suspension before target lookup", async () => {
+  it("评论写入 create_comment 在目标查找前检查封禁状态", async () => {
     const suspendedUser = await fixtures.prisma.user.create({
       data: {
         email: fixtures.integrationUserEmail("mcp-comment-suspended"),
@@ -807,7 +807,7 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
     }
   });
 
-  it("comment write tools reject replies and reactions on deleted comments", async () => {
+  it("评论写入工具拒绝已删除评论的回复和反应", async () => {
     const marker = `[integration-test] mcp-comment-locked-${Date.now()}`;
     let commentId: string | undefined;
 
@@ -863,7 +863,7 @@ describe("comment write tools — MCP mirrors ordinary-user REST writes", () => 
     }
   });
 
-  it("comment write tools reject owner delete on softbanned comments", async () => {
+  it("评论写入工具拒绝软封禁评论的所有者删除", async () => {
     const marker = `[integration-test] mcp-comment-softbanned-delete-${Date.now()}`;
     let commentId: string | undefined;
 

--- a/tests/integration/mcp-03-descriptions.test.ts
+++ b/tests/integration/mcp-03-descriptions.test.ts
@@ -3,8 +3,8 @@ import * as fixtures from "./utils/mcp-tool-test-utils";
 
 const context = fixtures.createMcpToolTestContext();
 
-describe("description tools — MCP exposes the REST description payload", () => {
-  it("get_description returns seeded section description by public JW id", async () => {
+describe("描述工具 — MCP 暴露 REST 描述载荷", () => {
+  it("get_description 通过公开 JW id 返回种子班级描述", async () => {
     const section = await fixtures.prisma.section.findUnique({
       where: { jwId: fixtures.DEV_SEED.section.jwId },
       select: { id: true },
@@ -37,7 +37,7 @@ describe("description tools — MCP exposes the REST description payload", () =>
     });
   });
 
-  it("get_description reports missing public section targets", async () => {
+  it("get_description 报告缺失的公开班级目标", async () => {
     const result = await context.client.call<{
       success?: boolean;
       found?: boolean;
@@ -54,7 +54,7 @@ describe("description tools — MCP exposes the REST description payload", () =>
     expect(result.hint).toContain("search_sections");
   });
 
-  it("upsert_description creates, idempotently rereads, audits, and cleans up", async () => {
+  it("upsert_description 创建、幂等重读、审计并清理", async () => {
     const marker = `[integration-test] mcp-description-${Date.now()}`;
     const teacher = await fixtures.prisma.teacher.create({
       data: {

--- a/tests/integration/mcp-04-todos-homeworks.test.ts
+++ b/tests/integration/mcp-04-todos-homeworks.test.ts
@@ -4,7 +4,7 @@ import * as fixtures from "./utils/mcp-tool-test-utils";
 
 const context = fixtures.createMcpToolTestContext();
 
-describe("todo CRUD — update_my_todo returns updated entity", () => {
+describe("todo CRUD — update_my_todo 返回更新后的实体", () => {
   async function createIntegrationTodo(testName: string) {
     const result = await context.client.call<{
       success?: boolean;
@@ -25,7 +25,7 @@ describe("todo CRUD — update_my_todo returns updated entity", () => {
     await fixtures.prisma.todo.deleteMany({ where: { id: todoId } });
   }
 
-  it("update_my_todo returns the updated todo entity (not just success: true)", async () => {
+  it("update_my_todo 返回更新后的 todo 实体（不仅 success: true）", async () => {
     const todoId = await createIntegrationTodo("update returns todo");
     try {
       const result = await context.client.call<{
@@ -58,7 +58,7 @@ describe("todo CRUD — update_my_todo returns updated entity", () => {
     }
   });
 
-  it("update_my_todo validates normalized content length", async () => {
+  it("update_my_todo 校验规范化内容长度", async () => {
     const todoId = await createIntegrationTodo("normalized content");
     const content = "x".repeat(TODO_CONTENT_MAX_LENGTH);
     try {
@@ -82,7 +82,7 @@ describe("todo CRUD — update_my_todo returns updated entity", () => {
     }
   });
 
-  it("update_my_todo clears content when content is explicitly null", async () => {
+  it("update_my_todo 在内容显式为 null 时清空内容", async () => {
     const todoId = await createIntegrationTodo("clear content");
     try {
       const result = await context.client.call<{
@@ -105,7 +105,7 @@ describe("todo CRUD — update_my_todo returns updated entity", () => {
     }
   });
 
-  it("delete_my_todo deletes a todo", async () => {
+  it("delete_my_todo 删除 todo", async () => {
     const todoId = await createIntegrationTodo("delete");
     try {
       const result = await context.client.call<{ success?: boolean }>(
@@ -126,7 +126,7 @@ describe("todo CRUD — update_my_todo returns updated entity", () => {
     }
   });
 
-  it("create_my_todo returns the new todo id", async () => {
+  it("create_my_todo 返回新 todo id", async () => {
     const todoId = await createIntegrationTodo("create");
     try {
       const created = await fixtures.prisma.todo.findUnique({
@@ -146,8 +146,8 @@ describe("todo CRUD — update_my_todo returns updated entity", () => {
 // Homeworks
 // ---------------------------------------------------------------------------
 
-describe("homework write tools — MCP mirrors ordinary-user REST writes", () => {
-  it("delete_homework_on_section deletes creator-owned homework and records audit", async () => {
+describe("作业写入工具 — MCP 镜像普通用户 REST 写入", () => {
+  it("delete_homework_on_section 删除创建者拥有的作业并记录审计", async () => {
     const section = await fixtures.prisma.section.findUnique({
       where: { jwId: fixtures.DEV_SEED.section.jwId },
       select: { id: true },
@@ -202,7 +202,7 @@ describe("homework write tools — MCP mirrors ordinary-user REST writes", () =>
     }
   });
 
-  it("delete_homework_on_section serializes not-found and non-owner failures", async () => {
+  it("delete_homework_on_section 序列化未找到及非所有者失败", async () => {
     const section = await fixtures.prisma.section.findUnique({
       where: { jwId: fixtures.DEV_SEED.section.jwId },
       select: { id: true },

--- a/tests/integration/mcp-05-calendar-events.test.ts
+++ b/tests/integration/mcp-05-calendar-events.test.ts
@@ -3,7 +3,7 @@ import * as fixtures from "./utils/mcp-tool-test-utils";
 
 const context = fixtures.createMcpToolTestContext();
 
-describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools", () => {
+describe("flexDateInputSchema — 日期筛选工具接受裸 YYYY-MM-DD", () => {
   let originalSubscriptionSectionIds: number[] = [];
 
   beforeAll(async () => {
@@ -20,7 +20,7 @@ describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools"
     );
   });
 
-  it("list_my_schedules accepts bare date strings (no timezone offset)", async () => {
+  it("list_my_schedules 接受裸日期字符串（无时区偏移）", async () => {
     const result = await context.client.call<{
       schedules?: Array<{
         id?: number;
@@ -49,7 +49,7 @@ describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools"
     }
   });
 
-  it("list_my_exams accepts bare date strings", async () => {
+  it("list_my_exams 接受裸日期字符串", async () => {
     const result = await context.client.call<{
       exams?: Array<{ id?: number }>;
     }>("list_my_exams", {
@@ -62,7 +62,7 @@ describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools"
     expect(Array.isArray(result.exams)).toBe(true);
   });
 
-  it("list_my_calendar_events accepts bare date strings", async () => {
+  it("list_my_calendar_events 接受裸日期字符串", async () => {
     const result = await context.client.call<{
       events?: Array<{ type?: string; at?: string }>;
     }>("list_my_calendar_events", {
@@ -80,7 +80,7 @@ describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools"
     ).toBe(true);
   });
 
-  it("list_my_calendar_events treats same-day bare date ranges as full Shanghai days", async () => {
+  it("list_my_calendar_events 将同日裸日期范围视为完整上海天时区日", async () => {
     const result = await context.client.call<{
       events?: Array<{ type?: string; at?: string }>;
     }>("list_my_calendar_events", {
@@ -98,7 +98,7 @@ describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools"
     ).toBe(true);
   });
 
-  it("list_my_calendar_events honors an exact inclusive dateTo bound", async () => {
+  it("list_my_calendar_events 遵守精确包含的 dateTo 边界", async () => {
     const dueAt = `${fixtures.SEED_PLUS_THREE_DAYS}T21:00:00+08:00`;
     const result = await context.client.call<{
       events?: Array<{ type?: string; at?: string }>;
@@ -115,7 +115,7 @@ describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools"
     ).toBe(true);
   });
 
-  it("list_my_calendar_events includes todos at an exact inclusive dateTo bound", async () => {
+  it("list_my_calendar_events 在精确包含的 dateTo 边界包含 todo", async () => {
     const dueAt = `${fixtures.SEED_DATE}T06:45:00+08:00`;
     const todo = await fixtures.prisma.todo.create({
       data: {
@@ -152,7 +152,7 @@ describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools"
     }
   });
 
-  it("list_my_calendar_events includes timed events overlapping an exact window", async () => {
+  it("list_my_calendar_events 包含与精确窗口重叠的定时事件", async () => {
     const schedule = await fixtures.prisma.schedule.findFirst({
       where: {
         section: { jwId: fixtures.DEV_SEED.section.jwId },
@@ -186,7 +186,7 @@ describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools"
     ).toBe(true);
   });
 
-  it("list_my_calendar_events widens date-backed queries for exact windows", async () => {
+  it("list_my_calendar_events 为精确窗口放宽基于日期的查询", async () => {
     const section = await fixtures.prisma.section.findUnique({
       where: { jwId: fixtures.DEV_SEED.section.jwId },
       select: { id: true },
@@ -229,7 +229,7 @@ describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools"
     }
   });
 
-  it("list_my_calendar_events keeps no-time exams visible through their day", async () => {
+  it("list_my_calendar_events 使无时间考试在当天保持可见", async () => {
     const section = await fixtures.prisma.section.findUnique({
       where: { jwId: fixtures.DEV_SEED.section.jwId },
       select: { id: true },
@@ -274,7 +274,7 @@ describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools"
     }
   });
 
-  it("list_my_calendar_events respects endTime for exams without startTime", async () => {
+  it("list_my_calendar_events 对无 startTime 的考试尊重 endTime", async () => {
     const section = await fixtures.prisma.section.findUnique({
       where: { jwId: fixtures.DEV_SEED.section.jwId },
       select: { id: true },
@@ -317,7 +317,7 @@ describe("flexDateInputSchema — bare YYYY-MM-DD accepted by date-filter tools"
     }
   });
 
-  it("returns a descriptive error for a nonsense date string", async () => {
+  it("对无效日期字符串返回描述性错误", async () => {
     const result = await context.client.call<{
       success?: boolean;
       message?: string;

--- a/tests/integration/mcp-06-time-sensitive.test.ts
+++ b/tests/integration/mcp-06-time-sensitive.test.ts
@@ -3,7 +3,7 @@ import * as fixtures from "./utils/mcp-tool-test-utils";
 
 const context = fixtures.createMcpToolTestContext();
 
-describe("atTime override — time-sensitive tools are anchored to SEED_DATE", () => {
+describe("atTime 覆盖 — 时间敏感工具锚定到 SEED_DATE", () => {
   let originalSubscriptionSectionIds: number[] = [];
   let seedSectionId = 0;
 
@@ -23,7 +23,7 @@ describe("atTime override — time-sensitive tools are anchored to SEED_DATE", (
     );
   });
 
-  it("get_my_7days_timeline with atTime returns the seed window and correct range", async () => {
+  it("get_my_7days_timeline 使用 atTime 返回种子窗口和正确范围", async () => {
     const result = await context.client.call<{
       range?: { from?: string; to?: string };
       total?: number;
@@ -46,7 +46,7 @@ describe("atTime override — time-sensitive tools are anchored to SEED_DATE", (
     expect((result.events ?? []).some((e) => e.type === "schedule")).toBe(true);
   });
 
-  it("get_my_7days_timeline summary mode with atTime returns grouped collection", async () => {
+  it("get_my_7days_timeline 摘要模式使用 atTime 返回分组集合", async () => {
     const result = await context.client.call<{
       total?: number;
       events?: {
@@ -71,7 +71,7 @@ describe("atTime override — time-sensitive tools are anchored to SEED_DATE", (
     }
   });
 
-  it("get_upcoming_deadlines with atTime only returns events after the anchor", async () => {
+  it("get_upcoming_deadlines 使用 atTime 仅返回锚点之后的事件", async () => {
     const result = await context.client.call<{
       total?: number;
       deadlines?: Array<{ type?: string; at?: string }>;
@@ -95,7 +95,7 @@ describe("atTime override — time-sensitive tools are anchored to SEED_DATE", (
     }
   });
 
-  it("get_upcoming_deadlines excludes already-started exams", async () => {
+  it("get_upcoming_deadlines 排除已开始考试", async () => {
     const section = await fixtures.prisma.section.findUnique({
       where: { jwId: fixtures.DEV_SEED.section.jwId },
       select: { id: true },
@@ -142,7 +142,7 @@ describe("atTime override — time-sensitive tools are anchored to SEED_DATE", (
     }
   });
 
-  it("get_upcoming_deadlines treats date-only atTime as Shanghai day start", async () => {
+  it("get_upcoming_deadlines 将仅日期 atTime 视为上海天开始", async () => {
     const dueAt = `${fixtures.SEED_DATE}T06:30:00+08:00`;
     const todo = await fixtures.prisma.todo.create({
       data: {
@@ -179,7 +179,7 @@ describe("atTime override — time-sensitive tools are anchored to SEED_DATE", (
     }
   });
 
-  it("get_my_overview with atTime reflects the seed day's schedule count and sample limit", async () => {
+  it("get_my_overview 使用 atTime 反映种子日课程数及样本限制", async () => {
     const result = await context.client.call<{
       overview?: {
         pendingTodosCount?: number;
@@ -219,7 +219,7 @@ describe("atTime override — time-sensitive tools are anchored to SEED_DATE", (
     expect((summary.samples?.dueTodos?.items?.length ?? 0) <= 3).toBe(true);
   });
 
-  it("get_my_overview treats date-only atTime as Shanghai day start", async () => {
+  it("get_my_overview 将仅日期 atTime 视为上海天开始", async () => {
     const dueAt = `${fixtures.SEED_DATE}T06:30:00+08:00`;
     const todo = await fixtures.prisma.todo.create({
       data: {
@@ -250,7 +250,7 @@ describe("atTime override — time-sensitive tools are anchored to SEED_DATE", (
     }
   });
 
-  it("get_my_overview honors the compact overview homework window", async () => {
+  it("get_my_overview 遵守紧凑总览作业窗口", async () => {
     const title = `[integration-test] outside overview window ${Date.now()}`;
     const homework = await fixtures.prisma.homework.create({
       data: {
@@ -302,7 +302,7 @@ describe("atTime override — time-sensitive tools are anchored to SEED_DATE", (
     }
   });
 
-  it("get_my_overview summary mode stays smaller after all due samples pass", async () => {
+  it("get_my_overview 摘要模式在所有到期样本结束后保持更小", async () => {
     const atTime = `${fixtures.SEED_PLUS_TWELVE_DAYS}T12:00:00+08:00`;
     const defaultPayload = await context.client.callTool("get_my_overview", {
       locale: "zh-cn",
@@ -329,7 +329,7 @@ describe("atTime override — time-sensitive tools are anchored to SEED_DATE", (
     expect(summaryPayload.samples?.upcomingExams?.items).toBeUndefined();
   });
 
-  it("get_my_overview excludes same-day exams that already ended", async () => {
+  it("get_my_overview 排除当天已结束的考试", async () => {
     const atTime = `${fixtures.SEED_DATE}T12:00:00+08:00`;
     const before = await context.client.call<{
       overview?: { upcomingExamsCount?: number };
@@ -389,7 +389,7 @@ describe("atTime override — time-sensitive tools are anchored to SEED_DATE", (
     }
   });
 
-  it("get_my_overview excludes date-unknown exams from upcoming counts", async () => {
+  it("get_my_overview 从未知日期考试中排除待考计数", async () => {
     const before = await context.client.call<{
       overview?: { upcomingExamsCount?: number };
     }>("get_my_overview", {

--- a/tests/integration/mcp-07-section-records.test.ts
+++ b/tests/integration/mcp-07-section-records.test.ts
@@ -3,8 +3,8 @@ import * as fixtures from "./utils/mcp-tool-test-utils";
 
 const context = fixtures.createMcpToolTestContext();
 
-describe("list_schedules_by_section — date range filter", () => {
-  it("returns all schedules for the section when no date filter is given", async () => {
+describe("list_schedules_by_section — 日期范围筛选", () => {
+  it("无日期筛选时返回该班级所有课程安排", async () => {
     const all = await context.client.call<{
       found?: boolean;
       schedules?: Array<{ id?: number; date?: string }>;
@@ -17,7 +17,7 @@ describe("list_schedules_by_section — date range filter", () => {
     expect((all.schedules?.length ?? 0) > 0).toBe(true);
   });
 
-  it("narrows results to a specific week with dateFrom+dateTo bare dates", async () => {
+  it("使用 dateFrom+dateTo 裸日期将结果缩小到特定周", async () => {
     const week = await context.client.call<{
       found?: boolean;
       schedules?: Array<{ id?: number; date?: string }>;
@@ -39,7 +39,7 @@ describe("list_schedules_by_section — date range filter", () => {
     }
   });
 
-  it("returns empty schedules array for a window with no matching schedules", async () => {
+  it("对无匹配课程安排的窗口返回空数组", async () => {
     const result = await context.client.call<{
       found?: boolean;
       schedules?: unknown[];
@@ -54,7 +54,7 @@ describe("list_schedules_by_section — date range filter", () => {
     expect(result.schedules).toHaveLength(0);
   });
 
-  it("returns error message for invalid dateFrom", async () => {
+  it("无效 dateFrom 返回错误消息", async () => {
     const result = await context.client.call<{
       success?: boolean;
       message?: string;
@@ -69,8 +69,8 @@ describe("list_schedules_by_section — date range filter", () => {
   });
 });
 
-describe("query_schedules — flexible date filters", () => {
-  it("accepts bare dates and returns paginated public schedules", async () => {
+describe("query_schedules — 灵活日期筛选", () => {
+  it("接受裸日期并返回分页公开课程安排", async () => {
     const result = await context.client.call<{
       data?: Array<{ date?: string; endTime?: unknown; startTime?: unknown }>;
       pagination?: { total?: number };
@@ -93,7 +93,7 @@ describe("query_schedules — flexible date filters", () => {
     }
   });
 
-  it("returns a descriptive payload for invalid date filters", async () => {
+  it("对无效日期筛选返回描述性载荷", async () => {
     const result = await context.client.call<{
       success?: boolean;
       message?: string;

--- a/tests/integration/mcp-08-catalog.test.ts
+++ b/tests/integration/mcp-08-catalog.test.ts
@@ -3,8 +3,8 @@ import * as fixtures from "./utils/mcp-tool-test-utils";
 
 const context = fixtures.createMcpToolTestContext();
 
-describe("course and section lookups", () => {
-  it("search_courses returns the REST-equivalent paginated course hierarchy", async () => {
+describe("课程与班级查找", () => {
+  it("search_courses 返回 REST 等价分页课程层级", async () => {
     const seedCourseFilters = await fixtures.prisma.course.findUnique({
       where: { jwId: fixtures.DEV_SEED.course.jwId },
       select: {
@@ -63,7 +63,7 @@ describe("course and section lookups", () => {
     );
   });
 
-  it("get_section_by_jw_id returns the same detail hierarchy as REST section detail", async () => {
+  it("get_section_by_jw_id 返回与 REST 班级详情相同的层级", async () => {
     const result = await context.client.call<{
       found?: boolean;
       section?: {
@@ -93,7 +93,7 @@ describe("course and section lookups", () => {
     expect(Object.hasOwn(result.section ?? {}, "roomType")).toBe(true);
   });
 
-  it("get_section_by_jw_id returns a recovery hint when the jwId is missing", async () => {
+  it("get_section_by_jw_id 在 jwId 缺失时返回恢复提示", async () => {
     const result = await context.client.call<{
       found?: boolean;
       message?: string;

--- a/tests/integration/mcp-09-dashboard.test.ts
+++ b/tests/integration/mcp-09-dashboard.test.ts
@@ -3,7 +3,7 @@ import * as fixtures from "./utils/mcp-tool-test-utils";
 
 const context = fixtures.createMcpToolTestContext();
 
-describe("get_my_dashboard — default mode compactness", () => {
+describe("get_my_dashboard — 默认模式紧凑性", () => {
   let originalSubscriptionSectionIds: number[] = [];
 
   beforeAll(async () => {
@@ -20,7 +20,7 @@ describe("get_my_dashboard — default mode compactness", () => {
     );
   });
 
-  it("atTime anchors nextClass, deadlines, and events", async () => {
+  it("atTime 锚定下一节课、截止日期和事件", async () => {
     const dashboard = await context.client.call<{
       nextClass?: { type?: string; at?: string | null };
       upcomingDeadlines?: {
@@ -40,7 +40,7 @@ describe("get_my_dashboard — default mode compactness", () => {
     expect(dashboard.upcomingEvents?.total).toBeGreaterThan(0);
   });
 
-  it("scheduleGroup and roomType are stripped from nextClass payload", async () => {
+  it("nextClass payload 中移除 scheduleGroup 和 roomType", async () => {
     const dashboard = await context.client.call<{
       nextClass?: {
         payload?: {
@@ -64,7 +64,7 @@ describe("get_my_dashboard — default mode compactness", () => {
     expect(typeof dashboard.todos?.incompleteCount).toBe("number");
   });
 
-  it("summary mode is materially smaller than default mode", async () => {
+  it("summary 模式比 default 模式显著更小", async () => {
     const def = JSON.stringify(
       await context.client.callTool("get_my_dashboard", {
         locale: "zh-cn",

--- a/tests/integration/mcp-10-dashboard-links.test.ts
+++ b/tests/integration/mcp-10-dashboard-links.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createMcpHarness, type McpHarness } from "./utils/mcp-harness";
 import * as fixtures from "./utils/mcp-tool-test-utils";
 
-describe("dashboard link tools — list/search and pin state", () => {
+describe("dashboard link 工具 — 列表/搜索与置顶状态", () => {
   let dashboardLinkMcp: McpHarness | undefined;
   let dashboardLinkUserId: string | undefined;
 
@@ -35,7 +35,7 @@ describe("dashboard link tools — list/search and pin state", () => {
     await fixtures.prisma.$disconnect();
   });
 
-  it("list_dashboard_links searches pinyin and includes pin state", async () => {
+  it("list_dashboard_links 搜索拼音并包含置顶状态", async () => {
     const result = await dashboardLinkMcp?.call<{
       success?: boolean;
       query?: string | null;
@@ -77,7 +77,7 @@ describe("dashboard link tools — list/search and pin state", () => {
     expect(mail).not.toHaveProperty("descriptionPinyin");
   });
 
-  it("set_dashboard_link_pin_state pins and unpins for the MCP user", async () => {
+  it("set_dashboard_link_pin_state 为 MCP 用户置顶与取消置顶", async () => {
     if (!dashboardLinkUserId)
       throw new Error("Dashboard link test user missing");
     await fixtures.prisma.dashboardLinkPin.deleteMany({
@@ -134,7 +134,7 @@ describe("dashboard link tools — list/search and pin state", () => {
     expect(unpinned?.pinnedSlugs ?? []).not.toContain("mail");
   });
 
-  it("set_dashboard_link_pin_state returns validation payloads for invalid slugs", async () => {
+  it("set_dashboard_link_pin_state 对无效 slug 返回校验载荷", async () => {
     if (!dashboardLinkUserId)
       throw new Error("Dashboard link test user missing");
     await fixtures.prisma.dashboardLinkPin.deleteMany({

--- a/tests/integration/mcp-11-bus.test.ts
+++ b/tests/integration/mcp-11-bus.test.ts
@@ -12,8 +12,8 @@ type BusPreferenceToolResponse = {
   };
 };
 
-describe("get_next_buses — default mode drops repeated campus objects", () => {
-  it("accepts date-only atTime for deterministic departure queries", async () => {
+describe("get_next_buses — 默认模式去除重复的校区对象", () => {
+  it("接受仅日期的 atTime 以确定发车查询", async () => {
     const result = await context.client.call<{ totalRoutes?: number }>(
       "get_next_buses",
       {
@@ -28,7 +28,7 @@ describe("get_next_buses — default mode drops repeated campus objects", () => 
     expect(result.totalRoutes).toBeGreaterThan(0);
   });
 
-  it("rejects limits above the shared REST/MCP cap", async () => {
+  it("拒绝超过共享 REST/MCP 上限的 limit", async () => {
     await expect(
       context.client.call("get_next_buses", {
         locale: "zh-cn",
@@ -39,7 +39,7 @@ describe("get_next_buses — default mode drops repeated campus objects", () => 
     ).rejects.toThrow();
   });
 
-  it("rejects invalid atTime with the shared MCP date message", async () => {
+  it("以共享 MCP 日期提示拒绝无效的 atTime", async () => {
     const result = await context.client.call<{
       success?: boolean;
       message?: string;
@@ -57,7 +57,7 @@ describe("get_next_buses — default mode drops repeated campus objects", () => 
     });
   });
 
-  it("departure items omit originCampus and destinationCampus", async () => {
+  it("发车项省略 originCampus 和 destinationCampus", async () => {
     const result = await context.client.call<{
       originCampus?: { id?: number };
       destinationCampus?: { id?: number };
@@ -89,7 +89,7 @@ describe("get_next_buses — default mode drops repeated campus objects", () => 
   });
 });
 
-describe("bus preference tools", () => {
+describe("bus preference 工具", () => {
   let preferenceUserId: string | null = null;
   let preferenceMcp: McpHarness | undefined;
 
@@ -127,7 +127,7 @@ describe("bus preference tools", () => {
     );
   }
 
-  it("reads, saves, and resets the authenticated user's bus preferences", async () => {
+  it("读取、保存并重置已认证用户的 bus 偏好", async () => {
     const initial = await readPreference();
 
     expect(initial.preference).toEqual({
@@ -171,7 +171,7 @@ describe("bus preference tools", () => {
     });
   });
 
-  it("serializes unknown campus validation failures without writing", async () => {
+  it("序列化未知校区校验失败且不写入", async () => {
     const before = await readPreference();
 
     const result = await preferenceHarness().call<{

--- a/tests/integration/mcp-12-subscriptions.test.ts
+++ b/tests/integration/mcp-12-subscriptions.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createMcpHarness, type McpHarness } from "./utils/mcp-harness";
 import * as fixtures from "./utils/mcp-tool-test-utils";
 
-describe("subscribe_section_by_jw_id — returns action + compact subscription", () => {
+describe("subscribe_section_by_jw_id — 返回 action 与精简订阅", () => {
   let subscriptionMcp: McpHarness | undefined;
   let subscriptionUserId: string | undefined;
 
@@ -35,7 +35,7 @@ describe("subscribe_section_by_jw_id — returns action + compact subscription",
     return subscriptionMcp;
   }
 
-  it("subscribing returns action=subscribed or action=already_subscribed", async () => {
+  it("订阅返回 action=subscribed 或 action=already_subscribed", async () => {
     const result = await harness().call<{
       success?: boolean;
       action?: string;
@@ -59,7 +59,7 @@ describe("subscribe_section_by_jw_id — returns action + compact subscription",
     expect(typeof result.subscription?.sectionCount).toBe("number");
   });
 
-  it("returns not_found for missing subscribe and unsubscribe targets", async () => {
+  it("对缺失的订阅与取消订阅目标返回 not_found", async () => {
     const missingJwId = 2_147_483_647;
     const subscribeResult = await harness().call<{
       success?: boolean;

--- a/tests/unit/academic-list-cache.test.ts
+++ b/tests/unit/academic-list-cache.test.ts
@@ -31,7 +31,7 @@ function clearPublicRuntimeCache() {
   ).__lifeUstcPublicRuntimeCache;
 }
 
-describe("academic list route caching", () => {
+describe("academic 列表路由缓存", () => {
   afterEach(() => {
     listCourseSummariesMock.mockClear();
     listTeacherSummariesMock.mockClear();
@@ -39,7 +39,7 @@ describe("academic list route caching", () => {
     vi.resetModules();
   });
 
-  it("caches course list responses for equivalent query strings", async () => {
+  it("对等价查询字符串缓存课程列表响应", async () => {
     const { getCoursesRoute } = await import(
       "@/lib/api/routes/academic-course-routes"
     );
@@ -59,7 +59,7 @@ describe("academic list route caching", () => {
     expect(listCourseSummariesMock).toHaveBeenCalledTimes(1);
   });
 
-  it("caches teacher list responses for equivalent query strings", async () => {
+  it("对等价查询字符串缓存教师列表响应", async () => {
     const { getTeachersRoute } = await import(
       "@/lib/api/routes/academic-teacher-routes"
     );

--- a/tests/unit/academic-route-locale.test.ts
+++ b/tests/unit/academic-route-locale.test.ts
@@ -139,13 +139,13 @@ function clearPublicRuntimeCache() {
   ).__lifeUstcPublicRuntimeCache;
 }
 
-describe("academic REST locale adapters", () => {
+describe("academic REST 语言适配器", () => {
   afterEach(() => {
     vi.clearAllMocks();
     clearPublicRuntimeCache();
   });
 
-  it("passes request locale to course detail reads", async () => {
+  it("将请求语言传递给课程详情读取", async () => {
     const { getCourseDetailRoute } = await import(
       "@/lib/api/routes/academic-course-routes"
     );
@@ -158,7 +158,7 @@ describe("academic REST locale adapters", () => {
     expect(response.headers.get("Vary")).toBe("Accept-Language, Cookie");
   });
 
-  it("passes request locale to section detail reads", async () => {
+  it("将请求语言传递给班级详情读取", async () => {
     const { getSectionDetailRoute } = await import(
       "@/lib/api/routes/academic-section-routes"
     );
@@ -171,7 +171,7 @@ describe("academic REST locale adapters", () => {
     expect(response.headers.get("Vary")).toBe("Accept-Language, Cookie");
   });
 
-  it("passes request locale to teacher detail reads", async () => {
+  it("将请求语言传递给教师详情读取", async () => {
     const { getTeacherDetailRoute } = await import(
       "@/lib/api/routes/academic-teacher-routes"
     );
@@ -184,7 +184,7 @@ describe("academic REST locale adapters", () => {
     expect(response.headers.get("Vary")).toBe("Accept-Language, Cookie");
   });
 
-  it("passes request locale to section-code matching", async () => {
+  it("将请求语言传递给班级代码匹配", async () => {
     const { postSectionMatchCodesRoute } = await import(
       "@/lib/api/routes/academic-section-routes"
     );
@@ -203,7 +203,7 @@ describe("academic REST locale adapters", () => {
     );
   });
 
-  it("uses locale-aware shared section summaries for section lists", async () => {
+  it("班级列表使用支持语言的共享班级摘要", async () => {
     const { getSectionsRoute } = await import(
       "@/lib/api/routes/academic-section-routes"
     );
@@ -218,7 +218,7 @@ describe("academic REST locale adapters", () => {
     expect(response.headers.get("Vary")).toBe("Accept-Language, Cookie");
   });
 
-  it("passes request locale to course and teacher list reads", async () => {
+  it("将请求语言传递给课程与教师列表读取", async () => {
     const [{ getCoursesRoute }, { getTeachersRoute }] = await Promise.all([
       import("@/lib/api/routes/academic-course-routes"),
       import("@/lib/api/routes/academic-teacher-routes"),
@@ -243,7 +243,7 @@ describe("academic REST locale adapters", () => {
     );
   });
 
-  it("passes request locale to public schedule reads", async () => {
+  it("将请求语言传递给公共课表读取", async () => {
     const { getSchedulesRoute } = await import(
       "@/lib/api/routes/academic-schedule-routes"
     );
@@ -271,7 +271,7 @@ describe("academic REST locale adapters", () => {
     );
   });
 
-  it("passes request locale to section schedule reads", async () => {
+  it("将请求语言传递给班级课表读取", async () => {
     const { getSectionSchedulesRoute, getSectionScheduleGroupsRoute } =
       await import("@/lib/api/routes/academic-section-routes");
 

--- a/tests/unit/admin-api-service.test.ts
+++ b/tests/unit/admin-api-service.test.ts
@@ -65,7 +65,7 @@ vi.mock("@/lib/metrics/observability-metrics", () => ({
   recordAuditWriteMetric: vi.fn(),
 }));
 
-describe("admin API service", () => {
+describe("admin API 服务", () => {
   beforeEach(() => {
     auditLogCreateMock.mockReset();
     commentFindUniqueMock.mockReset();
@@ -104,7 +104,7 @@ describe("admin API service", () => {
     vi.resetModules();
   });
 
-  it("rejects self-demotion before updating the user", async () => {
+  it("更新用户前拒绝自我降权", async () => {
     prismaMock.user.findUnique.mockResolvedValue({
       id: "admin-1",
       isAdmin: true,
@@ -125,7 +125,7 @@ describe("admin API service", () => {
     expect(prismaMock.user.update).not.toHaveBeenCalled();
   });
 
-  it("rejects removing the final remaining admin", async () => {
+  it("拒绝移除最后一名管理员", async () => {
     prismaMock.user.findUnique.mockResolvedValue({
       id: "admin-2",
       isAdmin: true,
@@ -146,7 +146,7 @@ describe("admin API service", () => {
     expect(prismaMock.user.update).not.toHaveBeenCalled();
   });
 
-  it("retries final-admin demotion checks after serialization conflicts", async () => {
+  it("序列化冲突后重试末位管理员降权检查", async () => {
     prismaMock.$transaction
       .mockRejectedValueOnce({ code: "P2034" })
       .mockImplementationOnce(async (action) =>
@@ -173,7 +173,7 @@ describe("admin API service", () => {
     expect(prismaMock.user.update).not.toHaveBeenCalled();
   });
 
-  it("allows demoting another admin when at least one admin remains", async () => {
+  it("当至少保留一名管理员时允许降级其他管理员", async () => {
     const user = { id: "admin-2", isAdmin: false };
     prismaMock.user.findUnique.mockResolvedValue({
       id: "admin-2",
@@ -198,7 +198,7 @@ describe("admin API service", () => {
     });
   });
 
-  it("maps username uniqueness races to username_taken", async () => {
+  it("将用户名唯一性竞争映射为 username_taken", async () => {
     const uniqueConflict = new Error("unique conflict");
     isPrismaUniqueConstraintErrorMock.mockReturnValueOnce(true);
     prismaMock.user.findUnique
@@ -226,7 +226,7 @@ describe("admin API service", () => {
     expect(getAdminUserListItemMock).not.toHaveBeenCalled();
   });
 
-  it("rejects self-suspension before writing a suspension", async () => {
+  it("写入封禁前拒绝自我封禁", async () => {
     const { createAdminSuspension } = await import(
       "@/features/admin/server/admin-api-service"
     );
@@ -245,7 +245,7 @@ describe("admin API service", () => {
     expect(auditLogCreateMock).not.toHaveBeenCalled();
   });
 
-  it("closes existing open suspensions before creating the current suspension", async () => {
+  it("创建当前封禁前关闭现有未解除封禁", async () => {
     const createdSuspension = {
       id: "suspension-new",
       userId: "user-1",
@@ -293,7 +293,7 @@ describe("admin API service", () => {
     });
   });
 
-  it("rejects suspension creation when the required audit write fails", async () => {
+  it("所需审计写入失败时拒绝创建封禁", async () => {
     const auditError = new Error("audit unavailable");
     prismaMock.user.findUnique.mockResolvedValue({ id: "user-1" });
     prismaMock.userSuspension.create.mockResolvedValue({
@@ -319,7 +319,7 @@ describe("admin API service", () => {
     });
   });
 
-  it("retries suspension creation after an open-suspension uniqueness race", async () => {
+  it("未解除封禁唯一性竞争后重试封禁创建", async () => {
     const uniqueConflict = new Error("unique conflict");
     const createdSuspension = {
       id: "suspension-after-retry",
@@ -352,7 +352,7 @@ describe("admin API service", () => {
     expect(prismaMock.$transaction).toHaveBeenCalledTimes(2);
   });
 
-  it("lifts every open suspension for the requested suspension user", async () => {
+  it("解除请求封禁用户的所有未解除封禁", async () => {
     const liftedSuspension = {
       id: "suspension-1",
       userId: "user-1",
@@ -397,7 +397,7 @@ describe("admin API service", () => {
     });
   });
 
-  it("rejects comment moderation when the required audit write fails", async () => {
+  it("所需审计写入失败时拒绝评论审核", async () => {
     const auditError = new Error("audit unavailable");
     commentFindUniqueMock.mockResolvedValue({ id: "comment-1" });
     commentUpdateMock.mockResolvedValue({ id: "comment-1", status: "deleted" });
@@ -427,7 +427,7 @@ describe("admin API service", () => {
     });
   });
 
-  it("rejects description moderation when the required audit write fails", async () => {
+  it("所需审计写入失败时拒绝描述审核", async () => {
     const auditError = new Error("audit unavailable");
     descriptionFindUniqueMock.mockResolvedValue({
       id: "description-1",

--- a/tests/unit/admin-homework-delete-route.test.ts
+++ b/tests/unit/admin-homework-delete-route.test.ts
@@ -19,14 +19,14 @@ vi.mock("@/lib/api/routes/admin-route-auth", () => ({
   withAdminApiRoute: withAdminApiRouteMock,
 }));
 
-describe("admin homework delete route", () => {
+describe("admin homework 删除路由", () => {
   afterEach(() => {
     deleteHomeworkMock.mockReset();
     withAdminApiRouteMock.mockClear();
     vi.resetModules();
   });
 
-  it("maps missing homework to 404", async () => {
+  it("将缺失的作业映射为 404", async () => {
     deleteHomeworkMock.mockResolvedValue({ ok: false, error: "not_found" });
     const { deleteAdminHomeworkRoute } = await import(
       "@/lib/api/routes/admin-homework-delete-route"
@@ -42,7 +42,7 @@ describe("admin homework delete route", () => {
     expect(response.status).toBe(404);
   });
 
-  it("maps permission failures to 403", async () => {
+  it("将权限失败映射为 403", async () => {
     deleteHomeworkMock.mockResolvedValue({ ok: false, error: "forbidden" });
     const { deleteAdminHomeworkRoute } = await import(
       "@/lib/api/routes/admin-homework-delete-route"
@@ -58,7 +58,7 @@ describe("admin homework delete route", () => {
     expect(response.status).toBe(403);
   });
 
-  it("passes through admin authentication failures before deleting", async () => {
+  it("删除前透传管理员认证失败", async () => {
     withAdminApiRouteMock.mockResolvedValueOnce(
       Response.json({ error: "Unauthorized" }, { status: 401 }),
     );

--- a/tests/unit/admin-page-auth.test.ts
+++ b/tests/unit/admin-page-auth.test.ts
@@ -26,7 +26,7 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
-describe("admin page auth", () => {
+describe("admin 页面认证", () => {
   afterEach(() => {
     findActiveSuspensionMock.mockReset();
     getSessionFromHeadersMock.mockReset();
@@ -34,7 +34,7 @@ describe("admin page auth", () => {
     vi.resetModules();
   });
 
-  it("allows suspended admins to load read-only admin pages", async () => {
+  it("允许被暂停的管理员加载只读管理页面", async () => {
     getSessionFromHeadersMock.mockResolvedValue({
       user: { id: "admin-1" },
     });
@@ -60,7 +60,7 @@ describe("admin page auth", () => {
     expect(findActiveSuspensionMock).not.toHaveBeenCalled();
   });
 
-  it("blocks suspended admins from admin page actions", async () => {
+  it("阻止被暂停的管理员执行管理页面操作", async () => {
     getSessionFromHeadersMock.mockResolvedValue({
       user: { id: "admin-1" },
     });

--- a/tests/unit/admin-route-auth.test.ts
+++ b/tests/unit/admin-route-auth.test.ts
@@ -34,7 +34,7 @@ vi.mock("@/lib/mcp/urls", () => ({
   getOAuthTokenVerificationIssuers: () => ["https://life.example/api/auth"],
 }));
 
-describe("admin route auth", () => {
+describe("admin 路由认证", () => {
   afterEach(() => {
     findActiveSuspensionMock.mockReset();
     getSessionFromHeadersMock.mockReset();
@@ -43,7 +43,7 @@ describe("admin route auth", () => {
     vi.resetModules();
   });
 
-  it("returns 401 when no session user is authenticated", async () => {
+  it("未认证会话用户时返回 401", async () => {
     getSessionFromHeadersMock.mockResolvedValue(null);
     resolveAdminByUserIdMock.mockResolvedValue(null);
     const { requireAdminRequest } = await import(
@@ -60,7 +60,7 @@ describe("admin route auth", () => {
     expect(resolveAdminByUserIdMock).not.toHaveBeenCalled();
   });
 
-  it("rejects bearer-only admin REST requests", async () => {
+  it("拒绝仅 Bearer 的管理员 REST 请求", async () => {
     getSessionFromHeadersMock.mockResolvedValue({
       user: { id: "admin-from-cookie" },
     });
@@ -84,7 +84,7 @@ describe("admin route auth", () => {
     expect(resolveAdminByUserIdMock).not.toHaveBeenCalled();
   });
 
-  it("returns 401 when the session user is not an admin", async () => {
+  it("会话用户不是管理员时返回 401", async () => {
     getSessionFromHeadersMock.mockResolvedValue({
       user: { id: "user-1" },
     });
@@ -106,7 +106,7 @@ describe("admin route auth", () => {
     expect(resolveAdminByUserIdMock).toHaveBeenCalledWith("user-1");
   });
 
-  it("returns the admin session for a valid admin session cookie", async () => {
+  it("为有效的管理员会话 cookie 返回管理员会话", async () => {
     getSessionFromHeadersMock.mockResolvedValue({
       user: { id: "admin-1" },
     });
@@ -130,7 +130,7 @@ describe("admin route auth", () => {
     expect(resolveAdminByUserIdMock).toHaveBeenCalledWith("admin-1");
   });
 
-  it("returns 403 when an admin mutation requires an active admin but the admin is suspended", async () => {
+  it("管理员变更需要活跃管理员但该管理员被暂停时返回 403", async () => {
     getSessionFromHeadersMock.mockResolvedValue({
       user: { id: "admin-1" },
     });

--- a/tests/unit/admin-suspension-expiration.test.ts
+++ b/tests/unit/admin-suspension-expiration.test.ts
@@ -3,8 +3,8 @@ import { adminUserSuspensionExpiresAt } from "@/features/admin/lib/admin-users-d
 import { expiresAtFromModerationDuration } from "@/features/admin/lib/moderation-action-display";
 import { adminCreateSuspensionRequestSchema } from "@/lib/api/schemas/request-schemas";
 
-describe("admin suspension expiration input", () => {
-  it("accepts omitted, null, and empty expiration values as permanent", () => {
+describe("admin 封禁过期时间输入", () => {
+  it("将省略、null 和空过期值视为永久", () => {
     const base = { userId: "user-1" };
 
     expect(adminCreateSuspensionRequestSchema.safeParse(base).success).toBe(
@@ -24,7 +24,7 @@ describe("admin suspension expiration input", () => {
     ).toBe(true);
   });
 
-  it("rejects invalid non-empty expiration values", () => {
+  it("拒绝无效的非空过期值", () => {
     const result = adminCreateSuspensionRequestSchema.safeParse({
       userId: "user-1",
       expiresAt: "not-a-date",
@@ -33,7 +33,7 @@ describe("admin suspension expiration input", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects overflowing expiration calendar dates", () => {
+  it("拒绝溢出的日历日期", () => {
     for (const expiresAt of [
       "2026-02-31",
       "2026-13-01",
@@ -54,7 +54,7 @@ describe("admin suspension expiration input", () => {
     }
   });
 
-  it("preserves invalid custom UI expiration values for API rejection", () => {
+  it("保留无效的自定义 UI 过期值以供 API 拒绝", () => {
     expect(adminUserSuspensionExpiresAt("custom", "not-a-date")).toBe(
       "not-a-date",
     );

--- a/tests/unit/admin-user-read-model.test.ts
+++ b/tests/unit/admin-user-read-model.test.ts
@@ -4,8 +4,8 @@ import {
   toAdminUserListItem,
 } from "@/features/admin/server/admin-user-read-model";
 
-describe("admin user read model", () => {
-  it("builds one shared search filter for id, name, username, and email", () => {
+describe("admin 用户读取模型", () => {
+  it("为 id、name、username 和 email 构建一个共享搜索筛选器", () => {
     expect(buildAdminUsersWhere("  alice  ")).toEqual({
       OR: [
         { id: { contains: "alice", mode: "insensitive" } },
@@ -20,7 +20,7 @@ describe("admin user read model", () => {
     });
   });
 
-  it("keeps suspension data out of API rows unless selected", () => {
+  it("除非选中否则将封禁数据排除在 API 行之外", () => {
     const baseUser = {
       id: "user-1",
       name: "Alice",

--- a/tests/unit/admin-user-routes.test.ts
+++ b/tests/unit/admin-user-routes.test.ts
@@ -41,7 +41,7 @@ function jsonRequest(path: string, body: unknown) {
   });
 }
 
-describe("admin user routes", () => {
+describe("admin 用户路由", () => {
   afterEach(() => {
     createAdminSuspensionMock.mockReset();
     listAdminSuspensionsMock.mockReset();
@@ -50,7 +50,7 @@ describe("admin user routes", () => {
     vi.resetModules();
   });
 
-  it("passes the acting admin id into user updates", async () => {
+  it("将当前管理员 id 传入用户更新", async () => {
     updateAdminUserMock.mockResolvedValue({
       ok: true,
       user: { id: "user-1" },
@@ -70,7 +70,7 @@ describe("admin user routes", () => {
     });
   });
 
-  it("maps self-demotion to a public 400 response", async () => {
+  it("将自我降权映射为公开 400 响应", async () => {
     updateAdminUserMock.mockResolvedValue({
       ok: false,
       reason: "cannot_demote_self",
@@ -90,7 +90,7 @@ describe("admin user routes", () => {
     expect(response.status).toBe(400);
   });
 
-  it("maps final-admin removal to a public 400 response", async () => {
+  it("将移除最后管理员映射为公开 400 响应", async () => {
     updateAdminUserMock.mockResolvedValue({
       ok: false,
       reason: "cannot_remove_last_admin",
@@ -110,7 +110,7 @@ describe("admin user routes", () => {
     expect(response.status).toBe(400);
   });
 
-  it("maps self-suspension to a public 400 response", async () => {
+  it("将自我封禁映射为公开 400 响应", async () => {
     createAdminSuspensionMock.mockResolvedValue({
       ok: false,
       reason: "cannot_suspend_self",

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { extractApiErrorMessage, readApiErrorMessage } from "@/lib/api/client";
 
-describe("api client helpers", () => {
-  it("extracts plain and Error messages", () => {
+describe("api 客户端辅助函数", () => {
+  it("提取普通字符串与 Error 消息", () => {
     expect(extractApiErrorMessage("  failed  ")).toBe("failed");
     expect(extractApiErrorMessage(new Error("  failed  "))).toBe("failed");
   });
 
-  it("uses the first non-empty direct error string", () => {
+  it("使用第一个非空的直接错误字符串", () => {
     expect(
       extractApiErrorMessage({
         error: "",
@@ -17,7 +17,7 @@ describe("api client helpers", () => {
     ).toBe("validation failed");
   });
 
-  it("preserves whitespace-only field fallback behavior", () => {
+  it("保留仅空白字段的回退行为", () => {
     expect(
       extractApiErrorMessage({
         error: "   ",
@@ -36,7 +36,7 @@ describe("api client helpers", () => {
     ).toBeNull();
   });
 
-  it("falls back to nested and array error messages", () => {
+  it("回退到嵌套与数组错误消息", () => {
     expect(
       extractApiErrorMessage({ error: { detail: "  nested failure  " } }),
     ).toBe("nested failure");
@@ -47,12 +47,12 @@ describe("api client helpers", () => {
     ).toBe("first item failure");
   });
 
-  it("returns null when no usable message is present", () => {
+  it("没有可用消息时返回 null", () => {
     expect(extractApiErrorMessage(undefined)).toBeNull();
     expect(extractApiErrorMessage({ error: "   ", errors: [] })).toBeNull();
   });
 
-  it("reads API error messages from response bodies", async () => {
+  it("从响应体读取 API 错误消息", async () => {
     await expect(
       readApiErrorMessage(
         new Response(JSON.stringify({ error: "  server failed  " }), {
@@ -64,7 +64,7 @@ describe("api client helpers", () => {
     ).resolves.toBe("server failed");
   });
 
-  it("falls back when response bodies are not JSON error payloads", async () => {
+  it("响应体不是 JSON 错误载荷时回退", async () => {
     await expect(
       readApiErrorMessage(
         new Response("plain text failure", { status: 500 }),

--- a/tests/unit/api-docs-navigation.test.ts
+++ b/tests/unit/api-docs-navigation.test.ts
@@ -8,8 +8,8 @@ import generatedOpenApiDocument from "../../public/openapi.generated.json";
 
 const document = generatedOpenApiDocument as OpenApiDocument;
 
-describe("getApiDocsSelection", () => {
-  it("builds route links from the generated OpenAPI document", () => {
+describe("API 文档导航选择", () => {
+  it("从生成的 OpenAPI 文档构建路由链接", () => {
     const selection = getApiDocsSelection(document, "/api/docs");
     const tag = selection.groups.flatMap((group) => group.tags)[0];
     const operation = tag?.operations[0];
@@ -21,7 +21,7 @@ describe("getApiDocsSelection", () => {
     expect(operation?.href).not.toContain("#");
   });
 
-  it("uses compact operation summaries for sidebar navigation", () => {
+  it("使用紧凑的操作摘要作为侧边栏导航", () => {
     const selection = getApiDocsSelection(document, "/api/docs");
     const operations = selection.groups
       .flatMap((group) => group.tags)
@@ -44,7 +44,7 @@ describe("getApiDocsSelection", () => {
     });
   });
 
-  it("surfaces generated OPTIONS operations", () => {
+  it("展示生成的 OPTIONS 操作", () => {
     const selection = getApiDocsSelection(document, "/api/docs");
     const operation = selection.groups
       .flatMap((group) => group.tags)
@@ -66,7 +66,7 @@ describe("getApiDocsSelection", () => {
     ).toBeDefined();
   });
 
-  it("filters tag pages to the selected tag only", () => {
+  it("tag 页面仅过滤到选中的 tag", () => {
     const rootSelection = getApiDocsSelection(document, "/api/docs");
     const tag = rootSelection.groups
       .flatMap((group) => group.tags)
@@ -89,7 +89,7 @@ describe("getApiDocsSelection", () => {
     ).toBe(true);
   });
 
-  it("filters operation pages to the selected operation only", () => {
+  it("operation 页面仅过滤到选中的 operation", () => {
     const rootSelection = getApiDocsSelection(document, "/api/docs");
     const operation = rootSelection.groups
       .flatMap((group) => group.tags)

--- a/tests/unit/api-helpers.test.ts
+++ b/tests/unit/api-helpers.test.ts
@@ -10,20 +10,20 @@ import {
   parseRouteSearchParams,
 } from "@/lib/api/helpers";
 
-describe("api helpers", () => {
-  it("does not overwrite proxy-owned request id headers", () => {
+describe("API 辅助函数", () => {
+  it("不覆盖代理提供的请求 ID 标头", () => {
     const response = jsonResponse({ ok: true });
 
     expect(response.headers.has("x-request-id")).toBe(false);
   });
 
-  it("accepts safe integers from string and number", () => {
+  it("接受来自字符串和数字的安全整数", () => {
     expect(parseInteger("42")).toBe(42);
     expect(parseInteger("  -7 ")).toBe(-7);
     expect(parseInteger(9)).toBe(9);
   });
 
-  it("rejects partial and invalid numeric formats", () => {
+  it("拒绝部分和无效的数字格式", () => {
     expect(parseInteger("12abc")).toBeNull();
     expect(parseInteger("3.14")).toBeNull();
     expect(parseInteger(3.14)).toBeNull();
@@ -32,19 +32,19 @@ describe("api helpers", () => {
     expect(parseInteger(undefined)).toBeNull();
   });
 
-  it("parses integer list and drops invalid entries", () => {
+  it("解析整数列表并丢弃无效项", () => {
     expect(parseIntegerList("1,2,foo, 3")).toEqual([1, 2, 3]);
     expect(parseIntegerList(" ")).toEqual([]);
     expect(parseIntegerList(null)).toEqual([]);
   });
 
-  it("reads search params from Request", () => {
+  it("从 Request 读取搜索参数", () => {
     const request = new Request("https://example.test/path?page=2");
 
     expect(getRequestSearchParams(request).get("page")).toBe("2");
   });
 
-  it("parses route input with zod schemas", () => {
+  it("使用 Zod 模式解析路由输入", () => {
     const result = parseRouteInput(
       { page: "2" },
       z.object({ page: z.string() }),
@@ -54,7 +54,7 @@ describe("api helpers", () => {
     expect(result).toEqual({ page: "2" });
   });
 
-  it("returns a response for invalid route input", async () => {
+  it("为无效路由输入返回响应", async () => {
     const result = parseRouteInput(
       { page: 2 },
       z.object({ page: z.string() }),
@@ -67,7 +67,7 @@ describe("api helpers", () => {
     });
   });
 
-  it("parses route query params and normalizes pagination", () => {
+  it("解析路由查询参数并规范化分页", () => {
     const result = parseRouteQuery(
       new URLSearchParams("search=math&page=3&limit=250"),
       z.object({
@@ -86,7 +86,7 @@ describe("api helpers", () => {
     });
   });
 
-  it("parses route search params without pagination", () => {
+  it("解析不带分页的路由搜索参数", () => {
     const result = parseRouteSearchParams(
       new URLSearchParams("versionKey=current&unused=value"),
       z.object({ versionKey: z.string().optional() }),

--- a/tests/unit/api-observability.test.ts
+++ b/tests/unit/api-observability.test.ts
@@ -10,14 +10,14 @@ import {
   resetRuntimeMetricsForTest,
 } from "@/lib/metrics/runtime-metrics";
 
-describe("api observability", () => {
+describe("API 可观测性", () => {
   afterEach(() => {
     resetRuntimeMetricsForTest();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it("normalizes high-cardinality route segments", () => {
+  it("规范化高基数路由段", () => {
     expect(normalizeApiRoutePath("/api/todos/123")).toBe("/api/todos/:id");
     expect(normalizeApiRoutePath("/api/calendar-subscriptions/current")).toBe(
       "/api/calendar-subscriptions/current",
@@ -32,7 +32,7 @@ describe("api observability", () => {
     );
   });
 
-  it("redacts calendar feed path tokens", () => {
+  it("隐去日历订阅路径令牌", () => {
     const normalized = normalizeApiRoutePath(
       "/api/users/user-1:feed-token-0123456789/calendar.ics",
     );
@@ -46,7 +46,7 @@ describe("api observability", () => {
     expect(encodedSeparator).not.toContain("feed-token-0123456789");
   });
 
-  it("records safe request-start logs and metrics", () => {
+  it("记录安全的请求开始日志和指标", () => {
     const info = vi.spyOn(console, "info").mockImplementation(() => {});
 
     recordApiRequestStart({
@@ -70,7 +70,7 @@ describe("api observability", () => {
     );
   });
 
-  it("skips the metrics endpoint", () => {
+  it("跳过指标端点", () => {
     const info = vi.spyOn(console, "info").mockImplementation(() => {});
 
     expect(shouldObserveApiPath("/api/metrics")).toBe(false);
@@ -86,7 +86,7 @@ describe("api observability", () => {
     );
   });
 
-  it("records response status, duration, and auth mode", async () => {
+  it("记录响应状态、耗时和认证模式", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-07T00:00:01.000Z"));
     const info = vi.spyOn(console, "info").mockImplementation(() => {});
@@ -125,7 +125,7 @@ describe("api observability", () => {
     );
   });
 
-  it("records thrown route errors before rethrowing", async () => {
+  it("在重新抛出前记录抛出的路由错误", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-07T00:00:01.000Z"));
     vi.spyOn(console, "info").mockImplementation(() => {});

--- a/tests/unit/api-route-query-validation.test.ts
+++ b/tests/unit/api-route-query-validation.test.ts
@@ -13,8 +13,8 @@ async function expectInvalidQueryResponse(
   expect(await response.json()).toEqual({ error: message });
 }
 
-describe("API route query validation", () => {
-  it("rejects oversized public pagination limits before clamping", async () => {
+describe("API 路由查询校验", () => {
+  it("在限制前拒绝过大的公开分页限制", async () => {
     await expectInvalidQueryResponse(
       getCoursesRoute(
         new Request("https://example.test/api/courses?limit=101"),
@@ -30,7 +30,7 @@ describe("API route query validation", () => {
     );
   });
 
-  it("serializes next-bus and todo limit validation failures", async () => {
+  it("序列化下一班车与待办事项限制校验失败", async () => {
     await expectInvalidQueryResponse(
       getBusNextDeparturesRoute(
         new Request(

--- a/tests/unit/api-schemas.test.ts
+++ b/tests/unit/api-schemas.test.ts
@@ -52,7 +52,7 @@ function openApiSchema(name: string) {
 }
 
 describe("matchSectionCodesRequestSchema", () => {
-  it("accepts valid payload", () => {
+  it("接受有效 payload", () => {
     const result = matchSectionCodesRequestSchema.safeParse({
       codes: ["COMP101.01", "MATH204.02"],
       semesterId: "12",
@@ -61,7 +61,7 @@ describe("matchSectionCodesRequestSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("rejects empty codes and invalid code format", () => {
+  it("拒绝空 code 和无效 code 格式", () => {
     const empty = matchSectionCodesRequestSchema.safeParse({
       codes: [],
     });
@@ -75,7 +75,7 @@ describe("matchSectionCodesRequestSchema", () => {
 });
 
 describe("homeworkCreateRequestSchema", () => {
-  it("accepts valid payload", () => {
+  it("接受有效 payload", () => {
     const result = homeworkCreateRequestSchema.safeParse({
       sectionId: "12",
       title: "  作业 1  ",
@@ -85,7 +85,7 @@ describe("homeworkCreateRequestSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("accepts nullable description like the MCP create tool", () => {
+  it("接受可空 description，与 MCP 创建工具一致", () => {
     const result = homeworkCreateRequestSchema.safeParse({
       sectionJwId: "12345",
       title: "作业 1",
@@ -94,7 +94,7 @@ describe("homeworkCreateRequestSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("rejects missing title", () => {
+  it("拒绝缺失 title", () => {
     const result = homeworkCreateRequestSchema.safeParse({
       sectionId: 3,
       title: "",
@@ -102,7 +102,7 @@ describe("homeworkCreateRequestSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("validates homework description after trimming surrounding whitespace", () => {
+  it("在去除 homework description 首尾空白后校验长度", () => {
     const description = "x".repeat(HOMEWORK_DESCRIPTION_MAX_LENGTH);
     const result = homeworkCreateRequestSchema.safeParse({
       sectionId: "12",
@@ -118,7 +118,7 @@ describe("homeworkCreateRequestSchema", () => {
 });
 
 describe("todoCreateRequestSchema", () => {
-  it("validates todo content after trimming surrounding whitespace", () => {
+  it("在去除 todo content 首尾空白后校验长度", () => {
     const content = "x".repeat(TODO_CONTENT_MAX_LENGTH);
     const result = todoCreateRequestSchema.safeParse({
       title: "Read Chapter 1",
@@ -133,7 +133,7 @@ describe("todoCreateRequestSchema", () => {
 });
 
 describe("homeworkCompletionBatchRequestSchema", () => {
-  it("accepts completion updates", () => {
+  it("接受完成状态更新", () => {
     const result = homeworkCompletionBatchRequestSchema.safeParse({
       items: [
         { homeworkId: "homework-1", completed: true },
@@ -144,7 +144,7 @@ describe("homeworkCompletionBatchRequestSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("rejects empty item lists and blank homework IDs", () => {
+  it("拒绝空 item 列表和空 homework ID", () => {
     expect(
       homeworkCompletionBatchRequestSchema.safeParse({ items: [] }).success,
     ).toBe(false);
@@ -157,7 +157,7 @@ describe("homeworkCompletionBatchRequestSchema", () => {
 });
 
 describe("descriptionUpsertRequestSchema", () => {
-  it("accepts homework string targetId", () => {
+  it("接受 homework 字符串 targetId", () => {
     const result = descriptionUpsertRequestSchema.safeParse({
       targetType: "homework",
       targetId: "hw_123",
@@ -166,7 +166,7 @@ describe("descriptionUpsertRequestSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("rejects numeric targets with invalid id", () => {
+  it("拒绝带有无效 id 的数字目标", () => {
     const result = descriptionUpsertRequestSchema.safeParse({
       targetType: "section",
       targetId: "abc",
@@ -175,7 +175,7 @@ describe("descriptionUpsertRequestSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("documents required target-reference alternatives in OpenAPI", () => {
+  it("在 OpenAPI 中记录必填的目标引用可选方案", () => {
     const schema = openApiSchema("descriptionUpsertRequestSchema");
     expect(schema.required).toEqual(
       expect.arrayContaining(["targetType", "content"]),
@@ -192,8 +192,8 @@ describe("descriptionUpsertRequestSchema", () => {
   });
 });
 
-describe("other request schemas", () => {
-  it("validates upload create payload", () => {
+describe("其他请求 schema", () => {
+  it("校验 upload 创建 payload", () => {
     const valid = uploadCreateRequestSchema.safeParse({
       filename: "a.txt",
       size: "123",
@@ -201,7 +201,7 @@ describe("other request schemas", () => {
     expect(valid.success).toBe(true);
   });
 
-  it("rejects upload filenames with control characters", () => {
+  it("拒绝包含控制字符的 upload 文件名", () => {
     expect(
       uploadCreateRequestSchema.safeParse({
         filename: "a\nb.txt",
@@ -221,7 +221,7 @@ describe("other request schemas", () => {
     ).toBe(false);
   });
 
-  it("validates comment list public target identifiers", () => {
+  it("校验评论列表公开目标标识符", () => {
     expect(
       commentsQuerySchema.safeParse({
         targetType: "section",
@@ -248,7 +248,7 @@ describe("other request schemas", () => {
     ).toBe(false);
   });
 
-  it("validates comment create public target identifiers", () => {
+  it("校验评论创建公开目标标识符", () => {
     expect(
       commentCreateRequestSchema.safeParse({
         targetType: "section",
@@ -311,7 +311,7 @@ describe("other request schemas", () => {
     ).toBe(false);
   });
 
-  it("rejects unsupported anonymous comment visibility", () => {
+  it("拒绝不支持的匿名评论可见性", () => {
     expect(
       commentCreateRequestSchema.safeParse({
         targetType: "section",
@@ -328,7 +328,7 @@ describe("other request schemas", () => {
     ).toBe(false);
   });
 
-  it("validates centralized MCP comment target identifiers", () => {
+  it("校验集中式 MCP 评论目标标识符", () => {
     expect(
       commentMcpTargetReadInputSchema.safeParse({
         targetType: "section",
@@ -368,14 +368,14 @@ describe("other request schemas", () => {
     ).toBe(false);
   });
 
-  it("validates calendar subscription payload", () => {
+  it("校验日历订阅 payload", () => {
     const valid = calendarSubscriptionCreateRequestSchema.safeParse({
       sectionIds: [1, 2, 3],
     });
     expect(valid.success).toBe(true);
   });
 
-  it("validates calendar subscription append payload", () => {
+  it("校验日历订阅追加 payload", () => {
     const valid = calendarSubscriptionAppendRequestSchema.safeParse({
       sectionIds: [1, 2, 3],
     });
@@ -385,7 +385,7 @@ describe("other request schemas", () => {
     expect(missingIds.success).toBe(false);
   });
 
-  it("documents positive calendar subscription section IDs in OpenAPI", () => {
+  it("在 OpenAPI 中记录正数日历订阅 section ID", () => {
     for (const name of [
       "calendarSubscriptionAppendRequestSchema",
       "calendarSubscriptionRemoveRequestSchema",
@@ -401,21 +401,21 @@ describe("other request schemas", () => {
     }
   });
 
-  it("rejects invalid reaction type", () => {
+  it("拒绝无效 reaction 类型", () => {
     const invalid = commentReactionRequestSchema.safeParse({
       type: "boom",
     });
     expect(invalid.success).toBe(false);
   });
 
-  it("rejects unsupported locale", () => {
+  it("拒绝不支持的 locale", () => {
     const invalid = localeUpdateRequestSchema.safeParse({
       locale: "fr-fr",
     });
     expect(invalid.success).toBe(false);
   });
 
-  it("validates query schemas", () => {
+  it("校验查询 schema", () => {
     expect(
       sectionsQuerySchema.safeParse({ courseId: "1", ids: "1,2" }).success,
     ).toBe(true);
@@ -454,7 +454,7 @@ describe("other request schemas", () => {
     ).toBe(false);
   });
 
-  it("validates documented query limit bounds", () => {
+  it("校验文档中记录的查询 limit 边界", () => {
     for (const schema of [
       coursesQuerySchema,
       sectionsQuerySchema,
@@ -495,7 +495,7 @@ describe("other request schemas", () => {
     ).toBe(false);
   });
 
-  it("validates new section query fields added in filter expansion", () => {
+  it("校验筛选扩展中新增的 section 查询字段", () => {
     // JW-id aliases and string-based filters
     expect(
       sectionsQuerySchema.safeParse({
@@ -513,7 +513,7 @@ describe("other request schemas", () => {
     expect(sectionsQuerySchema.safeParse({ jwIds: "1" }).success).toBe(true);
   });
 
-  it("validates new schedule query fields added in filter expansion", () => {
+  it("校验筛选扩展中新增的 schedule 查询字段", () => {
     expect(
       schedulesQuerySchema.safeParse({
         sectionJwId: "9902001",
@@ -532,7 +532,7 @@ describe("other request schemas", () => {
     );
   });
 
-  it("validates shared response schemas", () => {
+  it("校验共享响应 schema", () => {
     expect(
       meResponseSchema.safeParse({
         id: "user_1",

--- a/tests/unit/app-logger.test.ts
+++ b/tests/unit/app-logger.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { logAppEvent, logRouteFailure, shouldLog } from "@/lib/log/app-logger";
 
-describe("app logger", () => {
+describe("应用日志记录器", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
-  it("honors configured log levels", () => {
+  it("遵循配置的日志级别", () => {
     vi.stubEnv("LOG_LEVEL", "warn");
 
     expect(shouldLog("debug")).toBe(false);
@@ -16,21 +16,21 @@ describe("app logger", () => {
     expect(shouldLog("error")).toBe(true);
   });
 
-  it("normalizes logger-only environment values", () => {
+  it("规范化仅用于日志的环境变量值", () => {
     vi.stubEnv("LOG_LEVEL", " WARN ");
 
     expect(shouldLog("info")).toBe(false);
     expect(shouldLog("warn")).toBe(true);
   });
 
-  it("falls back to info for invalid log levels", () => {
+  it("对无效日志级别回退到 info", () => {
     vi.stubEnv("LOG_LEVEL", "verbose");
 
     expect(shouldLog("debug")).toBe(false);
     expect(shouldLog("info")).toBe(true);
   });
 
-  it("suppresses non-server route failures in production", () => {
+  it("在生产环境中抑制非服务端路由失败", () => {
     vi.stubEnv("NODE_ENV", "production");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -39,7 +39,7 @@ describe("app logger", () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it("logs server route failures as structured production JSON", () => {
+  it("将服务端路由失败记录为结构化生产 JSON", () => {
     vi.stubEnv("NODE_ENV", "production");
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -63,7 +63,7 @@ describe("app logger", () => {
     expect(String(payload)).not.toContain("stack");
   });
 
-  it("emits app events as structured production JSON", () => {
+  it("以结构化生产 JSON 发送应用事件", () => {
     vi.stubEnv("NODE_ENV", "production");
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
 

--- a/tests/unit/audit-cleanup.test.ts
+++ b/tests/unit/audit-cleanup.test.ts
@@ -5,8 +5,8 @@ import {
   deleteAuditLogsForUsersAndTargets,
 } from "../shared/audit-cleanup";
 
-describe("audit cleanup helpers", () => {
-  it("builds deduplicated user and target predicates", () => {
+describe("审计清理辅助函数", () => {
+  it("构建去重的用户和目标谓词", () => {
     expect(
       buildAuditLogCleanupWhere({
         targets: [
@@ -26,7 +26,7 @@ describe("audit cleanup helpers", () => {
     });
   });
 
-  it("supports grouped target cleanup", async () => {
+  it("支持分组目标清理", async () => {
     const prisma = {
       auditLog: {
         deleteMany: vi.fn(async () => ({ count: 0 })),
@@ -53,7 +53,7 @@ describe("audit cleanup helpers", () => {
     });
   });
 
-  it("retries cleanup until matching audit rows stay absent", async () => {
+  it("重试清理直到匹配审计行不存在", async () => {
     const remainingCounts = [1, 0, 0];
     const prisma = {
       auditLog: {

--- a/tests/unit/audit-request-metadata.test.ts
+++ b/tests/unit/audit-request-metadata.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getAuditRequestMetadata } from "@/lib/audit/request-metadata";
 
 describe("getAuditRequestMetadata", () => {
-  it("prefers x-forwarded-for when present", () => {
+  it("优先使用 x-forwarded-for", () => {
     const request = new Request("https://example.test", {
       headers: {
         "user-agent": "vitest-agent",
@@ -17,7 +17,7 @@ describe("getAuditRequestMetadata", () => {
     });
   });
 
-  it("falls back to x-real-ip and omits missing headers", () => {
+  it("回退到 x-real-ip 并省略缺失标头", () => {
     const request = new Request("https://example.test", {
       headers: {
         "x-real-ip": "198.51.100.20",

--- a/tests/unit/audit-write-log.test.ts
+++ b/tests/unit/audit-write-log.test.ts
@@ -59,7 +59,7 @@ describe("fireAuditLog", () => {
     vi.resetModules();
   });
 
-  it("resolves after scheduling Worker waitUntil without waiting for the audit write", async () => {
+  it("在调度 Worker waitUntil 后完成，无需等待审计写入", async () => {
     const waitUntilMock = vi.fn();
     getRequestEventMock.mockReturnValue({
       platform: {
@@ -97,7 +97,7 @@ describe("fireAuditLog", () => {
     expect(logAppEventMock).not.toHaveBeenCalled();
   });
 
-  it("logs scheduled audit write failures", async () => {
+  it("记录已调度审计写入失败", async () => {
     const writeError = new Error("database unavailable");
     const waitUntilMock = vi.fn();
     getRequestEventMock.mockReturnValue({
@@ -133,7 +133,7 @@ describe("fireAuditLog", () => {
     );
   });
 
-  it("awaits the audit write when waitUntil is unavailable", async () => {
+  it("当 waitUntil 不可用时等待审计写入", async () => {
     getRequestEventMock.mockImplementation(() => {
       throw new Error("outside request");
     });

--- a/tests/unit/auth-config.test.ts
+++ b/tests/unit/auth-config.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-describe("auth config", () => {
+describe("认证配置", () => {
   afterEach(() => {
     vi.resetModules();
     vi.unstubAllEnvs();
   });
 
-  it("allows debug auth in development without enabling E2E mode", async () => {
+  it("允许开发环境调试认证但不启用 E2E 模式", async () => {
     vi.stubEnv("NODE_ENV", "development");
     vi.stubEnv("E2E_DEBUG_AUTH", "");
 
@@ -19,7 +19,7 @@ describe("auth config", () => {
     expect(allowDebugAuth()).toBe(true);
   });
 
-  it("allows E2E debug auth outside development when explicitly enabled", async () => {
+  it("在开发环境外显式启用时允许 E2E 调试认证", async () => {
     vi.stubEnv("NODE_ENV", "test");
     vi.stubEnv("E2E_DEBUG_AUTH", "1");
 
@@ -32,7 +32,7 @@ describe("auth config", () => {
     expect(allowDebugAuth()).toBe(true);
   });
 
-  it("rejects E2E debug auth in production", async () => {
+  it("在生产环境中拒绝 E2E 调试认证", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("E2E_DEBUG_AUTH", "1");
 

--- a/tests/unit/auth-helpers.test.ts
+++ b/tests/unit/auth-helpers.test.ts
@@ -32,7 +32,7 @@ vi.mock("@/lib/mcp/urls", () => ({
   getOAuthTokenVerificationIssuers: () => ["https://life.example/api/auth"],
 }));
 
-describe("auth helpers", () => {
+describe("认证辅助函数", () => {
   beforeEach(() => {
     vi.resetModules();
     getSessionFromHeadersMock.mockReset();
@@ -40,7 +40,7 @@ describe("auth helpers", () => {
     getViewerAuthDataForUserIdMock.mockReset();
   });
 
-  it("uses the route request headers for session-cookie fallback", async () => {
+  it("使用路由请求头进行 session cookie 回退", async () => {
     getSessionFromHeadersMock.mockResolvedValue({
       user: { id: "user-from-cookie" },
     });
@@ -56,7 +56,7 @@ describe("auth helpers", () => {
     expect(verifyAccessTokenMock).not.toHaveBeenCalled();
   });
 
-  it("prefers a valid bearer access token over session cookies", async () => {
+  it("优先使用有效的 bearer 访问令牌而非 session cookie", async () => {
     verifyAccessTokenMock.mockResolvedValue({
       scope: OAUTH_REST_READ_SCOPE,
       sub: "user-from-token",
@@ -83,10 +83,7 @@ describe("auth helpers", () => {
     );
   });
 
-  it.each([
-    "bearer",
-    "bEaReR",
-  ])("accepts a %s bearer access token", async (scheme) => {
+  it.each(["bearer", "bEaReR"])("接受 %s bearer 访问令牌", async (scheme) => {
     verifyAccessTokenMock.mockResolvedValue({
       scope: OAUTH_REST_READ_SCOPE,
       sub: "user-from-token",
@@ -110,7 +107,7 @@ describe("auth helpers", () => {
   it.each([
     "bearer",
     "bEaReR",
-  ])("treats a %s authorization header as an auth signal", async (scheme) => {
+  ])("将 %s authorization 标头视为认证信号", async (scheme) => {
     const { hasRequestAuthSignal } = await import(
       "@/lib/auth/request-auth-signal"
     );
@@ -122,7 +119,7 @@ describe("auth helpers", () => {
     ).toBe(true);
   });
 
-  it("rejects profile-only bearer access for protected REST reads", async () => {
+  it("拒绝仅 profile 的 bearer 访问受保护 REST 读取", async () => {
     verifyAccessTokenMock.mockResolvedValue({
       scope: OAUTH_PROFILE_SCOPE,
       sub: "user-from-token",
@@ -144,7 +141,7 @@ describe("auth helpers", () => {
     expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
   });
 
-  it("rejects MCP-only bearer access for protected REST reads", async () => {
+  it("拒绝仅 MCP 的 bearer 访问受保护 REST 读取", async () => {
     verifyAccessTokenMock.mockResolvedValue({
       scope: `${OAUTH_PROFILE_SCOPE} ${MCP_TOOLS_SCOPE}`,
       sub: "user-from-token",
@@ -166,7 +163,7 @@ describe("auth helpers", () => {
     expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
   });
 
-  it("rejects REST read-only bearer access for protected REST writes", async () => {
+  it("拒绝 REST 只读 bearer 访问受保护 REST 写入", async () => {
     verifyAccessTokenMock.mockResolvedValue({
       scope: OAUTH_REST_READ_SCOPE,
       sub: "user-from-token",
@@ -189,7 +186,7 @@ describe("auth helpers", () => {
     expect(getViewerAuthDataForUserIdMock).not.toHaveBeenCalled();
   });
 
-  it("rejects REST read-only bearer access for POST routes using requireAuth", async () => {
+  it("拒绝 REST 只读 bearer 访问使用 requireAuth 的 POST 路由", async () => {
     verifyAccessTokenMock.mockResolvedValue({
       scope: OAUTH_REST_READ_SCOPE,
       sub: "user-from-token",
@@ -212,7 +209,7 @@ describe("auth helpers", () => {
     expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
   });
 
-  it("rejects MCP-only bearer access for protected REST writes", async () => {
+  it("拒绝仅 MCP 的 bearer 访问受保护 REST 写入", async () => {
     verifyAccessTokenMock.mockResolvedValue({
       scope: `${OAUTH_PROFILE_SCOPE} ${MCP_TOOLS_SCOPE}`,
       sub: "user-from-token",
@@ -235,7 +232,7 @@ describe("auth helpers", () => {
     expect(getViewerAuthDataForUserIdMock).not.toHaveBeenCalled();
   });
 
-  it("does not fall back to session cookies when a bearer token is invalid", async () => {
+  it("当 bearer 令牌无效时不回退到 session cookie", async () => {
     verifyAccessTokenMock.mockRejectedValue(new Error("invalid token"));
     getSessionFromHeadersMock.mockResolvedValue({
       user: { id: "user-from-cookie" },
@@ -252,7 +249,7 @@ describe("auth helpers", () => {
     expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
   });
 
-  it("returns 401 instead of falling back to session cookies when a lowercase bearer token is invalid", async () => {
+  it("小写 bearer 令牌无效时返回 401 而不回退到 session cookie", async () => {
     verifyAccessTokenMock.mockRejectedValue(new Error("invalid token"));
     getSessionFromHeadersMock.mockResolvedValue({
       user: { id: "user-from-cookie" },
@@ -275,7 +272,7 @@ describe("auth helpers", () => {
     expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
   });
 
-  it("does not fall back to session cookies when a bearer token is empty", async () => {
+  it("当 bearer 令牌为空时不回退到 session cookie", async () => {
     getSessionFromHeadersMock.mockResolvedValue({
       user: { id: "user-from-cookie" },
     });
@@ -292,7 +289,7 @@ describe("auth helpers", () => {
     expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
   });
 
-  it("resolves session-only auth from cookies", async () => {
+  it("从 cookie 解析仅 session 认证", async () => {
     getSessionFromHeadersMock.mockResolvedValue({
       user: { id: "user-from-cookie" },
     });
@@ -310,7 +307,7 @@ describe("auth helpers", () => {
     expect(verifyAccessTokenMock).not.toHaveBeenCalled();
   });
 
-  it("rejects bearer authorization for session-only auth", async () => {
+  it("对仅 session 认证拒绝 bearer 授权", async () => {
     getSessionFromHeadersMock.mockResolvedValue({
       user: { id: "user-from-cookie" },
     });
@@ -327,7 +324,7 @@ describe("auth helpers", () => {
     expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
   });
 
-  it("rejects write auth when the resolved user no longer exists", async () => {
+  it("当解析到的用户不存在时拒绝写入认证", async () => {
     verifyAccessTokenMock.mockResolvedValue({
       scope: OAUTH_REST_WRITE_SCOPE,
       sub: "deleted-user",

--- a/tests/unit/auth-origins.test.ts
+++ b/tests/unit/auth-origins.test.ts
@@ -5,12 +5,12 @@ import {
   isTrustedAuthOrigin,
 } from "@/lib/auth/auth-origins";
 
-describe("auth origin helpers", () => {
+describe("认证来源辅助函数", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("includes public and pinned local origins", () => {
+  it("包含公开和固定的本地来源", () => {
     vi.stubEnv("APP_PUBLIC_ORIGIN", "https://preview-123.example.com");
 
     expect(getAuthTrustedOrigins()).toEqual([
@@ -20,7 +20,7 @@ describe("auth origin helpers", () => {
     ]);
   });
 
-  it("returns Better Auth allowed hosts for dynamic base URL resolution", () => {
+  it("返回 Better Auth 允许的 host 以支持动态 base URL 解析", () => {
     vi.stubEnv("APP_PUBLIC_ORIGIN", "https://preview-123.example.com");
 
     expect(getAuthAllowedHosts()).toEqual([
@@ -30,7 +30,7 @@ describe("auth origin helpers", () => {
     ]);
   });
 
-  it("deduplicates matching public and local origins", () => {
+  it("对匹配的公开和本地来源去重", () => {
     vi.stubEnv("APP_PUBLIC_ORIGIN", "https://life-ustc.tiankaima.dev");
 
     expect(getAuthTrustedOrigins()).toEqual([
@@ -40,7 +40,7 @@ describe("auth origin helpers", () => {
     ]);
   });
 
-  it("includes loopback sibling origin for custom localhost ports", () => {
+  it("为自定义 localhost 端口包含回环 sibling 来源", () => {
     vi.stubEnv("APP_PUBLIC_ORIGIN", "http://localhost:3010");
 
     expect(getAuthTrustedOrigins()).toEqual([
@@ -61,48 +61,48 @@ describe("isTrustedAuthOrigin", () => {
     vi.stubEnv("APP_PUBLIC_ORIGIN", current);
   }
 
-  it("accepts an exact match against the current public origin", () => {
+  it("接受与当前公开来源的精确匹配", () => {
     withOrigin("https://preview.example.com");
     expect(isTrustedAuthOrigin("https://preview.example.com")).toBe(true);
   });
 
-  it("accepts http://localhost:3000 which is always trusted", () => {
+  it("接受始终受信任的 http://localhost:3000", () => {
     withOrigin("https://preview.example.com");
     expect(isTrustedAuthOrigin("http://localhost:3000")).toBe(true);
   });
 
-  it("accepts http://127.0.0.1:3000 which is always trusted", () => {
+  it("接受始终受信任的 http://127.0.0.1:3000", () => {
     withOrigin("https://preview.example.com");
     expect(isTrustedAuthOrigin("http://127.0.0.1:3000")).toBe(true);
   });
 
-  it("accepts the loopback sibling for a custom local public origin", () => {
+  it("接受自定义本地公开来源的回环 sibling", () => {
     withOrigin("http://127.0.0.1:3010");
     expect(isTrustedAuthOrigin("http://localhost:3010")).toBe(true);
   });
 
-  it("rejects unconfigured example origins", () => {
+  it("拒绝未配置的示例来源", () => {
     withOrigin("https://preview.example.com");
     expect(isTrustedAuthOrigin("https://example.com")).toBe(false);
     expect(isTrustedAuthOrigin("https://myapp-abc123.example.com")).toBe(false);
   });
 
-  it("rejects a different port on an exact-match trusted origin", () => {
+  it("拒绝精确匹配受信来源上的不同端口", () => {
     withOrigin("https://preview.example.com");
     expect(isTrustedAuthOrigin("https://preview.example.com:8443")).toBe(false);
   });
 
-  it("rejects an unknown origin", () => {
+  it("拒绝未知来源", () => {
     withOrigin("https://preview.example.com");
     expect(isTrustedAuthOrigin("https://evil.example.com")).toBe(false);
   });
 
-  it("returns false for a non-URL string without throwing", () => {
+  it("对非 URL 字符串返回 false 且不抛出", () => {
     withOrigin("https://preview.example.com");
     expect(isTrustedAuthOrigin("not-a-url")).toBe(false);
   });
 
-  it("normalises origin before matching (strips path/query)", () => {
+  it("在匹配前规范化来源（去除路径和查询）", () => {
     withOrigin("https://preview.example.com");
     // new URL(origin).origin strips path — should still match
     expect(

--- a/tests/unit/auth-provider-routing.test.ts
+++ b/tests/unit/auth-provider-routing.test.ts
@@ -10,8 +10,8 @@ import {
   resolveAuthProviderDecision,
 } from "@/lib/auth/provider-ids";
 
-describe("auth provider routing", () => {
-  it("prefers redirectTo over callbackUrl", () => {
+describe("认证提供方路由", () => {
+  it("优先使用 redirectTo 而非 callbackUrl", () => {
     expect(
       resolveAuthRedirectTarget({
         redirectTo: "/dashboard",
@@ -20,7 +20,7 @@ describe("auth provider routing", () => {
     ).toBe("/dashboard");
   });
 
-  it("falls back when redirect targets are external", () => {
+  it("当重定向目标为外部时回退", () => {
     expect(
       resolveAuthRedirectTarget(
         {
@@ -32,13 +32,13 @@ describe("auth provider routing", () => {
     ).toBe("/settings");
   });
 
-  it("builds the sign-in page callback URL once", () => {
+  it("构建登录页 callback URL", () => {
     expect(buildSignInPageUrl("/oauth/authorize?client_id=test")).toBe(
       "/signin?callbackUrl=%2Foauth%2Fauthorize%3Fclient_id%3Dtest",
     );
   });
 
-  it("builds current-page callback URLs from path and query", () => {
+  it("从路径和查询构建当前页 callback URL", () => {
     expect(
       buildCurrentPathCallbackUrl(
         "/sections/123",
@@ -48,7 +48,7 @@ describe("auth provider routing", () => {
     expect(buildCurrentPathCallbackUrl("/courses/456")).toBe("/courses/456");
   });
 
-  it("builds sign-in redirects from the resolved destination", () => {
+  it("根据解析后的目标构建登录重定向", () => {
     expect(
       buildSignInRedirectUrl(
         {
@@ -63,7 +63,7 @@ describe("auth provider routing", () => {
     );
   });
 
-  it("classifies auth providers by runtime behavior", () => {
+  it("按运行时行为分类认证提供方", () => {
     expect(resolveAuthProviderDecision()).toEqual({ kind: "none" });
     expect(resolveAuthProviderDecision("oidc")).toEqual({
       kind: "oidc",
@@ -79,7 +79,7 @@ describe("auth provider routing", () => {
     });
   });
 
-  it("keeps the sign-in provider order stable", () => {
+  it("保持登录提供方顺序稳定", () => {
     expect(getSignInProviderIds(false)).toEqual(["oidc", "github", "google"]);
     expect(getSignInProviderIds(true)).toEqual([
       "oidc",

--- a/tests/unit/better-auth-prisma-adapter.test.ts
+++ b/tests/unit/better-auth-prisma-adapter.test.ts
@@ -7,7 +7,7 @@ vi.mock("better-auth/adapters/prisma", () => ({
 }));
 
 describe("createBetterAuthPrismaAdapter", () => {
-  it("centralizes Better Auth Prisma adapter configuration", async () => {
+  it("集中 Better Auth Prisma 适配器配置", async () => {
     const { createBetterAuthPrismaAdapter } = await import(
       "@/lib/auth/better-auth-prisma-adapter"
     );

--- a/tests/unit/bus-client.test.ts
+++ b/tests/unit/bus-client.test.ts
@@ -134,14 +134,14 @@ function createBusData(): BusTimetableData {
   };
 }
 
-describe("bus client timetable math", () => {
-  test("converts an absolute instant to Shanghai minutes since midnight", () => {
+describe("班车客户端时刻表计算", () => {
+  test("将绝对时刻转换为上海本地午夜以来的分钟数", () => {
     expect(
       getShanghaiMinutesSinceMidnight(new Date("2026-04-22T13:10:00.000Z")),
     ).toBe(21 * 60 + 10);
   });
 
-  test("resolves day type from the Shanghai calendar day", () => {
+  test("根据上海日历日期解析日期类型", () => {
     expect(resolveClientBusDayType(new Date("2026-04-24T15:59:00.000Z"))).toBe(
       "weekday",
     );
@@ -153,7 +153,7 @@ describe("bus client timetable math", () => {
     );
   });
 
-  test("sorts routes by the next Shanghai departure time", () => {
+  test("按下一班上海发车时间排序路线", () => {
     const routes = getApplicableBusRoutes({
       data: createBusData(),
       dayType: "weekday",
@@ -168,7 +168,7 @@ describe("bus client timetable math", () => {
     expect(routes[0]?.nextTrip?.status).toBe("upcoming");
   });
 
-  test("marks trips as departed once Shanghai local time passes the stop time", () => {
+  test("当上海本地时间超过站点时间后将行程标记为已发车", () => {
     const routes = getApplicableBusRoutes({
       data: createBusData(),
       dayType: "weekday",

--- a/tests/unit/bus-import.test.ts
+++ b/tests/unit/bus-import.test.ts
@@ -165,8 +165,8 @@ function createPayload(): BusStaticPayload {
   };
 }
 
-describe("bus schedule imports", () => {
-  it("keeps the active timetable intact when replacement trip writes fail", async () => {
+describe("班车时刻表导入", () => {
+  it("当替换行程写入失败时保持当前时刻表不变", async () => {
     const initialState: ImportState = {
       nextVersionId: 2,
       versions: [
@@ -202,7 +202,7 @@ describe("bus schedule imports", () => {
     expect(prisma.getState()).toEqual(initialState);
   });
 
-  it("rejects imports when key and checksum match different versions", async () => {
+  it("当 key 与 checksum 匹配到不同版本时拒绝导入", async () => {
     const payload = createPayload();
     const checksum = await checksumBusPayload(payload);
     const initialState: ImportState = {

--- a/tests/unit/bus-preferences-route.test.ts
+++ b/tests/unit/bus-preferences-route.test.ts
@@ -33,7 +33,7 @@ function preferenceRequest(body: unknown) {
   });
 }
 
-describe("POST /api/bus/preferences", () => {
+describe("POST /api/bus/preferences 班车偏好接口", () => {
   beforeEach(() => {
     vi.resetModules();
     requireAuthMock.mockReset();
@@ -44,7 +44,7 @@ describe("POST /api/bus/preferences", () => {
     requireAuthMock.mockResolvedValue({ userId: "user-1" });
   });
 
-  it("returns 400 for an unknown preferred origin campus", async () => {
+  it("未知的首选出发校区返回 400", async () => {
     prismaMock.busCampus.findMany.mockResolvedValue([]);
     const { postBusPreferencesRoute } = await import("@/lib/api/routes/bus");
 
@@ -63,7 +63,7 @@ describe("POST /api/bus/preferences", () => {
     expect(prismaMock.busUserPreference.upsert).not.toHaveBeenCalled();
   });
 
-  it("returns 400 for an unknown preferred destination campus", async () => {
+  it("未知的首选目的校区返回 400", async () => {
     prismaMock.busCampus.findMany.mockResolvedValue([{ id: 1 }]);
     const { postBusPreferencesRoute } = await import("@/lib/api/routes/bus");
 
@@ -82,7 +82,7 @@ describe("POST /api/bus/preferences", () => {
     expect(prismaMock.busUserPreference.upsert).not.toHaveBeenCalled();
   });
 
-  it("keeps null campus reset behavior", async () => {
+  it("保留 null 校区重置行为", async () => {
     prismaMock.busUserPreference.upsert.mockResolvedValue({});
     const { postBusPreferencesRoute } = await import("@/lib/api/routes/bus");
 

--- a/tests/unit/bus-service.test.ts
+++ b/tests/unit/bus-service.test.ts
@@ -98,14 +98,14 @@ function createNextDepartureData(): BusTimetableData {
   };
 }
 
-describe("bus service", () => {
-  it("parses exact HH:mm timetable values", () => {
+describe("班车服务", () => {
+  it("精确解析 HH:mm 时刻表值", () => {
     expect(parseBusTimeMinutes("08:05")).toBe(8 * 60 + 5);
     expect(parseBusTimeMinutes("8:05")).toBe(8 * 60 + 5);
     expect(parseBusTimeMinutes("23:59")).toBe(23 * 60 + 59);
   });
 
-  it("rejects malformed or out-of-range timetable values", () => {
+  it("拒绝格式错误或越界的时刻表值", () => {
     expect(parseBusTimeMinutes(null)).toBeNull();
     expect(parseBusTimeMinutes("08:05x")).toBeNull();
     expect(parseBusTimeMinutes("08:5")).toBeNull();
@@ -113,7 +113,7 @@ describe("bus service", () => {
     expect(parseBusTimeMinutes("08:60")).toBeNull();
   });
 
-  it("keeps upcoming next departures ahead of departed rows", () => {
+  it("将即将出发的班次排在已出发班次之前", () => {
     const result = buildNextBusDeparturesFromData(createNextDepartureData(), {
       originCampusId: east.id,
       destinationCampusId: west.id,

--- a/tests/unit/bus-static-source.test.ts
+++ b/tests/unit/bus-static-source.test.ts
@@ -4,18 +4,18 @@ import {
   loadBusStaticPayload,
 } from "@/features/bus/lib/bus-static-source";
 
-describe("bus static source", () => {
+describe("班车静态数据源", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("uses the published static bus data URL", () => {
+  it("使用已发布的静态班车数据 URL", () => {
     expect(getBusDataUrl()).toBe(
       "https://static.life-ustc.tiankaima.dev/bus_data_v3.json",
     );
   });
 
-  it("loads the payload from the published static host", async () => {
+  it("从已发布的静态主机加载数据载荷", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response(JSON.stringify({ versionKey: "2026.04" }), {
         status: 200,
@@ -31,7 +31,7 @@ describe("bus static source", () => {
     );
   });
 
-  it("throws when the published payload cannot be loaded", async () => {
+  it("已发布数据载荷无法加载时抛出异常", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => new Response("missing", { status: 404 })),

--- a/tests/unit/bus-tab-state.test.ts
+++ b/tests/unit/bus-tab-state.test.ts
@@ -95,8 +95,8 @@ function createBusData(): DashboardBusData {
   };
 }
 
-describe("bus tab state", () => {
-  test("initializes planner time and day type from fetchedAt", () => {
+describe("班车标签页状态", () => {
+  test("根据 fetchedAt 初始化规划器时间和日期类型", () => {
     const bus = createBusData();
     const state = createBusTabState({
       getBus: () => bus,

--- a/tests/unit/bus-timetable-data.test.ts
+++ b/tests/unit/bus-timetable-data.test.ts
@@ -118,8 +118,8 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
-describe("getBusTimetableData", () => {
-  it("uses topology from the requested historical version", async () => {
+describe("getBusTimetableData 班车时刻表数据", () => {
+  it("使用请求历史版本的拓扑结构", async () => {
     const data = await getBusTimetableData({
       locale: "zh-cn",
       now: "2026-02-01T00:00:00.000Z",

--- a/tests/unit/calendar-feed-token.test.ts
+++ b/tests/unit/calendar-feed-token.test.ts
@@ -39,12 +39,12 @@ function userWithToken(calendarFeedToken: string | null) {
   };
 }
 
-describe("ensureUserCalendarFeedToken", () => {
+describe("ensureUserCalendarFeedToken 日历订阅令牌", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("returns the generated token when it wins first-time creation", async () => {
+  it("首次创建成功时返回生成的令牌", async () => {
     findUniqueMock.mockResolvedValueOnce(userWithToken(null));
     randomBytesBase64UrlMock.mockReturnValue("generated-token");
     updateManyMock.mockResolvedValueOnce({ count: 1 });
@@ -61,7 +61,7 @@ describe("ensureUserCalendarFeedToken", () => {
     expect(updateMock).not.toHaveBeenCalled();
   });
 
-  it("rereads and returns the persisted token when a competing write wins", async () => {
+  it("并发写入由另一方完成时重读并返回持久化的令牌", async () => {
     findUniqueMock
       .mockResolvedValueOnce(userWithToken(null))
       .mockResolvedValueOnce(userWithToken("persisted-token"));

--- a/tests/unit/calendar-tools.test.ts
+++ b/tests/unit/calendar-tools.test.ts
@@ -4,8 +4,8 @@ import {
   summarizeCalendarSubscriptionBrief,
 } from "@/lib/mcp/tools/calendar-summary";
 
-describe("summarizeCalendarSubscription", () => {
-  it("counts semesters with missing bounds as open-ended", () => {
+describe("summarizeCalendarSubscription 日历订阅摘要", () => {
+  it("将缺少边界的学期视为开放式", () => {
     const input = {
       userId: "user-1",
       sections: [

--- a/tests/unit/catalog-summary-read-model.test.ts
+++ b/tests/unit/catalog-summary-read-model.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/features/catalog/server/course-section-query-filters", () => ({
   buildSectionListQuery: buildSectionListQueryMock,
 }));
 
-describe("catalog summary read models", () => {
+describe("课程目录摘要读取模型", () => {
   beforeEach(() => {
     buildCourseListWhereMock.mockReset();
     buildSectionListQueryMock.mockReset();
@@ -30,7 +30,7 @@ describe("catalog summary read models", () => {
     paginatedSectionSummaryQueryMock.mockReset();
   });
 
-  it("applies the shared course summary default order", async () => {
+  it("应用共享的课程摘要默认排序", async () => {
     buildCourseListWhereMock.mockReturnValueOnce({ search: "math" });
     const { COURSE_SUMMARY_DEFAULT_ORDER_BY, listCourseSummaries } =
       await import("@/features/catalog/server/course-summary-read-model");
@@ -50,7 +50,7 @@ describe("catalog summary read models", () => {
     );
   });
 
-  it("applies the shared section summary default order when filters do not provide one", async () => {
+  it("筛选条件未提供排序时使用共享的课段摘要默认排序", async () => {
     buildSectionListQueryMock.mockReturnValueOnce({
       where: { semesterId: 1 },
       orderBy: undefined,
@@ -73,7 +73,7 @@ describe("catalog summary read models", () => {
     );
   });
 
-  it("keeps explicit section ordering from filters", async () => {
+  it("保留筛选条件中的显式课段排序", async () => {
     const explicitOrder = { jwId: "asc" };
     buildSectionListQueryMock.mockReturnValueOnce({
       where: { search: "001" },

--- a/tests/unit/comment-mutations.test.ts
+++ b/tests/unit/comment-mutations.test.ts
@@ -100,7 +100,7 @@ function activeComment() {
   };
 }
 
-describe("comment mutation write guards", () => {
+describe("评论变更写入保护", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
@@ -113,7 +113,7 @@ describe("comment mutation write guards", () => {
     auditLogCreateMock.mockResolvedValue({});
   });
 
-  it("locks the parent row inside the reply creation transaction", async () => {
+  it("在回复创建事务中锁定父行", async () => {
     resolveCommentMutationTargetReferenceMock.mockResolvedValue({
       ok: true,
       rawTargetId: 1,
@@ -182,7 +182,7 @@ describe("comment mutation write guards", () => {
     ).toBeLessThan(auditLogCreateMock.mock.invocationCallOrder[0]);
   });
 
-  it("writes edit audit through the shared update mutation transaction", async () => {
+  it("通过共享更新变更事务写入编辑审计", async () => {
     prismaMock.comment.findUnique
       .mockResolvedValueOnce(activeComment())
       .mockResolvedValueOnce({ id: "comment-1", body: "edited" });
@@ -221,7 +221,7 @@ describe("comment mutation write guards", () => {
     ).toBeLessThan(auditLogCreateMock.mock.invocationCallOrder[0]);
   });
 
-  it("does not sync edit attachments when the owner/status guard loses a race", async () => {
+  it("所有者/状态保护竞争失败时不同步编辑附件", async () => {
     prismaMock.comment.findUnique
       .mockResolvedValueOnce(activeComment())
       .mockResolvedValueOnce({ ...activeComment(), status: "deleted" });
@@ -260,7 +260,7 @@ describe("comment mutation write guards", () => {
     expect(auditLogCreateMock).not.toHaveBeenCalled();
   });
 
-  it("guards delete by owner and active status in the final write", async () => {
+  it("在最终写入时按所有者和活跃状态保护删除", async () => {
     prismaMock.comment.findUnique
       .mockResolvedValueOnce(activeComment())
       .mockResolvedValueOnce({ ...activeComment(), status: "deleted" });
@@ -285,7 +285,7 @@ describe("comment mutation write guards", () => {
     expect(auditLogCreateMock).not.toHaveBeenCalled();
   });
 
-  it("writes delete audit through the shared delete mutation transaction", async () => {
+  it("通过共享删除变更事务写入删除审计", async () => {
     prismaMock.comment.findUnique.mockResolvedValueOnce(activeComment());
     transactionMock.comment.updateMany.mockResolvedValue({ count: 1 });
 
@@ -313,7 +313,7 @@ describe("comment mutation write guards", () => {
     ).toBeLessThan(auditLogCreateMock.mock.invocationCallOrder[0]);
   });
 
-  it("writes reaction audit through the shared reaction mutation transaction", async () => {
+  it("通过共享反应变更事务写入反应审计", async () => {
     prismaMock.comment.findUnique.mockResolvedValue(activeComment());
     transactionMock.commentReaction.createMany.mockResolvedValue({ count: 1 });
 
@@ -342,7 +342,7 @@ describe("comment mutation write guards", () => {
     ).toBeLessThan(auditLogCreateMock.mock.invocationCallOrder[0]);
   });
 
-  it("writes reaction removal audit through the shared reaction mutation transaction", async () => {
+  it("通过共享反应变更事务写入反应移除审计", async () => {
     prismaMock.comment.findUnique.mockResolvedValue(activeComment());
     transactionMock.commentReaction.deleteMany.mockResolvedValue({ count: 1 });
 

--- a/tests/unit/comment-panel-interactions.test.ts
+++ b/tests/unit/comment-panel-interactions.test.ts
@@ -43,12 +43,12 @@ function viewer(overrides: Partial<ViewerContext> = {}): ViewerContext {
   };
 }
 
-describe("comment panel interactions", () => {
+describe("评论面板交互", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("blocks suspended reactions before submitting a request", async () => {
+  it("在提交请求前阻止被暂停用户的反应", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
     let message = "";

--- a/tests/unit/comment-panel-links.test.ts
+++ b/tests/unit/comment-panel-links.test.ts
@@ -5,8 +5,8 @@ import {
   commentTargetPermalinkBaseHref,
 } from "@/features/comments/lib/comment-panel-links";
 
-describe("comment panel links", () => {
-  it("builds homework comment permalinks with enough target context", () => {
+describe("评论面板链接", () => {
+  it("使用足够的作业目标上下文构建评论永久链接", () => {
     const baseHref = commentTargetPermalinkBaseHref({
       homeworkId: "homework-1",
       sectionJwId: 12345,
@@ -43,11 +43,11 @@ describe("comment panel links", () => {
       commentTargetPermalinkBaseHref({ teacherId: 42, type: "teacher" }),
       "/teachers/42?tab=comments#comment-comment-1",
     ],
-  ])("keeps %s comment permalinks target-aware", (_, baseHref, expected) => {
+  ])("根据目标类型保留 %s 评论永久链接", (_, baseHref, expected) => {
     expect(commentPermalinkHref(baseHref, "comment-1")).toBe(expected);
   });
 
-  it("copies absolute permalinks from a relative target base", () => {
+  it("从相对目标基础生成绝对永久链接", () => {
     expect(
       absoluteCommentPermalinkHref({
         commentId: "comment-1",

--- a/tests/unit/comment-panel-upload-pending.test.ts
+++ b/tests/unit/comment-panel-upload-pending.test.ts
@@ -147,7 +147,7 @@ function createSubmitActions({
   });
 }
 
-describe("comment panel upload pending state", () => {
+describe("评论面板上传挂起状态", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     apiClientMock.GET.mockResolvedValue({
@@ -162,7 +162,7 @@ describe("comment panel upload pending state", () => {
     });
   });
 
-  it("keeps pending state true until all uploads in that editor finish", () => {
+  it("在该编辑器的所有上传完成前保持挂起状态为 true", () => {
     let state = createCommentUploadPendingState();
 
     state = commentUploadPendingStateWithDelta({
@@ -197,7 +197,7 @@ describe("comment panel upload pending state", () => {
     expect(commentUploadPendingForMode(state, "new")).toBe(false);
   });
 
-  it("blocks new comment submission while the new-comment editor uploads", async () => {
+  it("新评论编辑器上传期间阻止新评论提交", async () => {
     const actions = createSubmitActions({ pendingModes: ["new"] });
 
     await actions.submitComment();
@@ -205,7 +205,7 @@ describe("comment panel upload pending state", () => {
     expect(apiClientMock.POST).not.toHaveBeenCalled();
   });
 
-  it("blocks reply submission while the reply editor uploads", async () => {
+  it("回复编辑器上传期间阻止回复提交", async () => {
     const actions = createSubmitActions({ pendingModes: ["reply"] });
 
     await actions.submitComment("comment-1", "reply body", target);
@@ -213,7 +213,7 @@ describe("comment panel upload pending state", () => {
     expect(apiClientMock.POST).not.toHaveBeenCalled();
   });
 
-  it("blocks edit save while the edit editor uploads", async () => {
+  it("编辑编辑器上传期间阻止编辑保存", async () => {
     const loadComments = vi.fn();
     const actions = createCommentPanelEditActions({
       applyEditDraftState: vi.fn(),
@@ -234,7 +234,7 @@ describe("comment panel upload pending state", () => {
     expect(loadComments).not.toHaveBeenCalled();
   });
 
-  it("does not let a reply upload block a new comment submission", async () => {
+  it("回复上传不会阻塞新评论提交", async () => {
     const actions = createSubmitActions({ pendingModes: ["reply"] });
 
     await actions.submitComment();

--- a/tests/unit/comment-section-teacher.test.ts
+++ b/tests/unit/comment-section-teacher.test.ts
@@ -21,12 +21,12 @@ vi.mock("@/lib/db/prisma", () => ({
   prisma: prismaMock,
 }));
 
-describe("comment section-teacher targets", () => {
+describe("评论 section-teacher 目标", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("does not resolve retired section-teacher rows as active targets", async () => {
+  it("不将已退役的 section-teacher 行解析为活跃目标", async () => {
     prismaMock.sectionTeacher.findUnique.mockResolvedValue({
       id: 9,
       retiredAt: new Date("2026-01-01T00:00:00.000Z"),
@@ -35,7 +35,7 @@ describe("comment section-teacher targets", () => {
     await expect(findSectionTeacherId(1, 2)).resolves.toBeNull();
   });
 
-  it("reports stale section-teacher rows as missing when the active assignment is gone", async () => {
+  it("当活跃分配不存在时将陈旧的 section-teacher 行报告为缺失", async () => {
     prismaMock.sectionTeacher.findUnique.mockResolvedValue({
       id: 9,
       retiredAt: new Date("2026-01-01T00:00:00.000Z"),
@@ -48,7 +48,7 @@ describe("comment section-teacher targets", () => {
     });
   });
 
-  it("reactivates an explicit target only after the active assignment exists", async () => {
+  it("仅在存在活跃分配后才重新激活显式目标", async () => {
     prismaMock.section.findFirst.mockResolvedValue({ id: 1 });
     prismaMock.sectionTeacher.upsert.mockResolvedValue({ id: 9 });
 
@@ -65,7 +65,7 @@ describe("comment section-teacher targets", () => {
     });
   });
 
-  it("rejects direct section-teacher ids when they are retired", async () => {
+  it("已退役的直接 section-teacher ID 被拒绝", async () => {
     prismaMock.sectionTeacher.findFirst.mockResolvedValue(null);
 
     await expect(

--- a/tests/unit/comment-serialization-permissions.test.ts
+++ b/tests/unit/comment-serialization-permissions.test.ts
@@ -55,8 +55,8 @@ function viewer(overrides: Partial<ViewerInfo> = {}): ViewerInfo {
   };
 }
 
-describe("comment serialization permissions", () => {
-  it("keeps normal author reply and edit affordances", () => {
+describe("评论序列化权限", () => {
+  it("保留普通作者的回复和编辑权限", () => {
     const { roots } = buildCommentNodes([comment()], viewer());
 
     expect(roots).toHaveLength(1);
@@ -70,7 +70,7 @@ describe("comment serialization permissions", () => {
     });
   });
 
-  it("removes write affordances for suspended authors", () => {
+  it("移除被暂停作者的写入权限", () => {
     const { roots } = buildCommentNodes(
       [comment()],
       viewer({ isSuspended: true }),
@@ -87,7 +87,7 @@ describe("comment serialization permissions", () => {
     });
   });
 
-  it("removes suspended admin moderation affordances", () => {
+  it("移除被暂停管理员的管理权限", () => {
     const { roots } = buildCommentNodes(
       [comment({ userId: "user-1" })],
       viewer({
@@ -108,7 +108,7 @@ describe("comment serialization permissions", () => {
     });
   });
 
-  it("keeps deleted tombstones for visible replies but omits attachments", () => {
+  it("为可见回复保留已删除占位但省略附件", () => {
     const { roots } = buildCommentNodes(
       [
         comment({
@@ -137,7 +137,7 @@ describe("comment serialization permissions", () => {
     expect(roots[0].replies).toHaveLength(1);
   });
 
-  it("removes write affordances from softbanned comments", () => {
+  it("从软封禁评论中移除写入权限", () => {
     const authorView = buildCommentNodes(
       [comment({ status: "softbanned" })],
       viewer(),
@@ -163,7 +163,7 @@ describe("comment serialization permissions", () => {
     });
   });
 
-  it("exposes attachment actions only to authenticated viewers", () => {
+  it("仅向已认证查看者暴露附件操作", () => {
     const rawComment = comment({ attachments: [attachment()] });
 
     const anonymous = buildCommentNodes(

--- a/tests/unit/compact-payload.test.ts
+++ b/tests/unit/compact-payload.test.ts
@@ -1,37 +1,37 @@
 import { describe, expect, it } from "vitest";
 import { compactMcpPayload } from "@/lib/mcp/compact-payload";
 
-describe("compactMcpPayload", () => {
-  describe("primitives and arrays", () => {
-    it("passes through null", () => {
+describe("compactMcpPayload MCP 载荷压缩", () => {
+  describe("原始类型和数组", () => {
+    it("原样透传 null", () => {
       expect(compactMcpPayload(null)).toBeNull();
     });
 
-    it("passes through undefined", () => {
+    it("原样透传 undefined", () => {
       expect(compactMcpPayload(undefined)).toBeUndefined();
     });
 
-    it("passes through strings", () => {
+    it("原样透传字符串", () => {
       expect(compactMcpPayload("hello")).toBe("hello");
     });
 
-    it("passes through numbers", () => {
+    it("原样透传数字", () => {
       expect(compactMcpPayload(42)).toBe(42);
     });
 
-    it("passes through booleans", () => {
+    it("原样透传布尔值", () => {
       expect(compactMcpPayload(true)).toBe(true);
     });
 
-    it("returns empty array for empty array", () => {
+    it("空数组返回空数组", () => {
       expect(compactMcpPayload([])).toEqual([]);
     });
 
-    it("returns array of primitives unchanged", () => {
+    it("原始类型数组保持不变", () => {
       expect(compactMcpPayload([1, "a", null])).toEqual([1, "a", null]);
     });
 
-    it("recursively compacts arrays of objects", () => {
+    it("递归压缩对象数组", () => {
       const input = [{ todos: [{ id: "1", title: "T", extra: "x" }] }];
       const result = compactMcpPayload(input) as Record<string, unknown>[];
       expect(result).toHaveLength(1);
@@ -40,7 +40,7 @@ describe("compactMcpPayload", () => {
       ).not.toHaveProperty("extra");
     });
 
-    it("compacts top-level arrays of known records", () => {
+    it("压缩顶层已知记录数组", () => {
       const input = [
         {
           id: "c1",
@@ -66,8 +66,8 @@ describe("compactMcpPayload", () => {
     });
   });
 
-  describe("todos", () => {
-    it("compacts todo items, keeping only expected fields", () => {
+  describe("待办事项", () => {
+    it("压缩待办项，仅保留预期字段", () => {
       const input = {
         todos: [
           {
@@ -98,15 +98,15 @@ describe("compactMcpPayload", () => {
       });
     });
 
-    it("preserves sibling fields on the wrapper object", () => {
+    it("保留包装对象的同级字段", () => {
       const input = { todos: [], totalCount: 5 };
       const result = compactMcpPayload(input) as Record<string, unknown>;
       expect(result.totalCount).toBe(5);
     });
   });
 
-  describe("courses", () => {
-    it("compacts course items", () => {
+  describe("课程", () => {
+    it("压缩课程项", () => {
       const input = {
         courses: [
           {
@@ -135,8 +135,8 @@ describe("compactMcpPayload", () => {
     });
   });
 
-  describe("sections", () => {
-    it("compacts sections with nested course and semester", () => {
+  describe("课段", () => {
+    it("压缩嵌套课程和学期的课段", () => {
       const input = {
         sections: [
           {
@@ -182,8 +182,8 @@ describe("compactMcpPayload", () => {
     });
   });
 
-  describe("homeworks", () => {
-    it("compacts homeworks with nested description and users", () => {
+  describe("作业", () => {
+    it("压缩嵌套描述和用户信息的作业", () => {
       const input = {
         homeworks: [
           {
@@ -230,7 +230,7 @@ describe("compactMcpPayload", () => {
       expect(hw.updatedBy).toBeNull();
     });
 
-    it("does not add missing optional nested fields", () => {
+    it("不添加缺失的可选嵌套字段", () => {
       const input = {
         homeworks: [
           {
@@ -256,8 +256,8 @@ describe("compactMcpPayload", () => {
     });
   });
 
-  describe("schedules", () => {
-    it("compacts schedules with nested section, room with building, and teachers", () => {
+  describe("日程", () => {
+    it("压缩嵌套课段、带楼宇的教室和教师的日程", () => {
       const input = {
         schedules: [
           {
@@ -318,8 +318,8 @@ describe("compactMcpPayload", () => {
     });
   });
 
-  describe("exams", () => {
-    it("compacts exams with examBatch and examRooms", () => {
+  describe("考试", () => {
+    it("压缩嵌套 examBatch 和 examRooms 的考试", () => {
       const input = {
         exams: [
           {
@@ -362,8 +362,8 @@ describe("compactMcpPayload", () => {
     });
   });
 
-  describe("events", () => {
-    it("routes schedule events through compactSchedule", () => {
+  describe("事件", () => {
+    it("通过 compactSchedule 路由日程事件", () => {
       const input = {
         events: [
           {
@@ -393,7 +393,7 @@ describe("compactMcpPayload", () => {
       );
     });
 
-    it("routes homework_due events through compactHomework", () => {
+    it("通过 compactHomework 路由作业到期事件", () => {
       const input = {
         events: [
           {
@@ -423,7 +423,7 @@ describe("compactMcpPayload", () => {
       );
     });
 
-    it("routes exam events through compactExam", () => {
+    it("通过 compactExam 路由考试事件", () => {
       const input = {
         events: [
           {
@@ -449,7 +449,7 @@ describe("compactMcpPayload", () => {
       );
     });
 
-    it("routes todo_due events through compactTodo", () => {
+    it("通过 compactTodo 路由待办到期事件", () => {
       const input = {
         events: [
           {
@@ -476,7 +476,7 @@ describe("compactMcpPayload", () => {
       );
     });
 
-    it("handles events without payload", () => {
+    it("处理无载荷事件", () => {
       const input = {
         events: [{ type: "schedule", at: "2024-01-01" }],
       };
@@ -485,7 +485,7 @@ describe("compactMcpPayload", () => {
       expect(events[0]).toEqual({ type: "schedule", at: "2024-01-01" });
     });
 
-    it("does not compact generic payloads by structural inference", () => {
+    it("不通过结构推断压缩通用载荷", () => {
       const input = {
         nextClass: {
           type: "schedule",
@@ -522,7 +522,7 @@ describe("compactMcpPayload", () => {
       });
     });
 
-    it("does not misidentify exam objects as schedules (exam has startTime/endTime/sectionId but no date+weekday)", () => {
+    it("不会将考试对象误判为日程（考试有 startTime/endTime/sectionId 但没有 date+weekday）", () => {
       const input = {
         exams: [
           {
@@ -568,8 +568,8 @@ describe("compactMcpPayload", () => {
     });
   });
 
-  describe("fallback singular keys", () => {
-    it("compacts singular 'course' key", () => {
+  describe("回退单数键", () => {
+    it("压缩单数 'course' 键", () => {
       const input = {
         course: { id: "c1", code: "CS101", namePrimary: "CS", extra: "x" },
         otherField: "preserved",
@@ -581,7 +581,7 @@ describe("compactMcpPayload", () => {
       expect(result.otherField).toBe("preserved");
     });
 
-    it("compacts singular 'todo' key", () => {
+    it("压缩单数 'todo' 键", () => {
       const input = {
         todo: { id: "t1", title: "T", userId: "removed" },
       };
@@ -591,15 +591,15 @@ describe("compactMcpPayload", () => {
       );
     });
 
-    it("preserves unknown fields in output", () => {
+    it("保留输出中的未知字段", () => {
       const input = { unknownField: "value", anotherField: 42 };
       const result = compactMcpPayload(input) as Record<string, unknown>;
       expect(result).toEqual({ unknownField: "value", anotherField: 42 });
     });
   });
 
-  describe("bus timetables", () => {
-    it("preserves stopTimes for raw trip arrays", () => {
+  describe("班车时刻表", () => {
+    it("为原始班次数组保留 stopTimes", () => {
       const input = {
         trips: [
           {
@@ -652,7 +652,7 @@ describe("compactMcpPayload", () => {
       );
     });
 
-    it("preserves per-stop timetable slots for single-route schedules", () => {
+    it("为单线路日程保留每站时刻槽", () => {
       const input = {
         weekday: [
           {
@@ -696,8 +696,8 @@ describe("compactMcpPayload", () => {
     });
   });
 
-  describe("calendar subscriptions", () => {
-    it("preserves summary subscription fields instead of coercing them into raw shape", () => {
+  describe("日历订阅", () => {
+    it("保留订阅摘要字段而不是强制转换为原始形状", () => {
       const input = {
         success: true,
         subscription: {

--- a/tests/unit/course-section-queries.test.ts
+++ b/tests/unit/course-section-queries.test.ts
@@ -20,8 +20,8 @@ beforeAll(async () => {
   buildSectionListQuery = queries.buildSectionListQuery;
 });
 
-describe("course and section query helpers", () => {
-  it("builds course filters from search and numeric ids", () => {
+describe("课程与开课查询辅助函数", () => {
+  it("根据搜索和数字 ID 构建课程筛选条件", () => {
     expect(
       buildCourseListWhere({
         search: "math",
@@ -41,7 +41,7 @@ describe("course and section query helpers", () => {
     });
   });
 
-  it("drops invalid course numeric filters", () => {
+  it("丢弃无效的课程数字筛选条件", () => {
     expect(
       buildCourseListWhere({
         educationLevelId: "foo",
@@ -51,7 +51,7 @@ describe("course and section query helpers", () => {
     ).toBeUndefined();
   });
 
-  it("builds section filters, ids, and parsed search order", () => {
+  it("构建开课筛选条件、ID 和解析后的搜索排序", () => {
     const result = buildSectionListQuery({
       courseId: "11",
       semesterId: 22,
@@ -125,7 +125,7 @@ describe("course and section query helpers", () => {
     expect(result.orderBy).toEqual({ semester: { jwId: "desc" } });
   });
 
-  it("builds advanced section search aliases", () => {
+  it("构建高级开课搜索别名", () => {
     const result = buildSectionListQuery({
       search:
         "coursecode:MATH sectioncode:SEC campus:west credit:3.5 dept:CS semester:fall category:core edulevel:ug type:lab sortby:campus order:DESC leftover",
@@ -201,7 +201,7 @@ describe("course and section query helpers", () => {
     expect(result.orderBy).toEqual({ campus: { nameCn: "desc" } });
   });
 
-  it("ignores inexact section credit search values", () => {
+  it("忽略不精确的开课学分搜索值", () => {
     const result = buildSectionListQuery({
       search: "credits:3abc",
     });
@@ -209,7 +209,7 @@ describe("course and section query helpers", () => {
     expect(result.where).toEqual({});
   });
 
-  it("accepts numeric id arrays for section filters", () => {
+  it("接受数字 ID 数组作为开课筛选条件", () => {
     expect(
       buildSectionListQuery({
         ids: [7, 8, 9],
@@ -221,7 +221,7 @@ describe("course and section query helpers", () => {
     });
   });
 
-  it("builds JW-id-based course and semester filters", () => {
+  it("根据 JW ID 构建课程和学期筛选条件", () => {
     const result = buildSectionListQuery({
       courseJwId: 101,
       semesterJwId: 202,
@@ -232,14 +232,14 @@ describe("course and section query helpers", () => {
     });
   });
 
-  it("builds teacherCode filter inside teachers.some", () => {
+  it("在 teachers.some 内构建 teacherCode 筛选条件", () => {
     const result = buildSectionListQuery({ teacherCode: "DEV-T-001" });
     expect(result.where).toMatchObject({
       teachers: { some: { code: "DEV-T-001" } },
     });
   });
 
-  it("combines teacherId and teacherCode into a single teachers.some filter", () => {
+  it("将 teacherId 和 teacherCode 合并为单个 teachers.some 筛选条件", () => {
     const result = buildSectionListQuery({
       teacherId: 55,
       teacherCode: "T-001",
@@ -249,21 +249,21 @@ describe("course and section query helpers", () => {
     });
   });
 
-  it("builds jwIds filter on section.jwId", () => {
+  it("在 section.jwId 上构建 jwIds 筛选条件", () => {
     const result = buildSectionListQuery({ jwIds: [9902001, 9902002] });
     expect(result.where).toMatchObject({
       jwId: { in: [9902001, 9902002] },
     });
   });
 
-  it("parses comma-separated jwIds string", () => {
+  it("解析逗号分隔的 jwIds 字符串", () => {
     const result = buildSectionListQuery({ jwIds: "9902001, 9902002, x" });
     expect(result.where).toMatchObject({
       jwId: { in: [9902001, 9902002] },
     });
   });
 
-  it("trims whitespace from teacherCode and ignores empty string", () => {
+  it("去除 teacherCode 首尾空白并忽略空字符串", () => {
     expect(
       buildSectionListQuery({ teacherCode: "  " }).where,
     ).not.toHaveProperty("teachers");

--- a/tests/unit/csp.test.ts
+++ b/tests/unit/csp.test.ts
@@ -4,17 +4,17 @@ import {
   createScriptNonce,
 } from "@/lib/security/csp";
 
-describe("csp helpers", () => {
+describe("CSP 辅助函数", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("creates a non-empty nonce", () => {
+  it("创建非空 nonce", () => {
     const nonce = createScriptNonce();
     expect(nonce.length).toBeGreaterThan(10);
   });
 
-  it("builds a CSP that requires a matching script nonce", () => {
+  it("构建要求匹配脚本 nonce 的 CSP", () => {
     const policy = buildContentSecurityPolicy("abc123");
     const scriptDirective = policy
       .split("; ")
@@ -28,7 +28,7 @@ describe("csp helpers", () => {
     expect(policy).toContain("object-src 'none'");
   });
 
-  it("allows configured external avatar image sources", () => {
+  it("允许配置的外部头像图片来源", () => {
     const policy = buildContentSecurityPolicy("abc123");
     const imageDirective = policy
       .split("; ")
@@ -40,7 +40,7 @@ describe("csp helpers", () => {
     expect(imageDirective).toContain("https://api.dicebear.com");
   });
 
-  it("keeps uploads on the same origin", () => {
+  it("保持上传资源同源", () => {
     const policy = buildContentSecurityPolicy("abc123");
     const connectDirective = policy
       .split("; ")

--- a/tests/unit/current-semester.test.ts
+++ b/tests/unit/current-semester.test.ts
@@ -10,8 +10,8 @@ type SemesterLike = {
   endDate: Date | null;
 };
 
-describe("current-semester helpers", () => {
-  it("builds date range where clause", () => {
+describe("当前学期辅助函数", () => {
+  it("构建日期范围 where 子句", () => {
     const now = new Date("2026-09-01T00:00:00.000Z");
     expect(buildCurrentSemesterWhere(now)).toEqual({
       startDate: { lte: now },
@@ -19,7 +19,7 @@ describe("current-semester helpers", () => {
     });
   });
 
-  it("prefers first unfinished semester", () => {
+  it("优先选择第一个未结束学期", () => {
     const referenceDate = new Date("2026-03-15T00:00:00.000Z");
     const semesters: SemesterLike[] = [
       {
@@ -42,7 +42,7 @@ describe("current-semester helpers", () => {
     expect(selectCurrentSemesterFromList(semesters, referenceDate)?.id).toBe(2);
   });
 
-  it("prefers the latest-starting semester when ranges overlap", () => {
+  it("当日期范围重叠时优先选择开始时间最晚的学期", () => {
     const referenceDate = new Date("2026-04-15T00:00:00.000Z");
     const semesters: SemesterLike[] = [
       {
@@ -60,7 +60,7 @@ describe("current-semester helpers", () => {
     expect(selectCurrentSemesterFromList(semesters, referenceDate)?.id).toBe(2);
   });
 
-  it("falls back to earliest unfinished future semester", () => {
+  it("回退到最早的未开始未来学期", () => {
     const referenceDate = new Date("2026-01-01T00:00:00.000Z");
     const semesters: SemesterLike[] = [
       {
@@ -80,7 +80,7 @@ describe("current-semester helpers", () => {
     );
   });
 
-  it("falls back to latest semester when all semesters are finished", () => {
+  it("当所有学期都已结束时回退到最晚学期", () => {
     const referenceDate = new Date("2026-02-01T12:00:00.000Z");
     const semesters: SemesterLike[] = [
       {

--- a/tests/unit/dashboard-calendar-actions.test.ts
+++ b/tests/unit/dashboard-calendar-actions.test.ts
@@ -3,7 +3,7 @@ import type { CalendarView } from "@/features/dashboard/lib/calendar";
 import { createDashboardCalendarActions } from "@/features/dashboard/lib/dashboard-controller-calendar-actions";
 import { dashboardTabHref } from "@/features/dashboard/lib/dashboard-nav";
 
-describe("dashboard calendar actions", () => {
+describe("仪表盘日历操作", () => {
   function calendarActions() {
     const navigateUrl = vi.fn();
     const replaceUrl = vi.fn();
@@ -48,7 +48,7 @@ describe("dashboard calendar actions", () => {
     };
   }
 
-  it("uses navigation for semester changes so dashboard load reruns", () => {
+  it("学期变更使用导航以便仪表盘重新加载", () => {
     const { actions, navigateUrl, replaceUrl, state } = calendarActions();
 
     actions.setCalendarSemester(2);
@@ -63,7 +63,7 @@ describe("dashboard calendar actions", () => {
     expect(replaceUrl).not.toHaveBeenCalled();
   });
 
-  it("keeps month changes as local URL replacements", () => {
+  it("月份变更保持为本地 URL 替换", () => {
     const { actions, navigateUrl, replaceUrl, state } = calendarActions();
 
     actions.setCalendarMonth("2026-03");

--- a/tests/unit/dashboard-calendar-date-keys.test.ts
+++ b/tests/unit/dashboard-calendar-date-keys.test.ts
@@ -11,8 +11,8 @@ import {
   dashboardCalendarViewPatch,
 } from "@/features/dashboard/lib/calendar-navigation";
 
-describe("dashboard calendar date keys", () => {
-  it("uses campus date keys for dashboard date navigation", () => {
+describe("仪表盘日历日期键", () => {
+  it("为仪表盘日期导航使用校区日期键", () => {
     expect(toDateKey(new Date("2026-03-01T15:59:59.000Z"))).toBe("2026-03-01");
     expect(toDateKey(new Date("2026-03-01T16:00:00.000Z"))).toBe("2026-03-02");
     expect(weekStartFor("2026-03-02")).toBe("2026-03-01");
@@ -29,7 +29,7 @@ describe("dashboard calendar date keys", () => {
     ]);
   });
 
-  it("normalizes dashboard reference dates before deriving URL state", () => {
+  it("在推导 URL 状态前规范化仪表盘参考日期", () => {
     const calendar = {
       activeCalendarSemesterId: 42,
       referenceDate: "2026-03-01T16:00:00.000Z",

--- a/tests/unit/dashboard-calendar-display-overview.test.ts
+++ b/tests/unit/dashboard-calendar-display-overview.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { overviewUpcomingExams } from "@/features/dashboard/lib/calendar-display-overview";
 
-describe("dashboard overview exam display", () => {
-  it("shows only exams that can still appear in the upcoming timeline", () => {
+describe("仪表盘概览考试展示", () => {
+  it("仅显示仍可出现在近期时间线中的考试", () => {
     const referenceDate = new Date("2026-05-22T10:30:00+08:00");
     const upcoming = overviewUpcomingExams(
       {

--- a/tests/unit/dashboard-controller-derived-state.test.ts
+++ b/tests/unit/dashboard-controller-derived-state.test.ts
@@ -73,7 +73,7 @@ function homework(id: string, completed: boolean): HomeworkItem {
   };
 }
 
-describe("dashboard controller derived state", () => {
+describe("仪表盘控制器派生状态", () => {
   it.each([
     { currentPinned: true, loadedPinned: false, name: "pin" },
     { currentPinned: false, loadedPinned: true, name: "unpin" },
@@ -108,7 +108,7 @@ describe("dashboard controller derived state", () => {
     ]);
   });
 
-  it("derives the signed dashboard homework badge count from local homework items", () => {
+  it("根据本地作业项推导已登录仪表盘作业徽章数量", () => {
     const data = {
       ...signedDashboardData([]),
       homeworks: {
@@ -135,7 +135,7 @@ describe("dashboard controller derived state", () => {
     expect(result?.homeworks?.homeworkSummaries).toBe(nextHomeworks);
   });
 
-  it("derives the signed dashboard todo badge count from local todo items", () => {
+  it("根据本地待办项推导已登录仪表盘待办徽章数量", () => {
     const data = {
       ...signedDashboardData([]),
       todos: [

--- a/tests/unit/dashboard-form-validation.test.ts
+++ b/tests/unit/dashboard-form-validation.test.ts
@@ -21,8 +21,8 @@ const homeworkCopy = {
   errorTitleTooLong: "title too long",
 };
 
-describe("dashboard form validation", () => {
-  it("uses strict todo due date parsing", () => {
+describe("仪表盘表单验证", () => {
+  it("对 todo 截止日期使用严格解析", () => {
     const formData = new FormData();
     formData.set("title", "Read Chapter 1");
     formData.set("dueAt", "2026-02-30T10:00");
@@ -30,7 +30,7 @@ describe("dashboard form validation", () => {
     expect(validateTodoForm(formData, todoCopy)).toBe("invalid due date");
   });
 
-  it("uses strict homework date parsing", () => {
+  it("对作业日期使用严格解析", () => {
     const formData = new FormData();
     formData.set("sectionId", "1");
     formData.set("title", "Project 1");

--- a/tests/unit/dashboard-helpers.test.ts
+++ b/tests/unit/dashboard-helpers.test.ts
@@ -40,8 +40,8 @@ function homework(
   };
 }
 
-describe("dashboard helpers", () => {
-  it("deduplicates and sorts time slots without reparsing numeric times", () => {
+describe("仪表盘辅助函数", () => {
+  it("去重并排序时间段，不重新解析数字时间", () => {
     expect(
       buildTimeSlots([
         session(1000, 1120),
@@ -54,7 +54,7 @@ describe("dashboard helpers", () => {
     ]);
   });
 
-  it("groups incomplete homework by Shanghai due date windows", () => {
+  it("按上海截止日期窗口对未完成作业分组", () => {
     const todayStart = shanghaiDayjs("2026-05-22T00:00:00+08:00");
     const today = homework("today", "2026-05-22T10:00:00+08:00");
     const soon = homework("soon", "2026-05-25T23:59:00+08:00");

--- a/tests/unit/dashboard-homework-actions.test.ts
+++ b/tests/unit/dashboard-homework-actions.test.ts
@@ -13,12 +13,12 @@ vi.mock("@/features/homeworks/lib/homework-completion-client", async () => {
   };
 });
 
-describe("dashboard homework actions", () => {
+describe("仪表盘作业操作", () => {
   beforeEach(() => {
     updateHomeworkCompletionMock.mockReset();
   });
 
-  it("updates homework completion through the shared client", async () => {
+  it("通过共享客户端更新作业完成状态", async () => {
     const homework = {
       id: "homework-1",
       completion: null,
@@ -51,7 +51,7 @@ describe("dashboard homework actions", () => {
     });
   });
 
-  it("surfaces localized dashboard completion failures", async () => {
+  it("展示本地化的仪表盘完成失败信息", async () => {
     const homework = {
       id: "homework-1",
       completion: null,

--- a/tests/unit/dashboard-homework-page-actions.test.ts
+++ b/tests/unit/dashboard-homework-page-actions.test.ts
@@ -26,13 +26,13 @@ function actionRequest() {
   );
 }
 
-describe("dashboard homework page actions", () => {
+describe("仪表盘作业页面操作", () => {
   beforeEach(() => {
     createHomeworkForSectionMock.mockReset();
     getSessionFromHeadersMock.mockReset();
   });
 
-  it("maps suspended dashboard homework creation failures", async () => {
+  it("映射被停用账户的仪表盘作业创建失败", async () => {
     getSessionFromHeadersMock.mockResolvedValue({
       user: { id: "suspended-user" },
     });

--- a/tests/unit/dashboard-link-pin-route.test.ts
+++ b/tests/unit/dashboard-link-pin-route.test.ts
@@ -28,7 +28,7 @@ describe("POST /api/dashboard-links/pin", () => {
     vi.clearAllMocks();
   });
 
-  it("returns a 500 JSON error when persisting a pin fails", async () => {
+  it("当固定链接持久化失败时返回 500 JSON 错误", async () => {
     transactionMock.mockRejectedValue(new Error("db write failed"));
     const { postDashboardLinkPinRoute } = await import(
       "@/lib/api/routes/dashboard-links"

--- a/tests/unit/dashboard-links.test.ts
+++ b/tests/unit/dashboard-links.test.ts
@@ -10,8 +10,8 @@ import {
 } from "@/features/dashboard-links/lib/dashboard-links";
 import { buildDashboardLinkSummaries } from "@/features/dashboard-links/server/dashboard-link-selection";
 
-describe("dashboard link recommendations", () => {
-  it("returns most-clicked links first", () => {
+describe("仪表盘链接推荐", () => {
+  it("按点击次数降序返回链接", () => {
     const result = recommendDashboardLinks({
       mail: 2,
       jw: 8,
@@ -22,7 +22,7 @@ describe("dashboard link recommendations", () => {
     expect(result.map((item) => item.slug)).toEqual(["jw", "library", "mail"]);
   });
 
-  it("falls back to deterministic order when no history exists", () => {
+  it("无历史记录时回退到确定性顺序", () => {
     const result = recommendDashboardLinks({});
 
     expect(result).toHaveLength(3);
@@ -33,7 +33,7 @@ describe("dashboard link recommendations", () => {
     ).toBe(true);
   });
 
-  it("supports exclude slugs and custom limit", () => {
+  it("支持排除 slug 和自定义数量限制", () => {
     const result = recommendDashboardLinks(
       {
         jw: 10,
@@ -47,14 +47,14 @@ describe("dashboard link recommendations", () => {
     expect(result.map((item) => item.slug)).toEqual(["mail", "official"]);
   });
 
-  it("requires English catalog labels for every link", () => {
+  it("要求每个链接都有英文目录标签", () => {
     for (const link of USTC_DASHBOARD_LINKS) {
       expect(link.localizations["en-us"]?.title, link.slug).toBeTruthy();
       expect(link.localizations["en-us"]?.description, link.slug).toBeTruthy();
     }
   });
 
-  it("projects dashboard link labels by locale", () => {
+  it("按地区设置投影仪表盘链接标签", () => {
     const mail = USTC_DASHBOARD_LINKS.find((link) => link.slug === "mail");
     expect(mail).toBeDefined();
     if (!mail) throw new Error("mail link missing");
@@ -69,7 +69,7 @@ describe("dashboard link recommendations", () => {
     });
   });
 
-  it("builds search summaries from localized link labels", () => {
+  it("根据本地化链接标签构建搜索摘要", () => {
     const zhLinks = buildDashboardLinkSummaries({}, new Set(), "zh-cn");
     const enLinks = buildDashboardLinkSummaries({}, new Set(), "en-us");
     const zhMail = zhLinks.dashboardLinks.find((link) => link.slug === "mail");

--- a/tests/unit/dashboard-nav-stats.test.ts
+++ b/tests/unit/dashboard-nav-stats.test.ts
@@ -35,7 +35,7 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
-describe("dashboard nav stats", () => {
+describe("仪表盘导航统计", () => {
   afterEach(() => {
     countIncompleteTodosMock.mockReset();
     countUpcomingSubscribedExamsMock.mockReset();
@@ -45,7 +45,7 @@ describe("dashboard nav stats", () => {
     vi.resetModules();
   });
 
-  it("uses the shared upcoming exam count semantics for the exams badge", async () => {
+  it("对考试徽章使用共享的即将到来考试计数语义", async () => {
     const referenceNow = new Date("2026-05-22T10:30:00.000Z");
     countIncompleteTodosMock.mockResolvedValue(4);
     homeworkCountMock.mockResolvedValue(2);

--- a/tests/unit/dashboard-semester-todos.test.ts
+++ b/tests/unit/dashboard-semester-todos.test.ts
@@ -15,12 +15,12 @@ function day(value: string) {
   };
 }
 
-describe("dashboard semester todos", () => {
+describe("仪表盘学期待办", () => {
   beforeEach(() => {
     listDueTodoSnapshotsMock.mockReset();
   });
 
-  it("loads only incomplete due todos for the semester calendar", async () => {
+  it("仅加载学期日历中未完成的到期待办", async () => {
     listDueTodoSnapshotsMock.mockResolvedValue([
       {
         completed: false,

--- a/tests/unit/dashboard-todo-form.test.ts
+++ b/tests/unit/dashboard-todo-form.test.ts
@@ -22,8 +22,8 @@ function todoRequest(input: { priority?: string; title?: string }) {
   });
 }
 
-describe("dashboard todo form", () => {
-  it("defaults missing priority to the todo feature default", async () => {
+describe("dashboard 待办表单", () => {
+  it("缺失优先级时默认使用待办功能默认值", async () => {
     const parsed = await readTodoForm(todoRequest({}), copy);
 
     expect("error" in parsed).toBe(false);
@@ -31,7 +31,7 @@ describe("dashboard todo form", () => {
     expect(parsed.todo.priority).toBe("medium");
   });
 
-  it("rejects invalid priority instead of silently coercing it", async () => {
+  it("拒绝无效优先级而非静默转换", async () => {
     const parsed = await readTodoForm(
       todoRequest({ priority: "urgent" }),
       copy,
@@ -45,7 +45,7 @@ describe("dashboard todo form", () => {
     expect(error.data).toEqual({ error: "invalid priority" });
   });
 
-  it("rejects impossible due dates with the todo feature parser", async () => {
+  it("使用待办功能解析器拒绝不存在的截止日期", async () => {
     const body = new FormData();
     body.set("title", "Read Chapter 1");
     body.set("dueAt", "2026-02-30T10:00");

--- a/tests/unit/date-utils.test.ts
+++ b/tests/unit/date-utils.test.ts
@@ -6,21 +6,21 @@ import {
   isSameDefaultWeek,
 } from "@/shared/lib/date-utils";
 
-describe("default week helpers", () => {
-  it("uses Monday as the shared week boundary", () => {
+describe("默认周辅助函数", () => {
+  it("以周一作为共享周边界", () => {
     const date = shanghaiDayjs("2026-03-18T10:00:00+08:00");
 
     expect(getDefaultWeekStart(date).format("YYYY-MM-DD")).toBe("2026-03-16");
   });
 
-  it("keeps the next Sunday in the same shared week", () => {
+  it("将下一个周日保留在同一共享周内", () => {
     const ref = shanghaiDayjs("2026-03-16T10:00:00+08:00");
     const due = shanghaiDayjs("2026-03-22T09:00:00+08:00");
 
     expect(isSameDefaultWeek(ref, due)).toBe(true);
   });
 
-  it("excludes the previous Sunday from the shared week", () => {
+  it("将上一个周日排除在共享周之外", () => {
     const ref = shanghaiDayjs("2026-03-18T10:00:00+08:00");
     const due = shanghaiDayjs("2026-03-15T09:00:00+08:00");
     const { start, endExclusive } = getDefaultWeekRange(ref);

--- a/tests/unit/debug-auth.test.ts
+++ b/tests/unit/debug-auth.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/lib/db/prisma", () => ({
   prisma: prismaMock,
 }));
 
-describe("debug auth config", () => {
+describe("debug 认证配置", () => {
   beforeEach(() => {
     hashPasswordMock.mockResolvedValue("hashed-debug-password");
     prismaMock.account.upsert.mockResolvedValue({});
@@ -37,7 +37,7 @@ describe("debug auth config", () => {
     vi.unstubAllEnvs();
   });
 
-  it("builds default debug provider configs", async () => {
+  it("构建默认 debug 提供者配置", async () => {
     const { getDebugProviderConfig } = await import("@/lib/auth/debug-auth");
 
     expect(getDebugProviderConfig(DEV_DEBUG_PROVIDER_ID)).toEqual({
@@ -57,7 +57,7 @@ describe("debug auth config", () => {
     });
   });
 
-  it("trims and lowercases environment overrides", async () => {
+  it("对环境变量覆盖值进行修剪并小写化", async () => {
     vi.stubEnv("DEV_DEBUG_USERNAME", "  Custom-User ");
     vi.stubEnv("DEV_DEBUG_NAME", " Custom User ");
     vi.stubEnv("DEV_DEBUG_EMAIL", " USER@Example.TEST ");
@@ -73,7 +73,7 @@ describe("debug auth config", () => {
     });
   });
 
-  it("requires explicit debug passwords for non-development E2E auth", async () => {
+  it("非开发环境 E2E 认证需要显式 debug 密码", async () => {
     vi.stubEnv("NODE_ENV", "test");
     vi.stubEnv("E2E_DEBUG_AUTH", "1");
 
@@ -84,7 +84,7 @@ describe("debug auth config", () => {
     );
   });
 
-  it("completes matched stale debug users", async () => {
+  it("补全匹配的过期 debug 用户", async () => {
     const { ensureDebugCredentialUser, getDebugProviderConfig } = await import(
       "@/lib/auth/debug-auth"
     );
@@ -137,7 +137,7 @@ describe("debug auth config", () => {
     });
   });
 
-  it("prefers username identity and neutralizes duplicate debug-email users", async () => {
+  it("优先使用用户名身份并中和重复的 debug 邮箱用户", async () => {
     const { ensureDebugCredentialUser, getDebugProviderConfig } = await import(
       "@/lib/auth/debug-auth"
     );

--- a/tests/unit/description-upsert-service.test.ts
+++ b/tests/unit/description-upsert-service.test.ts
@@ -90,7 +90,7 @@ describe("upsertDescriptionContent", () => {
     sectionFindUniqueMock.mockResolvedValue({ id: 1 });
   });
 
-  it("rejects changed content when the required audit write fails", async () => {
+  it("当必需的审计写入失败时拒绝变更内容", async () => {
     const auditError = new Error("audit unavailable");
     descriptionFindFirstMock.mockResolvedValue({
       id: "description-1",
@@ -136,7 +136,7 @@ describe("upsertDescriptionContent", () => {
     });
   });
 
-  it("does not write edit history or audit rows for idempotent content", async () => {
+  it("幂等内容不写入编辑历史或审计记录", async () => {
     descriptionFindFirstMock.mockResolvedValue({
       id: "description-1",
       content: "same content",

--- a/tests/unit/dev-seed-time.test.ts
+++ b/tests/unit/dev-seed-time.test.ts
@@ -6,7 +6,7 @@ async function importSeedTimeWithTimezone(timezone: string) {
   return import("../fixtures/dev-seed-time");
 }
 
-describe("dev seed time helpers", () => {
+describe("开发种子时间辅助函数", () => {
   afterEach(() => {
     vi.resetModules();
     vi.unstubAllEnvs();
@@ -15,7 +15,7 @@ describe("dev seed time helpers", () => {
   it.each([
     "UTC",
     "America/New_York",
-  ])("constructs Shanghai seed instants under %s host timezone", async (timezone) => {
+  ])("在 %s 主机时区下构建上海种子时刻", async (timezone) => {
     const { makeShanghaiSeedDateAt } =
       await importSeedTimeWithTimezone(timezone);
 
@@ -33,7 +33,7 @@ describe("dev seed time helpers", () => {
   it.each([
     "UTC",
     "America/New_York",
-  ])("constructs date-only seed values under %s host timezone", async (timezone) => {
+  ])("在 %s 主机时区下构建仅日期的种子值", async (timezone) => {
     const { makeSeedDateOnly } = await importSeedTimeWithTimezone(timezone);
 
     expect(makeSeedDateOnly().toISOString()).toBe("2026-04-29T00:00:00.000Z");
@@ -41,7 +41,7 @@ describe("dev seed time helpers", () => {
     expect(makeSeedDateOnly(-1).toISOString()).toBe("2026-04-28T00:00:00.000Z");
   });
 
-  it("derives weekdays from Shanghai calendar days under a UTC host timezone", async () => {
+  it("在 UTC 主机时区下从上海日历日期推导星期", async () => {
     const { makeSeedDateOnly, makeShanghaiSeedDateAt, toShanghaiWeekday } =
       await importSeedTimeWithTimezone("UTC");
 

--- a/tests/unit/device-approval-validation.test.ts
+++ b/tests/unit/device-approval-validation.test.ts
@@ -17,12 +17,12 @@ function record(
   };
 }
 
-describe("device approval validation", () => {
-  it("allows pending codes for enabled clients before expiry", () => {
+describe("设备授权验证", () => {
+  it("允许已启用客户端在过期前使用待处理代码", () => {
     expect(getDeviceApprovalFailureReason(record(), now)).toBeNull();
   });
 
-  it("rejects disabled clients before checking expiry or status", () => {
+  it("在检查过期时间或状态前拒绝已禁用客户端", () => {
     expect(
       getDeviceApprovalFailureReason(
         record({
@@ -35,13 +35,13 @@ describe("device approval validation", () => {
     ).toBe("disabled");
   });
 
-  it("rejects expired pending codes", () => {
+  it("拒绝已过期的待处理代码", () => {
     expect(
       getDeviceApprovalFailureReason(record({ expiresAt: past }), now),
     ).toBe("expired");
   });
 
-  it("rejects already-used codes", () => {
+  it("拒绝已使用过的代码", () => {
     expect(
       getDeviceApprovalFailureReason(
         record({ status: DEVICE_CODE_STATUS.DENIED }),

--- a/tests/unit/event-summary.test.ts
+++ b/tests/unit/event-summary.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/mcp/tools/event-summary";
 
 describe("summarizeCalendarEventCollection", () => {
-  it("groups events by day and type while trimming nested payloads", () => {
+  it("按天和类型分组事件并裁剪嵌套载荷", () => {
     const events = [
       {
         type: "schedule" as const,
@@ -101,7 +101,7 @@ describe("summarizeCalendarEventCollection", () => {
 });
 
 describe("summarizeBusDeparture", () => {
-  it("drops repeated campus payloads from departure summaries", () => {
+  it("从发车摘要中移除重复的校区载荷", () => {
     const summary = summarizeBusDeparture({
       tripId: 1,
       routeId: 8,

--- a/tests/unit/fuzzy-match.test.ts
+++ b/tests/unit/fuzzy-match.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { findClosestMatches } from "@/lib/fuzzy-match";
 
 describe("findClosestMatches", () => {
-  it("filters unrelated section codes that only share a short generic prefix", () => {
+  it("过滤仅共享短通用前缀的无关 section code", () => {
     expect(
       findClosestMatches("DEV-CS201.0", [
         "DEV-CS201.01",
@@ -12,7 +12,7 @@ describe("findClosestMatches", () => {
     ).toEqual(["DEV-CS201.01"]);
   });
 
-  it("returns suggestions for 3-character codes without digit (fallback chunk path)", () => {
+  it("为无数字的 3 字符代码返回建议（回退 chunk 路径）", () => {
     // "MAT" has no digit so is not a "significant" chunk; the code falls back
     // to using it as the lookup prefix anyway, so matches should still surface.
     const result = findClosestMatches("MAT", ["MAT201", "MAT101", "PHYSABC"]);
@@ -21,7 +21,7 @@ describe("findClosestMatches", () => {
     expect(result).not.toContain("PHYSABC");
   });
 
-  it("returns suggestions for 3-char codes with digit (significant chunk path)", () => {
+  it("为带数字的 3 字符代码返回建议（有效 chunk 路径）", () => {
     // "201" has a digit so is a significant chunk; candidates sharing the token
     // should be preferred over unrelated ones.
     const result = findClosestMatches("MA201", [

--- a/tests/unit/homework-completion-client.test.ts
+++ b/tests/unit/homework-completion-client.test.ts
@@ -13,12 +13,12 @@ function firstFetchCall(fetchMock: ReturnType<typeof vi.fn>) {
   return call as unknown as [string, RequestInit & { body: string }];
 }
 
-describe("homework completion client", () => {
+describe("作业完成状态客户端", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("updates completion through the shared route client", async () => {
+  it("通过共享路由客户端更新完成状态", async () => {
     const fetchMock = vi.fn(async () =>
       jsonResponse({
         completed: true,
@@ -44,7 +44,7 @@ describe("homework completion client", () => {
     expect(JSON.parse(init.body)).toEqual({ completed: true });
   });
 
-  it("uses API error payloads before fallback messages", async () => {
+  it("优先使用 API 错误负载而非回退消息", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
@@ -61,7 +61,7 @@ describe("homework completion client", () => {
     ).rejects.toThrow("homework not found");
   });
 
-  it("falls back when error payloads are not JSON", async () => {
+  it("当错误负载不是 JSON 时使用回退消息", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => new Response("plain failure", { status: 500 })),
@@ -76,7 +76,7 @@ describe("homework completion client", () => {
     ).rejects.toThrow("completion failed");
   });
 
-  it("rejects malformed successful payloads", async () => {
+  it("拒绝格式错误的成功响应负载", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => jsonResponse({ completed: true })),

--- a/tests/unit/homework-create-input.test.ts
+++ b/tests/unit/homework-create-input.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { parseCreateHomeworkInput } from "@/lib/api/routes/homework-create-input";
 
-describe("homework create input parsing", () => {
-  it("accepts a public section JW ID as an alternate section reference", () => {
+describe("作业创建输入解析", () => {
+  it("接受公开 section JW ID 作为替代 section 引用", () => {
     const result = parseCreateHomeworkInput({
       sectionJwId: 12345,
       title: "Homework 1",
@@ -16,7 +16,7 @@ describe("homework create input parsing", () => {
     });
   });
 
-  it("keeps accepting the internal section ID for compatibility", () => {
+  it("为兼容性继续接受内部 section ID", () => {
     const result = parseCreateHomeworkInput({
       sectionId: "42",
       title: "Homework 1",

--- a/tests/unit/homework-create-section-resolution.test.ts
+++ b/tests/unit/homework-create-section-resolution.test.ts
@@ -13,12 +13,12 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
-describe("homework create section resolution", () => {
+describe("作业创建 section 解析", () => {
   afterEach(() => {
     findUniqueMock.mockReset();
   });
 
-  it("verifies sectionId when no sectionJwId is provided", async () => {
+  it("未提供 sectionJwId 时验证 sectionId", async () => {
     findUniqueMock.mockResolvedValueOnce({ id: 12 });
 
     await expect(
@@ -30,7 +30,7 @@ describe("homework create section resolution", () => {
     });
   });
 
-  it("reports missing internal section ids", async () => {
+  it("报告缺失的内部 section id", async () => {
     findUniqueMock.mockResolvedValueOnce(null);
 
     await expect(
@@ -38,14 +38,14 @@ describe("homework create section resolution", () => {
     ).resolves.toEqual({ ok: false, error: "not_found" });
   });
 
-  it("reports missing section references when no id is provided", async () => {
+  it("未提供 id 时报告缺失的 section 引用", async () => {
     await expect(
       resolveSectionIdForHomeworkCreate({ sectionId: null, sectionJwId: null }),
     ).resolves.toEqual({ ok: false, error: "not_found" });
     expect(findUniqueMock).not.toHaveBeenCalled();
   });
 
-  it("resolves sectionJwId to the internal section id", async () => {
+  it("将 sectionJwId 解析为内部 section id", async () => {
     findUniqueMock.mockResolvedValueOnce({ id: 34 });
 
     await expect(
@@ -53,7 +53,7 @@ describe("homework create section resolution", () => {
     ).resolves.toEqual({ ok: true, sectionId: 34 });
   });
 
-  it("rejects conflicting sectionId and sectionJwId references", async () => {
+  it("拒绝冲突的 sectionId 与 sectionJwId 引用", async () => {
     findUniqueMock.mockResolvedValueOnce({ id: 34 });
 
     await expect(
@@ -61,7 +61,7 @@ describe("homework create section resolution", () => {
     ).resolves.toEqual({ ok: false, error: "mismatch" });
   });
 
-  it("reports missing sectionJwId targets separately from conflicts", async () => {
+  it("将缺失的 sectionJwId 目标与冲突分开报告", async () => {
     findUniqueMock.mockResolvedValueOnce(null);
 
     await expect(

--- a/tests/unit/homework-description.test.ts
+++ b/tests/unit/homework-description.test.ts
@@ -55,7 +55,7 @@ describe("updateHomeworkDescription", () => {
     descriptionEditCreateMock.mockResolvedValue({});
   });
 
-  it("writes description history and audit rows for homework description updates", async () => {
+  it("为作业描述更新写入描述历史与审计记录", async () => {
     descriptionFindFirstMock.mockResolvedValue({
       id: "description-1",
       content: "old content",

--- a/tests/unit/homework-list-section-resolution.test.ts
+++ b/tests/unit/homework-list-section-resolution.test.ts
@@ -18,15 +18,15 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
-describe("homework list section resolution", () => {
-  it("uses internal section references without a database lookup", async () => {
+describe("作业列表 section 解析", () => {
+  it("直接使用内部 section 引用而不查询数据库", async () => {
     await expect(
       resolveHomeworkSectionIds({ sectionId: 12, sectionIds: [34] }),
     ).resolves.toEqual({ ok: true, sectionIds: [34, 12] });
     expect(findUniqueMock).not.toHaveBeenCalled();
   });
 
-  it("resolves sectionJwId to the internal section id", async () => {
+  it("将 sectionJwId 解析为内部 section id", async () => {
     findUniqueMock.mockResolvedValueOnce({ id: 56 });
 
     await expect(
@@ -34,7 +34,7 @@ describe("homework list section resolution", () => {
     ).resolves.toEqual({ ok: true, sectionIds: [56] });
   });
 
-  it("reports missing sectionJwId targets", async () => {
+  it("报告缺失的 sectionJwId 目标", async () => {
     findUniqueMock.mockResolvedValueOnce(null);
 
     await expect(
@@ -42,7 +42,7 @@ describe("homework list section resolution", () => {
     ).resolves.toEqual({ ok: false, error: "not_found" });
   });
 
-  it("reports missing section references", async () => {
+  it("报告缺失的 section 引用", async () => {
     await expect(resolveHomeworkSectionIds({})).resolves.toEqual({
       ok: false,
       error: "invalid",

--- a/tests/unit/homework-mcp-date-parsing.test.ts
+++ b/tests/unit/homework-mcp-date-parsing.test.ts
@@ -11,8 +11,8 @@ function parseToolPayload(result: {
   };
 }
 
-describe("MCP homework date parsing", () => {
-  test("uses the shared homework date rule for create submission windows", () => {
+describe("MCP 作业日期解析", () => {
+  test("创建提交窗口使用共享的作业日期规则", () => {
     const result = parseCreateHomeworkTimestamps(
       {
         submissionDueAt: "2026-04-01T00:00:00Z",
@@ -30,7 +30,7 @@ describe("MCP homework date parsing", () => {
     });
   });
 
-  test("uses the shared homework date rule for update submission windows", () => {
+  test("更新提交窗口使用共享的作业日期规则", () => {
     const result = parseHomeworkUpdateDates(
       {
         submissionDueAt: "2026-04-01T00:00:00Z",

--- a/tests/unit/homework-mcp-update-tool.test.ts
+++ b/tests/unit/homework-mcp-update-tool.test.ts
@@ -21,7 +21,7 @@ describe("updateHomeworkOnSectionTool", () => {
     vi.resetModules();
   });
 
-  it("passes the requested locale to the homework read model", async () => {
+  it("将请求的语言区域传递给作业读取模型", async () => {
     updateHomeworkMock.mockResolvedValue({ ok: true });
     requireHomeworkItemByIdMock.mockResolvedValue({
       id: "homework-1",

--- a/tests/unit/homework-route-auth-order.test.ts
+++ b/tests/unit/homework-route-auth-order.test.ts
@@ -47,7 +47,7 @@ function jsonRequest(method: string, body: string) {
   });
 }
 
-describe("homework mutation route auth order", () => {
+describe("homework 变更路由的认证顺序", () => {
   afterEach(() => {
     requireAuthMock.mockReset();
     createHomeworkForSectionMock.mockReset();
@@ -57,7 +57,7 @@ describe("homework mutation route auth order", () => {
     vi.resetModules();
   });
 
-  it("authenticates homework creation before parsing the JSON body", async () => {
+  it("在解析 JSON 请求体前先认证作业创建", async () => {
     requireAuthMock.mockResolvedValue(unauthorizedResponse());
     const { postHomeworkRoute } = await import(
       "@/lib/api/routes/homework-mutation-routes"
@@ -69,7 +69,7 @@ describe("homework mutation route auth order", () => {
     expect(requireAuthMock).toHaveBeenCalledOnce();
   });
 
-  it("returns 400 when homework creation has conflicting section identifiers", async () => {
+  it("作业创建传入冲突的 section 标识符时返回 400", async () => {
     requireAuthMock.mockResolvedValue({ userId: "user-1" });
     createHomeworkForSectionMock.mockResolvedValue({
       ok: false,
@@ -104,7 +104,7 @@ describe("homework mutation route auth order", () => {
     });
   });
 
-  it("passes the request locale to updated homework response reads", async () => {
+  it("将请求 locale 传递给更新作业的响应读取", async () => {
     requireAuthMock.mockResolvedValue({ userId: "user-1" });
     updateHomeworkMock.mockResolvedValue({ ok: true });
     requireHomeworkItemByIdMock.mockResolvedValue({ id: "homework-1" });
@@ -132,7 +132,7 @@ describe("homework mutation route auth order", () => {
     });
   });
 
-  it("authenticates homework updates before parsing the JSON body", async () => {
+  it("在解析 JSON 请求体前先认证作业更新", async () => {
     requireAuthMock.mockResolvedValue(unauthorizedResponse());
     const { patchHomeworkRoute } = await import(
       "@/lib/api/routes/homework-mutation-routes"
@@ -146,7 +146,7 @@ describe("homework mutation route auth order", () => {
     expect(requireAuthMock).toHaveBeenCalledOnce();
   });
 
-  it("authenticates completion updates before parsing the JSON body", async () => {
+  it("在解析 JSON 请求体前先认证完成状态更新", async () => {
     requireAuthMock.mockResolvedValue(unauthorizedResponse());
     const { putHomeworkCompletionRoute } = await import(
       "@/lib/api/routes/homework-completion"
@@ -161,7 +161,7 @@ describe("homework mutation route auth order", () => {
     expect(setHomeworkCompletionsMock).not.toHaveBeenCalled();
   });
 
-  it("authenticates completion batches before parsing the JSON body", async () => {
+  it("在解析 JSON 请求体前先认证批量完成状态更新", async () => {
     requireAuthMock.mockResolvedValue(unauthorizedResponse());
     const { putHomeworkCompletionsRoute } = await import(
       "@/lib/api/routes/homework-completion"

--- a/tests/unit/homework-route-locale.test.ts
+++ b/tests/unit/homework-route-locale.test.ts
@@ -54,13 +54,13 @@ function request(path: string) {
   });
 }
 
-describe("homework REST locale adapters", () => {
+describe("homework REST locale 适配", () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
   });
 
-  it("passes request locale to public homework list reads", async () => {
+  it("将请求 locale 传递给公开作业列表读取", async () => {
     resolveApiUserIdMock.mockResolvedValue("viewer-1");
     resolveHomeworkSectionIdsMock.mockResolvedValue({
       ok: true,
@@ -93,7 +93,7 @@ describe("homework REST locale adapters", () => {
     });
   });
 
-  it("passes request locale to subscribed homework list reads", async () => {
+  it("将请求 locale 传递给已订阅作业列表读取", async () => {
     requireAuthMock.mockResolvedValue({ userId: "user-1" });
     getViewerContextMock.mockResolvedValue({ userId: "user-1" });
     getSubscribedSectionIdsMock.mockResolvedValue([12]);

--- a/tests/unit/homework-timestamp-defaults.test.ts
+++ b/tests/unit/homework-timestamp-defaults.test.ts
@@ -17,8 +17,8 @@ import {
   homeworkDueInDays as sectionHomeworkDueInDays,
 } from "@/features/section-detail/lib/section-detail-controller-helpers";
 
-describe("homework timestamp defaults", () => {
-  it("builds the shared initial homework timestamp draft", () => {
+describe("homework 时间戳默认值", () => {
+  it("构建共享的初始作业时间戳草稿", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-17T02:30:00.000Z"));
 
@@ -33,7 +33,7 @@ describe("homework timestamp defaults", () => {
     }
   });
 
-  it("builds shared homework timestamp shortcuts", () => {
+  it("构建共享的作业时间戳快捷方法", () => {
     const now = new Date("2026-03-17T10:30:00+08:00");
 
     expect(homeworkTimestampNow(now)).toBe("2026-03-17T10:30");
@@ -50,7 +50,7 @@ describe("homework timestamp defaults", () => {
     );
   });
 
-  it("exposes the same timestamp defaults to dashboard and section detail", () => {
+  it("向 dashboard 和 section detail 暴露相同的时间戳默认值", () => {
     expect(initialCreateHomeworkDraft).toBe(initialHomeworkTimestampDraft);
     expect(initialHomeworkDraft).toBe(initialHomeworkTimestampDraft);
     expect(dashboardHomeworkDueInDays).toBe(homeworkDueInDays);

--- a/tests/unit/homework-update-intent.test.ts
+++ b/tests/unit/homework-update-intent.test.ts
@@ -14,7 +14,7 @@ const emptyDates = {
 };
 
 describe("buildHomeworkUpdateIntent", () => {
-  test("keeps empty updates explicit", () => {
+  test("保持空更新显式", () => {
     const intent = buildHomeworkUpdateIntent({
       dates: emptyDates,
       hasDescription: false,
@@ -26,7 +26,7 @@ describe("buildHomeworkUpdateIntent", () => {
     expect(intent.homeworkUpdates).toBeUndefined();
   });
 
-  test("represents description-only updates without homework row data", () => {
+  test("仅描述更新时不生成 homework 行数据", () => {
     const intent = buildHomeworkUpdateIntent({
       dates: emptyDates,
       description: "updated description",
@@ -39,7 +39,7 @@ describe("buildHomeworkUpdateIntent", () => {
     expect(intent.homeworkUpdates).toBeUndefined();
   });
 
-  test("adds editor metadata only when homework row data changes", () => {
+  test("仅在 homework 行数据变化时添加编辑者元数据", () => {
     const dueAt = new Date("2026-05-15T15:00:00.000Z");
     const intent = buildHomeworkUpdateIntent({
       dates: {

--- a/tests/unit/location-utils.test.ts
+++ b/tests/unit/location-utils.test.ts
@@ -48,7 +48,7 @@ describe("location-utils", () => {
   }
 
   describe("getLocationGeo", () => {
-    it("returns null for empty string", async () => {
+    it("空字符串返回 null", async () => {
       const { getLocationGeo } = await import(
         "@/shared/lib/location/location-utils"
       );
@@ -56,7 +56,7 @@ describe("location-utils", () => {
       expect(result).toBeNull();
     });
 
-    it("finds exact match (case-insensitive)", async () => {
+    it("精确匹配（不区分大小写）", async () => {
       mockStaticFiles();
       const { getLocationGeo } = await import(
         "@/shared/lib/location/location-utils"
@@ -69,7 +69,7 @@ describe("location-utils", () => {
       });
     });
 
-    it("finds exact match with different casing", async () => {
+    it("不同大小写时精确匹配", async () => {
       mockStaticFiles();
       const { getLocationGeo } = await import(
         "@/shared/lib/location/location-utils"
@@ -82,7 +82,7 @@ describe("location-utils", () => {
       });
     });
 
-    it("falls back to starts-with match", async () => {
+    it("回退到前缀匹配", async () => {
       mockStaticFiles();
       const { getLocationGeo } = await import(
         "@/shared/lib/location/location-utils"
@@ -95,7 +95,7 @@ describe("location-utils", () => {
       });
     });
 
-    it("returns null when no match is found", async () => {
+    it("无匹配时返回 null", async () => {
       mockStaticFiles();
       const { getLocationGeo } = await import(
         "@/shared/lib/location/location-utils"
@@ -104,7 +104,7 @@ describe("location-utils", () => {
       expect(result).toBeNull();
     });
 
-    it("returns null when published geo data is unavailable", async () => {
+    it("发布的地理数据不可用时返回 null", async () => {
       vi.stubGlobal(
         "fetch",
         vi.fn(async () => new Response("not found", { status: 404 })),
@@ -116,7 +116,7 @@ describe("location-utils", () => {
       expect(result).toBeNull();
     });
 
-    it("logs and omits enrichment when published geo JSON is invalid", async () => {
+    it("发布的 geo JSON 无效时记录日志并跳过增强", async () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       vi.stubGlobal(
         "fetch",
@@ -134,7 +134,7 @@ describe("location-utils", () => {
   });
 
   describe("getBuildingImagePath", () => {
-    it("returns null for empty string", async () => {
+    it("空字符串返回 null", async () => {
       const { getBuildingImagePath } = await import(
         "@/shared/lib/location/location-utils"
       );
@@ -142,7 +142,7 @@ describe("location-utils", () => {
       expect(result).toBeNull();
     });
 
-    it("matches regex rules and builds a URL from the published static host", async () => {
+    it("按正则规则匹配并从发布的静态主机构建 URL", async () => {
       mockStaticFiles();
       const { getBuildingImagePath } = await import(
         "@/shared/lib/location/location-utils"
@@ -153,7 +153,7 @@ describe("location-utils", () => {
       );
     });
 
-    it("uses the published static host for relative building image rules", async () => {
+    it("相对建筑图片规则使用发布的静态主机", async () => {
       mockStaticFiles();
       const { getBuildingImagePath } = await import(
         "@/shared/lib/location/location-utils"
@@ -164,7 +164,7 @@ describe("location-utils", () => {
       );
     });
 
-    it("preserves absolute image URLs", async () => {
+    it("保留绝对图片 URL", async () => {
       mockStaticFiles({
         buildingRules: [
           { regex: "5101", path: "https://cdn.example.com/5101.jpg" },
@@ -177,7 +177,7 @@ describe("location-utils", () => {
       expect(result).toBe("https://cdn.example.com/5101.jpg");
     });
 
-    it("returns null when no regex matches", async () => {
+    it("无正则匹配时返回 null", async () => {
       mockStaticFiles();
       const { getBuildingImagePath } = await import(
         "@/shared/lib/location/location-utils"

--- a/tests/unit/markdown-renderer.test.ts
+++ b/tests/unit/markdown-renderer.test.ts
@@ -6,8 +6,8 @@ import {
 } from "@/features/markdown/lib/campus-reference-markdown";
 import { renderMarkdown } from "@/lib/components/markdown-preview-renderer";
 
-describe("markdown renderer", () => {
-  it("keeps campus references inert without injected feature plugins", () => {
+describe("markdown 渲染器", () => {
+  it("未注入特性插件时 campus 引用保持原样", () => {
     const html = renderMarkdown("See section#123 and teacher#456.");
 
     expect(html).toContain("section#123");
@@ -15,7 +15,7 @@ describe("markdown renderer", () => {
     expect(html).not.toContain('href="/teachers/456"');
   });
 
-  it("links campus references when the feature plugin is injected", () => {
+  it("注入特性插件时将 campus 引用转为链接", () => {
     const html = renderMarkdown("See section#123 and teacher#456.", {
       remarkPlugins: campusReferenceMarkdownPlugins,
     });
@@ -24,7 +24,7 @@ describe("markdown renderer", () => {
     expect(html).toContain('href="/teachers/456"');
   });
 
-  it("allows feature callers to inject a custom campus reference resolver", () => {
+  it("允许特性调用者注入自定义 campus 引用解析器", () => {
     const html = renderMarkdown("See teacher#456.", {
       remarkPlugins: [
         [

--- a/tests/unit/mcp-auth.test.ts
+++ b/tests/unit/mcp-auth.test.ts
@@ -35,13 +35,13 @@ vi.mock("@/lib/mcp/urls", () => ({
   getOAuthTokenVerificationIssuers: () => ["https://life.example/api/auth"],
 }));
 
-describe("MCP auth", () => {
+describe("MCP 认证", () => {
   beforeEach(() => {
     vi.resetModules();
     verifyOAuthAccessTokenMock.mockReset();
   });
 
-  it("verifies JWT access tokens against the canonical OAuth issuer", async () => {
+  it("使用规范 OAuth issuer 校验 JWT access token", async () => {
     verifyOAuthAccessTokenMock.mockResolvedValue({
       azp: "client-id",
       aud: "https://life.example/api/mcp",

--- a/tests/unit/mcp-observability.test.ts
+++ b/tests/unit/mcp-observability.test.ts
@@ -8,12 +8,12 @@ import {
   resetRuntimeMetricsForTest,
 } from "@/lib/metrics/runtime-metrics";
 
-describe("MCP observability", () => {
+describe("MCP 可观测性", () => {
   afterEach(() => {
     resetRuntimeMetricsForTest();
   });
 
-  it("summarizes initialize requests without sensitive values", async () => {
+  it("汇总 initialize 请求且不包含敏感值", async () => {
     const request = new Request("https://example.test/api/mcp", {
       method: "POST",
       body: JSON.stringify({
@@ -39,7 +39,7 @@ describe("MCP observability", () => {
     });
   });
 
-  it("records tool call names and argument keys, not argument values", async () => {
+  it("记录工具调用名称和参数键，不记录参数值", async () => {
     const request = new Request("https://example.test/api/mcp", {
       method: "POST",
       body: JSON.stringify({
@@ -71,7 +71,7 @@ describe("MCP observability", () => {
     expect(JSON.stringify(summary)).not.toContain("private title");
   });
 
-  it("summarizes JSON-RPC batches", async () => {
+  it("汇总 JSON-RPC 批处理", async () => {
     const request = new Request("https://example.test/api/mcp", {
       method: "POST",
       body: JSON.stringify([
@@ -94,7 +94,7 @@ describe("MCP observability", () => {
     });
   });
 
-  it("does not parse oversized bodies for observability", async () => {
+  it("可观测性不解析过大的请求体", async () => {
     const request = new Request("https://example.test/api/mcp", {
       method: "POST",
       headers: { "content-length": String(65 * 1024) },
@@ -107,7 +107,7 @@ describe("MCP observability", () => {
     });
   });
 
-  it("records tool result status and duration metrics", async () => {
+  it("记录工具结果状态和耗时指标", async () => {
     const summary = await summarizeMcpJsonRpcRequest(
       new Request("https://example.test/api/mcp", {
         method: "POST",

--- a/tests/unit/mcp-tool-helpers.test.ts
+++ b/tests/unit/mcp-tool-helpers.test.ts
@@ -17,8 +17,8 @@ function parseToolText(result: ReturnType<typeof jsonToolResult>) {
   return JSON.parse(text ?? "{}") as Record<string, unknown>;
 }
 
-describe("jsonToolResult summary mode", () => {
-  it("keeps paginated totals while reporting returned and sampled items", () => {
+describe("jsonToolResult summary 模式", () => {
+  it("保留分页总数，同时报告返回和采样项", () => {
     const result = parseToolText(
       jsonToolResult(
         {
@@ -55,7 +55,7 @@ describe("jsonToolResult summary mode", () => {
     });
   });
 
-  it("reports non-paginated list truncation metadata", () => {
+  it("报告非分页列表截断元数据", () => {
     const result = parseToolText(
       jsonToolResult(
         {

--- a/tests/unit/mcp-urls.test.ts
+++ b/tests/unit/mcp-urls.test.ts
@@ -15,35 +15,35 @@ import {
   getPublicOrigin,
 } from "@/lib/site-url";
 
-describe("MCP URL helpers", () => {
+describe("MCP URL 辅助函数", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("uses APP_PUBLIC_ORIGIN for public links", () => {
+  it("public 链接使用 APP_PUBLIC_ORIGIN", () => {
     vi.stubEnv("APP_PUBLIC_ORIGIN", "https://preview.example.com");
     expect(getPublicOrigin()).toBe("https://preview.example.com");
     expect(getBetterAuthBaseUrl()).toBe("https://preview.example.com/api/auth");
   });
 
-  it("falls back to pinned local origin when APP_PUBLIC_ORIGIN is unset", () => {
+  it("APP_PUBLIC_ORIGIN 未设置时回退到固定的本地 origin", () => {
     vi.stubEnv("APP_PUBLIC_ORIGIN", "");
     expect(getPublicOrigin()).toBe("http://localhost:3000");
   });
 
-  it("uses public origin as canonical origin", () => {
+  it("将 public origin 作为 canonical origin", () => {
     vi.stubEnv("APP_PUBLIC_ORIGIN", "https://life-ustc.tiankaima.dev");
     expect(getCanonicalOrigin()).toBe("https://life-ustc.tiankaima.dev");
   });
 
-  it("prefers APP_CANONICAL_ORIGIN for canonical origin", () => {
+  it("canonical origin 优先使用 APP_CANONICAL_ORIGIN", () => {
     vi.stubEnv("APP_PUBLIC_ORIGIN", "https://preview.example.com");
     vi.stubEnv("APP_CANONICAL_ORIGIN", "https://life.example.com");
 
     expect(getCanonicalOrigin()).toBe("https://life.example.com");
   });
 
-  it("derives canonical OAuth and MCP metadata URLs from path-based issuer/resource identifiers", () => {
+  it("从基于路径的 issuer/resource 标识符派生规范 OAuth 与 MCP 元数据 URL", () => {
     vi.stubEnv("APP_PUBLIC_ORIGIN", "https://life.example.com");
     expect(getCanonicalOAuthIssuer()).toBe("https://life.example.com/api/auth");
     expect(getOAuthRestAudienceUrls()).toEqual([
@@ -72,7 +72,7 @@ describe("MCP URL helpers", () => {
     );
   });
 
-  it("includes loopback sibling MCP audiences for custom local ports", () => {
+  it("自定义本地端口包含 loopback 兄弟 MCP audience", () => {
     vi.stubEnv("APP_PUBLIC_ORIGIN", "http://localhost:3010");
 
     expect(getOAuthProviderValidAudiences()).toEqual([

--- a/tests/unit/metrics-route.test.ts
+++ b/tests/unit/metrics-route.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GET } from "@/routes/api/metrics/+server";
 
-describe("metrics route", () => {
+describe("metrics 路由", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("allows direct localhost reads without a token", async () => {
+  it("允许 localhost 直接读取而无需 token", async () => {
     const response = GET({
       request: new Request("http://127.0.0.1:3000/api/metrics"),
     });
@@ -17,7 +17,7 @@ describe("metrics route", () => {
     );
   });
 
-  it("hides metrics from public hosts unless a token is configured", () => {
+  it("未配置 token 时对 public host 隐藏指标", () => {
     const response = GET({
       request: new Request("https://life.example.com/api/metrics"),
     });
@@ -25,7 +25,7 @@ describe("metrics route", () => {
     expect(response.status).toBe(404);
   });
 
-  it("requires the configured bearer token", () => {
+  it("要求配置的 bearer token", () => {
     vi.stubEnv("METRICS_BEARER_TOKEN", "secret-token");
 
     expect(
@@ -42,7 +42,7 @@ describe("metrics route", () => {
     ).toBe(200);
   });
 
-  it("allows IPv6 loopback host headers", () => {
+  it("允许 IPv6 loopback host 请求头", () => {
     const response = GET({
       request: new Request("http://[::1]:3000/api/metrics", {
         headers: { Host: "[::1]:3000" },

--- a/tests/unit/oauth-client-registration.test.ts
+++ b/tests/unit/oauth-client-registration.test.ts
@@ -15,13 +15,13 @@ import {
 } from "@/lib/oauth/constants";
 
 describe("resolveOAuthClientScopes", () => {
-  it("uses the default OAuth profile scopes when none are requested", () => {
+  it("未请求 scope 时使用默认 OAuth profile scope", () => {
     expect(resolveOAuthClientScopes()).toEqual({
       scopes: [OAUTH_OPENID_SCOPE, OAUTH_PROFILE_SCOPE],
     });
   });
 
-  it("deduplicates requested scopes while preserving request order", () => {
+  it("去重请求的 scope 并保留请求顺序", () => {
     expect(
       resolveOAuthClientScopes([
         OAUTH_PROFILE_SCOPE,
@@ -33,7 +33,7 @@ describe("resolveOAuthClientScopes", () => {
     });
   });
 
-  it("accepts space-delimited requested scopes", () => {
+  it("接受空格分隔的请求 scope", () => {
     expect(
       resolveOAuthClientScopes(
         `${OAUTH_OPENID_SCOPE} ${MCP_TOOLS_SCOPE} ${OAUTH_OFFLINE_ACCESS_SCOPE} ${OAUTH_REST_READ_SCOPE} ${OAUTH_REST_WRITE_SCOPE}`,
@@ -49,13 +49,13 @@ describe("resolveOAuthClientScopes", () => {
     });
   });
 
-  it("rejects unsupported requested scopes", () => {
+  it("拒绝不支持的请求 scope", () => {
     expect(resolveOAuthClientScopes([OAUTH_OPENID_SCOPE, "email"])).toEqual({
       error: "Unsupported scopes requested: email",
     });
   });
 
-  it("uses authorization-code grants unless offline access is requested", () => {
+  it("除非请求 offline access，否则使用 authorization-code 授权类型", () => {
     expect(
       resolveOAuthClientGrantTypes([OAUTH_OPENID_SCOPE, OAUTH_PROFILE_SCOPE]),
     ).toEqual([OAUTH_AUTHORIZATION_CODE_GRANT_TYPE]);

--- a/tests/unit/oauth-consent-action.test.ts
+++ b/tests/unit/oauth-consent-action.test.ts
@@ -32,7 +32,7 @@ function consentRequest(
   });
 }
 
-describe("OAuth consent action", () => {
+describe("OAuth consent 操作", () => {
   beforeEach(() => {
     oauth2ConsentMock.mockReset();
     vi.stubEnv("APP_PUBLIC_ORIGIN", "https://life.example");
@@ -42,7 +42,7 @@ describe("OAuth consent action", () => {
     vi.unstubAllEnvs();
   });
 
-  it("uses the provider consent API and redirects to its target", async () => {
+  it("使用 provider consent API 并重定向到目标", async () => {
     oauth2ConsentMock.mockResolvedValue({
       redirect_uri: "https://client.example/callback?code=code-1",
     });
@@ -86,7 +86,7 @@ describe("OAuth consent action", () => {
     expect(headers.get("accept")).toBe("application/json");
   });
 
-  it("redirects to the consent failure page when provider consent fails", async () => {
+  it("provider consent 失败时重定向到 consent 失败页面", async () => {
     oauth2ConsentMock.mockRejectedValue(new Error("provider failed"));
 
     await expect(
@@ -103,7 +103,7 @@ describe("OAuth consent action", () => {
     });
   });
 
-  it("rejects a cookie-bearing consent request without origin or referer", async () => {
+  it("拒绝缺少 origin 或 referer 的携带 cookie 的 consent 请求", async () => {
     await expect(
       submitOAuthConsentAction({
         request: consentRequest(
@@ -120,7 +120,7 @@ describe("OAuth consent action", () => {
     expect(oauth2ConsentMock).not.toHaveBeenCalled();
   });
 
-  it("rejects a cookie-bearing consent request from an untrusted origin", async () => {
+  it("拒绝来自不受信任 origin 的携带 cookie 的 consent 请求", async () => {
     await expect(
       submitOAuthConsentAction({
         request: consentRequest(

--- a/tests/unit/oauth-constants.test.ts
+++ b/tests/unit/oauth-constants.test.ts
@@ -14,8 +14,8 @@ import {
   OAUTH_REST_WRITE_SCOPE,
 } from "@/lib/oauth/constants";
 
-describe("oauth constants", () => {
-  it("detects supported OAuth client authentication methods", () => {
+describe("oauth 常量", () => {
+  it("检测支持的 OAuth 客户端认证方式", () => {
     expect(
       isSupportedOAuthClientAuthMethod(OAUTH_CLIENT_SECRET_BASIC_AUTH_METHOD),
     ).toBe(true);
@@ -28,7 +28,7 @@ describe("oauth constants", () => {
     expect(isSupportedOAuthClientAuthMethod("client_secret_jwt")).toBe(false);
   });
 
-  it("keeps provider-advertised OAuth scopes in stable order", () => {
+  it("保持 provider 公布的 OAuth scope 顺序稳定", () => {
     expect(OAUTH_PROVIDER_SCOPES).toEqual([
       OAUTH_OPENID_SCOPE,
       OAUTH_PROFILE_SCOPE,

--- a/tests/unit/oauth-debug.test.ts
+++ b/tests/unit/oauth-debug.test.ts
@@ -5,12 +5,12 @@ import {
   summarizeOAuthRedirectUri,
 } from "@/lib/log/oauth-debug";
 
-describe("oauth debug logging", () => {
+describe("oauth 调试日志", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("parses debug logging modes from env", () => {
+  it("从环境变量解析调试日志模式", () => {
     vi.stubEnv("OAUTH_DEBUG_LOGGING", "");
     expect(getOAuthDebugMode()).toBe("off");
 
@@ -30,7 +30,7 @@ describe("oauth debug logging", () => {
     expect(getOAuthDebugMode()).toBe("standard");
   });
 
-  it("redacts sensitive redirect query values", () => {
+  it("编辑敏感的重定向查询值", () => {
     expect(
       sanitizeOAuthRedirectLocation(
         "/callback?code=secret&state=ok&access_token=token",
@@ -41,7 +41,7 @@ describe("oauth debug logging", () => {
     );
   });
 
-  it("summarizes redirect URL shape without query values", () => {
+  it("汇总重定向 URL 结构而不包含查询值", () => {
     expect(
       summarizeOAuthRedirectUri(
         "https://client.example:8443/callback?state=ok&code=secret",
@@ -56,7 +56,7 @@ describe("oauth debug logging", () => {
     });
   });
 
-  it("keeps invalid redirect summaries explicit", () => {
+  it("保持无效重定向汇总明确", () => {
     expect(summarizeOAuthRedirectUri("not a url")).toEqual({
       redirectOrigin: null,
       redirectHost: "invalid_redirect_uri",

--- a/tests/unit/oauth-device-authorization.test.ts
+++ b/tests/unit/oauth-device-authorization.test.ts
@@ -44,12 +44,12 @@ function publicDeviceClient(overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe("device authorization", () => {
+describe("设备授权", () => {
   beforeEach(() => {
     findUniqueMock.mockReset();
   });
 
-  it("rejects clients that are not registered for the device grant", async () => {
+  it("拒绝未注册设备授权许可的客户端", async () => {
     findUniqueMock.mockResolvedValue(
       publicDeviceClient({ grantTypes: ["authorization_code"] }),
     );
@@ -73,7 +73,7 @@ describe("device authorization", () => {
     });
   });
 
-  it("rejects confidential clients for device authorization", async () => {
+  it("拒绝机密客户端使用设备授权", async () => {
     findUniqueMock.mockResolvedValue(
       publicDeviceClient({
         public: false,
@@ -101,7 +101,7 @@ describe("device authorization", () => {
     });
   });
 
-  it("requires the MCP resource when mcp:tools scope is requested", async () => {
+  it("请求 mcp:tools 作用域时要求 MCP 资源", async () => {
     const { resolveRequestedDeviceResources } = await import(
       "@/features/oauth/server/device-authorization-policy.server"
     );
@@ -121,7 +121,7 @@ describe("device authorization", () => {
     throw new Error("Expected device resource policy error");
   });
 
-  it("defaults omitted device scopes to low-risk client defaults", async () => {
+  it("将省略的设备作用域默认为低风险客户端默认值", async () => {
     findUniqueMock.mockResolvedValue(publicDeviceClient());
     const { resolveDeviceAuthorizationClient } = await import(
       "@/features/oauth/server/device-authorization-policy.server"
@@ -139,7 +139,7 @@ describe("device authorization", () => {
     });
   });
 
-  it("accepts and canonicalizes valid REST and MCP resources", async () => {
+  it("接受并规范化有效的 REST 与 MCP 资源", async () => {
     findUniqueMock.mockResolvedValue(publicDeviceClient());
     const { resolveDeviceAuthorizationClient } = await import(
       "@/features/oauth/server/device-authorization-policy.server"

--- a/tests/unit/oauth-device-token-grant.test.ts
+++ b/tests/unit/oauth-device-token-grant.test.ts
@@ -56,7 +56,7 @@ function approvedDeviceRecord(resources = ["https://life.example/api/mcp"]) {
   };
 }
 
-describe("device token grant", () => {
+describe("设备令牌授予", () => {
   beforeEach(() => {
     findUniqueMock.mockReset();
     updateMock.mockReset();
@@ -68,7 +68,7 @@ describe("device token grant", () => {
     });
   });
 
-  it("inherits approved resources when token polling omits resource", async () => {
+  it("令牌轮询省略资源时继承已批准资源", async () => {
     findUniqueMock.mockResolvedValue(approvedDeviceRecord());
     const { handleDeviceCodeGrant } = await import(
       "@/lib/api/routes/auth-token-device-grant"
@@ -93,7 +93,7 @@ describe("device token grant", () => {
     );
   });
 
-  it("rejects token polling that changes the approved resource set", async () => {
+  it("拒绝更改已批准资源集的令牌轮询", async () => {
     findUniqueMock.mockResolvedValue(
       approvedDeviceRecord(["https://life.example/api/mcp"]),
     );

--- a/tests/unit/oauth-device-token-issuer.test.ts
+++ b/tests/unit/oauth-device-token-issuer.test.ts
@@ -40,12 +40,12 @@ function createPrismaMock() {
   };
 }
 
-describe("device token issuer", () => {
+describe("设备令牌签发器", () => {
   beforeEach(() => {
     signJwtMock.mockReset();
   });
 
-  it("uses a resource-bound JWT access token without issuing refresh tokens", async () => {
+  it("使用绑定资源的 JWT 访问令牌且不签发刷新令牌", async () => {
     signJwtMock.mockResolvedValue({ token: "header.payload.signature" });
     const { prisma, accessTokenCreate, refreshTokenCreate } =
       createPrismaMock();
@@ -92,7 +92,7 @@ describe("device token issuer", () => {
     });
   });
 
-  it("keeps resource-less access tokens opaque and skips refresh without offline_access", async () => {
+  it("无资源访问令牌保持不透明且无 offline_access 时跳过刷新", async () => {
     const { prisma, accessTokenCreate, refreshTokenCreate } =
       createPrismaMock();
     const { issueDeviceGrantTokens } = await import(
@@ -120,7 +120,7 @@ describe("device token issuer", () => {
     expect(signJwtMock).not.toHaveBeenCalled();
   });
 
-  it("issues refresh tokens for resource-less device grants with offline_access", async () => {
+  it("为带 offline_access 的无资源设备授权签发刷新令牌", async () => {
     const { prisma, accessTokenCreate, refreshTokenCreate } =
       createPrismaMock();
     const { issueDeviceGrantTokens } = await import(

--- a/tests/unit/oauth-discovery-metadata.test.ts
+++ b/tests/unit/oauth-discovery-metadata.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/lib/auth/core", () => ({
   },
 }));
 
-describe("OAuth discovery metadata routes", () => {
+describe("OAuth 发现元数据路由", () => {
   afterEach(() => {
     authServerMetadataHandlerMock.mockReset();
     openIdMetadataHandlerMock.mockReset();
@@ -29,7 +29,7 @@ describe("OAuth discovery metadata routes", () => {
     vi.unstubAllEnvs();
   });
 
-  it("adds discovery CORS headers to redirects without dropping Location", async () => {
+  it("为重定向添加发现 CORS 头且保留 Location", async () => {
     vi.stubEnv("DATABASE_URL", "postgresql://unit:unit@127.0.0.1:5432/unit");
     vi.stubEnv("AUTH_SECRET", "unit-test-secret");
 
@@ -59,7 +59,7 @@ describe("OAuth discovery metadata routes", () => {
     );
   });
 
-  it("does not advertise client credentials in authorization server metadata", async () => {
+  it("不在授权服务器元数据中宣告 client_credentials", async () => {
     authServerMetadataHandlerMock.mockResolvedValue(
       Response.json({
         issuer: "https://life.example/api/auth",
@@ -92,7 +92,7 @@ describe("OAuth discovery metadata routes", () => {
     );
   });
 
-  it("does not advertise client credentials in OpenID metadata", async () => {
+  it("不在 OpenID 元数据中宣告 client_credentials", async () => {
     openIdMetadataHandlerMock.mockResolvedValue(
       Response.json({
         issuer: "https://life.example/api/auth",

--- a/tests/unit/oauth-loopback-redirect.test.ts
+++ b/tests/unit/oauth-loopback-redirect.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { resolveEquivalentLoopbackRedirectUri } from "@/lib/oauth/loopback-redirect";
 
-describe("oauth loopback redirect normalization", () => {
-  it("returns the registered URI when localhost and 127.0.0.1 differ only by host", () => {
+describe("OAuth 环回重定向规范化", () => {
+  it("localhost 与 127.0.0.1 仅主机不同时返回已注册 URI", () => {
     expect(
       resolveEquivalentLoopbackRedirectUri(
         ["http://127.0.0.1:52877/callback"],
@@ -11,7 +11,7 @@ describe("oauth loopback redirect normalization", () => {
     ).toBe("http://127.0.0.1:52877/callback");
   });
 
-  it("keeps strict matching for path, port, query, and fragment", () => {
+  it("对路径、端口、查询和片段保持严格匹配", () => {
     expect(
       resolveEquivalentLoopbackRedirectUri(
         ["http://127.0.0.1:52877/callback"],
@@ -38,7 +38,7 @@ describe("oauth loopback redirect normalization", () => {
     ).toBeNull();
   });
 
-  it("does not rewrite non-loopback URIs", () => {
+  it("不重写非环回 URI", () => {
     expect(
       resolveEquivalentLoopbackRedirectUri(
         ["https://client.example/callback"],

--- a/tests/unit/oauth-profile.test.ts
+++ b/tests/unit/oauth-profile.test.ts
@@ -5,8 +5,8 @@ import {
   mapOidcProfileToUser,
 } from "@/lib/auth/oauth-profile";
 
-describe("OAuth profile mapping", () => {
-  it("accepts sparse USTC OIDC profiles with only an id", () => {
+describe("OAuth 档案映射", () => {
+  it("接受仅含 id 的稀疏 USTC OIDC 档案", () => {
     expect(
       mapOidcProfileToUser({
         id: "435",
@@ -23,7 +23,7 @@ describe("OAuth profile mapping", () => {
     });
   });
 
-  it("preserves provider supplied OIDC profile fields when present", () => {
+  it("保留提供者提供的 OIDC 档案字段", () => {
     expect(
       mapOidcProfileToUser({
         sub: "abc",
@@ -41,7 +41,7 @@ describe("OAuth profile mapping", () => {
     });
   });
 
-  it("accepts camelCase email verification from OIDC profiles", () => {
+  it("接受 OIDC 档案中的驼峰式邮箱验证字段", () => {
     expect(
       mapOidcProfileToUser({
         sub: "abc",
@@ -51,7 +51,7 @@ describe("OAuth profile mapping", () => {
     ).toBe(true);
   });
 
-  it("uses the first non-empty profile display name", () => {
+  it("使用第一个非空的档案显示名称", () => {
     expect(
       mapOidcProfileToUser({
         sub: "abc",
@@ -62,7 +62,7 @@ describe("OAuth profile mapping", () => {
     ).toBe("student");
   });
 
-  it("maps GitHub profiles without trusting the email verification state", () => {
+  it("映射 GitHub 档案时不信任邮箱验证状态", () => {
     expect(
       mapGithubProfileToUser({
         id: "octocat",
@@ -79,7 +79,7 @@ describe("OAuth profile mapping", () => {
     });
   });
 
-  it("uses a local fallback email for hidden GitHub emails", () => {
+  it("为隐藏的 GitHub 邮箱使用本地兜底邮箱", () => {
     expect(
       mapGithubProfileToUser({
         id: "octocat",
@@ -94,7 +94,7 @@ describe("OAuth profile mapping", () => {
     });
   });
 
-  it("maps Google email verification only when an email is present", () => {
+  it("仅在存在邮箱时映射 Google 邮箱验证状态", () => {
     expect(
       mapGoogleProfileToUser({
         sub: "google-user",

--- a/tests/unit/oauth-provider-plugin.test.ts
+++ b/tests/unit/oauth-provider-plugin.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/lib/mcp/urls", () => ({
 }));
 
 describe("buildOAuthProviderPlugin", () => {
-  it("restricts the provider to user-delegated OAuth grants", async () => {
+  it("将提供者限制为用户委托的 OAuth 授权", async () => {
     const { buildOAuthProviderPlugin } = await import(
       "@/lib/auth/better-auth-oauth-provider-plugin"
     );
@@ -41,7 +41,7 @@ describe("buildOAuthProviderPlugin", () => {
     );
   });
 
-  it("defaults DCR clients to profile scopes while keeping REST and MCP scopes requestable", async () => {
+  it("DCR 客户端默认使用 profile 作用域并保留 REST 与 MCP 作用域可请求", async () => {
     const { buildOAuthProviderPlugin } = await import(
       "@/lib/auth/better-auth-oauth-provider-plugin"
     );

--- a/tests/unit/oauth-registration-route.test.ts
+++ b/tests/unit/oauth-registration-route.test.ts
@@ -25,13 +25,13 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
-describe("OAuth registration route", () => {
+describe("OAuth 注册路由", () => {
   beforeEach(() => {
     betterAuthHandlerMock.mockReset();
     oauthClientUpdateMock.mockReset();
   });
 
-  it("rejects client_credentials during dynamic client registration", async () => {
+  it("动态客户端注册时拒绝 client_credentials", async () => {
     const response = await authPostRoute(
       new Request("https://life.example/api/auth/oauth2/register", {
         method: "POST",
@@ -52,7 +52,7 @@ describe("OAuth registration route", () => {
     expect(oauthClientUpdateMock).not.toHaveBeenCalled();
   });
 
-  it("rejects falsy unsupported grant values during dynamic client registration", async () => {
+  it("动态客户端注册时拒绝 falsy 的不支持授权值", async () => {
     const response = await authPostRoute(
       new Request("https://life.example/api/auth/oauth2/register", {
         method: "POST",
@@ -73,7 +73,7 @@ describe("OAuth registration route", () => {
     expect(oauthClientUpdateMock).not.toHaveBeenCalled();
   });
 
-  it("registers the custom device grant through the Better Auth adapter", async () => {
+  it("通过 Better Auth 适配器注册自定义设备授权", async () => {
     betterAuthHandlerMock.mockImplementationOnce(async (request: Request) => {
       const delegatedBody = await request.json();
       expect(delegatedBody).toMatchObject({
@@ -128,7 +128,7 @@ describe("OAuth registration route", () => {
     });
   });
 
-  it("delegates supported provider grants to Better Auth", async () => {
+  it("将受支持的提供者授权委托给 Better Auth", async () => {
     betterAuthHandlerMock.mockResolvedValueOnce(
       Response.json({ client_id: "client-1" }),
     );

--- a/tests/unit/oauth-token-mcp-refresh-binding.test.ts
+++ b/tests/unit/oauth-token-mcp-refresh-binding.test.ts
@@ -32,13 +32,13 @@ function refreshRequest(params: URLSearchParams) {
   });
 }
 
-describe("MCP refresh resource binding", () => {
+describe("MCP 刷新资源绑定", () => {
   beforeEach(() => {
     vi.resetModules();
     findRefreshTokenMock.mockReset();
   });
 
-  it("does not bind a resource-less mcp:tools refresh grant to the MCP resource", async () => {
+  it("不将无资源的 mcp:tools 刷新授权绑定到 MCP 资源", async () => {
     findRefreshTokenMock.mockResolvedValue({
       resources: [],
       scopes: [MCP_TOOLS_SCOPE],
@@ -58,7 +58,7 @@ describe("MCP refresh resource binding", () => {
     expect(params.has("resource")).toBe(false);
   });
 
-  it("does not bind a non-MCP-approved refresh grant to the MCP resource", async () => {
+  it("不将非 MCP 批准的刷新授权绑定到 MCP 资源", async () => {
     findRefreshTokenMock.mockResolvedValue({
       resources: ["https://life.example/api/auth"],
       scopes: [MCP_TOOLS_SCOPE],
@@ -78,7 +78,7 @@ describe("MCP refresh resource binding", () => {
     expect(params.has("resource")).toBe(false);
   });
 
-  it("binds omitted-resource refresh only when the stored grant includes the MCP resource", async () => {
+  it("仅在存储授权包含 MCP 资源时绑定省略资源的刷新", async () => {
     findRefreshTokenMock.mockResolvedValue({
       resources: ["https://life.example/api/mcp"],
       scopes: [MCP_TOOLS_SCOPE],

--- a/tests/unit/oauth-token-refresh-resources.test.ts
+++ b/tests/unit/oauth-token-refresh-resources.test.ts
@@ -39,7 +39,7 @@ function unsignedJwt(payload: Record<string, unknown>) {
   ].join(".");
 }
 
-describe("OAuth refresh token resource persistence", () => {
+describe("OAuth 刷新令牌资源持久化", () => {
   beforeEach(() => {
     vi.resetModules();
     findRefreshTokenMock.mockReset();
@@ -47,7 +47,7 @@ describe("OAuth refresh token resource persistence", () => {
     updateRefreshTokenMock.mockResolvedValue({ count: 1 });
   });
 
-  it("rejects refresh requests for resources outside the stored approval", async () => {
+  it("拒绝存储批准范围外的资源的刷新请求", async () => {
     findRefreshTokenMock.mockResolvedValue({
       resources: ["https://life.example/api/auth"],
     });
@@ -73,7 +73,7 @@ describe("OAuth refresh token resource persistence", () => {
     });
   });
 
-  it("allows refresh requests for stored approved resources", async () => {
+  it("允许已存储批准资源的刷新请求", async () => {
     findRefreshTokenMock.mockResolvedValue({
       resources: ["https://life.example/api/mcp"],
     });
@@ -94,7 +94,7 @@ describe("OAuth refresh token resource persistence", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("stores issued audience resources on authorization-code refresh tokens", async () => {
+  it("在授权码刷新令牌上存储已签发的受众资源", async () => {
     const { persistOAuthRefreshTokenResources } = await import(
       "@/lib/api/routes/auth-token-refresh-resources"
     );
@@ -119,7 +119,7 @@ describe("OAuth refresh token resource persistence", () => {
     });
   });
 
-  it("does not store requested resources absent from the issued access-token audience", async () => {
+  it("不存储已签发访问令牌受众中缺失的请求资源", async () => {
     const { persistOAuthRefreshTokenResources } = await import(
       "@/lib/api/routes/auth-token-refresh-resources"
     );
@@ -141,7 +141,7 @@ describe("OAuth refresh token resource persistence", () => {
     expect(updateRefreshTokenMock).not.toHaveBeenCalled();
   });
 
-  it("copies existing approved resources when a refresh grant rotates the refresh token", async () => {
+  it("刷新授权轮转刷新令牌时复制现有批准资源", async () => {
     findRefreshTokenMock.mockResolvedValue({
       resources: ["https://life.example/api/mcp"],
     });

--- a/tests/unit/oauth-token-route.test.ts
+++ b/tests/unit/oauth-token-route.test.ts
@@ -31,14 +31,14 @@ vi.mock("@/lib/mcp/urls", () => ({
   ],
 }));
 
-describe("OAuth token route", () => {
+describe("OAuth 令牌路由", () => {
   beforeEach(() => {
     betterAuthHandlerMock.mockReset();
     findRefreshTokenMock.mockReset();
     updateRefreshTokenMock.mockReset();
   });
 
-  it("returns JSON method guidance for GET", async () => {
+  it("为 GET 返回 JSON 方法指引", async () => {
     const response = await tokenGetRoute(
       new Request("http://localhost/api/auth/oauth2/token"),
     );
@@ -52,7 +52,7 @@ describe("OAuth token route", () => {
     expect(betterAuthHandlerMock).not.toHaveBeenCalled();
   });
 
-  it("normalizes delegated Better Auth validation errors", async () => {
+  it("规范化委托的 Better Auth 验证错误", async () => {
     betterAuthHandlerMock.mockResolvedValueOnce(
       Response.json(
         {
@@ -78,7 +78,7 @@ describe("OAuth token route", () => {
     });
   });
 
-  it("preserves delegated OAuth error headers", async () => {
+  it("保留委托的 OAuth 错误头", async () => {
     betterAuthHandlerMock.mockResolvedValueOnce(
       Response.json(
         {
@@ -118,7 +118,7 @@ describe("OAuth token route", () => {
     });
   });
 
-  it("rejects unapproved refresh-token resources before delegation", async () => {
+  it("在委托前拒绝未批准的刷新令牌资源", async () => {
     findRefreshTokenMock.mockResolvedValueOnce({
       resources: ["https://life.example/api/auth"],
     });

--- a/tests/unit/oauth-utils.test.ts
+++ b/tests/unit/oauth-utils.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/oauth/utils";
 
 describe("oauth/utils", () => {
-  it("hashes client secrets deterministically with SHA-256 base64url", async () => {
+  it("使用 SHA-256 base64url 确定性哈希客户端密钥", async () => {
     const secret = "super-secret-value";
     const hash = await hashOAuthClientSecretForDbStorage(secret);
 
@@ -20,7 +20,7 @@ describe("oauth/utils", () => {
     ).resolves.not.toBe(hash);
   });
 
-  it("normalizes resource indicators", () => {
+  it("规范化资源标识符", () => {
     expect(normalizeResourceIndicator("https://Example.COM/api/")).toBe(
       "https://example.com/api/",
     );
@@ -32,13 +32,13 @@ describe("oauth/utils", () => {
     );
   });
 
-  it("strips fragments from resource indicators", () => {
+  it("去除资源标识符中的片段", () => {
     expect(normalizeResourceIndicator("https://example.com/api#frag")).toBe(
       "https://example.com/api",
     );
   });
 
-  it("matches equivalent resource indicators", () => {
+  it("匹配等效资源标识符", () => {
     expect(
       resourceIndicatorsMatch(
         "https://Example.COM/api",
@@ -59,7 +59,7 @@ describe("oauth/utils", () => {
     ).toBe(false);
   });
 
-  it("matches localhost and 127.0.0.1 resource indicators on the same port", () => {
+  it("匹配相同端口下 localhost 与 127.0.0.1 资源标识符", () => {
     expect(
       resourceIndicatorsMatch(
         "http://localhost:3010/api/mcp",
@@ -68,7 +68,7 @@ describe("oauth/utils", () => {
     ).toBe(true);
   });
 
-  it("rejects loopback resource indicators with different ports or paths", () => {
+  it("拒绝不同端口或路径的环回资源标识符", () => {
     expect(
       resourceIndicatorsMatch(
         "http://localhost:3010/api/mcp",

--- a/tests/unit/pagination.test.ts
+++ b/tests/unit/pagination.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from "vitest";
 import { getPaginationTokens } from "@/lib/navigation/pagination";
 
 describe("getPaginationTokens", () => {
-  it("returns [1] for a single page", () => {
+  it("单页时返回 [1]", () => {
     expect(getPaginationTokens({ currentPage: 1, totalPages: 1 })).toEqual([1]);
   });
 
-  it("returns [1] when totalPages is 0", () => {
+  it("totalPages 为 0 时返回 [1]", () => {
     expect(getPaginationTokens({ currentPage: 1, totalPages: 0 })).toEqual([1]);
   });
 
-  it("returns all pages when totalPages <= maxVisible (default 5)", () => {
+  it("totalPages 不超过 maxVisible（默认 5）时返回所有页", () => {
     expect(getPaginationTokens({ currentPage: 1, totalPages: 3 })).toEqual([
       1, 2, 3,
     ]);
@@ -19,27 +19,27 @@ describe("getPaginationTokens", () => {
     ]);
   });
 
-  it("returns all pages when totalPages <= custom maxVisible", () => {
+  it("totalPages 不超过自定义 maxVisible 时返回所有页", () => {
     expect(
       getPaginationTokens({ currentPage: 1, totalPages: 7, maxVisible: 7 }),
     ).toEqual([1, 2, 3, 4, 5, 6, 7]);
   });
 
-  it("includes ellipsis before end when current is near start", () => {
+  it("当前页接近开头时在末尾前包含省略号", () => {
     const tokens = getPaginationTokens({ currentPage: 1, totalPages: 10 });
     expect(tokens[0]).toBe(1);
     expect(tokens).toContain("ellipsis");
     expect(tokens[tokens.length - 1]).toBe(10);
   });
 
-  it("includes ellipsis after start when current is near end", () => {
+  it("当前页接近末尾时在开头后包含省略号", () => {
     const tokens = getPaginationTokens({ currentPage: 10, totalPages: 10 });
     expect(tokens[0]).toBe(1);
     expect(tokens).toContain("ellipsis");
     expect(tokens[tokens.length - 1]).toBe(10);
   });
 
-  it("includes ellipsis on both sides when current is in middle", () => {
+  it("当前页在中间时两侧均包含省略号", () => {
     const tokens = getPaginationTokens({ currentPage: 5, totalPages: 10 });
     expect(tokens[0]).toBe(1);
     expect(tokens[tokens.length - 1]).toBe(10);
@@ -48,7 +48,7 @@ describe("getPaginationTokens", () => {
     expect(ellipses.length).toBe(2);
   });
 
-  it("always starts with 1 and ends with totalPages for large sets", () => {
+  it("大集合始终从 1 开始并以 totalPages 结束", () => {
     for (const current of [1, 5, 10, 15, 20]) {
       const tokens = getPaginationTokens({
         currentPage: current,
@@ -59,7 +59,7 @@ describe("getPaginationTokens", () => {
     }
   });
 
-  it("defaults maxVisible to 5", () => {
+  it("maxVisible 默认为 5", () => {
     // With 10 pages and page 5, default maxVisible=5 → window of 5 numeric pages
     const tokens = getPaginationTokens({ currentPage: 5, totalPages: 10 });
     const numericTokens = tokens.filter((t) => typeof t === "number");
@@ -69,7 +69,7 @@ describe("getPaginationTokens", () => {
     expect(numericTokens.length).toBeGreaterThanOrEqual(5);
   });
 
-  it("clamps maxVisible minimum to 3", () => {
+  it("maxVisible 最小值限制为 3", () => {
     const tokens = getPaginationTokens({
       currentPage: 5,
       totalPages: 10,
@@ -80,7 +80,7 @@ describe("getPaginationTokens", () => {
     expect(numericTokens.length).toBeGreaterThanOrEqual(3);
   });
 
-  it("does not produce duplicate page numbers", () => {
+  it("不产生重复页码", () => {
     for (const current of [1, 2, 3, 8, 9, 10]) {
       const tokens = getPaginationTokens({
         currentPage: current,
@@ -91,7 +91,7 @@ describe("getPaginationTokens", () => {
     }
   });
 
-  it("page numbers are in ascending order", () => {
+  it("页码按升序排列", () => {
     const tokens = getPaginationTokens({ currentPage: 6, totalPages: 20 });
     const numbers = tokens.filter((t): t is number => typeof t === "number");
     for (let i = 1; i < numbers.length; i++) {

--- a/tests/unit/parse-date-input.test.ts
+++ b/tests/unit/parse-date-input.test.ts
@@ -2,32 +2,32 @@ import { describe, expect, test } from "vitest";
 import { parseDateInput } from "@/lib/time/parse-date-input";
 
 describe("parseDateInput", () => {
-  test("returns null for empty-like values", () => {
+  test("空值返回 null", () => {
     expect(parseDateInput(undefined)).toBeNull();
     expect(parseDateInput(null)).toBeNull();
     expect(parseDateInput("   ")).toBeNull();
   });
 
-  test("parses explicit timezone input as-is", () => {
+  test("按原样解析显式时区输入", () => {
     const parsed = parseDateInput("2026-03-26T12:00:00+08:00");
     expect(parsed?.toISOString()).toBe("2026-03-26T04:00:00.000Z");
   });
 
-  test("interprets timezone-less datetime in Asia/Shanghai", () => {
+  test("将无时区日期时间按 Asia/Shanghai 解析", () => {
     const parsed = parseDateInput("2026-03-26T12:00");
     expect(parsed?.toISOString()).toBe("2026-03-26T04:00:00.000Z");
   });
 
-  test("interprets date-only string as UTC midnight", () => {
+  test("将仅日期字符串视为 UTC 午夜", () => {
     const parsed = parseDateInput("2026-03-26");
     expect(parsed?.toISOString()).toBe("2026-03-26T00:00:00.000Z");
   });
 
-  test("returns undefined for invalid input", () => {
+  test("无效输入返回 undefined", () => {
     expect(parseDateInput("not-a-date")).toBeUndefined();
   });
 
-  test("rejects overflowing calendar dates", () => {
+  test("拒绝溢出的日历日期", () => {
     expect(parseDateInput("2026-02-31")).toBeUndefined();
     expect(parseDateInput("2026-13-01")).toBeUndefined();
     expect(parseDateInput("2026-02-31T12:00")).toBeUndefined();
@@ -42,7 +42,7 @@ describe("parseDateInput", () => {
     expect(parseDateInput("February 31, 2026")).toBeUndefined();
   });
 
-  test("rejects unsupported date formats", () => {
+  test("拒绝不支持的日期格式", () => {
     expect(parseDateInput("03/26/2026")).toBeUndefined();
     expect(parseDateInput("February 28, 2026")).toBeUndefined();
   });

--- a/tests/unit/prisma-query-logging.test.ts
+++ b/tests/unit/prisma-query-logging.test.ts
@@ -6,7 +6,7 @@ import {
   shouldEnablePrismaQueryLogging,
 } from "@/lib/db/prisma-query-logging";
 
-describe("prisma query logging env", () => {
+describe("Prisma 查询日志环境", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
@@ -19,11 +19,11 @@ describe("prisma query logging env", () => {
     [{ PRISMA_QUERY_DEBUG: "true" }, "standard"],
     [{ PRISMA_QUERY_DEBUG: " yes " }, "standard"],
     [{ PRISMA_QUERY_DEBUG: " verbose " }, "verbose"],
-  ] as const)("resolves debug mode from %o", (input, expected) => {
+  ] as const)("从 %o 解析调试模式", (input, expected) => {
     expect(getPrismaQueryDebugMode(input)).toBe(expected);
   });
 
-  it("parses slow query threshold as an exact non-negative integer", () => {
+  it("将慢查询阈值解析为精确的非负整数", () => {
     expect(getPrismaSlowQueryThresholdMs({ PRISMA_SLOW_QUERY_MS: "0" })).toBe(
       0,
     );
@@ -41,7 +41,7 @@ describe("prisma query logging env", () => {
     ).toBeNull();
   });
 
-  it("enables query logging for debug mode or slow query threshold", () => {
+  it("为调试模式或慢查询阈值启用查询日志", () => {
     expect(shouldEnablePrismaQueryLogging({})).toBe(false);
     expect(shouldEnablePrismaQueryLogging({ PRISMA_QUERY_DEBUG: "true" })).toBe(
       true,
@@ -51,7 +51,7 @@ describe("prisma query logging env", () => {
     );
   });
 
-  it("omits verbose query params from production logs", () => {
+  it("生产日志中省略详细查询参数", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("PRISMA_QUERY_DEBUG", "verbose");
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});

--- a/tests/unit/profile-update-service.test.ts
+++ b/tests/unit/profile-update-service.test.ts
@@ -42,7 +42,7 @@ describe("updateOwnProfile", () => {
     vi.resetModules();
   });
 
-  it("maps username uniqueness races to username_taken", async () => {
+  it("将用户名唯一性竞争映射为 username_taken", async () => {
     const uniqueConflict = new Error("unique conflict");
     isPrismaUniqueConstraintErrorMock.mockReturnValueOnce(true);
     prismaMock.user.findUnique

--- a/tests/unit/profile-username.test.ts
+++ b/tests/unit/profile-username.test.ts
@@ -5,17 +5,17 @@ import {
   PROFILE_USERNAME_PATTERN,
 } from "@/features/profile/lib/profile-username";
 
-describe("profile username rules", () => {
-  it("exposes the same pattern and limit used by form inputs", () => {
+describe("个人资料用户名规则", () => {
+  it("暴露与表单输入相同的正则模式和长度限制", () => {
     expect(PROFILE_USERNAME_PATTERN).toBe("[a-z0-9-]+");
     expect(PROFILE_USERNAME_MAX_LENGTH).toBe(20);
   });
 
-  it("allows lowercase letters, numbers, and hyphens", () => {
+  it("允许小写字母、数字和连字符", () => {
     expect(isValidProfileUsername("student-2026")).toBe(true);
   });
 
-  it("rejects empty, overlong, uppercase, and reserved names", () => {
+  it("拒绝空、过长、大写和保留名称", () => {
     expect(isValidProfileUsername("")).toBe(false);
     expect(isValidProfileUsername("a".repeat(21))).toBe(false);
     expect(isValidProfileUsername("Student")).toBe(false);

--- a/tests/unit/protected-write-auth-order.test.ts
+++ b/tests/unit/protected-write-auth-order.test.ts
@@ -55,7 +55,7 @@ function jsonRequest(url: string, method: string) {
   });
 }
 
-describe("protected write route auth order", () => {
+describe("受保护写入路由认证顺序", () => {
   afterEach(() => {
     requireAuthMock.mockReset();
     requireWriteAuthMock.mockReset();
@@ -65,7 +65,7 @@ describe("protected write route auth order", () => {
     vi.resetModules();
   });
 
-  it("authenticates comment creation before parsing the JSON body", async () => {
+  it("在解析 JSON 请求体之前认证评论创建", async () => {
     requireAuthMock.mockResolvedValue(unauthorizedResponse());
     const { postCommentRoute } = await import(
       "@/lib/api/routes/comments-create-route"
@@ -79,7 +79,7 @@ describe("protected write route auth order", () => {
     expect(requireAuthMock).toHaveBeenCalledOnce();
   });
 
-  it("authenticates comment updates before parsing the JSON body", async () => {
+  it("在解析 JSON 请求体之前认证评论更新", async () => {
     requireAuthMock.mockResolvedValue(unauthorizedResponse());
     const { patchCommentRoute } = await import(
       "@/lib/api/routes/comments-update-route"
@@ -94,7 +94,7 @@ describe("protected write route auth order", () => {
     expect(requireAuthMock).toHaveBeenCalledOnce();
   });
 
-  it("authenticates description writes before parsing the JSON body", async () => {
+  it("在解析 JSON 请求体之前认证描述写入", async () => {
     requireAuthMock.mockResolvedValue(unauthorizedResponse());
     const { postDescriptionRoute } = await import(
       "@/lib/api/routes/description-upsert-route"
@@ -108,7 +108,7 @@ describe("protected write route auth order", () => {
     expect(requireAuthMock).toHaveBeenCalledOnce();
   });
 
-  it("authenticates upload renames before parsing the JSON body", async () => {
+  it("在解析 JSON 请求体之前认证上传重命名", async () => {
     requireWriteAuthMock.mockResolvedValue(unauthorizedResponse());
     const { patchUploadRoute } = await import(
       "@/lib/api/routes/upload-management-routes"
@@ -124,7 +124,7 @@ describe("protected write route auth order", () => {
     expect(renameOwnedUploadMock).not.toHaveBeenCalled();
   });
 
-  it("authenticates dashboard link pinning before parsing form data", async () => {
+  it("在解析表单数据之前认证仪表盘链接置顶", async () => {
     resolveApiUserIdMock.mockResolvedValue(null);
     const { postDashboardLinkPinRoute } = await import(
       "@/lib/api/routes/dashboard-link-pin-route"

--- a/tests/unit/provider-api.test.ts
+++ b/tests/unit/provider-api.test.ts
@@ -12,8 +12,8 @@ import {
   asOAuthProviderMetadataAuth,
 } from "@/lib/oauth/provider-api";
 
-describe("provider-api guards", () => {
-  it("accepts the expected OAuth provider API surface", async () => {
+describe("provider-api 守卫", () => {
+  it("接受预期的 OAuth 提供方 API 接口", async () => {
     const api = asOAuthProviderApi({
       adminCreateOAuthClient: async () => ({ client_id: "client-1" }),
       getOAuthClientPublic: async () => ({ client_id: "client-1" }),
@@ -52,19 +52,19 @@ describe("provider-api guards", () => {
     ).resolves.toMatchObject({ redirect_uri: "https://client/callback" });
   });
 
-  it("throws a clear error when the provider API is missing required methods", () => {
+  it("当提供方 API 缺少必要方法时抛出明确错误", () => {
     expect(() => asOAuthProviderApi({})).toThrow(
       /missing adminCreateOAuthClient\(\)/,
     );
   });
 
-  it("throws a clear error when metadata auth is missing required methods", () => {
+  it("当元数据认证缺少必要方法时抛出明确错误", () => {
     expect(() => asOAuthProviderMetadataAuth({ api: {} })).toThrow(
       /missing getOAuthServerConfig\(\)/,
     );
   });
 
-  it("accepts the generic OAuth API methods used by Svelte auth actions", () => {
+  it("接受 Svelte 认证动作使用的通用 OAuth API 方法", () => {
     const api = asGenericOAuthApi({
       signInWithOAuth2: async () => ({
         headers: new Headers(),
@@ -80,11 +80,11 @@ describe("provider-api guards", () => {
     expect(api.oAuth2LinkAccount).toBeTypeOf("function");
   });
 
-  it("throws a clear error when generic OAuth API is missing signInWithOAuth2", () => {
+  it("当通用 OAuth API 缺少 signInWithOAuth2 时抛出明确错误", () => {
     expect(() => asGenericOAuthApi({})).toThrow(/missing signInWithOAuth2\(\)/);
   });
 
-  it("throws a clear error when generic OAuth API is missing oAuth2LinkAccount", () => {
+  it("当通用 OAuth API 缺少 oAuth2LinkAccount 时抛出明确错误", () => {
     expect(() =>
       asGenericOAuthApi({ signInWithOAuth2: async () => ({}) }),
     ).toThrow(/missing oAuth2LinkAccount\(\)/);

--- a/tests/unit/readiness-route.test.ts
+++ b/tests/unit/readiness-route.test.ts
@@ -36,7 +36,7 @@ describe("/api/readiness", () => {
     vi.unstubAllEnvs();
   });
 
-  it("returns readiness checks for local requests", async () => {
+  it("为本地请求返回就绪检查", async () => {
     queryRawMock.mockResolvedValue([{ "?column?": 1 }]);
     vi.spyOn(console, "info").mockImplementation(() => {});
     const { GET } = await import("@/routes/api/readiness/+server");
@@ -65,7 +65,7 @@ describe("/api/readiness", () => {
     );
   });
 
-  it("records degraded readiness responses as api errors", async () => {
+  it("将降级就绪响应记录为 API 错误", async () => {
     queryRawMock.mockRejectedValue(new Error("database unavailable"));
     vi.spyOn(console, "info").mockImplementation(() => {});
     const { GET } = await import("@/routes/api/readiness/+server");
@@ -96,7 +96,7 @@ describe("/api/readiness", () => {
     );
   });
 
-  it("hides readiness from remote requests without a token", async () => {
+  it("对无令牌的远程请求隐藏就绪状态", async () => {
     vi.spyOn(console, "info").mockImplementation(() => {});
     const { GET } = await import("@/routes/api/readiness/+server");
 

--- a/tests/unit/request-locale.test.ts
+++ b/tests/unit/request-locale.test.ts
@@ -3,7 +3,7 @@ import { LOCALE_COOKIE } from "@/i18n/config";
 import { getRequestLocale } from "@/lib/api/routes/request-locale";
 
 describe("getRequestLocale", () => {
-  it("ignores malformed locale cookie values", () => {
+  it("忽略格式错误的语言 Cookie 值", () => {
     const request = new Request("https://life.example/api/bus", {
       headers: {
         "accept-language": "en-US,en;q=0.9",

--- a/tests/unit/runtime-metrics.test.ts
+++ b/tests/unit/runtime-metrics.test.ts
@@ -10,12 +10,12 @@ import {
   resetRuntimeMetricsForTest,
 } from "@/lib/metrics/runtime-metrics";
 
-describe("runtime metrics", () => {
+describe("运行时指标", () => {
   afterEach(() => {
     resetRuntimeMetricsForTest();
   });
 
-  it("renders counters with stable Prometheus labels", () => {
+  it("使用稳定的 Prometheus 标签渲染计数器", () => {
     incrementCounter("life_ustc_mcp_tool_calls_total", {
       tool: "get_my_profile",
     });
@@ -28,7 +28,7 @@ describe("runtime metrics", () => {
     );
   });
 
-  it("renders duration count and sum", () => {
+  it("渲染持续时间计数和总和", () => {
     observeDurationMs("life_ustc_mcp_http_request_duration_ms", 12, {
       method: "POST",
     });
@@ -43,7 +43,7 @@ describe("runtime metrics", () => {
     );
   });
 
-  it("bounds new metric series", () => {
+  it("限制新增指标序列", () => {
     for (let i = 0; i < 505; i += 1) {
       incrementCounter("life_ustc_mcp_tool_calls_total", {
         tool: `tool_${i}`,
@@ -58,7 +58,7 @@ describe("runtime metrics", () => {
     expect(metrics).not.toContain('tool="tool_504"');
   });
 
-  it("records storage operation status and duration", () => {
+  it("记录存储操作状态和持续时间", () => {
     recordStorageOperationMetric({
       operation: "PutObjectSignedUrl",
       status: "success",
@@ -74,7 +74,7 @@ describe("runtime metrics", () => {
     );
   });
 
-  it("records audit write status and duration", () => {
+  it("记录审计写入状态和持续时间", () => {
     recordAuditWriteMetric({
       action: "comment_create",
       status: "success",

--- a/tests/unit/schedule-queries.test.ts
+++ b/tests/unit/schedule-queries.test.ts
@@ -2,29 +2,29 @@ import { describe, expect, it } from "vitest";
 import { buildScheduleListWhere } from "@/features/catalog/lib/schedule-filters";
 
 describe("buildScheduleListWhere", () => {
-  it("returns an empty where clause when no filters are given", () => {
+  it("无过滤条件时返回空 where 子句", () => {
     expect(buildScheduleListWhere({})).toEqual({});
   });
 
-  it("applies sectionId as a direct field filter", () => {
+  it("将 sectionId 作为直接字段过滤", () => {
     expect(buildScheduleListWhere({ sectionId: 42 })).toEqual({
       sectionId: 42,
     });
   });
 
-  it("applies sectionJwId via nested section filter", () => {
+  it("通过嵌套 section 过滤应用 sectionJwId", () => {
     expect(buildScheduleListWhere({ sectionJwId: 9902001 })).toEqual({
       section: { jwId: 9902001 },
     });
   });
 
-  it("applies sectionCode via nested section filter", () => {
+  it("通过嵌套 section 过滤应用 sectionCode", () => {
     expect(buildScheduleListWhere({ sectionCode: "DEV-CS201.01" })).toEqual({
       section: { code: "DEV-CS201.01" },
     });
   });
 
-  it("combines sectionJwId and sectionCode into one section filter", () => {
+  it("将 sectionJwId 和 sectionCode 合并为一个 section 过滤", () => {
     expect(
       buildScheduleListWhere({ sectionJwId: 100, sectionCode: "CS101" }),
     ).toEqual({
@@ -32,19 +32,19 @@ describe("buildScheduleListWhere", () => {
     });
   });
 
-  it("applies teacherId via teachers.some.id", () => {
+  it("通过 teachers.some.id 应用 teacherId", () => {
     expect(buildScheduleListWhere({ teacherId: 7 })).toEqual({
       teachers: { some: { id: 7 } },
     });
   });
 
-  it("applies teacherCode via teachers.some.code", () => {
+  it("通过 teachers.some.code 应用 teacherCode", () => {
     expect(buildScheduleListWhere({ teacherCode: "DEV-T-001" })).toEqual({
       teachers: { some: { code: "DEV-T-001" } },
     });
   });
 
-  it("combines teacherId and teacherCode into one teachers.some filter", () => {
+  it("将 teacherId 和 teacherCode 合并为一个 teachers.some 过滤", () => {
     expect(
       buildScheduleListWhere({ teacherId: 5, teacherCode: "T-001" }),
     ).toEqual({
@@ -52,31 +52,31 @@ describe("buildScheduleListWhere", () => {
     });
   });
 
-  it("applies roomId as a direct field filter", () => {
+  it("将 roomId 作为直接字段过滤", () => {
     expect(buildScheduleListWhere({ roomId: 3 })).toEqual({ roomId: 3 });
   });
 
-  it("applies roomJwId via nested room filter", () => {
+  it("通过嵌套 room 过滤应用 roomJwId", () => {
     expect(buildScheduleListWhere({ roomJwId: 9910031 })).toEqual({
       room: { jwId: 9910031 },
     });
   });
 
-  it("applies a dateFrom-only date range", () => {
+  it("仅使用 dateFrom 的日期范围", () => {
     const from = new Date("2026-04-29T00:00:00.000Z");
     expect(buildScheduleListWhere({ dateFrom: from })).toEqual({
       date: { gte: from },
     });
   });
 
-  it("applies a dateTo-only date range", () => {
+  it("仅使用 dateTo 的日期范围", () => {
     const to = new Date("2026-05-05T23:59:59.000Z");
     expect(buildScheduleListWhere({ dateTo: to })).toEqual({
       date: { lte: to },
     });
   });
 
-  it("applies both dateFrom and dateTo as a range", () => {
+  it("同时使用 dateFrom 和 dateTo 作为范围", () => {
     const from = new Date("2026-04-29T00:00:00.000Z");
     const to = new Date("2026-05-05T23:59:59.000Z");
     expect(buildScheduleListWhere({ dateFrom: from, dateTo: to })).toEqual({
@@ -84,11 +84,11 @@ describe("buildScheduleListWhere", () => {
     });
   });
 
-  it("applies weekday filter", () => {
+  it("应用 weekday 过滤", () => {
     expect(buildScheduleListWhere({ weekday: 2 })).toEqual({ weekday: 2 });
   });
 
-  it("ignores non-integer string inputs without producing a filter", () => {
+  it("忽略非整数字符串输入，不生成过滤", () => {
     expect(buildScheduleListWhere({ sectionId: "abc" })).toEqual({});
     expect(buildScheduleListWhere({ sectionId: "42x" })).toEqual({});
     expect(buildScheduleListWhere({ weekday: "1.5" })).toEqual({});
@@ -97,7 +97,7 @@ describe("buildScheduleListWhere", () => {
     expect(buildScheduleListWhere({ weekday: undefined })).toEqual({});
   });
 
-  it("parses string integer inputs correctly", () => {
+  it("正确解析字符串形式的整数输入", () => {
     expect(buildScheduleListWhere({ sectionId: "42" })).toEqual({
       sectionId: 42,
     });
@@ -106,7 +106,7 @@ describe("buildScheduleListWhere", () => {
     });
   });
 
-  it("combines multiple independent filters", () => {
+  it("组合多个独立过滤条件", () => {
     const from = new Date("2026-04-29T00:00:00.000Z");
     const result = buildScheduleListWhere({
       sectionCode: "DEV-CS201.01",
@@ -124,7 +124,7 @@ describe("buildScheduleListWhere", () => {
     });
   });
 
-  it("trims whitespace from teacherCode and sectionCode, ignores blank strings", () => {
+  it("去除 teacherCode 和 sectionCode 的空白并忽略空字符串", () => {
     expect(buildScheduleListWhere({ teacherCode: "  " })).toEqual({});
     expect(buildScheduleListWhere({ sectionCode: "  " })).toEqual({});
     expect(buildScheduleListWhere({ teacherCode: "  T-001  " })).toEqual({

--- a/tests/unit/section-detail-date-display.test.ts
+++ b/tests/unit/section-detail-date-display.test.ts
@@ -11,8 +11,8 @@ import {
   isSameMonth,
 } from "@/features/section-detail/lib/date-display";
 
-describe("section detail date display", () => {
-  it("derives calendar keys with campus date boundaries", () => {
+describe("课程详情日期展示", () => {
+  it("根据校区日期边界派生日历键", () => {
     const boundary = new Date("2026-03-01T16:00:00.000Z");
     const campusFormatted = new Intl.DateTimeFormat(undefined, {
       timeZone: "Asia/Shanghai",
@@ -23,7 +23,7 @@ describe("section detail date display", () => {
     expect(formatDate(boundary, "n/a")).toBe(campusFormatted);
   });
 
-  it("builds section month grid keys from the shared Sunday week policy", () => {
+  it("基于共享的周日周策略构建课程月份网格键", () => {
     const monthStart = findCalendarBaseMonth([
       {
         badges: [],
@@ -54,7 +54,7 @@ describe("section detail date display", () => {
     expect(isSameMonth(lastDay, monthStart)).toBe(false);
   });
 
-  it("computes the Today month offset from the section base month", () => {
+  it("从课程基准月计算“今天”的月份偏移", () => {
     const baseMonth = findCalendarBaseMonth([
       {
         badges: [],
@@ -76,7 +76,7 @@ describe("section detail date display", () => {
     expect(dateKey(addMonths(baseMonth, offset))).toBe("2026-06-01");
   });
 
-  it("uses the provided today key as the empty-calendar base month", () => {
+  it("使用提供的 today 键作为空日历基准月", () => {
     const monthStart = findCalendarBaseMonth([], "2026-06-27");
 
     expect(dateKey(monthStart)).toBe("2026-06-01");

--- a/tests/unit/section-detail-homework-toggle-action.test.ts
+++ b/tests/unit/section-detail-homework-toggle-action.test.ts
@@ -61,12 +61,12 @@ function actionInput(
   };
 }
 
-describe("section detail homework toggle action", () => {
+describe("课程详情作业切换动作", () => {
   beforeEach(() => {
     updateHomeworkCompletionMock.mockReset();
   });
 
-  it("updates homework completion through the shared client", async () => {
+  it("通过共享客户端更新作业完成状态", async () => {
     const homework = {
       id: "homework-1",
       completion: null,
@@ -115,7 +115,7 @@ describe("section detail homework toggle action", () => {
     );
   });
 
-  it("surfaces localized completion failures instead of raw API messages", async () => {
+  it("显示本地化的完成失败信息，而非原始 API 消息", async () => {
     const homework = {
       id: "homework-1",
       completion: { completedAt: "2026-06-22T10:00:00.000Z" },

--- a/tests/unit/section-detail-homeworks-client.test.ts
+++ b/tests/unit/section-detail-homeworks-client.test.ts
@@ -14,12 +14,12 @@ const homeworkInput: SectionHomeworkRequest = {
   title: "Updated homework",
 };
 
-describe("section detail homeworks client", () => {
+describe("课程详情作业客户端", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("updates homework and description through one homework PATCH", async () => {
+  it("通过一次作业 PATCH 更新作业和描述", async () => {
     const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
 
@@ -47,7 +47,7 @@ describe("section detail homeworks client", () => {
     });
   });
 
-  it("maps failed homework PATCH requests to one update failure", async () => {
+  it("将失败的作业 PATCH 请求映射为一次更新失败", async () => {
     const fetchMock = vi.fn(async () => new Response("{}", { status: 500 }));
     vi.stubGlobal("fetch", fetchMock);
 

--- a/tests/unit/section-detail-subscription-actions.test.ts
+++ b/tests/unit/section-detail-subscription-actions.test.ts
@@ -21,13 +21,13 @@ function actionInput(jwId = "99999999") {
   };
 }
 
-describe("section detail subscription actions", () => {
+describe("课程详情订阅动作", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getSessionFromHeadersMock.mockResolvedValue({ user: { id: "user-1" } });
   });
 
-  it("returns 404 when subscribe target is missing", async () => {
+  it("订阅目标不存在时返回 404", async () => {
     subscribeUserToSectionByJwIdMock.mockResolvedValue(null);
     const { subscribeSectionAction } = await import(
       "@/features/section-detail/server/section-detail-subscription-actions"
@@ -42,7 +42,7 @@ describe("section detail subscription actions", () => {
     );
   });
 
-  it("returns 404 when unsubscribe target is missing", async () => {
+  it("取消订阅目标不存在时返回 404", async () => {
     unsubscribeUserFromSectionByJwIdMock.mockResolvedValue(null);
     const { unsubscribeSectionAction } = await import(
       "@/features/section-detail/server/section-detail-subscription-actions"

--- a/tests/unit/sections-page-helpers.test.ts
+++ b/tests/unit/sections-page-helpers.test.ts
@@ -4,8 +4,8 @@ import {
   groupSectionsBySemester,
 } from "@/features/subscriptions/lib/subscription-section-groups";
 
-describe("sections page helpers", () => {
-  it("groups sections by semester and sorts latest first", () => {
+describe("课程页面辅助函数", () => {
+  it("按学期分组课程并优先排序最新学期", () => {
     const sections = [
       {
         id: 1,
@@ -39,7 +39,7 @@ describe("sections page helpers", () => {
     expect(grouped[0]?.sections).toHaveLength(2);
   });
 
-  it("counts distinct semester ids across subscriptions", () => {
+  it("统计订阅中不同的学期 ID 数量", () => {
     const count = countDistinctSemesterIds([
       {
         sections: [{ semester: { id: 1 } }, { semester: { id: 2 } }],

--- a/tests/unit/serialize-date-output.test.ts
+++ b/tests/unit/serialize-date-output.test.ts
@@ -5,12 +5,12 @@ import {
 } from "@/lib/time/serialize-date-output";
 
 describe("serialize-date-output", () => {
-  test("formats date to shanghai iso with offset", () => {
+  test("将日期格式化为带偏移的上海 ISO", () => {
     const value = new Date("2026-03-26T04:00:00.000Z");
     expect(toShanghaiIsoString(value)).toBe("2026-03-26T12:00:00+08:00");
   });
 
-  test("serializes nested Date values", () => {
+  test("序列化嵌套的 Date 值", () => {
     const payload = {
       createdAt: new Date("2026-03-26T04:00:00.000Z"),
       nested: {

--- a/tests/unit/shanghai-format.test.ts
+++ b/tests/unit/shanghai-format.test.ts
@@ -4,8 +4,8 @@ import {
   toShanghaiDateTimeLocalValue,
 } from "@/lib/time/shanghai-format";
 
-describe("Shanghai date-time form helpers", () => {
-  it("formats Date and string values for datetime-local inputs", () => {
+describe("上海日期时间表单辅助函数", () => {
+  it("为 datetime-local 输入格式化 Date 和字符串值", () => {
     expect(
       toShanghaiDateTimeLocalValue(new Date("2026-03-17T10:30:00+08:00")),
     ).toBe("2026-03-17T10:30");
@@ -14,13 +14,13 @@ describe("Shanghai date-time form helpers", () => {
     );
   });
 
-  it("returns an empty form value for absent or invalid input", () => {
+  it("对缺失或无效输入返回空表单值", () => {
     expect(toShanghaiDateTimeLocalValue(null)).toBe("");
     expect(toShanghaiDateTimeLocalValue(undefined)).toBe("");
     expect(toShanghaiDateTimeLocalValue("not-a-date")).toBe("");
   });
 
-  it("parses blank form input as cleared and invalid input as undefined", () => {
+  it("将空白表单输入解析为已清除，无效输入解析为 undefined", () => {
     expect(parseShanghaiDateTimeLocalInput(" ")).toBeNull();
     expect(parseShanghaiDateTimeLocalInput("not-a-date")).toBeUndefined();
   });

--- a/tests/unit/signin-callback-url.test.ts
+++ b/tests/unit/signin-callback-url.test.ts
@@ -11,7 +11,7 @@ import {
 } from "@/lib/oauth/constants";
 
 describe("resolveSignInCallbackUrl", () => {
-  it("prefers explicit callbackUrl", () => {
+  it("优先使用显式 callbackUrl", () => {
     expect(
       resolveSignInCallbackUrl({
         callbackUrl: "/settings?tab=accounts",
@@ -20,7 +20,7 @@ describe("resolveSignInCallbackUrl", () => {
     ).toBe("/settings?tab=accounts");
   });
 
-  it("rejects external callbackUrl values", () => {
+  it("拒绝外部 callbackUrl 值", () => {
     expect(
       resolveSignInCallbackUrl({ callbackUrl: "https://attacker.example" }),
     ).toBe("/");
@@ -32,7 +32,7 @@ describe("resolveSignInCallbackUrl", () => {
     ).toBe("/");
   });
 
-  it("sanitizes app-relative callback URLs", () => {
+  it("清理应用内相对回调 URL", () => {
     expect(sanitizeAuthCallbackUrl("/settings?tab=profile#accounts")).toBe(
       "/settings?tab=profile#accounts",
     );
@@ -41,7 +41,7 @@ describe("resolveSignInCallbackUrl", () => {
     expect(sanitizeAuthCallbackUrl("/%5cattacker.example")).toBe("/");
   });
 
-  it("reconstructs oauth authorize continuation from raw sign-in params", () => {
+  it("根据原始登录参数重建 OAuth 授权继续请求", () => {
     expect(
       resolveSignInCallbackUrl({
         response_type: OAUTH_CODE_RESPONSE_TYPE,
@@ -60,7 +60,7 @@ describe("resolveSignInCallbackUrl", () => {
     );
   });
 
-  it("falls back to home when no continuation can be inferred", () => {
+  it("无法推断继续请求时回退到首页", () => {
     expect(resolveSignInCallbackUrl({ error: "OAuthAccountNotLinked" })).toBe(
       "/",
     );

--- a/tests/unit/static-assets.test.ts
+++ b/tests/unit/static-assets.test.ts
@@ -6,13 +6,13 @@ import {
   LIFE_USTC_STATIC_ORIGIN,
 } from "@/lib/static-assets";
 
-describe("static asset helpers", () => {
+describe("静态资源辅助函数", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
-  it("builds URLs from the published static origin", () => {
+  it("从已发布静态源构建 URL", () => {
     expect(LIFE_USTC_STATIC_ORIGIN).toBe(
       "https://static.life-ustc.tiankaima.dev",
     );
@@ -21,7 +21,7 @@ describe("static asset helpers", () => {
     );
   });
 
-  it("returns fallback data for optional static JSON failures", async () => {
+  it("可选静态 JSON 失败时返回兜底数据", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.stubGlobal(
       "fetch",
@@ -34,7 +34,7 @@ describe("static asset helpers", () => {
     expect(warnSpy).toHaveBeenCalled();
   });
 
-  it("throws for required static JSON failures", async () => {
+  it("必需静态 JSON 失败时抛出异常", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => new Response("missing", { status: 404 })),

--- a/tests/unit/subscription-import-client.test.ts
+++ b/tests/unit/subscription-import-client.test.ts
@@ -132,12 +132,12 @@ function appendPayload(sectionIds: number[], addedCount = sectionIds.length) {
   };
 }
 
-describe("subscription import client", () => {
+describe("订阅导入客户端", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("extracts and deduplicates schema-valid section code tokens", () => {
+  it("提取并去重符合 schema 的班级代码片段", () => {
     expect(
       extractSubscriptionSectionCodes(
         "MATH101 MATH.01 math.01 CS_A-2.03 cs-a_2 MATH.01",
@@ -145,7 +145,7 @@ describe("subscription import client", () => {
     ).toEqual(["MATH101", "MATH.01", "math.01", "CS_A-2.03", "cs-a_2"]);
   });
 
-  it("ignores tokens rejected by the shared section code schema", () => {
+  it("忽略被共享班级代码 schema 拒绝的片段", () => {
     const tooLong = "A".repeat(65);
 
     expect(
@@ -153,7 +153,7 @@ describe("subscription import client", () => {
     ).toEqual(["MATH.01", "CS_A-2.03"]);
   });
 
-  it("ignores long mixed prose while preserving code-shaped tokens", () => {
+  it("忽略长段混合文本但保留形似代码的片段", () => {
     const prose = Array.from(
       { length: 520 },
       (_, index) => `word${index}`,
@@ -166,7 +166,7 @@ describe("subscription import client", () => {
     ).toEqual(["MATH101", "001013.01", "math_01", "cs-a_2", "DEV-CS201.01"]);
   });
 
-  it("strips sentence delimiters from pasted section code tokens", () => {
+  it("去除粘贴班级代码片段中的句尾分隔符", () => {
     expect(
       extractSubscriptionSectionCodes(
         "Use COMP3001.01. Numeric example: 001013.01.",
@@ -174,7 +174,7 @@ describe("subscription import client", () => {
     ).toEqual(["COMP3001.01", "001013.01"]);
   });
 
-  it("posts match-code requests and validates successful payloads", async () => {
+  it("发送匹配代码请求并校验成功响应体", async () => {
     const fetchMock = vi.fn(async () => jsonResponse(matchPayload()));
     vi.stubGlobal("fetch", fetchMock);
 
@@ -197,7 +197,7 @@ describe("subscription import client", () => {
     });
   });
 
-  it("uses API error payloads before fallback messages", async () => {
+  it("优先使用 API 错误响应体而非兜底消息", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
@@ -213,7 +213,7 @@ describe("subscription import client", () => {
     ).rejects.toThrow("invalid semester");
   });
 
-  it("falls back when error payloads are not JSON", async () => {
+  it("错误响应体不是 JSON 时回退到兜底消息", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => new Response("plain failure", { status: 500 })),
@@ -227,7 +227,7 @@ describe("subscription import client", () => {
     ).rejects.toThrow("remove failed");
   });
 
-  it("rejects malformed successful payloads", async () => {
+  it("拒绝格式错误的成功响应体", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => jsonResponse({ sections: [] })),
@@ -241,7 +241,7 @@ describe("subscription import client", () => {
     ).rejects.toThrow("fetch failed");
   });
 
-  it("removes subscription section ids with a validated request", async () => {
+  it("以已校验请求移除订阅班级 ID", async () => {
     const fetchMock = vi.fn(async () => jsonResponse(subscriptionPayload([3])));
     vi.stubGlobal("fetch", fetchMock);
 
@@ -256,7 +256,7 @@ describe("subscription import client", () => {
     expect(JSON.parse(init.body)).toEqual({ sectionIds: [3] });
   });
 
-  it("does not call the remove route when no section ids are selected", async () => {
+  it("未选择班级 ID 时不调用移除路由", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
@@ -268,7 +268,7 @@ describe("subscription import client", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("appends selected section ids through the server-owned append route", async () => {
+  it("通过服务端追加路由添加所选班级 ID", async () => {
     const fetchMock = vi.fn(async () =>
       jsonResponse(appendPayload([1, 2, 3], 2)),
     );
@@ -288,7 +288,7 @@ describe("subscription import client", () => {
     expect(JSON.parse(init.body)).toEqual({ sectionIds: [2, 3] });
   });
 
-  it("does not call the append route when no section ids are selected", async () => {
+  it("未选择班级 ID 时不调用追加路由", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 

--- a/tests/unit/subscription-legacy-route.test.ts
+++ b/tests/unit/subscription-legacy-route.test.ts
@@ -25,8 +25,8 @@ function capabilityPages(contract: ContractModule, capability: string) {
   return web.pages;
 }
 
-describe("legacy subscription sections route", () => {
-  it("redirects GET requests to the canonical subscriptions page", async () => {
+describe("旧版订阅班级路由", () => {
+  it("将 GET 请求重定向到标准订阅页面", async () => {
     await expect(
       legacySubscriptionsRoute.load({
         url: new URL(
@@ -39,11 +39,11 @@ describe("legacy subscription sections route", () => {
     });
   });
 
-  it("does not expose page actions on the legacy redirect route", () => {
+  it("旧版重定向路由不暴露页面 actions", () => {
     expect("actions" in legacySubscriptionsRoute).toBe(false);
   });
 
-  it("documents the canonical page and keeps the legacy URL redirect-only", () => {
+  it("记录标准页面并保持旧版 URL 仅用于重定向", () => {
     const canonicalCapabilities = [
       [subscriptionContract, "batch-subscribe-by-codes"],
       [subscribedSectionsContract, "subscribed-sections-tab"],

--- a/tests/unit/time-utils.test.ts
+++ b/tests/unit/time-utils.test.ts
@@ -2,31 +2,31 @@ import { describe, expect, it } from "vitest";
 import { formatSmartDate, formatSmartDateTime } from "@/shared/lib/time-utils";
 
 describe("formatSmartDateTime", () => {
-  it("shows 今天 for same calendar day (zh)", () => {
+  it("同一日历日显示为今天（zh）", () => {
     const ref = new Date("2026-03-17T10:00:00+08:00");
     const due = new Date("2026-03-17T23:00:00+08:00");
     expect(formatSmartDateTime(due, ref, "zh-cn")).toBe("今天 23:00");
   });
 
-  it("uses Monday-based same-week labels across the shared week helper", () => {
+  it("使用基于周一的同一周标签跨共享 week helper", () => {
     const ref = new Date("2026-03-16T10:00:00+08:00");
     const due = new Date("2026-03-22T09:00:00+08:00");
     expect(formatSmartDateTime(due, ref, "en-us")).toBe("Sun, 09:00");
   });
 
-  it("does not treat the previous Sunday as this week", () => {
+  it("不将上周日视为本周", () => {
     const ref = new Date("2026-03-18T10:00:00+08:00");
     const due = new Date("2026-03-15T09:00:00+08:00");
     expect(formatSmartDateTime(due, ref, "zh-cn")).toBe("3月15日 09:00");
   });
 
-  it("omits year when same year but not same week (zh)", () => {
+  it("同一年但不同周时省略年份（zh）", () => {
     const ref = new Date("2026-03-17T10:00:00+08:00");
     const due = new Date("2026-04-20T15:30:00+08:00");
     expect(formatSmartDateTime(due, ref, "zh-cn")).toBe("4月20日 15:30");
   });
 
-  it("includes year when different from reference year (zh)", () => {
+  it("与参考年份不同时包含年份（zh）", () => {
     const ref = new Date("2026-03-17T10:00:00+08:00");
     const due = new Date("2025-12-01T09:00:00+08:00");
     expect(formatSmartDateTime(due, ref, "zh-cn")).toBe("2025年12月1日 09:00");
@@ -34,25 +34,25 @@ describe("formatSmartDateTime", () => {
 });
 
 describe("formatSmartDate", () => {
-  it("date-only today (zh)", () => {
+  it("仅日期时显示今天（zh）", () => {
     const ref = new Date("2026-03-17T10:00:00+08:00");
     const due = new Date("2026-03-17T08:00:00+08:00");
     expect(formatSmartDate(due, ref, "zh-cn")).toBe("今天");
   });
 
-  it("reuses the same Monday-based week boundary", () => {
+  it("复用相同的基于周一的周边界", () => {
     const ref = new Date("2026-03-16T10:00:00+08:00");
     const due = new Date("2026-03-22T08:00:00+08:00");
     expect(formatSmartDate(due, ref, "en-us")).toBe("Sunday");
   });
 
-  it("omits year when same year but not same week (zh)", () => {
+  it("同一年但不同周时省略年份（zh）", () => {
     const ref = new Date("2026-03-17T10:00:00+08:00");
     const due = new Date("2026-04-20T15:30:00+08:00");
     expect(formatSmartDate(due, ref, "zh-cn")).toBe("4月20日");
   });
 
-  it("includes year when different from reference year (zh)", () => {
+  it("与参考年份不同时包含年份（zh）", () => {
     const ref = new Date("2026-03-17T10:00:00+08:00");
     const due = new Date("2025-12-01T09:00:00+08:00");
     expect(formatSmartDate(due, ref, "zh-cn")).toBe("2025年12月1日");

--- a/tests/unit/upload-completion-service.test.ts
+++ b/tests/unit/upload-completion-service.test.ts
@@ -160,7 +160,7 @@ describe("completeUploadSession", () => {
     vi.clearAllMocks();
   });
 
-  it("validates the uploaded object before opening the serializable transaction", async () => {
+  it("在开启可串行事务前校验已上传对象", async () => {
     const calls: string[] = [];
     headStorageObjectMock.mockImplementation(async () => {
       calls.push("head");
@@ -193,7 +193,7 @@ describe("completeUploadSession", () => {
     });
   });
 
-  it("deletes pending quota outside the transaction when object validation fails", async () => {
+  it("对象校验失败时在事务外删除待处理配额", async () => {
     headStorageObjectMock.mockResolvedValue({ size: 0 });
 
     await expect(
@@ -209,7 +209,7 @@ describe("completeUploadSession", () => {
     });
   });
 
-  it("returns a concurrently completed upload instead of validating storage again", async () => {
+  it("返回并发完成的上传而非再次校验存储", async () => {
     pendingFindUniqueMock.mockResolvedValue(null);
     uploadFindUniqueMock
       .mockResolvedValueOnce(null)
@@ -234,7 +234,7 @@ describe("completeUploadSession", () => {
     });
   });
 
-  it("commits pending cleanup when the reservation expires before the transaction recheck", async () => {
+  it("预留会话在事务重新检查前过期时提交待清理项", async () => {
     const expiringPending = {
       expiresAt: new Date(FIXED_NOW.getTime() + 1_000),
       userId: USER_ID,
@@ -266,7 +266,7 @@ describe("completeUploadSession", () => {
     expect(txUploadCreateMock).not.toHaveBeenCalled();
   });
 
-  it("commits pending cleanup when quota validation fails in the transaction", async () => {
+  it("事务内配额校验失败时提交待清理项", async () => {
     txUploadAggregateMock.mockResolvedValue({
       _sum: { size: uploadConfig.totalQuotaBytes },
     });
@@ -316,7 +316,7 @@ describe("deleteOwnedUpload", () => {
     vi.clearAllMocks();
   });
 
-  it("waits for upload delete audit write before returning", async () => {
+  it("在返回前等待上传删除审计写入", async () => {
     const auditWrite = deferred<void>();
     auditLogCreateMock.mockReturnValue(auditWrite.promise);
     const settled = vi.fn();

--- a/tests/unit/upload-delete-service.test.ts
+++ b/tests/unit/upload-delete-service.test.ts
@@ -82,7 +82,7 @@ describe("deleteOwnedUpload", () => {
     vi.clearAllMocks();
   });
 
-  it("deletes the storage object before deleting upload metadata", async () => {
+  it("先删除存储对象再删除上传元数据", async () => {
     const result = await deleteOwnedUpload({
       audit: { source: "mcp" },
       id: upload.id,
@@ -110,7 +110,7 @@ describe("deleteOwnedUpload", () => {
     });
   });
 
-  it("surfaces audit failures after storage deletion instead of dropping audit rows", async () => {
+  it("在存储删除后暴露审计失败而不是丢弃审计记录", async () => {
     const auditError = new Error("audit unavailable");
     auditLogCreateMock.mockRejectedValueOnce(auditError);
 
@@ -133,7 +133,7 @@ describe("deleteOwnedUpload", () => {
     });
   });
 
-  it("preserves upload metadata when storage deletion fails", async () => {
+  it("存储删除失败时保留上传元数据", async () => {
     const storageError = new Error("R2 unavailable");
     deleteStorageObjectMock.mockRejectedValue(storageError);
 

--- a/tests/unit/upload-download-permissions.test.ts
+++ b/tests/unit/upload-download-permissions.test.ts
@@ -58,13 +58,13 @@ function attachmentComment(overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe("upload download permissions", () => {
+describe("上传下载权限", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getViewerContextMock.mockResolvedValue(viewer());
   });
 
-  it("allows owners to download unattached uploads", async () => {
+  it("允许所有者下载未附加的上传文件", async () => {
     findUniqueMock.mockResolvedValue(upload({ userId: "viewer" }));
 
     await expect(findDownloadableUpload("upload-1", "viewer")).resolves.toEqual(
@@ -72,7 +72,7 @@ describe("upload download permissions", () => {
     );
   });
 
-  it("allows signed-in non-owners through visible comment attachments", async () => {
+  it("允许登录的非所有者通过可见评论附件下载", async () => {
     findUniqueMock.mockResolvedValue(
       upload({ commentAttachments: [attachmentComment()] }),
     );
@@ -82,7 +82,7 @@ describe("upload download permissions", () => {
     );
   });
 
-  it("does not expose unattached non-owner uploads", async () => {
+  it("不暴露未附加的非所有者上传文件", async () => {
     findUniqueMock.mockResolvedValue(upload());
 
     await expect(
@@ -90,7 +90,7 @@ describe("upload download permissions", () => {
     ).resolves.toBeNull();
   });
 
-  it("does not expose uploads through hidden comments", async () => {
+  it("不通过隐藏评论暴露上传文件", async () => {
     findUniqueMock.mockResolvedValue(
       upload({
         commentAttachments: [
@@ -105,7 +105,7 @@ describe("upload download permissions", () => {
     ).resolves.toBeNull();
   });
 
-  it("allows admins to download softbanned comment attachments", async () => {
+  it("允许管理员下载被软禁评论的附件", async () => {
     getViewerContextMock.mockResolvedValue(viewer({ isAdmin: true }));
     findUniqueMock.mockResolvedValue(
       upload({

--- a/tests/unit/upload-management-routes.test.ts
+++ b/tests/unit/upload-management-routes.test.ts
@@ -31,7 +31,7 @@ vi.mock("@/lib/audit/write-audit-log", () => ({
   getAuditRequestMetadata: getAuditRequestMetadataMock,
 }));
 
-describe("upload management routes", () => {
+describe("上传管理路由", () => {
   beforeEach(() => {
     requireWriteAuthMock.mockResolvedValue({ userId: "user-1" });
     getAuditRequestMetadataMock.mockReturnValue({
@@ -44,7 +44,7 @@ describe("upload management routes", () => {
     vi.clearAllMocks();
   });
 
-  it("serializes storage cleanup failures without reporting delete success", async () => {
+  it("序列化存储清理失败且不报告删除成功", async () => {
     deleteOwnedUploadMock.mockResolvedValue({
       ok: false,
       error: "storage_delete_failed",

--- a/tests/unit/upload-object-put-route.test.ts
+++ b/tests/unit/upload-object-put-route.test.ts
@@ -68,7 +68,7 @@ describe("putUploadObjectRoute", () => {
     vi.resetModules();
   });
 
-  it("requires content length before writing to R2", async () => {
+  it("写入 R2 前要求 Content-Length", async () => {
     requireWriteAuthMock.mockResolvedValue({ userId: "user-1" });
     const { putUploadObjectRoute } = await import(
       "@/lib/api/routes/upload-object-put-route"
@@ -84,7 +84,7 @@ describe("putUploadObjectRoute", () => {
     expect(putStorageObjectMock).not.toHaveBeenCalled();
   });
 
-  it("rejects keys outside the authenticated user's upload prefix", async () => {
+  it("拒绝超出认证用户上传前缀的 key", async () => {
     requireWriteAuthMock.mockResolvedValue({ userId: "user-1" });
     const { putUploadObjectRoute } = await import(
       "@/lib/api/routes/upload-object-put-route"
@@ -102,7 +102,7 @@ describe("putUploadObjectRoute", () => {
     expect(putStorageObjectMock).not.toHaveBeenCalled();
   });
 
-  it("rejects expired upload sessions", async () => {
+  it("拒绝过期的上传会话", async () => {
     requireWriteAuthMock.mockResolvedValue({ userId: "user-1" });
     findUniqueMock.mockResolvedValue({
       contentType: "text/plain",
@@ -125,7 +125,7 @@ describe("putUploadObjectRoute", () => {
     expect(putStorageObjectMock).not.toHaveBeenCalled();
   });
 
-  it("rejects bodies larger than the pending reservation", async () => {
+  it("拒绝超过待处理预留大小的请求体", async () => {
     requireWriteAuthMock.mockResolvedValue({ userId: "user-1" });
     findUniqueMock.mockResolvedValue({
       contentType: "text/plain",
@@ -145,7 +145,7 @@ describe("putUploadObjectRoute", () => {
     expect(putStorageObjectMock).not.toHaveBeenCalled();
   });
 
-  it("writes a valid pending upload to R2", async () => {
+  it("将有效的待处理上传写入 R2", async () => {
     requireWriteAuthMock.mockResolvedValue({ userId: "user-1" });
     findUniqueMock.mockResolvedValue({
       contentType: "text/plain",

--- a/tests/unit/upload-tools.test.ts
+++ b/tests/unit/upload-tools.test.ts
@@ -43,12 +43,12 @@ function parseToolResult(result: { content: Array<{ text: string }> }) {
   return JSON.parse(result.content[0]?.text ?? "{}");
 }
 
-describe("upload MCP tools", () => {
+describe("上传 MCP 工具", () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it("serializes storage cleanup failures without reporting delete success", async () => {
+  it("序列化存储清理失败且不报告删除成功", async () => {
     deleteOwnedUploadMock.mockResolvedValue({
       ok: false,
       error: "storage_delete_failed",

--- a/tests/unit/upload-utils.test.ts
+++ b/tests/unit/upload-utils.test.ts
@@ -12,8 +12,8 @@ function hasHeaderControlCharacters(value: string) {
   });
 }
 
-describe("upload filename utilities", () => {
-  it("detects and normalizes filename control characters", () => {
+describe("上传文件名工具函数", () => {
+  it("检测并规范化文件名控制字符", () => {
     expect(hasAsciiControlCharacters("report\nfinal.txt")).toBe(true);
     expect(hasAsciiControlCharacters("report-final.txt")).toBe(false);
     expect(sanitizeFilename(" report\r\nfinal\u0000.txt ")).toBe(
@@ -21,7 +21,7 @@ describe("upload filename utilities", () => {
     );
   });
 
-  it("builds Content-Disposition without invalid header characters", () => {
+  it("构建不含无效头部字符的 Content-Disposition", () => {
     const header = buildContentDisposition('课程\r\n"final".txt');
 
     expect(header).toContain('filename="__ _final_.txt"');

--- a/tests/unit/user-profile-contributions.test.ts
+++ b/tests/unit/user-profile-contributions.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { buildUserProfileContributions } from "@/features/profile/server/user-profile-contributions";
 
-describe("user profile contributions", () => {
-  it("groups contribution events by campus date across Shanghai midnight", async () => {
+describe("用户主页贡献", () => {
+  it("以上海午夜为界按校区日期聚合贡献事件", async () => {
     const commentFindMany = vi.fn(async (_input: unknown) => [
       { createdAt: new Date("2026-03-01T15:59:00.000Z") },
     ]);

--- a/tests/unit/welcome-redirect.test.ts
+++ b/tests/unit/welcome-redirect.test.ts
@@ -10,19 +10,19 @@ function shouldRedirect(path: string, url = `http://localhost:3000${path}`) {
   });
 }
 
-describe("welcome redirect policy", () => {
-  it("redirects incomplete signed-in users away from normal pages", () => {
+describe("欢迎页重定向策略", () => {
+  it("将资料不完整的已登录用户从普通页面重定向", () => {
     expect(shouldRedirect("/")).toBe(true);
     expect(shouldRedirect("/settings")).toBe(true);
   });
 
-  it("allows profile completion and OAuth consent pages", () => {
+  it("允许资料补全页和 OAuth 授权页", () => {
     expect(shouldRedirect("/welcome")).toBe(false);
     expect(shouldRedirect("/signin")).toBe(false);
     expect(shouldRedirect("/oauth/authorize")).toBe(false);
   });
 
-  it("does not redirect API, discovery, or static asset requests", () => {
+  it("不重定向 API、发现服务或静态资源请求", () => {
     expect(shouldRedirect("/api/me")).toBe(false);
     expect(shouldRedirect("/.well-known/openid-configuration")).toBe(false);
     expect(shouldRedirect("/_app/immutable/start.js")).toBe(false);
@@ -30,7 +30,7 @@ describe("welcome redirect policy", () => {
     expect(shouldRedirect("/sitemap.xml")).toBe(false);
   });
 
-  it("allows OAuth callback continuations by protocol shape, not test path", () => {
+  it("按协议形态允许 OAuth 回调继续，而非测试路径", () => {
     expect(
       shouldRedirect(
         "/e2e/oauth/callback",
@@ -45,7 +45,7 @@ describe("welcome redirect policy", () => {
     ).toBe(false);
   });
 
-  it("does not treat arbitrary state-only URLs as OAuth callbacks", () => {
+  it("不将仅含 state 的任意 URL 视为 OAuth 回调", () => {
     expect(shouldRedirect("/", "http://localhost:3000/?state=xyz")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Translates every `describe` / `it` / `test` / `test.step` name in the repository to Chinese while preserving code logic, identifiers, route paths, and formatting.

- **231 test files** changed across `tests/unit`, `tests/integration`, and `tests/e2e`.
- No source code, contracts, or fixtures were modified.

## Verification

- `bunx biome check --no-errors-on-unmatched --files-ignore-unknown=true .` ✅
- `bunx tsc --noEmit -p tsconfig.typecheck.json` ✅
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json` ✅
- `bunx vitest run` ✅ — 130 files, 586 tests passed

## Agent-swarm inspection: coverage & alignment

Five read-only inspectors reviewed the test suite against `src/`, `docs/contracts/`, and the existing tests.

### Coverage snapshot

| Layer | Files | Names translated |
|---|---|---|
| E2E (`tests/e2e/src/app`) | 92 `test.ts` + 1 spec | ~546 cases, ~538 Chinese |
| Integration (`tests/integration`) | 13 files | 97 names, 95 Chinese |
| Unit (`tests/unit`) | 130 files | 718 names, 681 Chinese |

### What is well covered

- All 35 `+page.svelte` routes have at least a smoke/page-contract test.
- 51 of 64 `src/routes/api/**/+server.ts` routes have dedicated E2E API tests.
- Integration MCP tests exercise ~36 of ~59 registered tools across profile, comments, descriptions, todos/homeworks, calendar, sections/catalog, dashboard, dashboard links, bus, and subscriptions.
- Unit tests cover auth/OAuth, MCP plumbing, comment permissions, homework mutation, upload lifecycle, admin suspensions, dashboard helpers, and bus timetable logic.

### Drift / gaps identified for follow-up

The remaining English names are mostly function/route identifiers (e.g. `describe("parseDateInput")`) kept intact per the no-over-localization rule.

**E2E API gaps**
- `GET /api/admin/descriptions` — only probed in moderation page test.
- `GET /api/admin/homeworks` and `DELETE /api/admin/homeworks/[id]` — no dedicated E2E.
- `GET /api/me/subscriptions/homeworks` — documented in `homework.json`, not directly tested.
- `PUT /api/uploads/object` — contract documents on-site handler; helper currently PUTs to pre-signed R2 URL.
- `GET /api/health`, `/api/readiness`, `/api/metrics` — unit-tested, no E2E probe.
- `tests/e2e/src/app/_shared/api-contract.ts` `probeOnlyRoutes` is stale and masks routes that now have dedicated tests.

**UI interaction gaps**
- Anonymous comment checkbox / identity masking not verified end-to-end.
- Homework create/edit form does not exercise `isMajor` / `requiresTeam` or due-date/description fields.
- Admin bus import/activate/delete version actions are opened but not submitted.
- Admin OAuth scope/auth-pattern pickers are rendered but not interacted with.
- Settings danger zone only checks dialog state, not actual deletion.

**Integration MCP gaps**
- Catalog tools: `search_sections`, `search_teachers`, `get_teacher_by_id`, `match_section_codes`, `list_semesters`, `get_current_semester`, `get_course_by_jw_id`.
- Homework write tools: `create_homework_on_section`, `update_homework_on_section`, `set_my_homework_completion`.
- Bus timetable/route tools: `query_bus_timetable`, `list_bus_routes`, `get_bus_route_timetable`.
- Calendar subscription tools: `get_my_calendar_subscription`, `list_my_subscribed_sections`, `get_section_calendar_subscription`, `subscribe_my_sections_by_codes`.

**Unit gaps**
- `src/features/catalog/server/section-search-parser.ts` / `section-search-order.ts` / `section-search-where.ts` have no unit tests for the documented search syntax.
- Calendar event window/merging and dashboard overview serialization are covered by E2E/integration but lack focused unit tests.
- `vitest.config.ts` coverage `include` is limited to `src/lib/**/*.ts`, hiding feature coverage.

### Recommendations

1. Clean stale `probeOnlyRoutes` and add focused E2E for admin homework/description governance, subscribed homeworks, upload object route, and observability probes.
2. Add MCP integration files for catalog, bus routes/timetable, calendar subscriptions, and section homework CRUD.
3. Drive a few high-value UI actions to completion (anonymous comment, homework tags, admin bus/OAuth dialogs, account deletion).
4. Add unit tests for catalog search parsing/query building and calendar event window logic.

This PR intentionally keeps the change surface to test-name translation only; the gaps above are tracked for follow-up PRs.
