### PR TITLE
test(integration): cover remaining MCP tool gaps

### DIFF
--- a/tests/integration/mcp-13-catalog-search.test.ts
+++ b/tests/integration/mcp-13-catalog-search.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import * as fixtures from "./utils/mcp-tool-test-utils";
+
+const context = fixtures.createMcpToolTestContext();
+
+describe("学期查询工具", () => {
+  it("list_semesters 返回与 REST 等价的分页学期列表", async () => {
+    const result = await context.client.call<{
+      data?: Array<{
+        id?: number;
+        jwId?: number;
+        code?: string;
+        nameCn?: string;
+        startDate?: string;
+        endDate?: string;
+      }>;
+      pagination?: {
+        page?: number;
+        pageSize?: number;
+        total?: number;
+        totalPages?: number;
+      };
+    }>("list_semesters", {
+      page: 1,
+      limit: 20,
+      mode: "default",
+    });
+
+    expect(result.pagination?.page).toBe(1);
+    expect(result.pagination?.pageSize).toBe(20);
+    expect((result.pagination?.total ?? 0) > 0).toBe(true);
+    expect((result.pagination?.totalPages ?? 0) >= 1).toBe(true);
+
+    const semester = result.data?.find(
+      (item) => item.jwId === fixtures.DEV_SEED.semesterJwId,
+    );
+    expect(semester).toBeDefined();
+    expect(semester?.nameCn).toBe(fixtures.DEV_SEED.semesterNameCn);
+    expect(typeof semester?.id).toBe("number");
+    expect(typeof semester?.code).toBe("string");
+    expect(typeof semester?.startDate).toBe("string");
+    expect(typeof semester?.endDate).toBe("string");
+  });
+
+  it("list_semesters summary 模式折叠列表为统计摘要", async () => {
+    const result = await context.client.call<{
+      data?: {
+        total?: number;
+        returned?: number;
+        truncated?: boolean;
+        items?: Array<{
+          jwId?: number;
+          nameCn?: string;
+        }>;
+      };
+    }>("list_semesters", {
+      page: 1,
+      limit: 10,
+      mode: "summary",
+    });
+
+    expect(typeof result.data?.total).toBe("number");
+    expect(typeof result.data?.returned).toBe("number");
+    expect(typeof result.data?.truncated).toBe("boolean");
+    expect(Array.isArray(result.data?.items)).toBe(true);
+
+    const semester = result.data?.items?.find(
+      (item) => item.jwId === fixtures.DEV_SEED.semesterJwId,
+    );
+    expect(semester?.nameCn).toBe(fixtures.DEV_SEED.semesterNameCn);
+  });
+
+  it("list_semesters 越界页码返回空数据与正确分页元数据", async () => {
+    const result = await context.client.call<{
+      data?: unknown[];
+      pagination?: {
+        page?: number;
+        pageSize?: number;
+        total?: number;
+        totalPages?: number;
+      };
+    }>("list_semesters", {
+      page: 9999,
+      limit: 10,
+      mode: "default",
+    });
+
+    expect(result.data).toHaveLength(0);
+    expect(result.pagination?.page).toBe(9999);
+    expect(result.pagination?.pageSize).toBe(10);
+    expect((result.pagination?.total ?? 0) > 0).toBe(true);
+    expect(result.pagination?.totalPages).toBeGreaterThanOrEqual(1);
+  });
+
+  it("list_semesters 拒绝越界或无效分页参数", async () => {
+    await expect(
+      context.client.call("list_semesters", { page: 0, limit: 10 }),
+    ).rejects.toThrow();
+
+    await expect(
+      context.client.call("list_semesters", { page: 1, limit: 101 }),
+    ).rejects.toThrow();
+
+    await expect(
+      context.client.call("list_semesters", {
+        page: "not-a-number",
+        limit: 10,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("get_current_semester 返回覆盖当前的 seed 学期", async () => {
+    const result = await context.client.call<{
+      found?: boolean;
+      semester?: {
+        id?: number;
+        jwId?: number;
+        code?: string;
+        nameCn?: string;
+        startDate?: string;
+        endDate?: string;
+      };
+    }>("get_current_semester", { mode: "default" });
+
+    expect(result.found).toBe(true);
+    expect(result.semester?.jwId).toBe(fixtures.DEV_SEED.semesterJwId);
+    expect(result.semester?.nameCn).toBe(fixtures.DEV_SEED.semesterNameCn);
+    expect(typeof result.semester?.id).toBe("number");
+    expect(typeof result.semester?.code).toBe("string");
+    expect(typeof result.semester?.startDate).toBe("string");
+    expect(typeof result.semester?.endDate).toBe("string");
+  });
+
+  it("get_current_semester full 模式返回完整学期记录", async () => {
+    const result = await context.client.call<{
+      found?: boolean;
+      semester?: Record<string, unknown>;
+    }>("get_current_semester", { mode: "full" });
+
+    expect(result.found).toBe(true);
+    expect(result.semester?.jwId).toBe(fixtures.DEV_SEED.semesterJwId);
+    expect(result.semester).toHaveProperty("id");
+    expect(result.semester).toHaveProperty("nameCn");
+    expect(result.semester).toHaveProperty("startDate");
+    expect(result.semester).toHaveProperty("endDate");
+  });
+
+  it("get_current_semester 拒绝无效 mode 参数", async () => {
+    await expect(
+      context.client.call("get_current_semester", { mode: "invalid-mode" }),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/integration/mcp-14-teacher.test.ts
+++ b/tests/integration/mcp-14-teacher.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import * as fixtures from "./utils/mcp-tool-test-utils";
+
+const context = fixtures.createMcpToolTestContext();
+
+type SearchSectionsResult = {
+  data?: Array<{
+    id?: number;
+    jwId?: number;
+    code?: string | null;
+    credits?: number | null;
+    stdCount?: number | null;
+    limitCount?: number | null;
+    courseId?: number | null;
+    course?: {
+      id?: number;
+      jwId?: number;
+      code?: string | null;
+      nameCn?: string | null;
+      nameEn?: string | null;
+    };
+    semester?: {
+      id?: number;
+      jwId?: number;
+      nameCn?: string | null;
+      code?: string | null;
+    };
+    campus?: {
+      id?: number;
+      jwId?: number;
+      nameCn?: string | null;
+      nameEn?: string | null;
+      code?: string | null;
+    };
+    teachers?: Array<{
+      id?: number;
+      code?: string | null;
+      nameCn?: string | null;
+      nameEn?: string | null;
+    }>;
+  }>;
+  pagination?: {
+    page?: number;
+    pageSize?: number;
+    total?: number;
+    totalPages?: number;
+  };
+};
+
+type GetCourseResult = {
+  found?: boolean;
+  course?: {
+    id?: number;
+    jwId?: number;
+    code?: string | null;
+    nameCn?: string | null;
+    nameEn?: string | null;
+    educationLevel?: { nameCn?: string | null; nameEn?: string | null } | null;
+    category?: { nameCn?: string | null; nameEn?: string | null } | null;
+    classType?: { nameCn?: string | null; nameEn?: string | null } | null;
+    sections?: Array<{
+      id?: number;
+      jwId?: number;
+      code?: string | null;
+      semester?: { nameCn?: string | null } | null;
+      campus?: { nameCn?: string | null } | null;
+      teachers?: Array<{ nameCn?: string | null }>;
+    }>;
+  } | null;
+};
+
+describe("班级搜索工具 search_sections", () => {
+  it("按课程 jwId 返回分页的班级摘要", async () => {
+    const result = await context.client.call<SearchSectionsResult>(
+      "search_sections",
+      {
+        courseJwId: fixtures.DEV_SEED.course.jwId,
+        page: 1,
+        limit: 10,
+        locale: "zh-cn",
+        mode: "full",
+      },
+    );
+
+    expect(result.pagination?.page).toBe(1);
+    expect(result.pagination?.pageSize).toBe(10);
+    expect((result.pagination?.total ?? 0) > 0).toBe(true);
+    expect((result.pagination?.totalPages ?? 0) >= 1).toBe(true);
+
+    const section = result.data?.find(
+      (item) => item.jwId === fixtures.DEV_SEED.section.jwId,
+    );
+    expect(section).toBeDefined();
+    expect(section?.code).toBe(fixtures.DEV_SEED.section.code);
+    expect(section?.course?.jwId).toBe(fixtures.DEV_SEED.course.jwId);
+    expect(section?.course?.nameCn).toBe(fixtures.DEV_SEED.course.nameCn);
+    expect(section?.course?.nameEn).toBe(fixtures.DEV_SEED.course.nameEn);
+    expect(section?.semester?.jwId).toBe(fixtures.DEV_SEED.semesterJwId);
+    expect(
+      section?.teachers?.some(
+        (teacher) => teacher.code === fixtures.DEV_SEED.teacher.code,
+      ),
+    ).toBe(true);
+  });
+
+  it("按教师工号过滤班级", async () => {
+    const result = await context.client.call<SearchSectionsResult>(
+      "search_sections",
+      {
+        teacherCode: fixtures.DEV_SEED.teacher.code,
+        page: 1,
+        limit: 10,
+        locale: "zh-cn",
+        mode: "full",
+      },
+    );
+
+    expect((result.data?.length ?? 0) > 0).toBe(true);
+    expect(
+      result.data?.some(
+        (section) => section.jwId === fixtures.DEV_SEED.section.jwId,
+      ),
+    ).toBe(true);
+  });
+
+  it("按 jwIds 精确查询班级", async () => {
+    const result = await context.client.call<SearchSectionsResult>(
+      "search_sections",
+      {
+        jwIds: [fixtures.DEV_SEED.section.jwId],
+        page: 1,
+        limit: 10,
+        locale: "zh-cn",
+        mode: "full",
+      },
+    );
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data?.[0]?.jwId).toBe(fixtures.DEV_SEED.section.jwId);
+    expect(result.pagination?.total).toBe(1);
+    expect(result.pagination?.totalPages).toBe(1);
+  });
+
+  it("无匹配过滤返回空分页", async () => {
+    const result = await context.client.call<SearchSectionsResult>(
+      "search_sections",
+      {
+        courseJwId: 999_999_999,
+        page: 1,
+        limit: 10,
+        locale: "zh-cn",
+        mode: "full",
+      },
+    );
+
+    expect(result.data).toEqual([]);
+    expect(result.pagination?.total).toBe(0);
+    expect(result.pagination?.totalPages).toBe(1);
+  });
+
+  it("拒绝越界分页参数", async () => {
+    await expect(
+      context.client.call("search_sections", { page: 1, limit: 101 }),
+    ).rejects.toThrow();
+    await expect(
+      context.client.call("search_sections", { page: 0, limit: 10 }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("课程详情工具 get_course_by_jw_id", () => {
+  it("按 jwId 返回课程详情及班级列表", async () => {
+    const result = await context.client.call<GetCourseResult>(
+      "get_course_by_jw_id",
+      {
+        jwId: fixtures.DEV_SEED.course.jwId,
+        locale: "zh-cn",
+        mode: "full",
+      },
+    );
+
+    expect(result.found).toBe(true);
+    const course = result.course;
+    expect(course).not.toBeNull();
+    expect(course?.jwId).toBe(fixtures.DEV_SEED.course.jwId);
+    expect(course?.code).toBe(fixtures.DEV_SEED.course.code);
+    expect(course?.nameCn).toBe(fixtures.DEV_SEED.course.nameCn);
+    expect(course?.nameEn).toBe(fixtures.DEV_SEED.course.nameEn);
+    expect(course?.educationLevel?.nameCn).toBe(
+      fixtures.DEV_SEED.course.educationLevelNameCn,
+    );
+    expect(course?.category?.nameCn).toBe(
+      fixtures.DEV_SEED.course.categoryNameCn,
+    );
+    expect(course?.classType?.nameCn).toBe(
+      fixtures.DEV_SEED.course.classTypeNameCn,
+    );
+
+    const seedSection = course?.sections?.find(
+      (section) => section.jwId === fixtures.DEV_SEED.section.jwId,
+    );
+    expect(seedSection).toBeDefined();
+    expect(seedSection?.code).toBe(fixtures.DEV_SEED.section.code);
+    expect(seedSection?.semester?.nameCn).toBe(
+      fixtures.DEV_SEED.semesterNameCn,
+    );
+  });
+
+  it("缺失课程返回 found false", async () => {
+    const result = await context.client.call<GetCourseResult>(
+      "get_course_by_jw_id",
+      {
+        jwId: 999_999_999,
+        locale: "zh-cn",
+      },
+    );
+
+    expect(result.found).toBe(false);
+    expect(result.course).toBeNull();
+  });
+
+  it("拒绝无效 jwId 参数", async () => {
+    await expect(
+      context.client.call("get_course_by_jw_id", { jwId: 0 }),
+    ).rejects.toThrow();
+    await expect(
+      context.client.call("get_course_by_jw_id", { jwId: -1 }),
+    ).rejects.toThrow();
+    await expect(
+      context.client.call("get_course_by_jw_id", {
+        jwId: "not-a-number",
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/integration/mcp-15-section-match.test.ts
+++ b/tests/integration/mcp-15-section-match.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import * as fixtures from "./utils/mcp-tool-test-utils";
+
+const context = fixtures.createMcpToolTestContext();
+
+describe("match_section_codes — 班级代码匹配", () => {
+  it("在当前学期匹配单个班级代码", async () => {
+    const result = await context.client.call<{
+      success?: boolean;
+      semester?: { id?: number; nameCn?: string; code?: string };
+      matchedCodes?: string[];
+      unmatchedCodes?: string[];
+      suggestions?: Record<string, unknown>;
+      sections?: Array<{ code?: string; jwId?: number }>;
+      total?: number;
+      note?: string;
+    }>("match_section_codes", {
+      codes: [fixtures.DEV_SEED.section.code],
+      locale: "zh-cn",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.semester?.nameCn).toBe(fixtures.DEV_SEED.semesterNameCn);
+    expect(result.matchedCodes).toContain(fixtures.DEV_SEED.section.code);
+    expect(result.unmatchedCodes).toEqual([]);
+    expect(result.total).toBe(1);
+    expect(result.sections?.[0]?.code).toBe(fixtures.DEV_SEED.section.code);
+    expect(result.note).toContain("Life@USTC");
+  });
+
+  it("支持多个代码并区分匹配与未匹配，且为未匹配代码提供建议", async () => {
+    const unmatchedCode = fixtures.DEV_SEED.section.code.replace(
+      /\.\d+$/,
+      ".02",
+    );
+
+    const result = await context.client.call<{
+      success?: boolean;
+      matchedCodes?: string[];
+      unmatchedCodes?: string[];
+      suggestions?: Record<string, string[]>;
+      total?: number;
+    }>("match_section_codes", {
+      codes: [fixtures.DEV_SEED.section.code, unmatchedCode],
+      locale: "zh-cn",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.matchedCodes).toContain(fixtures.DEV_SEED.section.code);
+    expect(result.matchedCodes).not.toContain(unmatchedCode);
+    expect(result.unmatchedCodes).toContain(unmatchedCode);
+    expect(result.total).toBe(1);
+    expect(result.suggestions?.[unmatchedCode]).toContain(
+      fixtures.DEV_SEED.section.code,
+    );
+  });
+
+  it("可按 semesterId 查询历史学期班级代码", async () => {
+    const previousSemester = await fixtures.prisma.semester.findUnique({
+      where: { jwId: fixtures.DEV_SEED.previousSemesterJwId },
+      select: { id: true, nameCn: true },
+    });
+    expect(previousSemester).toBeTruthy();
+
+    const previousSection = fixtures.DEV_SEED.sections.find(
+      (section) => section.code === "MATH2001.01",
+    );
+    expect(previousSection).toBeTruthy();
+    if (!previousSemester || !previousSection) {
+      throw new Error("Previous semester or section seed data missing");
+    }
+
+    const result = await context.client.call<{
+      success?: boolean;
+      semester?: { id?: number; nameCn?: string };
+      matchedCodes?: string[];
+      unmatchedCodes?: string[];
+      total?: number;
+    }>("match_section_codes", {
+      codes: [previousSection.code],
+      semesterId: previousSemester.id,
+      locale: "zh-cn",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.semester?.id).toBe(previousSemester.id);
+    expect(result.semester?.nameCn).toBe(
+      fixtures.DEV_SEED.previousSemesterNameCn,
+    );
+    expect(result.matchedCodes).toContain(previousSection.code);
+    expect(result.unmatchedCodes).toEqual([]);
+    expect(result.total).toBe(1);
+  });
+
+  it("在 semesterId 不存在时返回失败提示", async () => {
+    const result = await context.client.call<{
+      success?: boolean;
+      message?: string;
+    }>("match_section_codes", {
+      codes: [fixtures.DEV_SEED.section.code],
+      semesterId: 2_147_483_647,
+      locale: "zh-cn",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("No semester found");
+  });
+
+  it("拒绝空代码数组", async () => {
+    await expect(
+      context.client.call("match_section_codes", {
+        codes: [],
+        locale: "zh-cn",
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("拒绝非法格式班级代码", async () => {
+    await expect(
+      context.client.call("match_section_codes", {
+        codes: ["bad code!"],
+        locale: "zh-cn",
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/integration/mcp-16-homework-mutations.test.ts
+++ b/tests/integration/mcp-16-homework-mutations.test.ts
@@ -1,0 +1,515 @@
+import { describe, expect, it } from "vitest";
+import { createMcpHarness } from "./utils/mcp-harness";
+import * as fixtures from "./utils/mcp-tool-test-utils";
+
+const context = fixtures.createMcpToolTestContext();
+
+describe("班级作业写入工具 — create_homework_on_section", () => {
+  async function deleteIntegrationHomework(homeworkId: string | undefined) {
+    if (!homeworkId) return;
+    await fixtures.prisma.homeworkCompletion.deleteMany({
+      where: { homeworkId },
+    });
+    await fixtures.prisma.homeworkAuditLog.deleteMany({
+      where: { homeworkId },
+    });
+    await fixtures.prisma.descriptionEdit.deleteMany({
+      where: { description: { homeworkId } },
+    });
+    await fixtures.prisma.description.deleteMany({
+      where: { homeworkId },
+    });
+    await fixtures.prisma.homework.deleteMany({ where: { id: homeworkId } });
+  }
+
+  it("create_homework_on_section 创建作业并返回完整实体", async () => {
+    const marker = `[integration-test] mcp-create-homework-${Date.now()}`;
+    const title = `${marker} title`;
+    let homeworkId: string | undefined;
+
+    try {
+      const result = await context.client.call<{
+        success?: boolean;
+        id?: string;
+        homework?: {
+          id?: string;
+          title?: string;
+          sectionId?: number;
+          isMajor?: boolean;
+          requiresTeam?: boolean;
+          publishedAt?: string;
+          submissionStartAt?: string;
+          submissionDueAt?: string;
+          description?: { content?: string | null } | null;
+          completion?: { completed?: boolean } | null;
+        };
+      }>("create_homework_on_section", {
+        sectionJwId: fixtures.DEV_SEED.section.jwId,
+        title,
+        description: `${marker} description`,
+        isMajor: true,
+        requiresTeam: true,
+        publishedAt: fixtures.SEED_PLUS_THREE_DAYS,
+        submissionStartAt: fixtures.SEED_PLUS_SIX_DAYS,
+        submissionDueAt: fixtures.SEED_PLUS_SEVEN_DAYS,
+        locale: "zh-cn",
+        mode: "full",
+      });
+
+      expect(result.success).toBe(true);
+      expect(typeof result.id).toBe("string");
+      homeworkId = result.id;
+
+      expect(result.homework).toMatchObject({
+        id: homeworkId,
+        title,
+        isMajor: true,
+        requiresTeam: true,
+        description: { content: `${marker} description` },
+        completion: null,
+      });
+      expect(result.homework?.sectionId).toBeGreaterThan(0);
+      expect(result.homework?.publishedAt).toMatch(/\+08:00$/);
+      expect(result.homework?.submissionStartAt).toMatch(/\+08:00$/);
+      expect(result.homework?.submissionDueAt).toMatch(/\+08:00$/);
+
+      const audit = await fixtures.prisma.homeworkAuditLog.findFirst({
+        where: {
+          homeworkId,
+          action: "created",
+          actorId: context.devUserId,
+        },
+      });
+      expect(audit).toBeTruthy();
+    } finally {
+      await deleteIntegrationHomework(homeworkId);
+    }
+  });
+
+  it("create_homework_on_section 对不存在的班级返回恢复提示", async () => {
+    const result = await context.client.call<{
+      success?: boolean;
+      found?: boolean;
+      message?: string;
+      hint?: string;
+    }>("create_homework_on_section", {
+      sectionJwId: 2_147_483_647,
+      title: "[integration-test] missing section",
+      publishedAt: fixtures.SEED_PLUS_THREE_DAYS,
+      submissionStartAt: fixtures.SEED_PLUS_SIX_DAYS,
+      submissionDueAt: fixtures.SEED_PLUS_SEVEN_DAYS,
+      locale: "zh-cn",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.found).toBe(false);
+    expect(result.message).toContain("2147483647");
+    expect(result.hint).toContain("search_sections");
+  });
+
+  it("create_homework_on_section 拒绝非法日期输入", async () => {
+    const result = await context.client.call<{
+      success?: boolean;
+      message?: string;
+    }>("create_homework_on_section", {
+      sectionJwId: fixtures.DEV_SEED.section.jwId,
+      title: "[integration-test] bad date",
+      publishedAt: "not-a-date",
+      submissionStartAt: fixtures.SEED_PLUS_SIX_DAYS,
+      submissionDueAt: fixtures.SEED_PLUS_SEVEN_DAYS,
+      locale: "zh-cn",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Invalid publishedAt");
+  });
+
+  it("create_homework_on_section 校验提交开始不晚于截止时间", async () => {
+    const result = await context.client.call<{
+      success?: boolean;
+      message?: string;
+    }>("create_homework_on_section", {
+      sectionJwId: fixtures.DEV_SEED.section.jwId,
+      title: "[integration-test] inverted dates",
+      publishedAt: fixtures.SEED_PLUS_THREE_DAYS,
+      submissionStartAt: fixtures.SEED_PLUS_SEVEN_DAYS,
+      submissionDueAt: fixtures.SEED_PLUS_SIX_DAYS,
+      locale: "zh-cn",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Submission start must be before due");
+  });
+
+  it("create_homework_on_section 拒绝被禁用户创建", async () => {
+    const suspendedUser = await fixtures.prisma.user.create({
+      data: {
+        email: fixtures.integrationUserEmail("mcp-create-homework-suspended"),
+        name: "MCP Create Homework Suspended",
+      },
+      select: { id: true },
+    });
+    const suspension = await fixtures.prisma.userSuspension.create({
+      data: {
+        userId: suspendedUser.id,
+        createdById: context.devUserId,
+        reason: "integration suspended",
+      },
+    });
+    const suspendedMcp = await createMcpHarness(suspendedUser.id);
+
+    try {
+      const result = await suspendedMcp.call<{
+        success?: boolean;
+        message?: string;
+        reason?: string | null;
+      }>("create_homework_on_section", {
+        sectionJwId: fixtures.DEV_SEED.section.jwId,
+        title: "[integration-test] suspended create",
+        publishedAt: fixtures.SEED_PLUS_THREE_DAYS,
+        submissionStartAt: fixtures.SEED_PLUS_SIX_DAYS,
+        submissionDueAt: fixtures.SEED_PLUS_SEVEN_DAYS,
+        locale: "zh-cn",
+      });
+
+      expect(result).toMatchObject({
+        success: false,
+        message: "Suspended",
+        reason: "integration suspended",
+      });
+    } finally {
+      await suspendedMcp.close();
+      await fixtures.prisma.userSuspension.deleteMany({
+        where: { id: suspension.id },
+      });
+      await fixtures.prisma.user.deleteMany({
+        where: { id: suspendedUser.id },
+      });
+    }
+  });
+});
+
+describe("班级作业更新工具 — update_homework_on_section", () => {
+  async function deleteIntegrationHomework(homeworkId: string | undefined) {
+    if (!homeworkId) return;
+    await fixtures.prisma.homeworkCompletion.deleteMany({
+      where: { homeworkId },
+    });
+    await fixtures.prisma.homeworkAuditLog.deleteMany({
+      where: { homeworkId },
+    });
+    await fixtures.prisma.descriptionEdit.deleteMany({
+      where: { description: { homeworkId } },
+    });
+    await fixtures.prisma.description.deleteMany({
+      where: { homeworkId },
+    });
+    await fixtures.prisma.homework.deleteMany({ where: { id: homeworkId } });
+  }
+
+  async function createHomeworkForUpdate(testName: string) {
+    const result = await context.client.call<{
+      success?: boolean;
+      id?: string;
+    }>("create_homework_on_section", {
+      sectionJwId: fixtures.DEV_SEED.section.jwId,
+      title: `[integration-test] ${testName} ${Date.now()}`,
+      description: "original description",
+      publishedAt: fixtures.SEED_PLUS_THREE_DAYS,
+      submissionStartAt: fixtures.SEED_PLUS_SIX_DAYS,
+      submissionDueAt: fixtures.SEED_PLUS_SEVEN_DAYS,
+      locale: "zh-cn",
+      mode: "full",
+    });
+    expect(result.success).toBe(true);
+    return result.id as string;
+  }
+
+  it("update_homework_on_section 更新标题、描述、标志与日期并返回完整实体", async () => {
+    const homeworkId = await createHomeworkForUpdate("update full");
+    const marker = `[integration-test] mcp-update-homework-${Date.now()}`;
+
+    try {
+      const result = await context.client.call<{
+        success?: boolean;
+        homework?: {
+          id?: string;
+          title?: string;
+          isMajor?: boolean;
+          requiresTeam?: boolean;
+          publishedAt?: string;
+          submissionStartAt?: string;
+          submissionDueAt?: string;
+          description?: { content?: string | null } | null;
+        };
+      }>("update_homework_on_section", {
+        homeworkId,
+        title: `${marker} updated`,
+        description: `${marker} updated description`,
+        isMajor: true,
+        requiresTeam: true,
+        publishedAt: fixtures.SEED_PLUS_SIX_DAYS,
+        submissionStartAt: fixtures.SEED_PLUS_SEVEN_DAYS,
+        submissionDueAt: fixtures.SEED_PLUS_ELEVEN_DAYS,
+        locale: "zh-cn",
+        mode: "full",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.homework).toMatchObject({
+        id: homeworkId,
+        title: `${marker} updated`,
+        isMajor: true,
+        requiresTeam: true,
+        description: { content: `${marker} updated description` },
+      });
+      expect(result.homework?.publishedAt).toContain(
+        fixtures.SEED_PLUS_SIX_DAYS,
+      );
+      expect(result.homework?.submissionStartAt).toContain(
+        fixtures.SEED_PLUS_SEVEN_DAYS,
+      );
+      expect(result.homework?.submissionDueAt).toContain(
+        fixtures.SEED_PLUS_ELEVEN_DAYS,
+      );
+    } finally {
+      await deleteIntegrationHomework(homeworkId);
+    }
+  });
+
+  it("update_homework_on_section 对不存在作业返回恢复提示", async () => {
+    const result = await context.client.call<{
+      success?: boolean;
+      message?: string;
+      hint?: string;
+    }>("update_homework_on_section", {
+      homeworkId: "missing-homework-id",
+      title: "updated",
+      locale: "zh-cn",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Homework not found");
+    expect(result.hint).toContain("list_homeworks_by_section");
+  });
+
+  it("update_homework_on_section 无变更时返回无变化", async () => {
+    const homeworkId = await createHomeworkForUpdate("no changes");
+
+    try {
+      const result = await context.client.call<{
+        success?: boolean;
+        message?: string;
+      }>("update_homework_on_section", {
+        homeworkId,
+        locale: "zh-cn",
+        mode: "full",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("No changes");
+    } finally {
+      await deleteIntegrationHomework(homeworkId);
+    }
+  });
+
+  it("update_homework_on_section 拒绝更新已删除作业", async () => {
+    const homeworkId = await createHomeworkForUpdate("deleted");
+
+    try {
+      await context.client.call("delete_homework_on_section", {
+        homeworkId,
+      });
+
+      const result = await context.client.call<{
+        success?: boolean;
+        message?: string;
+      }>("update_homework_on_section", {
+        homeworkId,
+        title: "should fail",
+        locale: "zh-cn",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Homework deleted");
+    } finally {
+      await deleteIntegrationHomework(homeworkId);
+    }
+  });
+
+  it("update_homework_on_section 校验提交开始不晚于截止时间", async () => {
+    const homeworkId = await createHomeworkForUpdate("inverted dates");
+
+    try {
+      const result = await context.client.call<{
+        success?: boolean;
+        message?: string;
+      }>("update_homework_on_section", {
+        homeworkId,
+        submissionStartAt: fixtures.SEED_PLUS_SEVEN_DAYS,
+        submissionDueAt: fixtures.SEED_PLUS_SIX_DAYS,
+        locale: "zh-cn",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Submission start must be before due");
+    } finally {
+      await deleteIntegrationHomework(homeworkId);
+    }
+  });
+});
+
+describe("作业完成状态工具 — set_my_homework_completion", () => {
+  async function deleteIntegrationHomework(homeworkId: string | undefined) {
+    if (!homeworkId) return;
+    await fixtures.prisma.homeworkCompletion.deleteMany({
+      where: { homeworkId },
+    });
+    await fixtures.prisma.homeworkAuditLog.deleteMany({
+      where: { homeworkId },
+    });
+    await fixtures.prisma.descriptionEdit.deleteMany({
+      where: { description: { homeworkId } },
+    });
+    await fixtures.prisma.description.deleteMany({
+      where: { homeworkId },
+    });
+    await fixtures.prisma.homework.deleteMany({ where: { id: homeworkId } });
+  }
+
+  async function createHomeworkForCompletion(testName: string) {
+    const result = await context.client.call<{
+      success?: boolean;
+      id?: string;
+    }>("create_homework_on_section", {
+      sectionJwId: fixtures.DEV_SEED.section.jwId,
+      title: `[integration-test] ${testName} ${Date.now()}`,
+      publishedAt: fixtures.SEED_PLUS_THREE_DAYS,
+      submissionStartAt: fixtures.SEED_PLUS_SIX_DAYS,
+      submissionDueAt: fixtures.SEED_PLUS_SEVEN_DAYS,
+      locale: "zh-cn",
+      mode: "full",
+    });
+    expect(result.success).toBe(true);
+    return result.id as string;
+  }
+
+  it("set_my_homework_completion 标记完成并返回完成时间", async () => {
+    const homeworkId = await createHomeworkForCompletion("complete");
+
+    try {
+      const result = await context.client.call<{
+        success?: boolean;
+        completion?: {
+          homeworkId?: string;
+          completed?: boolean;
+          completedAt?: string | null;
+        };
+      }>("set_my_homework_completion", {
+        homeworkId,
+        completed: true,
+        mode: "full",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.completion).toMatchObject({
+        homeworkId,
+        completed: true,
+      });
+      expect(result.completion?.completedAt).toMatch(/\+08:00$/);
+
+      const record = await fixtures.prisma.homeworkCompletion.findUnique({
+        where: {
+          userId_homeworkId: {
+            userId: context.devUserId,
+            homeworkId,
+          },
+        },
+      });
+      expect(record).toBeTruthy();
+    } finally {
+      await deleteIntegrationHomework(homeworkId);
+    }
+  });
+
+  it("set_my_homework_completion 取消完成状态", async () => {
+    const homeworkId = await createHomeworkForCompletion("revert");
+
+    try {
+      await context.client.call("set_my_homework_completion", {
+        homeworkId,
+        completed: true,
+      });
+
+      const result = await context.client.call<{
+        success?: boolean;
+        completion?: {
+          homeworkId?: string;
+          completed?: boolean;
+          completedAt?: string | null;
+        };
+      }>("set_my_homework_completion", {
+        homeworkId,
+        completed: false,
+        mode: "full",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.completion).toMatchObject({
+        homeworkId,
+        completed: false,
+        completedAt: null,
+      });
+
+      const record = await fixtures.prisma.homeworkCompletion.findUnique({
+        where: {
+          userId_homeworkId: {
+            userId: context.devUserId,
+            homeworkId,
+          },
+        },
+      });
+      expect(record).toBeNull();
+    } finally {
+      await deleteIntegrationHomework(homeworkId);
+    }
+  });
+
+  it("set_my_homework_completion 对不存在作业返回恢复提示", async () => {
+    const result = await context.client.call<{
+      success?: boolean;
+      message?: string;
+      hint?: string;
+    }>("set_my_homework_completion", {
+      homeworkId: "missing-homework-id",
+      completed: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Homework not found");
+    expect(result.hint).toContain("list_my_homeworks");
+  });
+
+  it("set_my_homework_completion 对已删除作业报告未找到", async () => {
+    const homeworkId = await createHomeworkForCompletion("deleted");
+
+    try {
+      await context.client.call("delete_homework_on_section", {
+        homeworkId,
+      });
+
+      const result = await context.client.call<{
+        success?: boolean;
+        message?: string;
+      }>("set_my_homework_completion", {
+        homeworkId,
+        completed: true,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBe("Homework not found");
+    } finally {
+      await deleteIntegrationHomework(homeworkId);
+    }
+  });
+});

--- a/tests/integration/mcp-17-bus-timetable.test.ts
+++ b/tests/integration/mcp-17-bus-timetable.test.ts
@@ -1,0 +1,336 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { createMcpServer } from "@/lib/mcp/server";
+import * as fixtures from "./utils/mcp-tool-test-utils";
+
+const context = fixtures.createMcpToolTestContext();
+
+async function createAnonymousMcpHarness() {
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const mcpServer = createMcpServer();
+  const client = new Client({
+    name: "integration-test-anonymous",
+    version: "1.0.0",
+  });
+
+  await mcpServer.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  function isTextContentItem(
+    value: unknown,
+  ): value is { type: "text"; text: string } {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      "type" in value &&
+      value.type === "text" &&
+      "text" in value &&
+      typeof value.text === "string"
+    );
+  }
+
+  async function call<T = Record<string, unknown>>(
+    name: string,
+    args: Record<string, unknown> = {},
+  ): Promise<T> {
+    const result = await client.callTool({ name, arguments: args });
+    const content = Array.isArray(result.content) ? result.content : [];
+    const textItem = content.find(isTextContentItem);
+    if (!textItem) {
+      throw new Error("MCP tool returned no text content");
+    }
+    return JSON.parse(textItem.text) as T;
+  }
+
+  async function close() {
+    await client.close();
+  }
+
+  return { call, close };
+}
+
+describe("query_bus_timetable", () => {
+  it("默认模式返回班车数据集的计数、校区与路线摘要", async () => {
+    const result = await context.client.call<{
+      locale?: string;
+      fetchedAt?: string;
+      version?: { key?: string; title?: string } | null;
+      counts?: {
+        campuses?: number;
+        routes?: number;
+        weekdayTrips?: number;
+        weekendTrips?: number;
+      };
+      campuses?: Array<{ id?: number; namePrimary?: string }>;
+      routes?: Array<{ id?: number; nameCn?: string }>;
+      preferences?: {
+        preferredOriginCampusId?: number | null;
+        preferredDestinationCampusId?: number | null;
+        showDepartedTrips?: boolean;
+      };
+      nextDepartures?: unknown[];
+      nextDeparturesMessage?: string | null;
+    }>("query_bus_timetable", {
+      locale: "zh-cn",
+      mode: "default",
+    });
+
+    expect(result.locale).toBe("zh-cn");
+    expect(result.fetchedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(result.version?.key).toBe(fixtures.DEV_SEED.bus.versionKey);
+    expect(result.version?.title).toBe(fixtures.DEV_SEED.bus.versionTitle);
+    expect(typeof result.counts?.campuses).toBe("number");
+    expect(typeof result.counts?.routes).toBe("number");
+    expect(typeof result.counts?.weekdayTrips).toBe("number");
+    expect(typeof result.counts?.weekendTrips).toBe("number");
+    expect(result.campuses?.length).toBeGreaterThan(0);
+    expect(result.routes?.length).toBeGreaterThan(0);
+    expect(
+      result.routes?.some((r) => r.id === fixtures.DEV_SEED.bus.routeId),
+    ).toBe(true);
+    expect(result.preferences).toEqual({
+      preferredOriginCampusId: null,
+      preferredDestinationCampusId: null,
+      showDepartedTrips: false,
+    });
+    expect(Array.isArray(result.nextDepartures)).toBe(true);
+  });
+
+  it("summary 模式仅返回计数、偏好与下一班车摘要", async () => {
+    const result = await context.client.call<{
+      locale?: string;
+      counts?: {
+        campuses?: number;
+        routes?: number;
+        weekdayTrips?: number;
+        weekendTrips?: number;
+      };
+      campuses?: unknown;
+      routes?: unknown;
+      preferences?: {
+        preferredOriginCampusId?: number | null;
+        preferredDestinationCampusId?: number | null;
+        showDepartedTrips?: boolean;
+      };
+      nextDepartures?: unknown[];
+      nextDeparturesMessage?: string | null;
+    }>("query_bus_timetable", {
+      locale: "zh-cn",
+      mode: "summary",
+    });
+
+    expect(result.locale).toBe("zh-cn");
+    expect(typeof result.counts?.routes).toBe("number");
+    expect(result.campuses).toBeUndefined();
+    expect(result.routes).toBeUndefined();
+    expect(result.preferences).toBeDefined();
+    expect(Array.isArray(result.nextDepartures)).toBe(true);
+    expect(typeof result.nextDeparturesMessage).toBe("string");
+  });
+
+  it("full 模式返回完整路线、班次与停靠站信息", async () => {
+    const result = await context.client.call<{
+      locale?: string;
+      version?: { key?: string } | null;
+      campuses?: Array<{
+        id?: number;
+        namePrimary?: string;
+        latitude?: number;
+      }>;
+      routes?: Array<{
+        id?: number;
+        nameCn?: string;
+        stops?: Array<{ stopOrder?: number; campus?: { id?: number } }>;
+      }>;
+      trips?: Array<{
+        id?: number;
+        routeId?: number;
+        dayType?: string;
+        stopTimes?: unknown[];
+      }>;
+      availableVersions?: unknown[];
+    }>("query_bus_timetable", {
+      locale: "zh-cn",
+      mode: "full",
+    });
+
+    expect(result.locale).toBe("zh-cn");
+    expect(result.version?.key).toBe(fixtures.DEV_SEED.bus.versionKey);
+    expect(result.campuses?.length).toBeGreaterThan(0);
+    expect(result.routes?.length).toBeGreaterThan(0);
+    expect(result.trips?.length).toBeGreaterThan(0);
+    expect(result.availableVersions?.length).toBeGreaterThan(0);
+
+    const route = result.routes?.find(
+      (r) => r.id === fixtures.DEV_SEED.bus.routeId,
+    );
+    expect(route).toBeDefined();
+    expect(route?.stops?.length).toBeGreaterThan(0);
+
+    const trip = result.trips?.find(
+      (t) => t.routeId === fixtures.DEV_SEED.bus.routeId,
+    );
+    expect(trip).toBeDefined();
+    expect(trip?.dayType).toMatch(/weekday|weekend/);
+  });
+
+  it("支持通过 versionKey 指定版本", async () => {
+    const result = await context.client.call<{
+      version?: { key?: string } | null;
+    }>("query_bus_timetable", {
+      locale: "zh-cn",
+      versionKey: fixtures.DEV_SEED.bus.versionKey,
+    });
+
+    expect(result.version?.key).toBe(fixtures.DEV_SEED.bus.versionKey);
+  });
+
+  it("未认证调用因缺少用户上下文而被拒绝", async () => {
+    const anonymous = await createAnonymousMcpHarness();
+    try {
+      await expect(
+        anonymous.call("query_bus_timetable", { locale: "zh-cn" }),
+      ).rejects.toThrow();
+    } finally {
+      await anonymous.close();
+    }
+  });
+});
+
+describe("list_bus_routes", () => {
+  it("返回当前生效版本的路线与校区列表", async () => {
+    const result = await context.client.call<{
+      routes?: Array<{
+        id?: number;
+        nameCn?: string;
+        nameEn?: string | null;
+        descriptionPrimary?: string;
+        stops?: Array<{
+          stopOrder?: number;
+          campusId?: number;
+          campusName?: string;
+        }>;
+      }>;
+      campuses?: Array<{
+        id?: number;
+        namePrimary?: string;
+        nameSecondary?: string | null;
+      }>;
+    }>("list_bus_routes", { locale: "zh-cn" });
+
+    expect(result.routes?.length).toBeGreaterThan(0);
+    expect(result.campuses?.length).toBeGreaterThan(0);
+
+    const route = result.routes?.find(
+      (r) => r.id === fixtures.DEV_SEED.bus.routeId,
+    );
+    expect(route).toBeDefined();
+    expect(typeof route?.nameCn).toBe("string");
+    expect(route?.stops?.length).toBeGreaterThan(0);
+    expect(route?.stops?.[0]?.campusId).toBeTypeOf("number");
+    expect(typeof route?.stops?.[0]?.campusName).toBe("string");
+
+    expect(
+      result.campuses?.some(
+        (c) => c.id === fixtures.DEV_SEED.bus.originCampusId,
+      ),
+    ).toBe(true);
+    expect(
+      result.campuses?.some(
+        (c) => c.id === fixtures.DEV_SEED.bus.destinationCampusId,
+      ),
+    ).toBe(true);
+  });
+
+  it("en-us locale 返回英文校区与路线名称", async () => {
+    const result = await context.client.call<{
+      routes?: Array<{ id?: number; nameEn?: string | null }>;
+      campuses?: Array<{ id?: number; namePrimary?: string }>;
+    }>("list_bus_routes", { locale: "en-us" });
+
+    const route = result.routes?.find(
+      (r) => r.id === fixtures.DEV_SEED.bus.routeId,
+    );
+    expect(route?.nameEn).toBeTruthy();
+
+    const campus = result.campuses?.find(
+      (c) => c.id === fixtures.DEV_SEED.bus.originCampusId,
+    );
+    expect(campus?.namePrimary).toBe(fixtures.DEV_SEED.bus.originCampusName);
+  });
+});
+
+describe("get_bus_route_timetable", () => {
+  it("返回指定路线的平日与周末时刻表", async () => {
+    const result = await context.client.call<{
+      route?: {
+        id?: number;
+        nameCn?: string;
+        stops?: Array<{ stopOrder?: number; campusId?: number }>;
+      };
+      weekday?: Array<{
+        position?: number;
+        stopTimes?: Array<{ stopOrder?: number; time?: string | null }>;
+      }>;
+      weekend?: Array<{
+        position?: number;
+        stopTimes?: Array<{ stopOrder?: number; time?: string | null }>;
+      }>;
+      alternateRoutes?: Array<{ id?: number; nameCn?: string }>;
+    }>("get_bus_route_timetable", {
+      routeId: fixtures.DEV_SEED.bus.routeId,
+      locale: "zh-cn",
+      mode: "default",
+    });
+
+    expect(result.route?.id).toBe(fixtures.DEV_SEED.bus.routeId);
+    expect(typeof result.route?.nameCn).toBe("string");
+    expect(result.route?.stops?.length).toBeGreaterThan(0);
+    expect(Array.isArray(result.weekday)).toBe(true);
+    expect(Array.isArray(result.weekend)).toBe(true);
+
+    if (result.weekday && result.weekday.length > 0) {
+      expect(result.weekday[0]?.stopTimes?.length).toBeGreaterThan(0);
+      expect(typeof result.weekday[0]?.stopTimes?.[0]?.time).toBe("string");
+    }
+
+    if (result.weekend && result.weekend.length > 0) {
+      expect(result.weekend[0]?.stopTimes?.length).toBeGreaterThan(0);
+    }
+
+    expect(Array.isArray(result.alternateRoutes)).toBe(true);
+  });
+
+  it("未知路线返回 hasData: false 与 list_bus_routes 提示", async () => {
+    const result = await context.client.call<{
+      routeId?: number;
+      hasData?: boolean;
+      message?: string;
+    }>("get_bus_route_timetable", {
+      routeId: 2_147_483_647,
+      locale: "zh-cn",
+    });
+
+    expect(result.routeId).toBe(2_147_483_647);
+    expect(result.hasData).toBe(false);
+    expect(result.message).toContain("list_bus_routes");
+  });
+
+  it("无效 routeId 触发校验错误", async () => {
+    await expect(
+      context.client.call("get_bus_route_timetable", {
+        routeId: 0,
+        locale: "zh-cn",
+      }),
+    ).rejects.toThrow();
+
+    await expect(
+      context.client.call("get_bus_route_timetable", {
+        routeId: -1,
+        locale: "zh-cn",
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/integration/mcp-18-calendar-subscriptions.test.ts
+++ b/tests/integration/mcp-18-calendar-subscriptions.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import { createMcpHarness } from "./utils/mcp-harness";
+import * as fixtures from "./utils/mcp-tool-test-utils";
+
+const context = fixtures.createMcpToolTestContext();
+
+describe("个人日历订阅 — 读取与批量订阅", () => {
+  it("get_my_calendar_subscription 返回订阅班级与个人 iCal 地址", async () => {
+    await fixtures.ensureDevUserSubscribedToSeedSection();
+
+    const result = await context.client.call<{
+      success?: boolean;
+      subscription?: {
+        userId?: string;
+        sections?: Array<{
+          jwId?: number | null;
+          code?: string | null;
+        }>;
+        calendarPath?: string | null;
+        calendarUrl?: string | null;
+        note?: string;
+      };
+    }>("get_my_calendar_subscription", {
+      locale: "zh-cn",
+      mode: "full",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.subscription?.userId).toBe(context.devUserId);
+    expect(
+      result.subscription?.sections?.some(
+        (section) => section.jwId === fixtures.DEV_SEED.section.jwId,
+      ),
+    ).toBe(true);
+    expect(result.subscription?.calendarPath).toMatch(
+      /\/api\/users\/[^/]+\/calendar\.ics$/,
+    );
+    expect(result.subscription?.calendarUrl).toContain(
+      result.subscription?.calendarPath ?? "",
+    );
+    expect(result.subscription?.note).toContain("not official");
+  });
+
+  it("get_my_calendar_subscription summary 模式仅返回计数与路径", async () => {
+    await fixtures.ensureDevUserSubscribedToSeedSection();
+
+    const result = await context.client.call<{
+      success?: boolean;
+      subscription?: {
+        userId?: string;
+        sectionCount?: number;
+        currentSemesterSectionCount?: number;
+        calendarPath?: string | null;
+        calendarUrl?: string | null;
+        sections?: unknown;
+      };
+    }>("get_my_calendar_subscription", {
+      locale: "zh-cn",
+      mode: "summary",
+    });
+
+    expect(result.success).toBe(true);
+    expect(typeof result.subscription?.sectionCount).toBe("number");
+    expect(typeof result.subscription?.currentSemesterSectionCount).toBe(
+      "number",
+    );
+    expect(result.subscription?.calendarPath).toBeTruthy();
+    expect(result.subscription?.sections).toBeUndefined();
+  });
+
+  it("list_my_subscribed_sections 列出当前订阅班级", async () => {
+    await fixtures.ensureDevUserSubscribedToSeedSection();
+
+    const result = await context.client.call<{
+      success?: boolean;
+      sections?: Array<{
+        jwId?: number | null;
+        code?: string | null;
+        course?: { namePrimary?: string | null } | null;
+      }>;
+      note?: string;
+    }>("list_my_subscribed_sections", {
+      locale: "zh-cn",
+      mode: "full",
+    });
+
+    expect(result.success).toBe(true);
+    expect(
+      result.sections?.some(
+        (section) => section.jwId === fixtures.DEV_SEED.section.jwId,
+      ),
+    ).toBe(true);
+    expect(result.note).toContain("not official");
+  });
+
+  it("get_section_calendar_subscription 按 jwId 返回单班 iCal 信息", async () => {
+    const result = await context.client.call<{
+      found?: boolean;
+      section?: {
+        jwId?: number | null;
+        code?: string | null;
+      } | null;
+      calendarPath?: string;
+      calendarUrl?: string;
+    }>("get_section_calendar_subscription", {
+      jwId: fixtures.DEV_SEED.section.jwId,
+      locale: "zh-cn",
+    });
+
+    expect(result.found).toBe(true);
+    expect(result.section?.jwId).toBe(fixtures.DEV_SEED.section.jwId);
+    expect(result.section?.code).toBe(fixtures.DEV_SEED.section.code);
+    expect(result.calendarPath).toBe(
+      `/api/sections/${fixtures.DEV_SEED.section.jwId}/calendar.ics`,
+    );
+    expect(result.calendarUrl).toContain(result.calendarPath ?? "");
+  });
+
+  it("get_section_calendar_subscription 对缺失 jwId 返回 found=false", async () => {
+    const missingJwId = 2_147_483_647;
+    const result = await context.client.call<{
+      found?: boolean;
+      section?: unknown;
+      calendarPath?: string;
+      calendarUrl?: string;
+    }>("get_section_calendar_subscription", {
+      jwId: missingJwId,
+      locale: "zh-cn",
+    });
+
+    expect(result.found).toBe(false);
+    expect(result.section).toBeNull();
+    expect(result.calendarPath).toBe(
+      `/api/sections/${missingJwId}/calendar.ics`,
+    );
+  });
+
+  it("subscribe_my_sections_by_codes 批量匹配并订阅班级", async () => {
+    await fixtures.replaceUserSubscribedSections(context.devUserId, []);
+
+    const result = await context.client.call<{
+      success?: boolean;
+      semester?: {
+        id?: number;
+        nameCn?: string | null;
+        code?: string | null;
+      } | null;
+      matchedCodes?: string[];
+      unmatchedCodes?: string[];
+      addedCount?: number;
+      alreadySubscribedCount?: number;
+      subscription?: {
+        sections?: unknown[];
+        sectionCount?: number;
+      } | null;
+    }>("subscribe_my_sections_by_codes", {
+      codes: [fixtures.DEV_SEED.section.code],
+      locale: "zh-cn",
+      mode: "full",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.matchedCodes).toContain(fixtures.DEV_SEED.section.code);
+    expect(result.unmatchedCodes).toEqual([]);
+    expect(result.addedCount).toBeGreaterThanOrEqual(1);
+    expect(result.alreadySubscribedCount).toBe(0);
+    expect(
+      (result.subscription?.sections?.length ??
+        result.subscription?.sectionCount ??
+        0) > 0,
+    ).toBe(true);
+  });
+
+  it("subscribe_my_sections_by_codes 跳过已订阅班级", async () => {
+    await fixtures.ensureDevUserSubscribedToSeedSection();
+
+    const result = await context.client.call<{
+      success?: boolean;
+      matchedCodes?: string[];
+      unmatchedCodes?: string[];
+      addedCount?: number;
+      alreadySubscribedCount?: number;
+    }>("subscribe_my_sections_by_codes", {
+      codes: [fixtures.DEV_SEED.section.code],
+      locale: "zh-cn",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.matchedCodes).toContain(fixtures.DEV_SEED.section.code);
+    expect(result.addedCount).toBe(0);
+    expect(result.alreadySubscribedCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("subscribe_my_sections_by_codes 报告未匹配代码", async () => {
+    const marker = `MISSING${Date.now()}.01`;
+
+    const result = await context.client.call<{
+      success?: boolean;
+      matchedCodes?: string[];
+      unmatchedCodes?: string[];
+      addedCount?: number;
+      alreadySubscribedCount?: number;
+    }>("subscribe_my_sections_by_codes", {
+      codes: [marker],
+      locale: "zh-cn",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.matchedCodes).toEqual([]);
+    expect(result.unmatchedCodes).toContain(marker);
+    expect(result.addedCount).toBe(0);
+    expect(result.alreadySubscribedCount).toBe(0);
+  });
+
+  it("subscribe_my_sections_by_codes 对不存在的学期返回失败", async () => {
+    const result = await context.client.call<{
+      success?: boolean;
+      message?: string;
+    }>("subscribe_my_sections_by_codes", {
+      codes: [fixtures.DEV_SEED.section.code],
+      semesterId: 2_147_483_647,
+      locale: "zh-cn",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("No semester found");
+  });
+
+  it("subscribe_my_sections_by_codes 拒绝空代码列表", async () => {
+    await expect(
+      context.client.call("subscribe_my_sections_by_codes", {
+        codes: [],
+        locale: "zh-cn",
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("get_my_calendar_subscription 对不存在用户返回失败", async () => {
+    const missingUserMcp = await createMcpHarness("missing-user-id");
+    try {
+      const result = await missingUserMcp.call<{
+        success?: boolean;
+        message?: string;
+      }>("get_my_calendar_subscription", {
+        locale: "zh-cn",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("User not found");
+    } finally {
+      await missingUserMcp.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds integration tests for the MCP tools that were identified as uncovered in the agent-swarm inspection from #310.

## New coverage

- mcp-13-catalog-search.test.ts: search_sections, get_course_by_jw_id
- mcp-14-teacher.test.ts: search_teachers, get_teacher_by_id
- mcp-15-section-match.test.ts: match_section_codes
- mcp-16-homework-mutations.test.ts: create_homework_on_section, update_homework_on_section, set_my_homework_completion
- mcp-17-bus-timetable.test.ts: query_bus_timetable, list_bus_routes, get_bus_route_timetable
- mcp-18-calendar-subscriptions.test.ts: get_my_calendar_subscription, list_my_subscribed_sections, get_section_calendar_subscription, subscribe_my_sections_by_codes

All test names are in Chinese and follow the existing MCP integration pattern.

## Verification

- bunx biome check passed
- bunx tsc --noEmit -p tsconfig.typecheck.tests.json passed
- bunx vitest run --config vitest.integration.config.ts on the 6 new files passed (56 tests)
