### PR TITLE
test(unit): cover catalog search, calendar window, and dashboard serialization gaps

### DIFF
--- a/tests/unit/calendar-event-window-and-merging.test.ts
+++ b/tests/unit/calendar-event-window-and-merging.test.ts
@@ -1,0 +1,486 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { loadCalendarEventSourcesMock } = vi.hoisted(() => ({
+  loadCalendarEventSourcesMock: vi.fn(),
+}));
+
+vi.mock("@/features/calendar/server/calendar-event-sources", () => ({
+  loadCalendarEventSources: loadCalendarEventSourcesMock,
+}));
+
+import {
+  mapExamCalendarEvent,
+  mapHomeworkCalendarEvent,
+  mapScheduleCalendarEvent,
+  mapTodoCalendarEvent,
+} from "@/features/calendar/server/calendar-event-mappers";
+import {
+  isWithinExactWindow,
+  resolveCalendarEventWindow,
+} from "@/features/calendar/server/calendar-event-window";
+import { listUserCalendarEvents } from "@/features/calendar/server/calendar-events";
+
+function shanghaiDate(iso: string) {
+  return new Date(iso);
+}
+
+describe("日历事件窗口解析", () => {
+  it("无参数时使用当天上海午夜并默认覆盖 7 天", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-21T16:00:00.000Z"));
+
+    try {
+      const window = resolveCalendarEventWindow({
+        dateFromIsDateOnly: false,
+        dateToInclusive: false,
+        dateToIsDateOnly: false,
+      });
+
+      expect(window.windowStart.toISOString()).toBe("2026-05-21T16:00:00.000Z");
+      expect(window.windowEnd.toISOString()).toBe("2026-05-28T16:00:00.000Z");
+      expect(window.calendarDateStart.toISOString()).toBe(
+        "2026-05-21T16:00:00.000Z",
+      );
+      expect(window.calendarDateEnd.toISOString()).toBe(
+        "2026-05-29T16:00:00.000Z",
+      );
+      expect(window.includeWindowEnd).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dateFrom 仅日期时归到该上海日开始", () => {
+    const window = resolveCalendarEventWindow({
+      dateFrom: shanghaiDate("2026-05-22"),
+      dateFromIsDateOnly: true,
+      dateToInclusive: false,
+      dateToIsDateOnly: false,
+    });
+
+    expect(window.windowStart.toISOString()).toBe("2026-05-21T16:00:00.000Z");
+    expect(window.calendarDateStart.toISOString()).toBe(
+      "2026-05-21T16:00:00.000Z",
+    );
+    expect(window.windowEnd.toISOString()).toBe("2026-05-28T16:00:00.000Z");
+    expect(window.includeWindowEnd).toBe(false);
+  });
+
+  it("dateFrom 含时间时保留时间但 calendarDateStart 仍归到日开始", () => {
+    const window = resolveCalendarEventWindow({
+      dateFrom: shanghaiDate("2026-05-22T10:30:00+08:00"),
+      dateFromIsDateOnly: false,
+      dateToInclusive: false,
+      dateToIsDateOnly: false,
+    });
+
+    expect(window.windowStart.toISOString()).toBe("2026-05-22T02:30:00.000Z");
+    expect(window.calendarDateStart.toISOString()).toBe(
+      "2026-05-21T16:00:00.000Z",
+    );
+  });
+
+  it("dateTo 仅日期时延伸到次日零点的日历窗口", () => {
+    const window = resolveCalendarEventWindow({
+      dateFrom: shanghaiDate("2026-05-22"),
+      dateFromIsDateOnly: true,
+      dateTo: shanghaiDate("2026-05-25"),
+      dateToInclusive: false,
+      dateToIsDateOnly: true,
+    });
+
+    expect(window.windowEnd.toISOString()).toBe("2026-05-25T16:00:00.000Z");
+    expect(window.calendarDateEnd.toISOString()).toBe(
+      "2026-05-26T16:00:00.000Z",
+    );
+    expect(window.includeWindowEnd).toBe(false);
+  });
+
+  it("dateTo 含时间且 inclusive 时包含边界", () => {
+    const window = resolveCalendarEventWindow({
+      dateFrom: shanghaiDate("2026-05-22T00:00:00+08:00"),
+      dateFromIsDateOnly: false,
+      dateTo: shanghaiDate("2026-05-25T18:00:00+08:00"),
+      dateToInclusive: true,
+      dateToIsDateOnly: false,
+    });
+
+    expect(window.windowEnd.toISOString()).toBe("2026-05-25T10:00:00.000Z");
+    expect(window.includeWindowEnd).toBe(true);
+  });
+
+  it("dateTo 含时间且非 inclusive 时不包含边界", () => {
+    const window = resolveCalendarEventWindow({
+      dateFrom: shanghaiDate("2026-05-22T00:00:00+08:00"),
+      dateFromIsDateOnly: false,
+      dateTo: shanghaiDate("2026-05-25T18:00:00+08:00"),
+      dateToInclusive: false,
+      dateToIsDateOnly: false,
+    });
+
+    expect(window.windowEnd.toISOString()).toBe("2026-05-25T10:00:00.000Z");
+    expect(window.includeWindowEnd).toBe(false);
+  });
+});
+
+describe("日历事件窗口命中判断", () => {
+  const windowStart = shanghaiDate("2026-05-22T00:00:00+08:00");
+  const windowEnd = shanghaiDate("2026-05-25T00:00:00+08:00");
+
+  it("overlap 模式在事件与窗口相交时命中", () => {
+    expect(
+      isWithinExactWindow(
+        {
+          start: shanghaiDate("2026-05-21T20:00:00+08:00"),
+          end: shanghaiDate("2026-05-22T04:00:00+08:00"),
+        },
+        windowStart,
+        windowEnd,
+        false,
+        "overlap",
+      ),
+    ).toBe(true);
+
+    expect(
+      isWithinExactWindow(
+        {
+          start: shanghaiDate("2026-05-22T08:00:00+08:00"),
+          end: shanghaiDate("2026-05-22T10:00:00+08:00"),
+        },
+        windowStart,
+        windowEnd,
+        false,
+        "overlap",
+      ),
+    ).toBe(true);
+  });
+
+  it("overlap 模式在事件完全在窗口外时未命中", () => {
+    expect(
+      isWithinExactWindow(
+        {
+          start: shanghaiDate("2026-05-25T08:00:00+08:00"),
+          end: shanghaiDate("2026-05-25T10:00:00+08:00"),
+        },
+        windowStart,
+        windowEnd,
+        false,
+        "overlap",
+      ),
+    ).toBe(false);
+
+    expect(
+      isWithinExactWindow(
+        {
+          start: shanghaiDate("2026-05-21T08:00:00+08:00"),
+          end: shanghaiDate("2026-05-21T10:00:00+08:00"),
+        },
+        windowStart,
+        windowEnd,
+        false,
+        "overlap",
+      ),
+    ).toBe(false);
+  });
+
+  it("overlap 模式无结束时间时退化为按开始时间判断", () => {
+    expect(
+      isWithinExactWindow(
+        { start: shanghaiDate("2026-05-22T08:00:00+08:00"), end: null },
+        windowStart,
+        windowEnd,
+        false,
+        "overlap",
+      ),
+    ).toBe(true);
+
+    expect(
+      isWithinExactWindow(
+        { start: shanghaiDate("2026-05-25T08:00:00+08:00"), end: null },
+        windowStart,
+        windowEnd,
+        false,
+        "overlap",
+      ),
+    ).toBe(false);
+  });
+
+  it("start 模式仅按事件开始时间判断", () => {
+    expect(
+      isWithinExactWindow(
+        {
+          start: shanghaiDate("2026-05-22T00:00:00+08:00"),
+          end: shanghaiDate("2026-05-22T02:00:00+08:00"),
+        },
+        windowStart,
+        windowEnd,
+        false,
+        "start",
+      ),
+    ).toBe(true);
+
+    expect(
+      isWithinExactWindow(
+        {
+          start: shanghaiDate("2026-05-21T20:00:00+08:00"),
+          end: shanghaiDate("2026-05-22T04:00:00+08:00"),
+        },
+        windowStart,
+        windowEnd,
+        false,
+        "start",
+      ),
+    ).toBe(false);
+  });
+
+  it("includeWindowEnd 为 true 时包含结束边界", () => {
+    expect(
+      isWithinExactWindow(
+        {
+          start: shanghaiDate("2026-05-25T00:00:00+08:00"),
+          end: shanghaiDate("2026-05-25T02:00:00+08:00"),
+        },
+        windowStart,
+        windowEnd,
+        true,
+        "start",
+      ),
+    ).toBe(true);
+
+    expect(
+      isWithinExactWindow(
+        {
+          start: shanghaiDate("2026-05-25T00:00:00+08:00"),
+          end: shanghaiDate("2026-05-25T02:00:00+08:00"),
+        },
+        windowStart,
+        windowEnd,
+        false,
+        "start",
+      ),
+    ).toBe(false);
+  });
+
+  it("开始时间为 null 或 NaN 时安全返回 false", () => {
+    expect(
+      isWithinExactWindow(
+        { start: null, end: shanghaiDate("2026-05-22T10:00:00+08:00") },
+        windowStart,
+        windowEnd,
+        false,
+        "overlap",
+      ),
+    ).toBe(false);
+
+    expect(
+      isWithinExactWindow(
+        { start: new Date(NaN), end: null },
+        windowStart,
+        windowEnd,
+        false,
+        "start",
+      ),
+    ).toBe(false);
+
+    expect(
+      isWithinExactWindow(
+        {
+          start: shanghaiDate("2026-05-22T08:00:00+08:00"),
+          end: new Date(NaN),
+        },
+        windowStart,
+        windowEnd,
+        false,
+        "overlap",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("日历事件源映射", () => {
+  it("将 schedule 的日期和时间组合为上海 ISO 字符串", () => {
+    const event = mapScheduleCalendarEvent({
+      date: shanghaiDate("2026-05-22"),
+      endTime: 1000,
+      startTime: 800,
+    });
+
+    expect(event.type).toBe("schedule");
+    expect(event.at).toBe("2026-05-22T08:00:00+08:00");
+    expect(event.filterStart?.toISOString()).toBe("2026-05-22T00:00:00.000Z");
+    expect(event.filterEnd?.toISOString()).toBe("2026-05-22T02:00:00.000Z");
+    expect(event.sortKey).toBe(event.filterStart?.getTime());
+  });
+
+  it("schedule 缺少日期时返回 null 时间并放到排序末尾", () => {
+    const event = mapScheduleCalendarEvent({
+      date: null,
+      endTime: 1000,
+      startTime: 800,
+    });
+
+    expect(event.at).toBeNull();
+    expect(event.filterStart).toBeNull();
+    expect(event.sortKey).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("将 homework 的 submissionDueAt 序列化为上海 ISO 字符串", () => {
+    const event = mapHomeworkCalendarEvent({
+      submissionDueAt: shanghaiDate("2026-05-22T23:00:00+08:00"),
+    });
+
+    expect(event.type).toBe("homework_due");
+    expect(event.at).toBe("2026-05-22T23:00:00+08:00");
+    expect(event.filterEnd).toBeNull();
+  });
+
+  it("将 exam 的日期和时间组合，无结束时间时延伸为全天", () => {
+    const event = mapExamCalendarEvent({
+      endTime: 1100,
+      examDate: shanghaiDate("2026-05-22"),
+      startTime: 900,
+    });
+
+    expect(event.type).toBe("exam");
+    expect(event.at).toBe("2026-05-22T09:00:00+08:00");
+    expect(event.filterEnd?.toISOString()).toBe("2026-05-22T03:00:00.000Z");
+  });
+
+  it("将 exam 的开始和结束时间均为空时视为全天事件", () => {
+    const event = mapExamCalendarEvent({
+      endTime: null,
+      examDate: shanghaiDate("2026-05-22"),
+      startTime: null,
+    });
+
+    expect(event.at).toBe("2026-05-22T00:00:00+08:00");
+    expect(event.filterEnd?.toISOString()).toBe("2026-05-22T16:00:00.000Z");
+  });
+
+  it("将 todo 的 dueAt 序列化为上海 ISO 字符串", () => {
+    const event = mapTodoCalendarEvent({
+      dueAt: shanghaiDate("2026-05-22T20:00:00+08:00"),
+    });
+
+    expect(event.type).toBe("todo_due");
+    expect(event.at).toBe("2026-05-22T20:00:00+08:00");
+    expect(event.filterEnd).toBeNull();
+  });
+});
+
+describe("日历事件合并与过滤", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-21T16:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("合并多个来源并按 sortKey 排序", async () => {
+    loadCalendarEventSourcesMock.mockResolvedValueOnce({
+      exams: [
+        { examDate: shanghaiDate("2026-05-22"), endTime: 1000, startTime: 800 },
+      ],
+      homeworkItems: [
+        { submissionDueAt: shanghaiDate("2026-05-22T10:00:00+08:00") },
+      ],
+      schedules: [
+        { date: shanghaiDate("2026-05-22"), endTime: 1500, startTime: 1400 },
+      ],
+      todos: [{ dueAt: shanghaiDate("2026-05-22T18:00:00+08:00") }],
+    });
+
+    const events = await listUserCalendarEvents("user-1");
+
+    expect(events.map((event) => event.type)).toEqual([
+      "exam",
+      "homework_due",
+      "schedule",
+      "todo_due",
+    ]);
+    expect(events.map((event) => event.at)).toEqual([
+      "2026-05-22T08:00:00+08:00",
+      "2026-05-22T10:00:00+08:00",
+      "2026-05-22T14:00:00+08:00",
+      "2026-05-22T18:00:00+08:00",
+    ]);
+  });
+
+  it("按 overlap 模式过滤跨窗口边界的事件", async () => {
+    loadCalendarEventSourcesMock.mockResolvedValueOnce({
+      exams: [],
+      homeworkItems: [
+        { submissionDueAt: shanghaiDate("2026-05-22T10:00:00+08:00") },
+        { submissionDueAt: shanghaiDate("2026-05-30T10:00:00+08:00") },
+      ],
+      schedules: [],
+      todos: [],
+    });
+
+    const events = await listUserCalendarEvents("user-1");
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.at).toBe("2026-05-22T10:00:00+08:00");
+  });
+
+  it("按 start 模式过滤窗口外开始的事件", async () => {
+    loadCalendarEventSourcesMock.mockResolvedValueOnce({
+      exams: [],
+      homeworkItems: [
+        { submissionDueAt: shanghaiDate("2026-05-22T10:00:00+08:00") },
+        { submissionDueAt: shanghaiDate("2026-05-22T14:00:00+08:00") },
+      ],
+      schedules: [],
+      todos: [],
+    });
+
+    const events = await listUserCalendarEvents("user-1", {
+      dateTo: shanghaiDate("2026-05-22T12:00:00+08:00"),
+      eventWindowMode: "start",
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.at).toBe("2026-05-22T10:00:00+08:00");
+  });
+
+  it("输出中剥离 filterStart/filterEnd/sortKey 内部字段", async () => {
+    loadCalendarEventSourcesMock.mockResolvedValueOnce({
+      exams: [],
+      homeworkItems: [
+        { submissionDueAt: shanghaiDate("2026-05-22T10:00:00+08:00") },
+      ],
+      schedules: [],
+      todos: [],
+    });
+
+    const events = await listUserCalendarEvents("user-1");
+
+    expect(events[0]).not.toHaveProperty("filterStart");
+    expect(events[0]).not.toHaveProperty("filterEnd");
+    expect(events[0]).not.toHaveProperty("sortKey");
+    expect(events[0]).toHaveProperty("type");
+    expect(events[0]).toHaveProperty("at");
+    expect(events[0]).toHaveProperty("payload");
+  });
+
+  it("将 sectionIds 透传给事件源加载器", async () => {
+    loadCalendarEventSourcesMock.mockResolvedValueOnce({
+      exams: [],
+      homeworkItems: [],
+      schedules: [],
+      todos: [],
+    });
+
+    await listUserCalendarEvents("user-1", { sectionIds: [1, 2] });
+
+    expect(loadCalendarEventSourcesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sectionIds: [1, 2],
+        userId: "user-1",
+      }),
+    );
+  });
+});

--- a/tests/unit/catalog-section-search.test.ts
+++ b/tests/unit/catalog-section-search.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import { buildSectionOrderBy } from "@/features/catalog/server/section-search-order";
+import { parseSectionSearchQuery } from "@/features/catalog/server/section-search-parser";
+import { buildSectionSearchWhere } from "@/features/catalog/server/section-search-where";
+
+function contains(value: string) {
+  return { contains: value, mode: "insensitive" as const };
+}
+
+describe("课段搜索语法解析器", () => {
+  it("识别所有标签并保留普通搜索词", () => {
+    const result = parseSectionSearchQuery(
+      "teacher:张三 coursecode:CS101 campus:东区 机器学习",
+    );
+
+    expect(result).toEqual({
+      teacher: "张三",
+      courseCode: "CS101",
+      campus: "东区",
+      general: "机器学习",
+    });
+  });
+
+  it("识别各类别名", () => {
+    const result = parseSectionSearchQuery(
+      "sectioncode:A1.01 dept:CS credit:3 edulevel:本科 type:必修 sortby:code",
+    );
+
+    expect(result.lectureCode).toBe("A1.01");
+    expect(result.department).toBe("CS");
+    expect(result.credits).toBe("3");
+    expect(result.level).toBe("本科");
+    expect(result.classType).toBe("必修");
+    expect(result.sort).toBe("code");
+  });
+
+  it("将 order 标签统一转换为小写", () => {
+    expect(parseSectionSearchQuery("order:ASC").order).toBe("asc");
+    expect(parseSectionSearchQuery("order:DESC").order).toBe("desc");
+  });
+
+  it("去除标签后裁剪普通搜索词并折叠多余空白", () => {
+    const result = parseSectionSearchQuery(
+      "  teacher:李四   深度学习   sort:credits  ",
+    );
+
+    expect(result.general).toBe("深度学习");
+  });
+
+  it("仅含标签时无普通搜索词", () => {
+    const result = parseSectionSearchQuery("coursecode:MA201 order:asc");
+
+    expect(result.general).toBeUndefined();
+  });
+
+  it("空字符串或纯空白返回空对象", () => {
+    expect(parseSectionSearchQuery("")).toEqual({});
+    expect(parseSectionSearchQuery("   ")).toEqual({});
+  });
+
+  it("忽略不符合规则的 order 值", () => {
+    const result = parseSectionSearchQuery("order:random");
+
+    expect(result.order).toBeUndefined();
+  });
+
+  it("重复标签时取第一个匹配值", () => {
+    const result = parseSectionSearchQuery(
+      "teacher:张三 teacher:李四 人工智能",
+    );
+
+    expect(result.teacher).toBe("张三");
+    expect(result.general).toBe("人工智能");
+  });
+
+  it("保留普通搜索词中的冒号短语", () => {
+    const result = parseSectionSearchQuery("name:包含冒号的内容");
+
+    expect(result.general).toBe("name:包含冒号的内容");
+  });
+});
+
+describe("课段排序构造器", () => {
+  it("未提供排序字段时返回 undefined", () => {
+    expect(buildSectionOrderBy(undefined)).toBeUndefined();
+    expect(buildSectionOrderBy("")).toBeUndefined();
+  });
+
+  it("未知排序字段返回 undefined", () => {
+    expect(buildSectionOrderBy("unknown")).toBeUndefined();
+    expect(buildSectionOrderBy("  ")).toBeUndefined();
+  });
+
+  it("默认升序", () => {
+    expect(buildSectionOrderBy("code")).toEqual({ code: "asc" });
+  });
+
+  it("支持显式降序", () => {
+    expect(buildSectionOrderBy("credits", "desc")).toEqual({
+      credits: "desc",
+    });
+  });
+
+  it("字段名大小写不敏感", () => {
+    expect(buildSectionOrderBy("Code", "desc")).toEqual({ code: "desc" });
+    expect(buildSectionOrderBy("COURSE", "asc")).toEqual({
+      course: { nameCn: "asc" },
+    });
+  });
+
+  it("映射所有支持的字段与别名", () => {
+    expect(buildSectionOrderBy("credits")).toEqual({ credits: "asc" });
+    expect(buildSectionOrderBy("credit")).toEqual({ credits: "asc" });
+    expect(buildSectionOrderBy("capacity")).toEqual({ stdCount: "asc" });
+    expect(buildSectionOrderBy("semester")).toEqual({
+      semester: { jwId: "asc" },
+    });
+    expect(buildSectionOrderBy("course")).toEqual({
+      course: { nameCn: "asc" },
+    });
+    expect(buildSectionOrderBy("coursename")).toEqual({
+      course: { nameCn: "asc" },
+    });
+    expect(buildSectionOrderBy("sectioncode")).toEqual({ code: "asc" });
+    expect(buildSectionOrderBy("teacher")).toEqual({
+      teachers: { _count: "asc" },
+    });
+    expect(buildSectionOrderBy("campus")).toEqual({
+      campus: { nameCn: "asc" },
+    });
+  });
+});
+
+describe("课段搜索条件构造器", () => {
+  it("空搜索返回空条件", () => {
+    expect(buildSectionSearchWhere(undefined)).toEqual({});
+    expect(buildSectionSearchWhere("")).toEqual({});
+    expect(buildSectionSearchWhere("   ")).toEqual({});
+  });
+
+  it("将标签条件组合为 AND", () => {
+    const result = buildSectionSearchWhere(
+      "teacher:张三 coursecode:CS101 campus:东区",
+    );
+
+    expect(result.where).toEqual({
+      AND: [
+        { teachers: { some: { nameCn: contains("张三") } } },
+        { course: { code: contains("CS101") } },
+        { campus: { nameCn: contains("东区") } },
+      ],
+    });
+  });
+
+  it("lectureCode 别名映射到 section code", () => {
+    const result = buildSectionSearchWhere("sectioncode:MA101.02");
+
+    expect(result.where).toEqual({
+      AND: [{ code: contains("MA101.02") }],
+    });
+  });
+
+  it("credits 为有效数字时生成等值条件", () => {
+    const result = buildSectionSearchWhere("credits:3.5");
+
+    expect(result.where).toEqual({ AND: [{ credits: 3.5 }] });
+  });
+
+  it("credits 无效时忽略该条件", () => {
+    const result = buildSectionSearchWhere("credits:abc");
+
+    expect(result.where).toBeUndefined();
+  });
+
+  it("普通搜索词生成课程与课段字段的 OR 条件", () => {
+    const result = buildSectionSearchWhere("机器学习");
+
+    expect(result.where).toEqual({
+      AND: [
+        {
+          OR: [
+            { course: { nameCn: contains("机器学习") } },
+            { course: { nameEn: contains("机器学习") } },
+            { course: { code: contains("机器学习") } },
+            { code: contains("机器学习") },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("同时组合标签条件与普通 OR 条件", () => {
+    const result = buildSectionSearchWhere("teacher:张三 机器学习");
+
+    expect(result.where).toEqual({
+      AND: [
+        { teachers: { some: { nameCn: contains("张三") } } },
+        {
+          OR: [
+            { course: { nameCn: contains("机器学习") } },
+            { course: { nameEn: contains("机器学习") } },
+            { course: { code: contains("机器学习") } },
+            { code: contains("机器学习") },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("排序字段为空时 orderBy 为 undefined", () => {
+    const result = buildSectionSearchWhere("teacher:张三");
+
+    expect(result.orderBy).toBeUndefined();
+  });
+
+  it("sort 标签生成对应 orderBy 并默认升序", () => {
+    const result = buildSectionSearchWhere("sort:credits");
+
+    expect(result.orderBy).toEqual({ credits: "asc" });
+  });
+
+  it("sort 与 order 标签共同生效", () => {
+    const result = buildSectionSearchWhere("sort:course order:desc");
+
+    expect(result.orderBy).toEqual({
+      course: { nameCn: "desc" },
+    });
+  });
+
+  it("未知 sort 字段不产生 orderBy", () => {
+    const result = buildSectionSearchWhere("sort:unknown");
+
+    expect(result.orderBy).toBeUndefined();
+  });
+});

--- a/tests/unit/dashboard-overview-serialization.test.ts
+++ b/tests/unit/dashboard-overview-serialization.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it } from "vitest";
+import { serializeDashboardOverview } from "@/features/dashboard/server/dashboard-overview-serialization";
+import type { OverviewData } from "@/features/dashboard/server/dashboard-overview-types";
+import type {
+  ExamItem,
+  HomeworkWithSection,
+  SessionItem,
+} from "@/features/dashboard/server/dashboard-types";
+import { TodoPriority } from "@/generated/prisma/client";
+import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
+import { DEV_SEED_ANCHOR } from "../fixtures/dev-seed";
+
+const today = shanghaiDayjs(DEV_SEED_ANCHOR.startOfDayAtTime);
+
+function buildOverviewData(partial: Partial<OverviewData> = {}): OverviewData {
+  return {
+    user: { id: "user-1", name: "Test User", username: "testuser" },
+    currentTermName: "2026春",
+    hasAnySelection: true,
+    hasCurrentTermSelection: true,
+    todaySessions: [],
+    tomorrowSessions: [],
+    weeklySessions: [],
+    weekDays: [],
+    timeSlots: [],
+    incompleteHomeworks: [],
+    dueToday: [],
+    dueWithin3Days: [],
+    calendarSessions: [],
+    calendarHomeworks: [],
+    calendarDays: [],
+    weekDayFormatter: new Intl.DateTimeFormat("zh-CN"),
+    referenceNow: today,
+    todayStart: today.startOf("day"),
+    semesterStart: today.subtract(30, "day"),
+    semesterEnd: today.add(60, "day"),
+    semesterWeeks: [
+      Array.from({ length: 7 }, (_, index) =>
+        today.startOf("week").add(index, "day"),
+      ),
+    ],
+    allSessions: [],
+    allExams: [],
+    semesterHomeworks: [],
+    semesterTodos: [],
+    calendarSemesterPicker: [],
+    calendarSemesterNavList: [],
+    activeCalendarSemesterId: null,
+    defaultCalendarSemesterId: null,
+    activeCalendarSemesterName: null,
+    dashboardLinks: [],
+    recommendedLinks: [],
+    pinnedLinks: [],
+    overviewLinks: [],
+    ...partial,
+  };
+}
+
+function buildSession(overrides: Partial<SessionItem> = {}): SessionItem {
+  return {
+    id: "session-1",
+    sectionJwId: 101,
+    courseName: "计算机导论",
+    date: new Date("2026-04-29T08:00:00+08:00"),
+    startTime: 800,
+    endTime: 920,
+    location: "第二教学楼 201",
+    teacherDisplay: "张教授",
+    ...overrides,
+  };
+}
+
+function buildExam(overrides: Partial<ExamItem> = {}): ExamItem {
+  return {
+    id: "exam-1",
+    courseName: "高等数学",
+    date: new Date("2026-05-10T09:00:00+08:00"),
+    startTime: 900,
+    endTime: 1100,
+    examType: 1,
+    examMode: "offline",
+    examTakeCount: 1,
+    rooms: [{ room: "第三教学楼 301", count: 45 }],
+    ...overrides,
+  };
+}
+
+function buildHomework(
+  overrides: Partial<HomeworkWithSection> = {},
+): HomeworkWithSection {
+  return {
+    id: "hw-1",
+    title: "第一次作业",
+    publishedAt: new Date("2026-04-28T08:00:00+08:00"),
+    submissionStartAt: new Date("2026-04-28T08:00:00+08:00"),
+    submissionDueAt: new Date("2026-04-29T23:59:00+08:00"),
+    homeworkCompletions: [],
+    section: {
+      id: 101,
+      jwId: 101,
+      course: {
+        id: 1,
+        jwId: 1001,
+        code: "CS101",
+        nameCn: "计算机导论",
+        nameEn: null,
+        categoryId: null,
+        classTypeId: null,
+        classifyId: null,
+        educationLevelId: null,
+        gradationId: null,
+        typeId: null,
+        namePrimary: "计算机导论",
+      },
+    } as HomeworkWithSection["section"],
+    ...overrides,
+  } as HomeworkWithSection;
+}
+
+function buildLinkSummary() {
+  return {
+    slug: "library",
+    title: "图书馆",
+    url: "https://lib.ustc.edu.cn",
+    description: "馆藏查询",
+    titlePinyin: "tushuguan",
+    descriptionPinyin: "guangcangchaxun",
+    icon: "book-open" as const,
+    group: "study" as const,
+    isPinned: false,
+    clickCount: 3,
+  };
+}
+
+describe("仪表盘概览序列化", () => {
+  it("将完整的概览数据序列化为 JSON 友好的结构", () => {
+    const overview = buildOverviewData({
+      user: { id: "u1", name: "Alice", username: "alice" },
+      currentTermName: "2026春",
+      hasAnySelection: true,
+      hasCurrentTermSelection: true,
+      todaySessions: [buildSession()],
+      tomorrowSessions: [buildSession({ id: "session-2" })],
+      dueToday: [buildHomework({ id: "hw-due-today" })],
+      dueWithin3Days: [buildHomework({ id: "hw-due-soon" })],
+      incompleteHomeworks: [buildHomework({ id: "hw-incomplete" })],
+      allSessions: [buildSession()],
+      allExams: [buildExam()],
+      semesterHomeworks: [
+        buildHomework({
+          id: "hw-semester",
+          description: { content: "完成课后习题 1-5" },
+        }),
+      ],
+      semesterTodos: [
+        {
+          id: "todo-1",
+          title: "复习笔记",
+          dueAt: "2026-05-01T10:00:00+08:00",
+          priority: TodoPriority.high,
+          content: "重点复习第一章",
+          completed: false,
+        },
+      ],
+      calendarSemesterNavList: [{ id: 1, nameCn: "2026春" }],
+      activeCalendarSemesterId: 1,
+      defaultCalendarSemesterId: 1,
+      activeCalendarSemesterName: "2026春",
+      overviewLinks: [buildLinkSummary()],
+    });
+
+    const result = serializeDashboardOverview(overview);
+
+    expect(result.user).toEqual({
+      id: "u1",
+      name: "Alice",
+      username: "alice",
+    });
+    expect(result.currentTermName).toBe("2026春");
+    expect(result.hasAnySelection).toBe(true);
+    expect(result.hasCurrentTermSelection).toBe(true);
+    expect(result.todaySessions).toHaveLength(1);
+    expect(result.tomorrowSessions).toHaveLength(1);
+
+    expect(result.dueToday).toHaveLength(1);
+    expect(result.dueToday[0].id).toBe("hw-due-today");
+    expect(result.dueWithin3Days).toHaveLength(1);
+    expect(result.pendingHomeworks).toHaveLength(3);
+
+    expect(result.calendar.todayDate).toBe("2026-04-29");
+    expect(result.calendar.referenceDate).toBe("2026-04-29");
+    expect(result.calendar.semesterStart).toBe("2026-03-30");
+    expect(result.calendar.semesterEnd).toBe("2026-06-28");
+    expect(result.calendar.semesterWeeks).toHaveLength(1);
+    expect(result.calendar.semesterWeeks[0]).toHaveLength(7);
+
+    expect(result.calendar.allSessions).toHaveLength(1);
+    const serializedSession = result.calendar.allSessions[0];
+    expect(serializedSession.id).toBe("session-1");
+    expect(serializedSession.date).toBeInstanceOf(Date);
+    expect(serializedSession.dateKey).toBe("2026-04-29");
+    expect(serializedSession.courseName).toBe("计算机导论");
+
+    expect(result.calendar.allExams).toHaveLength(1);
+    const serializedExam = result.calendar.allExams[0];
+    expect(serializedExam.id).toBe("exam-1");
+    expect(serializedExam.date).toBeInstanceOf(Date);
+    expect(serializedExam.dateKey).toBe("2026-05-10");
+    expect(serializedExam.examMode).toBe("offline");
+    expect(serializedExam.rooms).toEqual([
+      { room: "第三教学楼 301", count: 45 },
+    ]);
+
+    expect(result.calendar.semesterHomeworks).toHaveLength(1);
+    const serializedSemesterHomework = result.calendar.semesterHomeworks[0];
+    expect(serializedSemesterHomework.id).toBe("hw-semester");
+    expect(serializedSemesterHomework.description).toBe("完成课后习题 1-5");
+    expect(serializedSemesterHomework.dateKey).toBe("2026-04-29");
+
+    expect(result.calendar.semesterTodos).toHaveLength(1);
+    const serializedTodo = result.calendar.semesterTodos[0];
+    expect(serializedTodo.id).toBe("todo-1");
+    expect(serializedTodo.dateKey).toBe("2026-05-01");
+
+    expect(result.calendar.calendarSemesterNavList).toEqual([
+      { id: 1, nameCn: "2026春" },
+    ]);
+    expect(result.calendar.activeCalendarSemesterId).toBe(1);
+    expect(result.calendar.defaultCalendarSemesterId).toBe(1);
+    expect(result.calendar.activeCalendarSemesterName).toBe("2026春");
+
+    expect(result.overviewLinks).toHaveLength(1);
+    expect(result.overviewLinks[0].slug).toBe("library");
+  });
+
+  it("去重 pendingHomeworks 中的重复作业", () => {
+    const sharedHomework = buildHomework({ id: "shared" });
+    const overview = buildOverviewData({
+      dueToday: [sharedHomework],
+      dueWithin3Days: [sharedHomework],
+      incompleteHomeworks: [sharedHomework, buildHomework({ id: "other" })],
+    });
+
+    const result = serializeDashboardOverview(overview);
+
+    expect(result.dueToday).toHaveLength(1);
+    expect(result.dueWithin3Days).toHaveLength(1);
+    expect("incompleteHomeworks" in result).toBe(false);
+    expect(result.pendingHomeworks).toHaveLength(2);
+    expect(result.pendingHomeworks.map((item) => item.id)).toEqual([
+      "shared",
+      "other",
+    ]);
+  });
+
+  it("根据 homeworkCompletions 标记作业完成状态", () => {
+    const overview = buildOverviewData({
+      dueToday: [
+        buildHomework({
+          id: "completed",
+          homeworkCompletions: [{ completedAt: new Date() }],
+        }),
+        buildHomework({ id: "pending", homeworkCompletions: [] }),
+      ],
+    });
+
+    const result = serializeDashboardOverview(overview);
+
+    expect(result.dueToday[0].completed).toBe(true);
+    expect(result.dueToday[1].completed).toBe(false);
+  });
+
+  it("处理缺失或空的 section 与 course 名称", () => {
+    const overview = buildOverviewData({
+      dueToday: [
+        buildHomework({
+          id: "no-section",
+          section: null,
+        }),
+        buildHomework({
+          id: "empty-course-name",
+          section: {
+            id: 102,
+            jwId: 102,
+            course: {
+              id: 2,
+              jwId: 1002,
+              code: "CS102",
+              nameCn: "",
+              nameEn: null,
+              categoryId: null,
+              classTypeId: null,
+              classifyId: null,
+              educationLevelId: null,
+              gradationId: null,
+              typeId: null,
+              namePrimary: null,
+            },
+          } as HomeworkWithSection["section"],
+        }),
+      ],
+    });
+
+    const result = serializeDashboardOverview(overview);
+
+    expect(result.dueToday[0].section).toBeNull();
+    expect(result.dueToday[1].section).toEqual({
+      jwId: 102,
+      course: { namePrimary: null },
+    });
+  });
+
+  it("将日期按上海时区格式化为日期键", () => {
+    const overview = buildOverviewData({
+      allSessions: [
+        buildSession({
+          id: "utc-edge",
+          date: new Date("2026-04-28T16:00:00.000Z"),
+        }),
+      ],
+      allExams: [buildExam({ id: "null-date", date: null })],
+      semesterTodos: [
+        {
+          id: "todo-string-date",
+          title: "string date todo",
+          dueAt: "2026-04-28T16:00:00.000Z",
+          priority: TodoPriority.low,
+          content: null,
+          completed: false,
+        },
+      ],
+    });
+
+    const result = serializeDashboardOverview(overview);
+
+    expect(result.calendar.allSessions[0].dateKey).toBe("2026-04-29");
+    expect(result.calendar.allExams[0].dateKey).toBeNull();
+    expect(result.calendar.semesterTodos[0].dateKey).toBe("2026-04-29");
+  });
+
+  it("处理空的学期边界和周网格", () => {
+    const overview = buildOverviewData({
+      semesterStart: null,
+      semesterEnd: null,
+      semesterWeeks: [],
+    });
+
+    const result = serializeDashboardOverview(overview);
+
+    expect(result.calendar.semesterStart).toBeNull();
+    expect(result.calendar.semesterEnd).toBeNull();
+    expect(result.calendar.semesterWeeks).toEqual([]);
+  });
+
+  it("保留未改动的 overviewLinks", () => {
+    const links = [buildLinkSummary(), { ...buildLinkSummary(), slug: "mail" }];
+    const overview = buildOverviewData({ overviewLinks: links });
+
+    const result = serializeDashboardOverview(overview);
+
+    expect(result.overviewLinks).toBe(links);
+    expect(result.overviewLinks).toHaveLength(2);
+  });
+
+  it("处理缺失的描述和空数组", () => {
+    const overview = buildOverviewData({
+      semesterHomeworks: [
+        buildHomework({
+          id: "with-description",
+          description: {
+            content: null,
+          } as unknown as HomeworkWithSection["description"],
+        }),
+        buildHomework({
+          id: "without-description",
+        }),
+      ],
+      allSessions: [],
+      allExams: [],
+      semesterTodos: [],
+    });
+
+    const result = serializeDashboardOverview(overview);
+
+    expect(result.calendar.semesterHomeworks[0].description).toBeNull();
+    expect(result.calendar.semesterHomeworks[1].description).toBeNull();
+    expect(result.calendar.allSessions).toEqual([]);
+    expect(result.calendar.allExams).toEqual([]);
+    expect(result.calendar.semesterTodos).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused unit tests for the unit-test gaps identified in the agent-swarm inspection from #310.

## New coverage

- tests/unit/catalog-section-search.test.ts (26 tests)
  - parseSectionSearchQuery tag parsing and aliases
  - buildSectionOrderBy field/alias handling and direction
  - buildSectionSearchWhere combined tag and general-text queries

- tests/unit/calendar-event-window-and-merging.test.ts (23 tests)
  - resolveCalendarEventWindow default and explicit windows
  - isWithinExactWindow overlap/start modes
  - Event mappers for schedule, homework_due, exam, todo_due
  - listUserCalendarEvents multi-source merge, sort, filter, sectionIds passthrough

- tests/unit/dashboard-overview-serialization.test.ts (8 tests)
  - serializeDashboardOverview full shape
  - pendingHomeworks deduplication
  - completion flag derivation
  - null section/course handling
  - Shanghai timezone date keys
  - null semester bounds and empty arrays

All test names are in Chinese.

## Verification

- bunx biome check passed
- bunx tsc --noEmit -p tsconfig.typecheck.tests.json passed
- bunx vitest run passed — 133 files, 643 tests
