### PR TITLE
ci(workflows): serialize E2E HTML report publishing to avoid push races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,9 @@ jobs:
     needs: test-e2e
     if: always()
     runs-on: ubuntu-latest
+    concurrency:
+      group: publish-e2e-html-report
+      cancel-in-progress: false
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Problem

The `Publish E2E HTML report` job pushes a new report directory plus an updated `index.html` to the `e2e-snapshot-artifacts` branch. When several main-branch workflows run close together (e.g. after merging multiple PRs back-to-back), the second push can fail with:

```
! [rejected]  e2e-snapshot-artifacts -> e2e-snapshot-artifacts (fetch first)
error: failed to push some refs to ...
```

The branch moved because another publish job committed in between.

## Fix

Add a job-level `concurrency` group to `publish-e2e-html-report` so only one publish job runs at a time across all workflows.

```yaml
concurrency:
  group: publish-e2e-html-report
  cancel-in-progress: false
```

This serializes writes to the artifacts branch without cancelling in-progress E2E tests.

## Verification

This change only affects CI orchestration; no application code or tests were modified.
