### PR TITLE
ci(workflows): publish E2E reports to separate artifacts repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,12 +125,13 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
 
-      - name: Checkout e2e-snapshot-artifacts branch
+      - name: Checkout e2e-snapshot-artifacts repo
         uses: actions/checkout@v6
         with:
-          ref: e2e-snapshot-artifacts
+          repository: Life-USTC/e2e-snapshot-artifacts
+          ref: main
           path: e2e-snapshot-artifacts
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.E2E_ARTIFACTS_TOKEN }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -174,6 +175,10 @@ jobs:
           # Disable Jekyll so GitHub Pages serves the static HTML and assets as-is.
           touch .nojekyll
 
+          # Keep only the latest 30 reports to avoid unbounded growth in the
+          # artifacts repo. The new report has already been copied in above.
+          ls -1 reports 2>/dev/null | sort -rn | tail -n +31 | xargs -r rm -rf
+
           cat > index.html <<'INDEX_EOF'
           <!doctype html>
           <html lang="en">
@@ -210,8 +215,8 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           marker="<!-- e2e-report -->"
-          report_url="https://life-ustc.github.io/server/reports/${RUN_ID}/index.html"
-          index_url="https://life-ustc.github.io/server/"
+          report_url="https://life-ustc.github.io/e2e-snapshot-artifacts/reports/${RUN_ID}/index.html"
+          index_url="https://life-ustc.github.io/e2e-snapshot-artifacts/"
           body=$(printf '%s\nE2E HTML report is ready: %s\nAll reports: %s' "$marker" "$report_url" "$index_url")
 
           # Commit comment (create or update existing report comment)


### PR DESCRIPTION
## Summary

Moves E2E HTML reports and screenshots out of the `Life-USTC/server` repo into a dedicated repository, deletes the old `e2e-snapshot-artifacts` branch, and migrates GitHub Pages.

## What was done

1. Created `Life-USTC/e2e-snapshot-artifacts` (public, issues/wiki disabled).
2. Migrated the latest E2E report (`run 28322945405`, ~39 MB) into the new repo as the initial `main` commit. Older reports were intentionally dropped because the server branch had grown to ~7.8 GB.
3. Enabled GitHub Pages on the new repo from the `main` branch: https://life-ustc.github.io/e2e-snapshot-artifacts/
4. Disabled GitHub Pages on `Life-USTC/server` and deleted the `e2e-snapshot-artifacts` branch.

## CI changes

- `publish-e2e-html-report` now checks out `Life-USTC/e2e-snapshot-artifacts` instead of the server branch.
- Publishes using the `E2E_ARTIFACTS_TOKEN` secret (a PAT with contents write access to the artifacts repo).
- Updated report URLs in PR/commit comments to the new Pages domain.
- Added retention cleanup: only the latest 30 report directories are kept in the artifacts repo.

## Required secret

Before merging, create a repository secret named `E2E_ARTIFACTS_TOKEN` in `Life-USTC/server` with a fine-grained personal access token that has **contents:write** permission for `Life-USTC/e2e-snapshot-artifacts`.

## Verification

- `bunx biome check .github/workflows/ci.yml` passed.
- The new repo and Pages site are live; the old branch is gone.
- Full CI verification will happen after the secret is configured and this PR lands.
