### PR TITLE
ci(workflows): run svelte-kit sync before prisma generate in migrate deploy

### DIFF
--- a/.github/workflows/db-migrate-deploy.yml
+++ b/.github/workflows/db-migrate-deploy.yml
@@ -32,6 +32,8 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
-          # Generate the Prisma client so migrate deploy can use the correct schema.
+          # Prepare SvelteKit generated files and generate the Prisma client
+          # before running migrate deploy.
+          bunx svelte-kit sync
           bun run db:generate
           bun run db:migrate:deploy


### PR DESCRIPTION
The first migrate-deploy run failed because `prisma generate` requires `.svelte-kit/tsconfig.json`. This PR adds `bunx svelte-kit sync` before generating the Prisma client and deploying migrations.