### PR TITLE
fix(ci): update e2e report commit comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
           # Commit comment (create or update existing report comment)
           commit_comment_id=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}/comments" --jq ".[] | select(.body | contains(\"${marker}\")) | .id" | head -n1)
           if [ -n "$commit_comment_id" ]; then
-            gh api --method PATCH "repos/${REPO}/issues/comments/${commit_comment_id}" -f body="$body" >/dev/null
+            gh api --method PATCH "repos/${REPO}/comments/${commit_comment_id}" -f body="$body" >/dev/null
           else
             gh api --method POST "repos/${REPO}/commits/${COMMIT_SHA}/comments" -f body="$body" >/dev/null
           fi


### PR DESCRIPTION
## Summary
- update E2E report commit comment edits to use the commit-comment endpoint
- fixes main CI failure where an existing commit report comment ID was patched through the issue-comment endpoint and GitHub returned 404

## Verification
- `git diff --check`
- observed failed main run 28454043950 had all E2E shards passing after rerun; only report comment update failed with `gh: Not Found (HTTP 404)`.