### PR TITLE
fix(oauth): OAuth consent redirect handling

### DIFF
--- a/src/features/oauth/components/OAuthAuthorizeConsentPanel.svelte
+++ b/src/features/oauth/components/OAuthAuthorizeConsentPanel.svelte
@@ -1,17 +1,12 @@
 <script lang="ts">
-import type { SubmitFunction } from "@sveltejs/kit";
-import { enhance } from "$app/forms";
 import CheckCircle from "$lib/components/icons/check-circle.svelte";
-import RefreshCw from "$lib/components/icons/refresh-cw.svelte";
 import ShieldAlert from "$lib/components/icons/shield-alert.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
 import { Checkbox } from "$lib/components/ui/checkbox/index.js";
 
-export let consentAction: (decision: "allow" | "deny") => SubmitFunction;
 export let copy: Record<string, string>;
 export let oauthQuery: string;
-export let pendingConsent: "allow" | "deny" | null;
 export let scope: string;
 export let scopes: Array<{ label: string; value: string }>;
 
@@ -70,16 +65,15 @@ $: canAllow = scopes.length === 0 || selectedScopes.length > 0;
 </div>
 
 <div class="grid grid-cols-2 gap-3">
-  <form method="POST" action="?/consent" use:enhance={consentAction("deny")}>
+  <form method="POST" action="?/consent">
     <input type="hidden" name="accept" value="false" />
     <input type="hidden" name="scope" value={scope} />
     <input type="hidden" name="oauthQuery" value={oauthQuery} />
-    <Button class="w-full" disabled={Boolean(pendingConsent)} type="submit" variant="outline">
-      {#if pendingConsent === "deny"}<RefreshCw class="animate-spin" />{/if}
+    <Button class="w-full" type="submit" variant="outline">
       {copy.deny}
     </Button>
   </form>
-  <form method="POST" action="?/consent" use:enhance={consentAction("allow")}>
+  <form method="POST" action="?/consent">
     <input type="hidden" name="accept" value="true" />
     <input type="hidden" name="scope" value={selectedScopeValue || scope} />
     <input type="hidden" name="scopeSelectionEnabled" value="true" />
@@ -87,14 +81,9 @@ $: canAllow = scopes.length === 0 || selectedScopes.length > 0;
       <input type="hidden" name="scopes" value={selectedScope} />
     {/each}
     <input type="hidden" name="oauthQuery" value={oauthQuery} />
-    <Button class="w-full" disabled={Boolean(pendingConsent) || !canAllow} type="submit">
-      {#if pendingConsent === "allow"}
-        <RefreshCw class="animate-spin" />
-        {copy.authorizing}
-      {:else}
-        <CheckCircle />
-        {copy.allow}
-      {/if}
+    <Button class="w-full" disabled={!canAllow} type="submit">
+      <CheckCircle />
+      {copy.allow}
     </Button>
   </form>
 </div>

--- a/src/features/oauth/components/OAuthAuthorizePage.svelte
+++ b/src/features/oauth/components/OAuthAuthorizePage.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import type { SubmitFunction } from "@sveltejs/kit";
 import PageHeader from "$lib/components/PageHeader.svelte";
 import * as Card from "$lib/components/ui/card/index.js";
 import OAuthAuthorizeConsentPanel from "./OAuthAuthorizeConsentPanel.svelte";
@@ -24,27 +23,6 @@ type PageData = {
 };
 
 export let data: PageData;
-
-let pendingConsent: "allow" | "deny" | null = null;
-
-function followOAuthRedirect(location: string) {
-  const target = new URL(location, window.location.href);
-  window.location.assign(target.href);
-}
-
-function consentAction(decision: "allow" | "deny"): SubmitFunction {
-  return () => {
-    pendingConsent = decision;
-    return async ({ result, update }) => {
-      if (result.type === "redirect") {
-        followOAuthRedirect(result.location);
-        return;
-      }
-      await update({ reset: false });
-      pendingConsent = null;
-    };
-  };
-}
 
 $: appName = data.state === "consent" ? (data.clientName ?? "OAuth") : "OAuth";
 $: pageTitle =
@@ -78,10 +56,8 @@ $: sideNoteLabel =
           />
         {:else if data.copy}
           <OAuthAuthorizeConsentPanel
-            {consentAction}
             copy={data.copy}
             oauthQuery={data.oauthQuery ?? ""}
-            {pendingConsent}
             scope={data.scope ?? ""}
             scopes={data.scopes ?? []}
           />


### PR DESCRIPTION
## Summary
- switch OAuth consent forms back to native POST submission
- rely on the server action 303 to follow the loopback callback directly
- remove the enhanced-form pending state that could leave the consent page stuck

## Verification
- bunx biome check src/features/oauth/components/OAuthAuthorizePage.svelte src/features/oauth/components/OAuthAuthorizeConsentPanel.svelte
- bunx tsc --noEmit -p tsconfig.typecheck.json
- bun run build

## Production finding
After PR #325 deployed, direct `/api/auth/oauth2/consent` returned the correct localhost callback, but the enhanced consent form could remain on `/oauth/authorize`. Native form POST removes that fragile client-side redirect hop.