### PR TITLE
perf(ical): personal iCal feeds

### DIFF
--- a/docs/contracts/ical.json
+++ b/docs/contracts/ical.json
@@ -9,6 +9,7 @@
   "rules": {
     "copyable-links": "iCal links should be presented as copyable links rather than requiring users to manually construct them.",
     "no-second-model": "iCal is an export / subscription capability and should not carry a second business model.",
+    "personal-feed-cache": "Personal feed responses may be served from a short-lived private server-side cache, include ETag, return 304 Not Modified for matching If-None-Match, and write cache hit/miss Cloudflare Analytics Engine datapoints without user IDs or feed tokens.",
     "static-json-resilient": "Calendar location and building image enhancements only read static JSON published at https://static.life-ustc.tiankaima.dev; when loading fails or data is corrupted, diagnostic information should be logged and a valid iCal should still be returned."
   },
   "capabilities": {

--- a/src/features/calendar/server/calendar-export-cache.ts
+++ b/src/features/calendar/server/calendar-export-cache.ts
@@ -1,0 +1,115 @@
+import { sha256Base64Url } from "@/lib/crypto/web-crypto";
+import { writeCalendarFeedCacheAnalytics } from "@/lib/metrics/analytics-engine";
+
+const USER_CALENDAR_EXPORT_CACHE_TTL_MS = 60_000;
+const MAX_USER_CALENDAR_EXPORT_CACHE_ENTRIES = 100;
+
+export type UserCalendarExportCacheStatus = "hit" | "miss";
+
+type UserCalendarExport = {
+  cacheControl: string;
+  filename: string;
+  text: string;
+};
+
+export type UserCalendarExportWithEtag = UserCalendarExport & {
+  etag: string;
+};
+
+type CacheEntry = {
+  calendar: UserCalendarExportWithEtag;
+  expiresAtMs: number;
+};
+
+const userCalendarExportCache = new Map<string, CacheEntry>();
+
+function pruneExpiredEntries(nowMs: number) {
+  for (const [key, entry] of userCalendarExportCache) {
+    if (entry.expiresAtMs <= nowMs) {
+      userCalendarExportCache.delete(key);
+    }
+  }
+}
+
+function pruneOldestEntries() {
+  while (
+    userCalendarExportCache.size > MAX_USER_CALENDAR_EXPORT_CACHE_ENTRIES
+  ) {
+    const oldestKey = userCalendarExportCache.keys().next().value;
+    if (!oldestKey) return;
+    userCalendarExportCache.delete(oldestKey);
+  }
+}
+
+function recordCalendarFeedCacheStatus(status: UserCalendarExportCacheStatus) {
+  writeCalendarFeedCacheAnalytics({
+    feed: "user",
+    status,
+    storeSize: userCalendarExportCache.size,
+    ttlMs: USER_CALENDAR_EXPORT_CACHE_TTL_MS,
+  });
+}
+
+export async function createCalendarEtag(text: string) {
+  return `"sha256-${await sha256Base64Url(text)}"`;
+}
+
+export function requestMatchesEtag(request: Request, etag: string) {
+  const ifNoneMatch = request.headers.get("If-None-Match");
+  if (!ifNoneMatch) return false;
+
+  return ifNoneMatch.split(",").some((token) => {
+    const normalized = token.trim().replace(/^W\//, "");
+    return normalized === "*" || normalized === etag;
+  });
+}
+
+export async function getCachedUserCalendarExport(
+  userId: string,
+  buildExport: () => Promise<UserCalendarExport | null>,
+) {
+  const nowMs = Date.now();
+  pruneExpiredEntries(nowMs);
+
+  const cached = userCalendarExportCache.get(userId);
+  if (cached && cached.expiresAtMs > nowMs) {
+    recordCalendarFeedCacheStatus("hit");
+    return {
+      calendar: cached.calendar,
+      status: "hit" satisfies UserCalendarExportCacheStatus,
+    };
+  }
+
+  if (cached) {
+    userCalendarExportCache.delete(userId);
+  }
+
+  const calendar = await buildExport();
+  if (!calendar) {
+    recordCalendarFeedCacheStatus("miss");
+    return {
+      calendar: null,
+      status: "miss" satisfies UserCalendarExportCacheStatus,
+    };
+  }
+
+  const calendarWithEtag = {
+    ...calendar,
+    etag: await createCalendarEtag(calendar.text),
+  };
+  userCalendarExportCache.set(userId, {
+    calendar: calendarWithEtag,
+    expiresAtMs: nowMs + USER_CALENDAR_EXPORT_CACHE_TTL_MS,
+  });
+  pruneOldestEntries();
+
+  recordCalendarFeedCacheStatus("miss");
+  return {
+    calendar: calendarWithEtag,
+    status: "miss" satisfies UserCalendarExportCacheStatus,
+  };
+}
+
+export function resetUserCalendarExportCacheForTest() {
+  userCalendarExportCache.clear();
+}

--- a/src/lib/api/routes/calendar-route-actions.ts
+++ b/src/lib/api/routes/calendar-route-actions.ts
@@ -2,13 +2,20 @@ import {
   getSectionForCalendar,
   getSectionsForCalendar,
 } from "@/features/calendar/server/calendar-export-data";
+import {
+  getCachedUserCalendarExport,
+  requestMatchesEtag,
+} from "@/features/calendar/server/calendar-export-cache";
 import { buildUserCalendarExport } from "@/features/calendar/server/calendar-export-service";
 import {
   createMultiSectionCalendar,
   createSectionCalendar,
 } from "@/features/calendar/server/ical";
 import { handleRouteError, notFound } from "@/lib/api/helpers";
-import { calendarResponse } from "./calendar-route-utils";
+import {
+  calendarNotModifiedResponse,
+  calendarResponse,
+} from "./calendar-route-utils";
 
 export async function generateSectionsCalendarAction(sectionIds: number[]) {
   const sections = await getSectionsForCalendar(sectionIds);
@@ -45,15 +52,24 @@ export async function generateSectionCalendarAction(sectionJwId: number) {
 export async function generateUserCalendarAction(
   user: Parameters<typeof buildUserCalendarExport>[0],
   userId: string,
+  request: Request,
 ) {
-  const calendar = await buildUserCalendarExport(user, userId);
+  const { calendar } = await getCachedUserCalendarExport(userId, () =>
+    buildUserCalendarExport(user, userId),
+  );
   if (!calendar) {
     return notFound("No calendar items found");
+  }
+
+  const etagHeaders = { ETag: calendar.etag };
+  if (requestMatchesEtag(request, calendar.etag)) {
+    return calendarNotModifiedResponse(calendar.cacheControl, etagHeaders);
   }
 
   return calendarResponse(
     calendar.text,
     calendar.filename,
     calendar.cacheControl,
+    etagHeaders,
   );
 }

--- a/src/lib/api/routes/calendar-route-actions.ts
+++ b/src/lib/api/routes/calendar-route-actions.ts
@@ -1,11 +1,11 @@
 import {
-  getSectionForCalendar,
-  getSectionsForCalendar,
-} from "@/features/calendar/server/calendar-export-data";
-import {
   getCachedUserCalendarExport,
   requestMatchesEtag,
 } from "@/features/calendar/server/calendar-export-cache";
+import {
+  getSectionForCalendar,
+  getSectionsForCalendar,
+} from "@/features/calendar/server/calendar-export-data";
 import { buildUserCalendarExport } from "@/features/calendar/server/calendar-export-service";
 import {
   createMultiSectionCalendar,

--- a/src/lib/api/routes/calendar-route-utils.ts
+++ b/src/lib/api/routes/calendar-route-utils.ts
@@ -2,13 +2,31 @@ export function calendarResponse(
   icsData: string,
   filename: string,
   cacheControl: string,
+  headers: HeadersInit = {},
 ) {
+  const responseHeaders = new Headers(headers);
+  responseHeaders.set("Content-Type", "text/calendar; charset=utf-8");
+  responseHeaders.set(
+    "Content-Disposition",
+    `attachment; filename="${filename}"`,
+  );
+  responseHeaders.set("Cache-Control", cacheControl);
+
   return new Response(icsData, {
-    headers: {
-      "Content-Type": "text/calendar; charset=utf-8",
-      "Content-Disposition": `attachment; filename="${filename}"`,
-      "Cache-Control": cacheControl,
-    },
+    headers: responseHeaders,
+  });
+}
+
+export function calendarNotModifiedResponse(
+  cacheControl: string,
+  headers: HeadersInit = {},
+) {
+  const responseHeaders = new Headers(headers);
+  responseHeaders.set("Cache-Control", cacheControl);
+
+  return new Response(null, {
+    status: 304,
+    headers: responseHeaders,
   });
 }
 

--- a/src/lib/api/routes/calendars.ts
+++ b/src/lib/api/routes/calendars.ts
@@ -51,7 +51,11 @@ export async function getUserCalendarRoute(
       return access.response;
     }
 
-    return await generateUserCalendarAction(access.user, access.userId);
+    return await generateUserCalendarAction(
+      access.user,
+      access.userId,
+      request,
+    );
   } catch (error) {
     return handleRouteError("Failed to generate user calendar", error);
   }

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -55,6 +55,13 @@ type CacheEventAnalyticsInput = {
   ttlMs: number;
 };
 
+type CalendarFeedCacheAnalyticsInput = {
+  feed: "user";
+  status: "hit" | "miss";
+  storeSize: number;
+  ttlMs: number;
+};
+
 function statusClass(status: number) {
   if (!Number.isFinite(status)) return "unknown";
   return `${Math.floor(status / 100)}xx`;
@@ -196,5 +203,15 @@ export function writeCacheEventAnalytics(input: CacheEventAnalyticsInput) {
     indexes: [`cache:${boundedValue(cacheNamespace(input.key))}`],
     blobs: ["public_runtime_cache", input.event, cacheNamespace(input.key)],
     doubles: [input.durationMs, input.ttlMs, input.storeSize],
+  });
+}
+
+export function writeCalendarFeedCacheAnalytics(
+  input: CalendarFeedCacheAnalyticsInput,
+) {
+  writeAnalyticsDataPoint({
+    indexes: [`cache:calendar:${boundedValue(input.feed)}`],
+    blobs: ["calendar_feed_cache", input.feed, input.status],
+    doubles: [input.ttlMs, input.storeSize],
   });
 }

--- a/tests/unit/calendar-export-cache.test.ts
+++ b/tests/unit/calendar-export-cache.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getCachedUserCalendarExport,
+  requestMatchesEtag,
+  resetUserCalendarExportCacheForTest,
+} from "@/features/calendar/server/calendar-export-cache";
+import { setCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
+
+const calendarExport = {
+  cacheControl: "private, max-age=300",
+  filename: "life-ustc-subscriptions.ics",
+  text: "BEGIN:VCALENDAR\nEND:VCALENDAR",
+};
+
+describe("用户 iCal 导出缓存", () => {
+  afterEach(() => {
+    resetUserCalendarExportCacheForTest();
+    setCloudflareRuntimeEnv(undefined);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("在 TTL 内复用已生成的日历导出", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-07T00:00:00.000Z"));
+    const writeDataPoint = vi.fn();
+    setCloudflareRuntimeEnv({ ANALYTICS: { writeDataPoint } });
+    const buildExport = vi.fn().mockResolvedValue(calendarExport);
+
+    const first = await getCachedUserCalendarExport("user-1", buildExport);
+    const second = await getCachedUserCalendarExport("user-1", buildExport);
+
+    expect(first.status).toBe("miss");
+    expect(second.status).toBe("hit");
+    expect(buildExport).toHaveBeenCalledTimes(1);
+    expect(second.calendar?.etag).toMatch(/^"sha256-[A-Za-z0-9_-]+"$/);
+
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      indexes: ["cache:calendar:user"],
+      blobs: ["calendar_feed_cache", "user", "miss"],
+      doubles: [60_000, 1],
+    });
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      indexes: ["cache:calendar:user"],
+      blobs: ["calendar_feed_cache", "user", "hit"],
+      doubles: [60_000, 1],
+    });
+    expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain("user-1");
+  });
+
+  it("TTL 过期后重新生成导出", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-07T00:00:00.000Z"));
+    const buildExport = vi
+      .fn()
+      .mockResolvedValueOnce(calendarExport)
+      .mockResolvedValueOnce({
+        ...calendarExport,
+        text: "BEGIN:VCALENDAR\nX-UPDATED:1\nEND:VCALENDAR",
+      });
+
+    await getCachedUserCalendarExport("user-1", buildExport);
+    vi.setSystemTime(new Date("2026-06-07T00:01:01.000Z"));
+    const refreshed = await getCachedUserCalendarExport("user-1", buildExport);
+
+    expect(refreshed.status).toBe("miss");
+    expect(refreshed.calendar?.text).toContain("X-UPDATED:1");
+    expect(buildExport).toHaveBeenCalledTimes(2);
+  });
+
+  it("不缓存空日历结果", async () => {
+    const buildExport = vi.fn().mockResolvedValue(null);
+
+    await getCachedUserCalendarExport("user-1", buildExport);
+    await getCachedUserCalendarExport("user-1", buildExport);
+
+    expect(buildExport).toHaveBeenCalledTimes(2);
+  });
+
+  it("限制缓存条目数量", async () => {
+    const buildExport = vi.fn().mockResolvedValue(calendarExport);
+
+    for (let index = 0; index < 101; index += 1) {
+      await getCachedUserCalendarExport(`user-${index}`, buildExport);
+    }
+    await getCachedUserCalendarExport("user-0", buildExport);
+
+    expect(buildExport).toHaveBeenCalledTimes(102);
+  });
+
+  it("匹配强 ETag、弱 ETag 和多值 If-None-Match", () => {
+    const etag = '"sha256-calendar"';
+
+    expect(
+      requestMatchesEtag(
+        new Request("https://example.test", {
+          headers: { "If-None-Match": '"other", W/"sha256-calendar"' },
+        }),
+        etag,
+      ),
+    ).toBe(true);
+    expect(
+      requestMatchesEtag(
+        new Request("https://example.test", {
+          headers: { "If-None-Match": '"other"' },
+        }),
+        etag,
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a bounded 60-second runtime cache for personal iCal exports
- return ETag headers and 304 Not Modified for matching If-None-Match requests
- add cache hit/miss metrics and document the personal-feed cache contract

## Verification
- bunx vitest run tests/unit/calendar-export-cache.test.ts tests/unit/runtime-metrics.test.ts
- DATABASE_URL='postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev' AUTH_SECRET='local-build-secret' WEBHOOK_SECRET='local-webhook-secret' bun run build
- DATABASE_URL='postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev' AUTH_SECRET='local-build-secret' WEBHOOK_SECRET='local-webhook-secret' bun run openapi:check

## Notes
- log sampling is unchanged
- an accidental direct push to main was immediately corrected with a normal revert commit; this PR reapplies the iCal cache change on top of corrected main