### PR TITLE
fix(mcp): keep MCP transport stateless

### DIFF
--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -1169,20 +1169,12 @@
     "/api/mcp": {
       "get": {
         "operationId": "listMcp",
-        "summary": "Open an MCP Streamable HTTP transport session",
+        "summary": "Standalone GET streams are disabled for the stateless MCP transport",
         "tags": [
           "Api"
         ],
-        "security": [
-          {
-            "mcpBearerAuth": []
-          }
-        ],
         "responses": {
-          "200": {
-            "description": "Response 200"
-          },
-          "401": {
+          "403": {
             "description": "Error response",
             "content": {
               "application/json": {
@@ -1192,7 +1184,7 @@
               }
             }
           },
-          "403": {
+          "405": {
             "description": "Error response",
             "content": {
               "application/json": {

--- a/src/features/bus/lib/bus-applicable-routes.ts
+++ b/src/features/bus/lib/bus-applicable-routes.ts
@@ -12,6 +12,7 @@ import type {
   BusRouteStopSummary,
   BusRouteSummary,
   BusTimetableData,
+  BusTripSummary,
 } from "./bus-types";
 
 export type { BusApplicableTrip } from "./bus-applicable-trip";
@@ -23,6 +24,23 @@ export type BusApplicableRoute = {
   visibleTrips: BusApplicableTrip[];
   upcomingTrips: BusApplicableTrip[];
 };
+
+function indexTripsByRoute(
+  trips: BusTripSummary[],
+  dayType: "weekday" | "weekend",
+) {
+  const tripsByRoute = new Map<number, BusTripSummary[]>();
+  for (const trip of trips) {
+    if (trip.dayType !== dayType) continue;
+    const routeTrips = tripsByRoute.get(trip.routeId);
+    if (routeTrips) {
+      routeTrips.push(trip);
+    } else {
+      tripsByRoute.set(trip.routeId, [trip]);
+    }
+  }
+  return tripsByRoute;
+}
 
 export function buildApplicableBusRoutes(input: {
   data: BusTimetableData;
@@ -41,6 +59,7 @@ export function buildApplicableBusRoutes(input: {
     now,
   } = input;
   const nowMinutes = getShanghaiMinutesSinceMidnight(now);
+  const tripsByRoute = indexTripsByRoute(data.trips, dayType);
 
   return sortApplicableRoutes(
     data.routes.flatMap<BusApplicableRoute>((route) => {
@@ -53,21 +72,17 @@ export function buildApplicableBusRoutes(input: {
       const { endIndex, endStop, startIndex, startStop } = stopSelection;
 
       const allTrips = sortApplicableTrips(
-        data.trips
-          .filter(
-            (trip) => trip.routeId === route.id && trip.dayType === dayType,
-          )
-          .map<BusApplicableTrip>((trip) => {
-            return buildApplicableBusTrip({
-              endIndex,
-              endStop,
-              nowMinutes,
-              route,
-              startIndex,
-              startStop,
-              trip,
-            });
-          }),
+        (tripsByRoute.get(route.id) ?? []).map<BusApplicableTrip>((trip) => {
+          return buildApplicableBusTrip({
+            endIndex,
+            endStop,
+            nowMinutes,
+            route,
+            startIndex,
+            startStop,
+            trip,
+          });
+        }),
       );
 
       const upcomingTrips = allTrips.filter(

--- a/src/features/bus/lib/bus-next-departure-guidance.ts
+++ b/src/features/bus/lib/bus-next-departure-guidance.ts
@@ -1,10 +1,22 @@
 import type { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
+import {
+  getShanghaiMinutesSinceMidnight,
+  resolveApplicableRouteStops,
+} from "./bus-applicable-route-helpers";
+import { buildApplicableBusTrip } from "./bus-applicable-trip";
 import { resolveBusDayType } from "./bus-day-type";
 import type {
+  BusCampusSummary,
+  BusNextDeparture,
   BusNextDeparturesResult,
   BusResolvedDayType,
+  BusRouteStopSummary,
+  BusRouteSummary,
   BusTimetableData,
+  BusTripSummary,
 } from "./bus-types";
+
+type ScheduleDayType = ReturnType<typeof resolveBusDayType>;
 
 export function buildNoBusDepartureMessage({
   applicableRouteCount,
@@ -27,29 +39,38 @@ export function buildNoBusDepartureMessage({
 }
 
 export function findNextAvailableBusDeparture({
-  buildSnapshot,
   data,
+  destinationCampus,
   destinationCampusId,
   now,
+  originCampus,
   originCampusId,
 }: {
-  buildSnapshot: (
-    data: BusTimetableData,
-    input: {
-      originCampusId: number;
-      destinationCampusId: number;
-      atTime?: string;
-      dayType?: BusResolvedDayType;
-      limit?: number;
-      includeDeparted?: boolean;
-      includeNextAvailableGuidance?: boolean;
-    },
-  ) => BusNextDeparturesResult;
   data: BusTimetableData;
+  destinationCampus: BusCampusSummary | null;
   destinationCampusId: number;
   now: ReturnType<typeof shanghaiDayjs>;
+  originCampus: BusCampusSummary | null;
   originCampusId: number;
 }) {
+  const routeCandidates = data.routes.flatMap<{
+    endIndex: number;
+    endStop: BusRouteStopSummary;
+    route: BusRouteSummary;
+    startIndex: number;
+    startStop: BusRouteStopSummary;
+  }>((route) => {
+    const stopSelection = resolveApplicableRouteStops({
+      destinationCampusId,
+      originCampusId,
+      route,
+    });
+
+    return stopSelection ? [{ route, ...stopSelection }] : [];
+  });
+  if (routeCandidates.length === 0) return null;
+
+  const tripsByDayType = indexTripsByDayType(data.trips);
   for (let dayOffset = 1; dayOffset < 7; dayOffset += 1) {
     const probeTime = now
       .add(dayOffset, "day")
@@ -58,19 +79,111 @@ export function findNextAvailableBusDeparture({
       .second(0)
       .millisecond(0);
     const probeDayType = resolveBusDayType(undefined, probeTime);
-    const probeResult = buildSnapshot(data, {
-      originCampusId,
-      destinationCampusId,
-      atTime: probeTime.toISOString(),
-      dayType: probeDayType,
-      limit: 1,
-      includeDeparted: false,
-      includeNextAvailableGuidance: false,
+    const nextDeparture = findFirstDepartureForDay({
+      destinationCampus,
+      nowMinutes: getShanghaiMinutesSinceMidnight(probeTime.toDate()),
+      originCampus,
+      routeCandidates,
+      tripsByRoute: tripsByDayType[probeDayType],
     });
-    if (probeResult.departures.length > 0) {
-      return probeResult.departures[0] ?? null;
+    if (nextDeparture) {
+      return nextDeparture;
     }
   }
 
   return null;
+}
+
+function indexTripsByDayType(trips: BusTripSummary[]) {
+  const tripsByDayType = {
+    weekday: new Map<number, BusTripSummary[]>(),
+    weekend: new Map<number, BusTripSummary[]>(),
+  } satisfies Record<ScheduleDayType, Map<number, BusTripSummary[]>>;
+
+  for (const trip of trips) {
+    const tripsByRoute = tripsByDayType[trip.dayType];
+    const routeTrips = tripsByRoute.get(trip.routeId);
+    if (routeTrips) {
+      routeTrips.push(trip);
+    } else {
+      tripsByRoute.set(trip.routeId, [trip]);
+    }
+  }
+
+  return tripsByDayType;
+}
+
+function findFirstDepartureForDay({
+  destinationCampus,
+  nowMinutes,
+  originCampus,
+  routeCandidates,
+  tripsByRoute,
+}: {
+  destinationCampus: BusCampusSummary | null;
+  nowMinutes: number;
+  originCampus: BusCampusSummary | null;
+  routeCandidates: Array<{
+    endIndex: number;
+    endStop: BusRouteStopSummary;
+    route: BusRouteSummary;
+    startIndex: number;
+    startStop: BusRouteStopSummary;
+  }>;
+  tripsByRoute: Map<number, BusTripSummary[]>;
+}) {
+  let firstDeparture: BusNextDeparture | null = null;
+
+  for (const routeCandidate of routeCandidates) {
+    for (const trip of tripsByRoute.get(routeCandidate.route.id) ?? []) {
+      const applicableTrip = buildApplicableBusTrip({
+        endIndex: routeCandidate.endIndex,
+        endStop: routeCandidate.endStop,
+        nowMinutes,
+        route: routeCandidate.route,
+        startIndex: routeCandidate.startIndex,
+        startStop: routeCandidate.startStop,
+        trip,
+      });
+      if (applicableTrip.status !== "upcoming") continue;
+
+      const departure = {
+        tripId: trip.id,
+        routeId: routeCandidate.route.id,
+        route: {
+          id: routeCandidate.route.id,
+          nameCn: routeCandidate.route.nameCn,
+          nameEn: routeCandidate.route.nameEn,
+          descriptionPrimary: routeCandidate.route.descriptionPrimary,
+          descriptionSecondary: routeCandidate.route.descriptionSecondary,
+        },
+        originCampus,
+        destinationCampus,
+        departureTime: applicableTrip.startTime.displayTime,
+        arrivalTime: applicableTrip.endTime.displayTime,
+        departureEstimated: applicableTrip.startTime.isEstimated,
+        arrivalEstimated: applicableTrip.endTime.isEstimated,
+        minutesUntilDeparture: applicableTrip.minutesUntilDeparture,
+        dayType: trip.dayType,
+        status: applicableTrip.status,
+      } satisfies BusNextDeparture;
+
+      if (
+        !firstDeparture ||
+        compareNextDeparture(departure, firstDeparture) < 0
+      ) {
+        firstDeparture = departure;
+      }
+    }
+  }
+
+  return firstDeparture;
+}
+
+function compareNextDeparture(left: BusNextDeparture, right: BusNextDeparture) {
+  const leftMinutes = left.minutesUntilDeparture ?? Number.MAX_SAFE_INTEGER;
+  const rightMinutes = right.minutesUntilDeparture ?? Number.MAX_SAFE_INTEGER;
+  return leftMinutes !== rightMinutes
+    ? leftMinutes - rightMinutes
+    : left.routeId - right.routeId;
 }

--- a/src/features/bus/lib/bus-next-departures.ts
+++ b/src/features/bus/lib/bus-next-departures.ts
@@ -55,10 +55,11 @@ export function buildNextBusDeparturesFromData(
     applicableRoutes.length > 0
   ) {
     nextAvailableDeparture = findNextAvailableBusDeparture({
-      buildSnapshot: buildNextBusDeparturesFromData,
       data,
+      destinationCampus,
       destinationCampusId: input.destinationCampusId,
       now,
+      originCampus,
       originCampusId: input.originCampusId,
     });
   }

--- a/src/features/bus/server/bus-query-service.ts
+++ b/src/features/bus/server/bus-query-service.ts
@@ -1,12 +1,61 @@
 import type { AppLocale } from "@/i18n/config";
 import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
+import { resolveApplicableRouteStops } from "../lib/bus-applicable-route-helpers";
 import { buildNextBusDeparturesFromData } from "../lib/bus-departures";
 import { searchBusRoutesFromData } from "../lib/bus-route-search";
 import type {
   BusNextDeparturesResult,
   BusResolvedDayType,
+  BusRouteSummary,
+  BusTimetableData,
 } from "../lib/bus-types";
-import { getBusTimetableData } from "./bus-timetable-data";
+import {
+  getBusTimetableData,
+  getStaticBusTimetableData,
+} from "./bus-timetable-data";
+
+function isRouteCandidate(
+  route: BusRouteSummary,
+  input: { destinationCampusId: number; originCampusId: number },
+) {
+  return (
+    resolveApplicableRouteStops({
+      destinationCampusId: input.destinationCampusId,
+      originCampusId: input.originCampusId,
+      route,
+    }) != null
+  );
+}
+
+async function getNextBusTimetableData(input: {
+  locale: AppLocale;
+  now: string;
+  originCampusId: number;
+  destinationCampusId: number;
+  versionKey?: string | null;
+}): Promise<BusTimetableData | null> {
+  const data = await getStaticBusTimetableData({
+    locale: input.locale,
+    now: input.now,
+    versionKey: input.versionKey,
+  });
+  if (!data) return null;
+
+  const routes = data.routes.filter((route) =>
+    isRouteCandidate(route, {
+      destinationCampusId: input.destinationCampusId,
+      originCampusId: input.originCampusId,
+    }),
+  );
+  const routeIds = new Set(routes.map((route) => route.id));
+
+  return {
+    ...data,
+    routes,
+    trips: data.trips.filter((trip) => routeIds.has(trip.routeId)),
+    preferences: null,
+  };
+}
 
 export async function getNextBusDepartures(input: {
   locale: AppLocale;
@@ -20,11 +69,12 @@ export async function getNextBusDepartures(input: {
   userId?: string | null;
 }): Promise<BusNextDeparturesResult | null> {
   const now = input.atTime ? shanghaiDayjs(input.atTime) : shanghaiDayjs();
-  const data = await getBusTimetableData({
+  const data = await getNextBusTimetableData({
     locale: input.locale,
     now: now.toISOString(),
+    originCampusId: input.originCampusId,
+    destinationCampusId: input.destinationCampusId,
     versionKey: input.versionKey,
-    userId: input.userId,
   });
   if (!data) return null;
 

--- a/src/features/bus/server/bus-timetable-data.ts
+++ b/src/features/bus/server/bus-timetable-data.ts
@@ -18,6 +18,14 @@ import {
   summarizeBusVersions,
 } from "./bus-version";
 
+type StaticBusTimetableData = Omit<BusTimetableData, "preferences">;
+
+const STATIC_BUS_TIMETABLE_CACHE_TTL_MS = 60_000;
+const staticBusTimetableCache = new Map<
+  string,
+  { data: StaticBusTimetableData | null; expiresAt: number }
+>();
+
 function busVersionNotice(version: {
   sourceMessage?: string | null;
   sourceUrl?: string | null;
@@ -30,28 +38,58 @@ function busVersionNotice(version: {
     : null;
 }
 
-export async function getBusTimetableData(
+function getStaticBusTimetableCacheKey(input: {
+  dateKey: string;
+  locale: string;
+  versionKey?: string | null;
+}) {
+  return [input.locale, input.dateKey, input.versionKey ?? "auto"].join(":");
+}
+
+export async function getStaticBusTimetableData(
   input: BusTimetableInput,
-): Promise<BusTimetableData | null> {
+): Promise<StaticBusTimetableData | null> {
   const locale = input.locale ?? "zh-cn";
   const now = input.now ? shanghaiDayjs(input.now) : shanghaiDayjs();
   const dateKey = now.format("YYYY-MM-DD");
+  const cacheKey = getStaticBusTimetableCacheKey({
+    dateKey,
+    locale,
+    versionKey: input.versionKey,
+  });
+  const cached = staticBusTimetableCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.data
+      ? { ...cached.data, fetchedAt: now.toISOString() }
+      : null;
+  }
 
   const versionRecords = await listEnabledBusVersionRecords();
   const version = input.versionKey
     ? await findEffectiveBusVersion(dateKey, input.versionKey)
     : findEffectiveBusVersionFromRecords(versionRecords, dateKey);
-  if (!version) return null;
+  if (!version) {
+    staticBusTimetableCache.set(cacheKey, {
+      data: null,
+      expiresAt: Date.now() + STATIC_BUS_TIMETABLE_CACHE_TTL_MS,
+    });
+    return null;
+  }
 
-  const [topology, preference, tripRows] = await Promise.all([
+  const [topology, tripRows] = await Promise.all([
     getBusVersionTopology(locale, version.id),
-    getBusPreference(input.userId ?? null),
     prisma.busTrip.findMany({
       where: { versionId: version.id },
       orderBy: [{ dayType: "asc" }, { routeId: "asc" }, { position: "asc" }],
     }),
   ]);
-  if (!topology) return null;
+  if (!topology) {
+    staticBusTimetableCache.set(cacheKey, {
+      data: null,
+      expiresAt: Date.now() + STATIC_BUS_TIMETABLE_CACHE_TTL_MS,
+    });
+    return null;
+  }
 
   const versionRouteIds = new Set(tripRows.map((trip) => trip.routeId));
   const routes = topology.routes
@@ -68,7 +106,7 @@ export async function getBusTimetableData(
     })
     .filter((trip): trip is BusTripSummary => trip != null);
 
-  return {
+  const data = {
     locale,
     fetchedAt: now.toISOString(),
     version: {
@@ -84,9 +122,25 @@ export async function getBusTimetableData(
     routes,
     trips,
     availableVersions: summarizeBusVersions(versionRecords),
-    preferences: preference,
     notice: busVersionNotice(version),
   };
+  staticBusTimetableCache.set(cacheKey, {
+    data,
+    expiresAt: Date.now() + STATIC_BUS_TIMETABLE_CACHE_TTL_MS,
+  });
+  return data;
+}
+
+export async function getBusTimetableData(
+  input: BusTimetableInput,
+): Promise<BusTimetableData | null> {
+  const [data, preference] = await Promise.all([
+    getStaticBusTimetableData(input),
+    getBusPreference(input.userId ?? null),
+  ]);
+  if (!data) return null;
+
+  return { ...data, preferences: preference };
 }
 
 export async function getBusDashboardSnapshot(

--- a/src/lib/api/routes/mcp-cors.ts
+++ b/src/lib/api/routes/mcp-cors.ts
@@ -1,7 +1,7 @@
 import { isTrustedAuthOrigin } from "@/lib/auth/auth-origins";
 
 const MCP_CORS_HEADERS = {
-  "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+  "Access-Control-Allow-Methods": "POST, DELETE, OPTIONS",
   "Access-Control-Allow-Headers":
     "Authorization, Content-Type, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID",
   "Access-Control-Expose-Headers": "MCP-Session-Id, WWW-Authenticate",

--- a/src/lib/api/routes/mcp.ts
+++ b/src/lib/api/routes/mcp.ts
@@ -2,7 +2,17 @@ import { buildMcpCorsHeaders, validateMcpOrigin } from "./mcp-cors";
 import { handleMcpRequest } from "./mcp-request-handler";
 
 export async function mcpGetRoute(request: Request) {
-  return handleMcpRequest(request);
+  const originError = validateMcpOrigin(request);
+  if (originError) {
+    return originError;
+  }
+  return new Response(JSON.stringify({ error: "method_not_allowed" }), {
+    status: 405,
+    headers: buildMcpCorsHeaders(request, {
+      Allow: "POST, DELETE, OPTIONS",
+      "Content-Type": "application/json",
+    }),
+  });
 }
 
 export async function mcpPostRoute(request: Request) {

--- a/src/lib/mcp/tool-output-schemas.ts
+++ b/src/lib/mcp/tool-output-schemas.ts
@@ -29,7 +29,7 @@ const COMMON_OUTPUT_SHAPE = {
   success: z.boolean().optional(),
   found: z.boolean().optional(),
   error: z.unknown().optional(),
-  message: z.string().optional(),
+  message: z.string().nullable().optional(),
   hint: z.string().optional(),
   result: z.unknown().optional(),
 } satisfies OutputShape;

--- a/src/routes/api/mcp/+server.ts
+++ b/src/routes/api/mcp/+server.ts
@@ -9,9 +9,8 @@ import type { RequestHandler } from "./$types";
 export const trailingSlash = "ignore";
 
 /**
- * Open an MCP Streamable HTTP transport session.
- * @response 200
- * @response 401:openApiErrorSchema
+ * Standalone GET streams are disabled for the stateless MCP transport.
+ * @response 405:openApiErrorSchema
  * @response 403:openApiErrorSchema
  */
 export const GET: RequestHandler = ({ request }) => mcpGetRoute(request);

--- a/tests/e2e/src/app/api/mcp/helpers.ts
+++ b/tests/e2e/src/app/api/mcp/helpers.ts
@@ -291,7 +291,14 @@ export function getTextContent(result: unknown) {
 }
 
 export function parseTextContent(result: unknown) {
-  return JSON.parse(getTextContent(result)) as Record<string, unknown>;
+  const text = getTextContent(result);
+  try {
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch (cause) {
+    throw new Error(`MCP text content is not JSON: ${text.slice(0, 500)}`, {
+      cause,
+    });
+  }
 }
 
 export function expectMcpCorsHeaders(
@@ -306,7 +313,6 @@ export function expectMcpCorsHeaders(
     headers["access-control-expose-headers"]?.toLowerCase() ?? "";
 
   expect(headers["access-control-allow-origin"]).toBe(expectedOrigin);
-  expect(allowMethods).toContain("get");
   expect(allowMethods).toContain("post");
   expect(allowMethods).toContain("delete");
   expect(allowMethods).toContain("options");

--- a/tests/e2e/src/app/api/mcp/transport.test.ts
+++ b/tests/e2e/src/app/api/mcp/transport.test.ts
@@ -44,6 +44,22 @@ test.describe("/api/mcp - 传输与授权", () => {
     await expect(response.json()).resolves.toEqual({ error: "invalid_token" });
   });
 
+  test("/api/mcp stateless transport does not hold a GET SSE stream", async ({
+    request,
+  }) => {
+    const response = await request.get("/api/mcp", {
+      headers: {
+        Accept: "text/event-stream",
+      },
+    });
+
+    expect(response.status()).toBe(405);
+    expect(response.headers().allow).toBe("POST, DELETE, OPTIONS");
+    await expect(response.json()).resolves.toEqual({
+      error: "method_not_allowed",
+    });
+  });
+
   test("/api/mcp 支持受信任浏览器来源的预检和 transport CORS headers", async ({
     page,
     request,

--- a/tests/e2e/src/app/api/openapi/test.ts
+++ b/tests/e2e/src/app/api/openapi/test.ts
@@ -221,9 +221,11 @@ test.describe("GET /api/openapi - OpenAPI 规范", () => {
     expect(
       body.paths?.["/api/dashboard-links/visit"]?.post?.security,
     ).toBeUndefined();
-    expect(body.paths?.["/api/mcp"]?.get?.security).toEqual([
-      { mcpBearerAuth: [] },
-    ]);
+    const mcpGetOperation = body.paths?.["/api/mcp"]?.get as
+      | { responses?: Record<string, unknown>; security?: unknown[] }
+      | undefined;
+    expect(mcpGetOperation?.security).toBeUndefined();
+    expect(mcpGetOperation?.responses?.["405"]).toBeDefined();
     expect(body.paths?.["/api/readiness"]).toBeUndefined();
     expect(body.paths?.["/api/metrics"]).toBeUndefined();
     expect(body.paths?.["/api/health"]?.get?.security).toBeUndefined();

--- a/tests/unit/bus-service.test.ts
+++ b/tests/unit/bus-service.test.ts
@@ -27,7 +27,11 @@ const west: BusCampusSummary = {
   longitude: 0,
 };
 
-function createTrip(id: number, departureTime: string): BusTripSummary {
+function createTrip(
+  id: number,
+  departureTime: string,
+  dayType: BusTripSummary["dayType"] = "weekday",
+): BusTripSummary {
   const departureMinutes = parseBusTimeMinutes(departureTime);
   const arrivalMinutes =
     departureMinutes == null ? null : departureMinutes + 20;
@@ -41,7 +45,7 @@ function createTrip(id: number, departureTime: string): BusTripSummary {
   return {
     id,
     routeId: 8,
-    dayType: "weekday",
+    dayType,
     position: id,
     stopTimes: [
       {
@@ -127,5 +131,19 @@ describe("班车服务", () => {
     expect(result.departures[0]?.departureTime).toBe("10:00");
     expect(result.departures[0]?.status).toBe("upcoming");
     expect(result.departures[0]?.minutesUntilDeparture).toBe(30);
+  });
+
+  it("当天没有剩余班次时返回下一天可用班次", () => {
+    const result = buildNextBusDeparturesFromData(createNextDepartureData(), {
+      originCampusId: east.id,
+      destinationCampusId: west.id,
+      atTime: "2026-04-22T03:30:00.000Z",
+      dayType: "weekday",
+    });
+
+    expect(result.departures).toHaveLength(0);
+    expect(result.nextAvailableDeparture?.departureTime).toBe("08:00");
+    expect(result.nextAvailableDeparture?.routeId).toBe(8);
+    expect(result.message).toContain("08:00");
   });
 });

--- a/tests/unit/bus-timetable-data.test.ts
+++ b/tests/unit/bus-timetable-data.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BusStaticPayload } from "@/features/bus/lib/bus-types";
+import { getNextBusDepartures } from "@/features/bus/server/bus-query-service";
 import { getBusTimetableData } from "@/features/bus/server/bus-timetable-data";
 
 const db = vi.hoisted(() => {
@@ -118,6 +119,10 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("getBusTimetableData 班车时刻表数据", () => {
   it("使用请求历史版本的拓扑结构", async () => {
     const data = await getBusTimetableData({
@@ -137,5 +142,30 @@ describe("getBusTimetableData 班车时刻表数据", () => {
     expect(trip?.routeId).toBe(8);
     expect(trip?.stopTimes.map((stop) => stop.campusId)).toEqual([1, 2]);
     expect(trip?.arrivalTime).toBe("08:20");
+  });
+
+  it("get_next_buses 复用静态时刻表缓存", async () => {
+    await getBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+      versionKey: "old-bus",
+    });
+    vi.clearAllMocks();
+
+    const data = await getNextBusDepartures({
+      locale: "zh-cn",
+      originCampusId: 1,
+      destinationCampusId: 2,
+      atTime: "2026-01-31T23:30:00.000Z",
+      dayType: "weekday",
+      versionKey: "old-bus",
+    });
+
+    expect(data?.departures[0]?.departureTime).toBe("08:00");
+    expect(db.busTripFindMany).not.toHaveBeenCalled();
+    expect(db.busScheduleVersionFindMany).not.toHaveBeenCalled();
+    expect(db.busScheduleVersionFindUnique).not.toHaveBeenCalled();
+    expect(db.busCampusFindMany).not.toHaveBeenCalled();
+    expect(db.busRouteFindMany).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- return 405 for standalone `GET /api/mcp` so the stateless Worker transport does not hold idle SSE streams that workerd cancels as hung requests
- remove `GET` from MCP CORS advertised methods and update generated OpenAPI/docs/tests for the stateless transport contract
- allow nullable MCP structured `message` fields so `get_next_buses` can return the existing `message: null` success shape without SDK output-validation errors
- keep the bus runtime optimization from the original branch: route/trip indexing and short-lived static timetable cache reuse for repeated MCP bus calls

## Context
- The failing `api-mcp` E2E surfaced at `get_next_buses`, but the underlying Worker log showed repeated hung-request cancellations.
- The MCP SDK client treats HTTP 405 on initial GET SSE as the supported fallback for servers that do not provide a standalone stream; our server is stateless and has no server-initiated stream to hold.
- After fixing GET, the remaining local failure was an output-schema mismatch for `message: null`; that is now aligned with the existing bus result contract.

## Docs / contracts
- `GET /api/mcp` is now documented as 405 for the stateless transport instead of advertising a streaming session.
- Tool parameters and bus result payload shape are unchanged.

## Verification
- `bunx biome check src/routes/api/mcp/+server.ts src/lib/api/routes/mcp-cors.ts src/lib/api/routes/mcp.ts src/lib/mcp/tool-output-schemas.ts tests/e2e/src/app/api/mcp/helpers.ts tests/e2e/src/app/api/mcp/transport.test.ts tests/e2e/src/app/api/openapi/test.ts`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx vitest run tests/unit/mcp-observability.test.ts tests/unit/mcp-request-logging.test.ts tests/unit/mcp-auth.test.ts tests/unit/bus-timetable-data.test.ts tests/unit/bus-service.test.ts`
- `bun run openapi:check`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev WEBHOOK_SECRET=e2e-ci-secret NO_PROXY=127.0.0.1,localhost,::1 bun run build`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev WEBHOOK_SECRET=e2e-ci-secret NO_PROXY=127.0.0.1,localhost,::1 bunx playwright test tests/e2e/src/app/api/mcp/transport.test.ts tests/e2e/src/app/api/mcp/seeded-tools.test.ts tests/e2e/src/app/api/openapi/test.ts`

## Local notes
- `prisma db seed` is not idempotent against the already-seeded local Docker database and fails on duplicate `User_pkey`; the focused E2E run used that existing seeded DB.