### PR TITLE
fix(ui): 主内容区缺少独立的 ScrollArea

### DIFF
--- a/src/features/catalog/components/CourseDetailPageController.svelte
+++ b/src/features/catalog/components/CourseDetailPageController.svelte
@@ -9,7 +9,6 @@ import DescriptionCard from "@/features/descriptions/components/DescriptionCard.
 import DetailSectionNav from "$lib/components/DetailSectionNav.svelte";
 import PageHeader from "$lib/components/PageHeader.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
-import { ScrollArea } from "$lib/components/ui/scroll-area/index.js";
 import type { CatalogNamed } from "../lib/catalog-list-display";
 import {
   formatCatalogDetailMessage as formatMessage,
@@ -153,11 +152,10 @@ $: activeNavItem =
       label={copy.common.courses}
     />
 
-    <ScrollArea
-      class="min-w-0 min-h-0"
+    <div
+      class="min-w-0 min-h-0 overflow-y-auto px-4 py-4 sm:px-5 lg:px-6"
       data-detail-scroll-container
     >
-      <div class="px-4 py-4 sm:px-5 lg:px-6">
       {#if data.detailSection === "overview"}
       <section id="course-overview">
         <CourseDetailBasicInfo
@@ -203,7 +201,6 @@ $: activeNavItem =
         {/key}
       </section>
       {/if}
-      </div>
-    </ScrollArea>
+    </div>
   </div>
 </section>

--- a/src/features/catalog/components/TeacherDetailPageController.svelte
+++ b/src/features/catalog/components/TeacherDetailPageController.svelte
@@ -9,7 +9,6 @@ import DescriptionCard from "@/features/descriptions/components/DescriptionCard.
 import DetailSectionNav from "$lib/components/DetailSectionNav.svelte";
 import PageHeader from "$lib/components/PageHeader.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
-import { ScrollArea } from "$lib/components/ui/scroll-area/index.js";
 import {
   type CatalogNamed,
   catalogPrimaryName as primaryName,
@@ -141,11 +140,10 @@ $: activeNavItem =
       label={copy.common.teachers}
     />
 
-    <ScrollArea
-      class="min-w-0 min-h-0"
+    <div
+      class="min-w-0 min-h-0 overflow-y-auto px-4 py-4 sm:px-5 lg:px-6"
       data-detail-scroll-container
     >
-      <div class="px-4 py-4 sm:px-5 lg:px-6">
       {#if data.detailSection === "overview"}
       <section id="teacher-overview">
         <TeacherDetailBasicInfo
@@ -194,7 +192,6 @@ $: activeNavItem =
         {/key}
       </section>
       {/if}
-      </div>
-    </ScrollArea>
+    </div>
   </div>
 </section>

--- a/src/features/section-detail/components/SectionDetailMainContent.svelte
+++ b/src/features/section-detail/components/SectionDetailMainContent.svelte
@@ -11,7 +11,8 @@ import CommentsPanel from "@/features/comments/components/CommentsPanel.svelte";
 import DescriptionCard from "@/features/descriptions/components/DescriptionCard.svelte";
 import type { SectionDetailPageData } from "@/features/section-detail/lib/section-detail-controller-helpers";
 import DetailSectionNav from "$lib/components/DetailSectionNav.svelte";
-import { ScrollArea } from "$lib/components/ui/scroll-area/index.js";
+import * as Alert from "$lib/components/ui/alert/index.js";
+import { Button } from "$lib/components/ui/button/index.js";
 import SectionBasicInfoCard from "./SectionBasicInfoCard.svelte";
 import SectionCalendarTab from "./SectionCalendarTab.svelte";
 import SectionDetailHeader from "./SectionDetailHeader.svelte";
@@ -158,11 +159,10 @@ $: activeNavItem =
       label={sectionCopy.teachingSection}
     />
 
-    <ScrollArea
-      class="min-w-0 min-h-0"
+    <div
+      class="min-w-0 min-h-0 overflow-y-auto px-4 py-4 sm:px-5 lg:px-6"
       data-detail-scroll-container
     >
-      <div class="px-4 py-4 sm:px-5 lg:px-6">
       {#if data.detailSection === "overview"}
       <section id="section-overview">
         <SectionBasicInfoCard
@@ -251,7 +251,6 @@ $: activeNavItem =
         {/key}
       </section>
       {/if}
-      </div>
-    </ScrollArea>
+    </div>
   </div>
 </div>

--- a/src/lib/components/shell/AppShell.svelte
+++ b/src/lib/components/shell/AppShell.svelte
@@ -29,7 +29,6 @@ import {
   type ThemeMode,
 } from "$lib/components/shell/layout-shell";
 import RouteLoadingBar from "$lib/components/shell/RouteLoadingBar.svelte";
-import { ScrollArea } from "$lib/components/ui/scroll-area/index.js";
 import * as Sidebar from "$lib/components/ui/sidebar/index.js";
 import { setClientLocale } from "$lib/locale/client-locale";
 import type {
@@ -51,7 +50,7 @@ let themeMode: ThemeMode = "system";
 let userMenuOpen = false;
 let localeMenuOpen = false;
 let themeMenuOpen = false;
-let contentScrollViewport: HTMLElement | undefined;
+let contentScrollContainer: HTMLDivElement | undefined;
 
 $: profileHref = resolveProfileHref(data.user);
 $: avatarFallback = resolveAvatarFallback(data.user);
@@ -224,20 +223,10 @@ function closeMenus() {
 }
 
 function resetContentScroll() {
-  const shellViewport =
-    contentScrollViewport ??
-    document.querySelector<HTMLElement>(
-      '[data-shell-scroll-container] [data-slot="scroll-area-viewport"]',
-    );
-  shellViewport?.scrollTo({ left: 0, top: 0 });
-
-  const detailContainer = document.querySelector<HTMLElement>(
-    "[data-detail-scroll-container]",
-  );
-  const detailViewport = detailContainer?.querySelector<HTMLElement>(
-    '[data-slot="scroll-area-viewport"]',
-  );
-  (detailViewport ?? detailContainer)?.scrollTo({ left: 0, top: 0 });
+  contentScrollContainer?.scrollTo({ left: 0, top: 0 });
+  document
+    .querySelector<HTMLElement>("[data-detail-scroll-container]")
+    ?.scrollTo({ left: 0, top: 0 });
 }
 
 async function setLocale(locale: "en-us" | "zh-cn") {
@@ -315,29 +304,34 @@ afterNavigate(({ from, to }) => {
         {userMenuOpen}
       />
 
-      <ScrollArea
-        class="flex min-w-0 flex-1 flex-col"
+      <div
+        bind:this={contentScrollContainer}
         data-shell-scroll-container
-        bind:viewportRef={contentScrollViewport}
+        class={cn(
+          "flex min-w-0 flex-1 flex-col",
+          detailWorkspace
+            ? "lg:min-h-0 lg:overflow-hidden"
+            : "lg:min-h-0 lg:overflow-y-auto",
+        )}
       >
         <div
           class={cn(
-            "w-full",
+            "w-full flex-1",
             detailWorkspace
-              ? "bg-card p-0"
+              ? "bg-card p-0 lg:min-h-0 lg:overflow-hidden"
               : "px-4 py-4 sm:px-5 lg:px-6",
           )}
         >
           <slot />
         </div>
-      </ScrollArea>
 
-      {#if !detailWorkspace}
-        <AppFooter
-          copy={data.copy}
-          {footerLinks}
-        />
-      {/if}
+        {#if !detailWorkspace}
+          <AppFooter
+            copy={data.copy}
+            {footerLinks}
+          />
+        {/if}
+      </div>
     </Sidebar.Inset>
   </Sidebar.Provider>
 </div>

--- a/src/lib/components/shell/AppShell.svelte
+++ b/src/lib/components/shell/AppShell.svelte
@@ -224,10 +224,20 @@ function closeMenus() {
 }
 
 function resetContentScroll() {
-  contentScrollViewport?.scrollTo({ left: 0, top: 0 });
-  document
-    .querySelector<HTMLElement>("[data-detail-scroll-container]")
-    ?.scrollTo({ left: 0, top: 0 });
+  const shellViewport =
+    contentScrollViewport ??
+    document.querySelector<HTMLElement>(
+      '[data-shell-scroll-container] [data-slot="scroll-area-viewport"]',
+    );
+  shellViewport?.scrollTo({ left: 0, top: 0 });
+
+  const detailContainer = document.querySelector<HTMLElement>(
+    "[data-detail-scroll-container]",
+  );
+  const detailViewport = detailContainer?.querySelector<HTMLElement>(
+    '[data-slot="scroll-area-viewport"]',
+  );
+  (detailViewport ?? detailContainer)?.scrollTo({ left: 0, top: 0 });
 }
 
 async function setLocale(locale: "en-us" | "zh-cn") {

--- a/src/lib/components/shell/AppShell.svelte
+++ b/src/lib/components/shell/AppShell.svelte
@@ -29,6 +29,7 @@ import {
   type ThemeMode,
 } from "$lib/components/shell/layout-shell";
 import RouteLoadingBar from "$lib/components/shell/RouteLoadingBar.svelte";
+import { ScrollArea } from "$lib/components/ui/scroll-area/index.js";
 import * as Sidebar from "$lib/components/ui/sidebar/index.js";
 import { setClientLocale } from "$lib/locale/client-locale";
 import type {
@@ -50,7 +51,7 @@ let themeMode: ThemeMode = "system";
 let userMenuOpen = false;
 let localeMenuOpen = false;
 let themeMenuOpen = false;
-let contentScrollContainer: HTMLDivElement | undefined;
+let contentScrollViewport: HTMLElement | undefined;
 
 $: profileHref = resolveProfileHref(data.user);
 $: avatarFallback = resolveAvatarFallback(data.user);
@@ -223,11 +224,9 @@ function closeMenus() {
 }
 
 function resetContentScroll() {
-  contentScrollContainer?.scrollTo({ left: 0, top: 0 });
+  contentScrollViewport?.scrollTo({ left: 0, top: 0 });
   document
-    .querySelector<HTMLElement>(
-      '[data-detail-scroll-container] [data-slot="scroll-area-viewport"]',
-    )
+    .querySelector<HTMLElement>("[data-detail-scroll-container]")
     ?.scrollTo({ left: 0, top: 0 });
 }
 
@@ -306,34 +305,29 @@ afterNavigate(({ from, to }) => {
         {userMenuOpen}
       />
 
-      <div
-        bind:this={contentScrollContainer}
+      <ScrollArea
+        class="flex min-w-0 flex-1 flex-col"
         data-shell-scroll-container
-        class={cn(
-          "flex min-w-0 flex-1 flex-col",
-          detailWorkspace
-            ? "lg:min-h-0 lg:overflow-hidden"
-            : "lg:min-h-0 lg:overflow-y-auto",
-        )}
+        bind:viewportRef={contentScrollViewport}
       >
         <div
           class={cn(
-            "w-full flex-1",
+            "w-full",
             detailWorkspace
-              ? "bg-card p-0 lg:min-h-0 lg:overflow-hidden"
+              ? "bg-card p-0"
               : "px-4 py-4 sm:px-5 lg:px-6",
           )}
         >
           <slot />
         </div>
+      </ScrollArea>
 
-        {#if !detailWorkspace}
-          <AppFooter
-            copy={data.copy}
-            {footerLinks}
-          />
-        {/if}
-      </div>
+      {#if !detailWorkspace}
+        <AppFooter
+          copy={data.copy}
+          {footerLinks}
+        />
+      {/if}
     </Sidebar.Inset>
   </Sidebar.Provider>
 </div>

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -60,11 +60,7 @@ function getSectionNavLink(page: Page, name: RegExp) {
 }
 
 function getDetailViewport(page: Page) {
-  return page
-    .locator(
-      '[data-detail-scroll-container] [data-slot="scroll-area-viewport"]',
-    )
-    .first();
+  return page.locator("[data-detail-scroll-container]").first();
 }
 
 async function jumpToSection(page: Page, name: RegExp, selector: string) {

--- a/tests/e2e/src/app/test.ts
+++ b/tests/e2e/src/app/test.ts
@@ -149,7 +149,9 @@ test("/ shell 桌面导航后内容滚动回到顶部", async ({ page }) => {
   await page.evaluate(() => {
     window.scrollTo(0, 720);
     document
-      .querySelector("[data-shell-scroll-container]")
+      .querySelector(
+        '[data-shell-scroll-container] [data-slot="scroll-area-viewport"]',
+      )
       ?.scrollTo({ top: 720 });
   });
 
@@ -157,7 +159,7 @@ test("/ shell 桌面导航后内容滚动回到顶部", async ({ page }) => {
     .poll(async () =>
       page.evaluate(() => {
         const contentPane = document.querySelector(
-          "[data-shell-scroll-container]",
+          '[data-shell-scroll-container] [data-slot="scroll-area-viewport"]',
         );
         return Math.max(window.scrollY, contentPane?.scrollTop ?? 0);
       }),
@@ -175,7 +177,7 @@ test("/ shell 桌面导航后内容滚动回到顶部", async ({ page }) => {
     .poll(async () =>
       page.evaluate(() => {
         const contentPane = document.querySelector(
-          "[data-shell-scroll-container]",
+          '[data-shell-scroll-container] [data-slot="scroll-area-viewport"]',
         );
         return Math.max(window.scrollY, contentPane?.scrollTop ?? 0);
       }),

--- a/tests/e2e/src/app/test.ts
+++ b/tests/e2e/src/app/test.ts
@@ -149,9 +149,7 @@ test("/ shell 桌面导航后内容滚动回到顶部", async ({ page }) => {
   await page.evaluate(() => {
     window.scrollTo(0, 720);
     document
-      .querySelector(
-        '[data-shell-scroll-container] [data-slot="scroll-area-viewport"]',
-      )
+      .querySelector("[data-shell-scroll-container]")
       ?.scrollTo({ top: 720 });
   });
 
@@ -159,7 +157,7 @@ test("/ shell 桌面导航后内容滚动回到顶部", async ({ page }) => {
     .poll(async () =>
       page.evaluate(() => {
         const contentPane = document.querySelector(
-          '[data-shell-scroll-container] [data-slot="scroll-area-viewport"]',
+          "[data-shell-scroll-container]",
         );
         return Math.max(window.scrollY, contentPane?.scrollTop ?? 0);
       }),
@@ -177,7 +175,7 @@ test("/ shell 桌面导航后内容滚动回到顶部", async ({ page }) => {
     .poll(async () =>
       page.evaluate(() => {
         const contentPane = document.querySelector(
-          '[data-shell-scroll-container] [data-slot="scroll-area-viewport"]',
+          "[data-shell-scroll-container]",
         );
         return Math.max(window.scrollY, contentPane?.scrollTop ?? 0);
       }),


### PR DESCRIPTION
在 AppShell 中为主内容 slot 统一包一层 ScrollArea，使内容滚动不影响 topbar、sidebars、footer；同时调整详情页内部容器，避免双重滚动。

Closes #347