### PR TITLE
fix(ui): sidebar collapse 状态下部分按钮变成展开/折叠而非跳转

### DIFF
--- a/src/lib/components/shell/AppSidebar.svelte
+++ b/src/lib/components/shell/AppSidebar.svelte
@@ -4,15 +4,29 @@ import * as Collapsible from "$lib/components/ui/collapsible/index.js";
 import * as Sidebar from "$lib/components/ui/sidebar/index.js";
 import type { ShellCopy, ShellLink, ShellNavGroup } from "./types";
 
-export let copy: ShellCopy;
-export let isActiveLink: (link: ShellLink) => boolean;
-export let navGroups: ShellNavGroup[];
+let {
+  copy,
+  isActiveLink,
+  navGroups,
+}: {
+  copy: ShellCopy;
+  isActiveLink: (link: ShellLink) => boolean;
+  navGroups: ShellNavGroup[];
+} = $props();
+
+// biome-ignore lint/correctness/useHookAtTopLevel: useSidebar is a Svelte context helper, not a React hook
+const sidebar = Sidebar.useSidebar();
+const groupOpen = $state<boolean[]>([]);
 
 function hasActiveChild(link: ShellLink): boolean {
   return (
     link.items?.some((child) => isActiveLink(child) || hasActiveChild(child)) ??
     false
   );
+}
+
+function setGroupOpen(index: number, isOpen: boolean): void {
+  groupOpen[index] = isOpen;
 }
 </script>
 
@@ -54,12 +68,20 @@ function hasActiveChild(link: ShellLink): boolean {
   </Sidebar.Header>
 
   <Sidebar.Content>
-    {#each navGroups as group}
-      <Collapsible.Root open class="group/collapsible">
+    {#each navGroups as group, index}
+      {@const isCollapsed = sidebar.state === "collapsed"}
+      {@const isOpen = isCollapsed || (groupOpen[index] ?? true)}
+      <Collapsible.Root
+        open={isOpen}
+        onOpenChange={(v) => {
+          if (!isCollapsed) setGroupOpen(index, v);
+        }}
+        class="group/collapsible"
+      >
         <Sidebar.Group>
           <Sidebar.GroupLabel>
             {#snippet child({ props })}
-              <Collapsible.Trigger {...props}>
+              <Collapsible.Trigger {...props} disabled={isCollapsed}>
                 {group.label}
                 <ChevronDownIcon
                   class="ms-auto transition-transform group-data-[state=open]/collapsible:rotate-180"
@@ -94,7 +116,8 @@ function hasActiveChild(link: ShellLink): boolean {
                                 aria-current={isActiveLink(link) ? "page" : undefined}
                               >
                                 {#if link.icon}
-                                  <svelte:component this={link.icon} />
+                                  {@const Icon = link.icon}
+                                  <Icon />
                                 {/if}
                                 <span>{link.label}</span>
                                 {#if link.badge != null && link.badge > 0}
@@ -191,7 +214,8 @@ function hasActiveChild(link: ShellLink): boolean {
                             aria-current={active ? "page" : undefined}
                           >
                             {#if link.icon}
-                              <svelte:component this={link.icon} />
+                              {@const Icon = link.icon}
+                              <Icon />
                             {/if}
                             <span>{link.label}</span>
                           </a>

--- a/tests/e2e/src/app/test.ts
+++ b/tests/e2e/src/app/test.ts
@@ -183,6 +183,37 @@ test("/ shell 桌面导航后内容滚动回到顶部", async ({ page }) => {
     .toBeLessThan(8);
 });
 
+test("/ shell 折叠桌面侧边栏后图标链接仍可跳转", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await gotoAndWaitForReady(page, "/");
+
+  const sidebar = page.getByTestId("app-sidebar");
+  const coursesLink = sidebar.getByRole("link", {
+    name: /^(课程|Courses)$/i,
+  });
+
+  const catalogGroup = sidebar.getByRole("button", {
+    name: /^(课程目录|Catalog)$/i,
+  });
+  await expect(async () => {
+    await catalogGroup.click();
+    await expect(coursesLink).toHaveCount(0, { timeout: 1_000 });
+  }).toPass({ timeout: 10_000, intervals: [250, 500, 1_000] });
+
+  await page.locator('[data-sidebar="rail"]').click();
+
+  await expect(
+    page.locator('[data-slot="sidebar"][data-state="collapsed"]'),
+  ).toBeVisible();
+
+  await expect(coursesLink).toBeVisible();
+  await coursesLink.click();
+
+  await page.waitForURL("**/courses");
+  await waitForUiSettled(page);
+  await expect(page).toHaveURL(/\/courses(?:\?.*)?$/);
+});
+
 test("/ 登录用户在空状态总览页可看到班级发现入口", async ({
   page,
 }, testInfo) => {


### PR DESCRIPTION
在 sidebar collapsed（icon）模式下强制分组保持 open，并将 Collapsible.Trigger 设为 disabled，避免可导航的 menu button 点击被分组展开/折叠逻辑拦截。

Closes #350