### PR TITLE
fix(loader): deploy migrations in docker entrypoint

### DIFF
--- a/docker-entrypoint.load.sh
+++ b/docker-entrypoint.load.sh
@@ -3,4 +3,7 @@ set -eu
 
 : "${DATABASE_URL:?DATABASE_URL is required}"
 
+echo "Deploying database migrations..."
+bun run db:migrate:deploy
+
 exec scripts/load-static-sqlite.sh


### PR DESCRIPTION
Fixes the Static Loader Image CI failure on main.

The job creates a fresh Postgres container for its dry-run, but the loader image assumed the schema was already deployed. This runs  in the Docker entrypoint so the loader image is self-contained.