### PR TITLE
fix(oauth): resource-bound OAuth refresh audience

### DIFF
--- a/src/features/oauth/server/device-token-issuer.server.ts
+++ b/src/features/oauth/server/device-token-issuer.server.ts
@@ -7,7 +7,9 @@ import {
 import { DEVICE_CODE_STATUS } from "@/lib/oauth/device-code";
 import { hashOAuthClientSecretForDbStorage } from "@/lib/oauth/utils";
 
-export const DEVICE_ACCESS_TOKEN_EXPIRES_IN = 3600;
+export const RESOURCE_BOUND_ACCESS_TOKEN_EXPIRES_IN = 3600;
+export const DEVICE_ACCESS_TOKEN_EXPIRES_IN =
+  RESOURCE_BOUND_ACCESS_TOKEN_EXPIRES_IN;
 const DEVICE_REFRESH_TOKEN_EXPIRES_IN = 30 * 24 * 3600;
 
 type JwtSigner = (input: {
@@ -62,7 +64,7 @@ function resolveAccessTokenAudiences(resources: string[], scopes: string[]) {
   return [...new Set(audiences)];
 }
 
-async function signDeviceAccessToken(input: {
+export async function signResourceBoundOAuthAccessToken(input: {
   clientId: string;
   expiresAt: number;
   issuedAt: number;
@@ -118,7 +120,7 @@ export async function issueDeviceGrantTokens(
   const refreshExpiresAt = new Date(
     Date.now() + DEVICE_REFRESH_TOKEN_EXPIRES_IN * 1000,
   );
-  const jwtAccessToken = await signDeviceAccessToken({
+  const jwtAccessToken = await signResourceBoundOAuthAccessToken({
     clientId: input.clientId,
     expiresAt,
     issuedAt,

--- a/src/features/oauth/server/refresh-token-resources.server.ts
+++ b/src/features/oauth/server/refresh-token-resources.server.ts
@@ -1,3 +1,7 @@
+import {
+  RESOURCE_BOUND_ACCESS_TOKEN_EXPIRES_IN,
+  signResourceBoundOAuthAccessToken,
+} from "@/features/oauth/server/device-token-issuer.server";
 import { prisma as defaultPrisma } from "@/lib/db/prisma";
 import { getOAuthProviderValidAudiences } from "@/lib/mcp/urls";
 import {
@@ -15,8 +19,18 @@ type RefreshResourcePrisma = {
   oAuthRefreshToken: {
     findUnique: (input: {
       where: { token: string };
-      select: { resources: true };
-    }) => Promise<{ resources: string[] } | null>;
+      select: {
+        clientId?: true;
+        resources: true;
+        scopes?: true;
+        userId?: true;
+      };
+    }) => Promise<{
+      clientId?: string;
+      resources: string[];
+      scopes?: string[];
+      userId?: string;
+    } | null>;
     updateMany: (input: {
       where: { token: string };
       data: { resources: string[] };
@@ -183,6 +197,20 @@ function getIssuedAccessTokenResources(
   );
 }
 
+function getApprovedRequestedResources(
+  resourceValues: string[],
+  approvedResources: string[],
+) {
+  const requestedResources = parseRequestedRefreshResources(resourceValues);
+  if ("error" in requestedResources) return [];
+
+  return requestedResources.resources.filter((requested) =>
+    approvedResources.some((approved) =>
+      resourceIndicatorsMatch(approved, requested),
+    ),
+  );
+}
+
 async function resolveIssuedRefreshResources({
   accessToken,
   grantType,
@@ -247,6 +275,59 @@ export async function validateRefreshTokenResources({
     errorDescription:
       "Requested resource is not approved for this refresh token",
     requestedResourceCount: requestedResources.resources.length,
+  };
+}
+
+export async function issueResourceBoundRefreshAccessToken({
+  prisma = defaultPrisma,
+  refreshToken,
+  resourceValues,
+}: {
+  prisma?: RefreshResourcePrisma;
+  refreshToken: string | null;
+  resourceValues: string[];
+}) {
+  if (!refreshToken || resourceValues.length === 0) return undefined;
+
+  const tokenHash = await hashOAuthClientSecretForDbStorage(refreshToken);
+  const refreshRecord = await prisma.oAuthRefreshToken.findUnique({
+    where: { token: tokenHash },
+    select: {
+      clientId: true,
+      resources: true,
+      scopes: true,
+      userId: true,
+    },
+  });
+  if (
+    !refreshRecord?.clientId ||
+    !refreshRecord.userId ||
+    !refreshRecord.scopes
+  ) {
+    return undefined;
+  }
+
+  const resources = getApprovedRequestedResources(
+    resourceValues,
+    refreshRecord.resources,
+  );
+  if (resources.length === 0) return undefined;
+
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const expiresAt = issuedAt + RESOURCE_BOUND_ACCESS_TOKEN_EXPIRES_IN;
+  const accessToken = await signResourceBoundOAuthAccessToken({
+    clientId: refreshRecord.clientId,
+    expiresAt,
+    issuedAt,
+    resources,
+    scopes: refreshRecord.scopes,
+    userId: refreshRecord.userId,
+  });
+  if (!accessToken) return undefined;
+
+  return {
+    accessToken,
+    expiresIn: RESOURCE_BOUND_ACCESS_TOKEN_EXPIRES_IN,
   };
 }
 

--- a/src/lib/api/routes/auth-token-refresh-resources.ts
+++ b/src/lib/api/routes/auth-token-refresh-resources.ts
@@ -1,9 +1,11 @@
 import {
+  issueResourceBoundRefreshAccessToken,
   persistRefreshTokenResources,
   validateRefreshTokenResources,
 } from "@/features/oauth/server/refresh-token-resources.server";
 import { jsonResponse } from "@/lib/api/helpers";
 import { logOAuthDebug } from "@/lib/log/oauth-debug";
+import { OAUTH_REFRESH_TOKEN_GRANT_TYPE } from "@/lib/oauth/constants";
 
 function invalidRefreshResourceResponse(error_description: string) {
   return jsonResponse(
@@ -15,26 +17,30 @@ function invalidRefreshResourceResponse(error_description: string) {
   );
 }
 
-async function getTokenResponseBody(response: Response) {
+async function getTokenJsonBody(response: Response) {
   const contentType = response.headers.get("content-type") ?? "";
   if (!contentType.includes("application/json")) return null;
 
   try {
-    const body = (await response.clone().json()) as {
-      access_token?: unknown;
-      refresh_token?: unknown;
-    };
-    return {
-      accessToken:
-        typeof body.access_token === "string" ? body.access_token : undefined,
-      refreshToken:
-        typeof body.refresh_token === "string" && body.refresh_token.length > 0
-          ? body.refresh_token
-          : undefined,
-    };
+    const body = await response.clone().json();
+    return body && typeof body === "object"
+      ? (body as Record<string, unknown>)
+      : null;
   } catch {
     return null;
   }
+}
+
+async function getTokenResponseBody(response: Response) {
+  const body = await getTokenJsonBody(response);
+  return {
+    accessToken:
+      typeof body?.access_token === "string" ? body.access_token : undefined,
+    refreshToken:
+      typeof body?.refresh_token === "string" && body.refresh_token.length > 0
+        ? body.refresh_token
+        : undefined,
+  };
 }
 
 export async function validateOAuthRefreshTokenResources(
@@ -95,4 +101,46 @@ export async function persistOAuthRefreshTokenResources(
       resourceCount: result.resourceCount,
     });
   }
+}
+
+export async function replaceOAuthRefreshAccessToken(
+  request: Request,
+  params: URLSearchParams,
+  response: Response,
+) {
+  if (
+    !response.ok ||
+    params.get("grant_type") !== OAUTH_REFRESH_TOKEN_GRANT_TYPE
+  ) {
+    return response;
+  }
+
+  const body = await getTokenJsonBody(response);
+  if (!body || typeof body.access_token !== "string") return response;
+
+  const issued = await issueResourceBoundRefreshAccessToken({
+    refreshToken: params.get("refresh_token"),
+    resourceValues: params.getAll("resource"),
+  });
+  if (!issued) return response;
+
+  const headers = new Headers(response.headers);
+  headers.delete("Content-Length");
+  headers.set("Content-Type", "application/json; charset=utf-8");
+  logOAuthDebug("oauth.refresh-access-token.replaced", request, {
+    resourceCount: params.getAll("resource").length,
+  });
+
+  return jsonResponse(
+    {
+      ...body,
+      access_token: issued.accessToken,
+      expires_in: issued.expiresIn,
+    },
+    {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    },
+  );
 }

--- a/src/lib/api/routes/auth-token.ts
+++ b/src/lib/api/routes/auth-token.ts
@@ -12,6 +12,7 @@ import {
 } from "./auth-token-normalization";
 import {
   persistOAuthRefreshTokenResources,
+  replaceOAuthRefreshAccessToken,
   validateOAuthRefreshTokenResources,
 } from "./auth-token-refresh-resources";
 import { rewriteTokenFormRequest } from "./auth-token-request-rewrite";
@@ -168,7 +169,11 @@ async function postRoute(request: Request) {
       delegatedRequest,
       authHandler,
     );
-    const response = await normalizeOAuthTokenErrorResponse(delegatedResponse);
+    const response = await replaceOAuthRefreshAccessToken(
+      delegatedRequest,
+      params,
+      await normalizeOAuthTokenErrorResponse(delegatedResponse),
+    );
     await persistOAuthRefreshTokenResources(delegatedRequest, params, response);
     return response;
   });

--- a/tests/unit/oauth-token-route.test.ts
+++ b/tests/unit/oauth-token-route.test.ts
@@ -1,15 +1,29 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { tokenGetRoute, tokenPostRoute } from "@/lib/api/routes/auth-token";
+import {
+  OAUTH_OFFLINE_ACCESS_SCOPE,
+  OAUTH_OPENID_SCOPE,
+  OAUTH_PROFILE_SCOPE,
+  OAUTH_REFRESH_TOKEN_GRANT_TYPE,
+} from "@/lib/oauth/constants";
 
-const { betterAuthHandlerMock, findRefreshTokenMock, updateRefreshTokenMock } =
-  vi.hoisted(() => ({
-    betterAuthHandlerMock: vi.fn(),
-    findRefreshTokenMock: vi.fn(),
-    updateRefreshTokenMock: vi.fn(),
-  }));
+const {
+  betterAuthHandlerMock,
+  findRefreshTokenMock,
+  signJwtMock,
+  updateRefreshTokenMock,
+} = vi.hoisted(() => ({
+  betterAuthHandlerMock: vi.fn(),
+  findRefreshTokenMock: vi.fn(),
+  signJwtMock: vi.fn(),
+  updateRefreshTokenMock: vi.fn(),
+}));
 
 vi.mock("@/lib/auth/core", () => ({
   betterAuthInstance: {
+    api: {
+      signJWT: signJwtMock,
+    },
     handler: betterAuthHandlerMock,
   },
 }));
@@ -24,6 +38,7 @@ vi.mock("@/lib/db/prisma", () => ({
 }));
 
 vi.mock("@/lib/mcp/urls", () => ({
+  getCanonicalOAuthIssuer: () => "https://life.example/api/auth",
   getOAuthMcpResourceUrl: () => "https://life.example/api/mcp",
   getOAuthProviderValidAudiences: () => [
     "https://life.example/api/auth",
@@ -35,7 +50,9 @@ describe("OAuth 令牌路由", () => {
   beforeEach(() => {
     betterAuthHandlerMock.mockReset();
     findRefreshTokenMock.mockReset();
+    signJwtMock.mockReset();
     updateRefreshTokenMock.mockReset();
+    updateRefreshTokenMock.mockResolvedValue({ count: 1 });
   });
 
   it("为 GET 返回 JSON 方法指引", async () => {
@@ -142,5 +159,67 @@ describe("OAuth 令牌路由", () => {
         "Requested resource is not approved for this refresh token",
     });
     expect(betterAuthHandlerMock).not.toHaveBeenCalled();
+  });
+
+  it("刷新已绑定资源的令牌时返回覆盖批准资源的 JWT access token", async () => {
+    findRefreshTokenMock.mockResolvedValue({
+      clientId: "client-1",
+      resources: [
+        "https://life.example/api/auth",
+        "https://life.example/api/mcp",
+      ],
+      scopes: [
+        OAUTH_OPENID_SCOPE,
+        OAUTH_PROFILE_SCOPE,
+        OAUTH_OFFLINE_ACCESS_SCOPE,
+      ],
+      userId: "user-1",
+    });
+    betterAuthHandlerMock.mockResolvedValueOnce(
+      Response.json({
+        access_token: "better-auth-access-token",
+        expires_in: 3600,
+        refresh_token: "new-refresh-token",
+        token_type: "Bearer",
+      }),
+    );
+    signJwtMock.mockResolvedValueOnce({ token: "signed-refresh-access-token" });
+    const body = new URLSearchParams({
+      client_id: "client-1",
+      grant_type: OAUTH_REFRESH_TOKEN_GRANT_TYPE,
+      refresh_token: "old-refresh-token",
+    });
+    body.append("resource", "https://life.example/api/auth");
+    body.append("resource", "https://life.example/api/mcp");
+
+    const response = await tokenPostRoute(
+      new Request("http://localhost/api/auth/oauth2/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      access_token: "signed-refresh-access-token",
+      refresh_token: "new-refresh-token",
+      token_type: "Bearer",
+    });
+    expect(signJwtMock).toHaveBeenCalledWith({
+      body: {
+        payload: expect.objectContaining({
+          aud: [
+            "https://life.example/api/auth",
+            "https://life.example/api/mcp",
+            "https://life.example/api/auth/oauth2/userinfo",
+          ],
+          azp: "client-1",
+          iss: "https://life.example/api/auth",
+          scope: `${OAUTH_OPENID_SCOPE} ${OAUTH_PROFILE_SCOPE} ${OAUTH_OFFLINE_ACCESS_SCOPE}`,
+          sub: "user-1",
+        }),
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Reuse the resource-bound OAuth JWT signing path outside the device grant flow.
- Replace refresh-grant access tokens with a signed JWT that covers the requested approved resources.
- Add a route-level regression test for REST+MCP resource-bound refresh tokens.

## Root Cause

Device authorization initially issued a JWT access token with both REST and MCP audiences, but the later `refresh_token` grant delegated access-token creation to Better Auth without correcting the audience. The refresh token rotation itself succeeded, yet the refreshed access token could be rejected by REST endpoints, which made clients behave as if stored OAuth credentials had disappeared.

## Validation

- `bunx vitest run`
- `bunx tsc --noEmit`
- `bunx biome check src/features/oauth/server/device-token-issuer.server.ts src/features/oauth/server/refresh-token-resources.server.ts src/lib/api/routes/auth-token-refresh-resources.ts src/lib/api/routes/auth-token.ts tests/unit/oauth-token-route.test.ts`
- `bun run build`
- `git diff --check`