### PR TITLE
ci(mcp): run MCP integration suite

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -6,7 +6,7 @@ CI/CD pipelines.
 
 | Workflow | Trigger | Jobs |
 |----------|---------|------|
-| CI | push to main, PR to any branch | Default verification, Worker E2E artifact build, E2E shards |
+| CI | push to main, PR to any branch | Default verification, MCP integration, Worker E2E artifact build, E2E shards |
 | DB-backed Bun job | workflow_call | Reusable Postgres-backed Bun job |
 | Copilot Setup Steps | manual or setup workflow changes | Copilot bootstrap validation |
 | Release | successful CI completion on main | Semantic release |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,16 @@ jobs:
       database-name: life_ustc_ci
       job-phase: ci:verify
 
+  test-integration:
+    name: MCP Integration Test
+    needs: check
+    permissions:
+      contents: read
+    uses: ./.github/workflows/db-backed-bun-job.yml
+    with:
+      database-name: life_ustc_integration
+      job-phase: ci:integration
+
   build-e2e-artifacts:
     name: Build E2E artifacts
     needs: check
@@ -108,6 +118,7 @@ jobs:
     needs:
       - check
       - build-e2e-artifacts
+      - test-integration
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,9 @@ jobs:
       - name: Build static loader image
         shell: bash
         run: |
-          for attempt in 1 2 3; do
-            if docker build --target loader -t life-ustc-static-loader:check .; then
-              break
-            fi
-            echo "::warning::docker build failed (attempt ${attempt}/3), retrying..."
-            sleep 15
-          done
+          source .github/scripts/retry.sh
+          retry_command 3 15 "docker build" : \
+            docker build --target loader -t life-ustc-static-loader:check .
       - name: Smoke test static loader image
         run: |
           docker run --rm --entrypoint sh life-ustc-static-loader:check -c '

--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -153,6 +153,7 @@ jobs:
 
           case "$JOB_PHASE" in
             ci:verify)
+              bash tests/ci/retry.test.sh
               bun run app:prepare
               bunx biome check
               bunx svelte-check --tsconfig ./tsconfig.json

--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -111,7 +111,7 @@ jobs:
           install-playwright: ${{ inputs.install-playwright && 'true' || 'false' }}
 
       - name: Install PostgreSQL client
-        if: ${{ inputs.job-phase == 'ci:e2e:test' }}
+        if: ${{ inputs.job-phase == 'ci:integration' || inputs.job-phase == 'ci:e2e:test' }}
         shell: bash
         run: |
           sudo apt-get update
@@ -160,6 +160,12 @@ jobs:
               bunx tsc --noEmit -p tsconfig.typecheck.tests.json
               bunx tsc --noEmit -p tsconfig.typecheck.operational.json
               bunx vitest run
+              ;;
+            ci:integration)
+              bun run app:prepare
+              bun run db:migrate:deploy
+              bunx prisma db seed
+              bunx vitest run --config vitest.integration.config.ts
               ;;
             ci:e2e:build-artifacts)
               bun run app:prepare

--- a/src/lib/mcp/tool-output-schemas.ts
+++ b/src/lib/mcp/tool-output-schemas.ts
@@ -525,7 +525,9 @@ const TOOL_OUTPUT_SCHEMAS: Record<string, McpToolOutputSchema> = {
   }),
 
   search_courses: paginatedCourseMcpSchema,
-  get_course_by_jw_id: objectOutputSchema({ course: compactCourseSchema }),
+  get_course_by_jw_id: objectOutputSchema({
+    course: compactCourseSchema.nullable(),
+  }),
   list_semesters: paginatedSemesterMcpSchema,
   get_current_semester: objectOutputSchema({ semester: compactSemesterSchema }),
 


### PR DESCRIPTION
## What changed

- add a separate Postgres-backed MCP integration job to CI
- run prepare, migrate, seed, and the integration Vitest config in the reusable DB job
- require integration success before E2E shards run
- accept the contract-required `course: null` response exposed by the newly enforced suite

## Why

The documented MCP integration gate was not enforced by protected-branch CI. Enabling it also exposed a pre-existing output-schema mismatch for missing courses; keeping that one-line fix in this PR is required for the new job to be green.

## Validation

- fresh isolated Postgres: 19/19 files, 135/135 integration tests
- MCP descriptor tests: 8/8
- Actionlint and YAML validation
- Copilot Setup Steps branch run passed

Recommended merge order: after #369, because both PRs touch CI workflow files.

Closes #367