### PR TITLE
test(e2e): prevent Playwright false positives

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,15 +3,12 @@
 # `prisma generate` + `prisma migrate deploy` before starting SvelteKit.
 DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev"
 # Optional when running multiple worktrees at once: set a unique
-# COMPOSE_PROJECT_NAME, POSTGRES_PORT, POSTGRES_DB, DATABASE_URL, APP_DEV_PORT,
-# APP_HEALTH_URL, and PLAYWRIGHT_PORT per worktree.
+# COMPOSE_PROJECT_NAME, POSTGRES_PORT, POSTGRES_DB, and DATABASE_URL per
+# worktree.
 # COMPOSE_PROJECT_NAME="life-ustc-dev-main"
 # POSTGRES_PORT="5433"
 # POSTGRES_DB="life_ustc_dev_main"
 # DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5433/life_ustc_dev_main"
-# APP_DEV_PORT="3001"
-# APP_HEALTH_URL="http://127.0.0.1:3001/"
-# PLAYWRIGHT_PORT="3101"
 # Optional override for local Cloudflare Worker Hyperdrive emulation.
 # Defaults to the same value in wrangler.jsonc when running wrangler locally.
 # CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE="postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   ],
   outputDir: "playwright-report/e2e-results",
   fullyParallel: false,
-  forbidOnly: false,
+  forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   // Shared seeded users are mutated by several E2E files. Keep the suite
   // single-worker so those stateful cases run sequentially.
@@ -30,7 +30,7 @@ export default defineConfig({
   webServer: {
     command: "bun run e2e:server",
     url: baseURL,
-    reuseExistingServer: true,
+    reuseExistingServer: false,
     stdout: "ignore",
     stderr: "pipe",
     timeout: 300_000,

--- a/tests/e2e/AGENTS.md
+++ b/tests/e2e/AGENTS.md
@@ -21,8 +21,9 @@ Use the root `AGENTS.md` for the shared setup flow. E2E-only caveats:
 
 - Package scripts build the Cloudflare Worker bundle before Playwright starts.
 - Playwright starts the local Worker with `bun run e2e:server`, which runs `wrangler dev` with `wrangler.e2e.jsonc` and proxy variables cleared for localhost.
-- Playwright defaults to `127.0.0.1:3000`; set `PLAYWRIGHT_PORT` only when a local non-project process already owns that port.
-- Playwright global setup validates the database environment only; R2 is provided by Wrangler's local `R2_UPLOADS` binding.
+- Playwright and the local Worker use `127.0.0.1:3000`; stop any existing
+  process using that port before starting E2E locally.
+- R2 is provided by Wrangler's local `R2_UPLOADS` binding.
 
 ## Test Data
 

--- a/tests/unit/playwright-config.test.ts
+++ b/tests/unit/playwright-config.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+async function loadConfig(ci: string) {
+  vi.resetModules();
+  vi.stubEnv("CI", ci);
+  return (await import("../../playwright.config")).default;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("Playwright configuration", () => {
+  test("rejects focused tests and starts its own server in CI", async () => {
+    const config = await loadConfig("1");
+
+    expect(config).toMatchObject({
+      forbidOnly: true,
+      use: { baseURL: "http://127.0.0.1:3000" },
+      webServer: {
+        reuseExistingServer: false,
+        url: "http://127.0.0.1:3000",
+      },
+    });
+  });
+
+  test("starts its own server locally too", async () => {
+    const config = await loadConfig("");
+
+    expect(config).toMatchObject({
+      forbidOnly: false,
+      webServer: { reuseExistingServer: false },
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- reject committed focused tests in CI with `forbidOnly`
- always start the configured Wrangler E2E server instead of reusing any process on port 3000
- remove unused port/health override documentation
- correct the E2E setup guide and add config regression tests

## Why

The previous configuration could silently test an unrelated server and allowed `.only` tests to reduce CI coverage.

## Validation

- Playwright config unit tests: 2/2
- test TypeScript check
- direct CI/local config probes
- Playwright test discovery: 627 tests across 102 files
- Biome and diff checks

Closes #368