### PR TITLE
fix(ci): fail exhausted retry loops

### DIFF
--- a/.github/actions/setup-bun-env/action.yml
+++ b/.github/actions/setup-bun-env/action.yml
@@ -17,15 +17,15 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        for attempt in 1 2 3; do
-          if bun install --frozen-lockfile; then
-            break
-          fi
-          echo "::warning::bun install failed (attempt ${attempt}/3), retrying..."
+        source .github/scripts/retry.sh
+
+        cleanup_bun_install_retry() {
           rm -rf node_modules
           bun pm cache rm || true
-          sleep 10
-        done
+        }
+
+        retry_command 3 10 "bun install" cleanup_bun_install_retry \
+          bun install --frozen-lockfile
 
     - name: Install Playwright browser
       if: ${{ inputs.install-playwright == 'true' }}

--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+retry_command() {
+  local max_attempts="$1"
+  local delay_seconds="$2"
+  local label="$3"
+  local cleanup_command="$4"
+  shift 4
+
+  local attempt
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if "$@"; then
+      return 0
+    fi
+    if ((attempt == max_attempts)); then
+      echo "::error::${label} failed after ${attempt} attempts."
+      return 1
+    fi
+    echo "::warning::${label} failed (attempt ${attempt}/${max_attempts}), retrying..."
+    "$cleanup_command"
+    sleep "$delay_seconds"
+  done
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,9 @@ jobs:
       - name: Build static loader image
         shell: bash
         run: |
-          for attempt in 1 2 3; do
-            if docker build --target loader -t life-ustc-static-loader:check .; then
-              break
-            fi
-            echo "::warning::docker build failed (attempt ${attempt}/3), retrying..."
-            sleep 15
-          done
+          source .github/scripts/retry.sh
+          retry_command 3 15 "docker build" : \
+            docker build --target loader -t life-ustc-static-loader:check .
       - name: Smoke test static loader image
         run: |
           docker run --rm --entrypoint sh life-ustc-static-loader:check -c '

--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -153,6 +153,7 @@ jobs:
 
           case "$JOB_PHASE" in
             ci:verify)
+              bash tests/ci/retry.test.sh
               bun run app:prepare
               bunx biome check
               bunx svelte-check --tsconfig ./tsconfig.json

--- a/tests/ci/retry.test.sh
+++ b/tests/ci/retry.test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "${repo_root}/.github/scripts/retry.sh"
+
+fail() {
+  echo "retry test failed: $*" >&2
+  exit 1
+}
+
+attempts=0
+cleanups=0
+sleeps=0
+
+sleep() {
+  sleeps=$((sleeps + 1))
+}
+
+always_fail() {
+  attempts=$((attempts + 1))
+  return 1
+}
+
+record_cleanup() {
+  cleanups=$((cleanups + 1))
+}
+
+if retry_command 3 0 "test command" record_cleanup always_fail >/dev/null; then
+  fail "permanent failure returned success"
+fi
+((attempts == 3)) || fail "permanent failure ran ${attempts} attempts, expected 3"
+((cleanups == 2)) || fail "permanent failure ran ${cleanups} cleanups, expected 2"
+((sleeps == 2)) || fail "permanent failure ran ${sleeps} sleeps, expected 2"
+
+attempts=0
+cleanups=0
+sleeps=0
+
+succeed_on_second_attempt() {
+  attempts=$((attempts + 1))
+  if ((attempts == 2)); then
+    return 0
+  fi
+  return 1
+}
+
+retry_command 3 0 "test command" record_cleanup succeed_on_second_attempt >/dev/null ||
+  fail "eventual success returned failure"
+((attempts == 2)) || fail "eventual success ran ${attempts} attempts, expected 2"
+((cleanups == 1)) || fail "eventual success ran ${cleanups} cleanups, expected 1"
+((sleeps == 1)) || fail "eventual success ran ${sleeps} sleeps, expected 1"
+
+echo "retry regression tests passed"


### PR DESCRIPTION
## What changed

- share a small retry helper between Bun install and static-loader Docker builds
- return nonzero immediately after the final failed attempt
- preserve Bun cleanup between attempts without a final cleanup or sleep
- run a shell regression test in `ci:verify`

## Why

Both previous loops exited successfully after three failures, hiding the primary error behind later steps.

## Validation

The shell regression covers:

- permanent failure: nonzero, 3 attempts, 2 cleanups, 2 sleeps
- success on attempt 2: zero, 2 attempts, 1 cleanup, 1 sleep

Also passed Bash syntax, Actionlint, YAML validation, and Copilot Setup Steps.

Closes #369