### PR TITLE
fix(ci): gate database migrations on CI

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -6,7 +6,7 @@ CI/CD pipelines.
 
 | Workflow | Trigger | Jobs |
 |----------|---------|------|
-| CI | push to main, PR to any branch | Default verification, Worker E2E artifact build, E2E shards |
+| CI | push to main, PR to any branch | Default verification, MCP integration, Worker E2E artifact build, E2E shards |
 | DB-backed Bun job | workflow_call | Reusable Postgres-backed Bun job |
 | DB migrate deploy | successful CI completion on main, or manual | Production Prisma migrate deploy |
 | Copilot Setup Steps | manual or setup workflow changes | Copilot bootstrap validation |

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -8,6 +8,7 @@ CI/CD pipelines.
 |----------|---------|------|
 | CI | push to main, PR to any branch | Default verification, Worker E2E artifact build, E2E shards |
 | DB-backed Bun job | workflow_call | Reusable Postgres-backed Bun job |
+| DB migrate deploy | successful CI completion on main, or manual | Production Prisma migrate deploy |
 | Copilot Setup Steps | manual or setup workflow changes | Copilot bootstrap validation |
 | Release | successful CI completion on main | Semantic release |
 

--- a/.github/workflows/db-migrate-deploy.yml
+++ b/.github/workflows/db-migrate-deploy.yml
@@ -2,14 +2,13 @@ name: DB Migrate Deploy
 
 on:
   workflow_dispatch:
-  push:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
     branches:
       - main
-    paths:
-      - prisma/schema.prisma
-      - prisma/migrations/**
-      - prisma.config.ts
-      - .github/workflows/db-migrate-deploy.yml
 
 concurrency:
   group: db-migrate-deploy
@@ -19,11 +18,20 @@ jobs:
   migrate:
     name: Deploy Prisma migrations
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.repository == 'Life-USTC/server')
     permissions:
       contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Bun environment
         uses: ./.github/actions/setup-bun-env


### PR DESCRIPTION
## What changed

- trigger automatic migration deployment from a completed CI workflow on `main`
- require a successful push CI run from this repository
- check out the exact tested `head_sha`
- preserve explicit manual dispatch and serialized migration execution

## Why

The previous push-triggered workflow could mutate production before validation for the same commit completed.

## Validation

- Actionlint and YAML validation
- structural assertions for successful-push gating
- exact-SHA checkout assertion
- manual dispatch path assertion

Recommended merge order: after #367 so the migration gate includes the MCP integration signal.

Closes #370