### PR TITLE
fix(bus): keep transit map legible on mobile

### DIFF
--- a/src/features/bus/components/BusTransitSvg.svelte
+++ b/src/features/bus/components/BusTransitSvg.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { onMount } from "svelte";
 import { SVG_H, SVG_W } from "@/features/bus/components/bus-transit-map-layout";
 import type {
   BusMapActiveTrip,
@@ -23,11 +24,22 @@ export let mapData: BusMapData;
 export let offsets: Map<string, Map<number, number>>;
 export let positions: Map<number, BusMapPoint>;
 export let routePaths: Map<number, BusMapRoutePath>;
+
+let svgElement: SVGSVGElement;
+
+onMount(() => {
+  const viewport = svgElement.closest<HTMLElement>(
+    '[data-slot="scroll-area-viewport"]',
+  );
+  if (!viewport || viewport.scrollWidth <= viewport.clientWidth) return;
+  viewport.scrollLeft = (viewport.scrollWidth - viewport.clientWidth) / 2;
+});
 </script>
 
 <svg
+  bind:this={svgElement}
   viewBox={`0 0 ${SVG_W} ${SVG_H}`}
-  class="h-auto w-full rounded-md border border-border bg-card md:min-h-[34rem]"
+  class="h-auto w-full min-w-[45rem] rounded-md border border-border bg-card md:min-h-[34rem] md:min-w-0"
   role="img"
   aria-label={copy.mapTitle}
   onmouseleave={() => {

--- a/tests/e2e/src/app/bus-map/test.ts
+++ b/tests/e2e/src/app/bus-map/test.ts
@@ -52,6 +52,83 @@ test.describe("校车线路图", () => {
     await captureStepScreenshot(page, testInfo, "bus-map-overview");
   });
 
+  test("移动端地图保持可读尺寸并可水平滚动", async ({ page }, testInfo) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await gotoAndWaitForReady(page, "/bus-map", {
+      testInfo,
+      screenshotLabel: "bus-map-mobile",
+    });
+
+    const svg = page.locator('main svg[role="img"][aria-label]').first();
+    await expect(svg).toBeVisible();
+    await svg.scrollIntoViewIfNeeded();
+
+    const geometry = await svg.evaluate((node) => {
+      const svgElement = node as SVGSVGElement;
+      const viewport = svgElement.closest(
+        '[data-slot="scroll-area-viewport"]',
+      ) as HTMLElement | null;
+      if (!viewport) throw new Error("Bus map scroll viewport missing");
+
+      const labelHeights = Array.from(
+        svgElement.querySelectorAll("text"),
+        (label) => label.getBoundingClientRect().height,
+      );
+      const viewportBox = viewport.getBoundingClientRect();
+      const campusLabels = Array.from(svgElement.querySelectorAll("g"))
+        .filter(
+          (group) => group.querySelectorAll(":scope > circle").length >= 3,
+        )
+        .map((group) => group.querySelector(":scope > text"))
+        .filter((label): label is SVGTextElement => label !== null);
+      const visibleCampusLabels = campusLabels.filter((label) => {
+        const labelBox = label.getBoundingClientRect();
+        return (
+          labelBox.left >= viewportBox.left &&
+          labelBox.right <= viewportBox.right &&
+          labelBox.top >= viewportBox.top &&
+          labelBox.bottom <= viewportBox.bottom
+        );
+      });
+      return {
+        campusLabelCount: campusLabels.length,
+        labelHeights,
+        svgWidth: svgElement.getBoundingClientRect().width,
+        viewBoxWidth: svgElement.viewBox.baseVal.width,
+        viewportClientWidth: viewport.clientWidth,
+        viewportScrollLeft: viewport.scrollLeft,
+        viewportScrollWidth: viewport.scrollWidth,
+        visibleCampusLabelCount: visibleCampusLabels.length,
+      };
+    });
+
+    expect(geometry.viewBoxWidth).toBe(900);
+    expect(geometry.svgWidth).toBeGreaterThanOrEqual(700);
+    expect(geometry.viewportScrollWidth).toBeGreaterThan(
+      geometry.viewportClientWidth,
+    );
+    expect(geometry.viewportScrollLeft).toBeGreaterThan(0);
+    expect(geometry.campusLabelCount).toBeGreaterThan(0);
+    expect(geometry.visibleCampusLabelCount).toBe(geometry.campusLabelCount);
+    expect(geometry.labelHeights).not.toHaveLength(0);
+    expect(Math.min(...geometry.labelHeights)).toBeGreaterThanOrEqual(10);
+
+    await captureStepScreenshot(page, testInfo, "bus-map-mobile-readable");
+
+    const scrollViewport = svg.locator(
+      'xpath=ancestor::*[@data-slot="scroll-area-viewport"][1]',
+    );
+    await scrollViewport.evaluate((node) => {
+      const viewport = node as HTMLElement;
+      viewport.scrollLeft = viewport.scrollWidth - viewport.clientWidth;
+    });
+    await expect
+      .poll(() =>
+        scrollViewport.evaluate((node) => (node as HTMLElement).scrollLeft),
+      )
+      .toBeGreaterThan(geometry.viewportScrollLeft);
+  });
+
   test("图例显示线路说明与状态指示器", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, "/bus-map", {
       testInfo,


### PR DESCRIPTION
## What changed

- keep the SVG at a readable mobile scale inside the existing horizontal scroll area
- center the overflow once on mount so the useful network view is visible immediately
- preserve the current desktop overview
- add geometry, label-size, initial-framing, and panning regression coverage

## Validation

At 390×844:

- initial scroll centers at 201px
- 6/6 campus nodes and labels are fully visible
- campus labels render at approximately 13px instead of 7px
- horizontal panning remains available

Focused bus-map E2E: 6/6. Svelte diagnostics, Biome, and diff checks passed.

Closes #372