### PR TITLE
fix(calendar): remove dead links from section events

### DIFF
--- a/src/features/section-detail/lib/calendar.ts
+++ b/src/features/section-detail/lib/calendar.ts
@@ -18,7 +18,7 @@ export type SectionCalendarEvent = {
 
 type CalendarGridEvent = {
   detail: string;
-  href: string;
+  href?: string;
   label: string;
   meta: string;
   tone: "primary" | "warning";
@@ -83,7 +83,6 @@ export function buildCalendarGridEvent(input: {
   formatDate: (value: string | Date | null | undefined) => string;
 }) {
   return {
-    href: `#${input.event.id}`,
     label: input.event.title,
     meta: [input.formatDate(input.event.date), input.event.meta]
       .filter(Boolean)

--- a/src/lib/components/calendar/CalendarEventChip.svelte
+++ b/src/lib/components/calendar/CalendarEventChip.svelte
@@ -4,7 +4,7 @@ import * as Tooltip from "$lib/components/ui/tooltip/index.js";
 import { cn } from "$lib/utils.js";
 import type { CalendarTone } from "./types";
 
-export let href = "#";
+export let href: string | undefined = undefined;
 export let label = "";
 export let title = "";
 export let meta = "";
@@ -27,12 +27,26 @@ function eventChipProps(
       typeof itemClass === "string" ? itemClass : undefined,
       typeof triggerClass === "string" ? triggerClass : undefined,
     ),
-    href,
   };
 }
 
 $: tooltipText = tooltip || title || label;
 </script>
+
+{#snippet chipContent()}
+  <Item.Content class="gap-0">
+    <Item.Title class="max-w-full">{label}</Item.Title>
+    {#if title}
+      <Item.Description class="max-w-full line-clamp-1">{title}</Item.Description>
+    {/if}
+    {#if meta}
+      <Item.Description class="max-w-full line-clamp-1">{meta}</Item.Description>
+    {/if}
+    {#if detail}
+      <Item.Description class="max-w-full line-clamp-1">{detail}</Item.Description>
+    {/if}
+  </Item.Content>
+{/snippet}
 
 <Tooltip.Root>
   <Tooltip.Trigger>
@@ -57,20 +71,15 @@ $: tooltipText = tooltip || title || label;
         variant="outline"
       >
         {#snippet child({ props: itemProps })}
-          <a {...eventChipProps(itemProps, props)}>
-            <Item.Content class="gap-0">
-              <Item.Title class="max-w-full">{label}</Item.Title>
-              {#if title}
-                <Item.Description class="max-w-full line-clamp-1">{title}</Item.Description>
-              {/if}
-              {#if meta}
-                <Item.Description class="max-w-full line-clamp-1">{meta}</Item.Description>
-              {/if}
-              {#if detail}
-                <Item.Description class="max-w-full line-clamp-1">{detail}</Item.Description>
-              {/if}
-            </Item.Content>
-          </a>
+          {#if href}
+            <a {...eventChipProps(itemProps, props)} {href}>
+              {@render chipContent()}
+            </a>
+          {:else}
+            <div {...eventChipProps(itemProps, props)}>
+              {@render chipContent()}
+            </div>
+          {/if}
         {/snippet}
       </Item.Root>
     {/snippet}

--- a/src/lib/components/calendar/CalendarGridDayCell.svelte
+++ b/src/lib/components/calendar/CalendarGridDayCell.svelte
@@ -40,7 +40,7 @@ export let variant: "week" | "month" = "week";
   <div class="mt-3 grid gap-1.5">
     {#each day.events.slice(0, eventLimit) as event}
       <CalendarEventChip
-        href={event.href ?? "#"}
+        href={event.href}
         label={event.label}
         title={event.title}
         tooltip={event.tooltip}

--- a/src/lib/components/calendar/CalendarWeekStrip.svelte
+++ b/src/lib/components/calendar/CalendarWeekStrip.svelte
@@ -55,7 +55,7 @@ export let moreLabel: (count: number) => string = (count) => `+${count}`;
         <div class="mt-3 grid gap-1.5">
           {#each day.events.slice(0, eventLimit) as event}
             <CalendarEventChip
-              href={event.href ?? "#"}
+              href={event.href}
               label={event.label}
               title={event.title}
               tooltip={event.tooltip}

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -262,7 +262,7 @@ test.describe("/sections/[jwId] 班级详情页", () => {
     await captureStepScreenshot(page, testInfo, "section/admin-classes");
   });
 
-  test("日历区块显示课表、教室、教学楼与教师", async ({ page }, testInfo) => {
+  test("日历区块以非交互芯片显示课表详情", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
 
     await jumpToSection(page, /日历|Calendar/i, "#tab-calendar");
@@ -271,10 +271,13 @@ test.describe("/sections/[jwId] 班级详情页", () => {
     // month grid, not as a separate list of cards.
     const monthView = getSectionCalendarMonthView(page);
     const classEventChip = monthView
-      .locator("a")
+      .locator('[data-slot="tooltip-trigger"]')
       .filter({ hasText: /上课事件|Class event/i })
       .first();
     await expect(classEventChip).toBeVisible();
+    await expect(classEventChip).not.toHaveAttribute("href", /.+/);
+    await expect(classEventChip).toHaveAttribute("tabindex", "0");
+    await expect(monthView.locator('a[href^="#"]')).toHaveCount(0);
 
     // schedule.room.namePrimary and schedule.room.building.namePrimary
     // are rendered in the chip meta text.
@@ -298,6 +301,10 @@ test.describe("/sections/[jwId] 班级详情页", () => {
         .or(classEventChip.getByText(DEV_SEED.campus.nameEn, { exact: false }))
         .first(),
     ).toBeVisible();
+
+    const beforeClickUrl = page.url();
+    await classEventChip.click();
+    expect(page.url()).toBe(beforeClickUrl);
 
     await captureStepScreenshot(page, testInfo, "section/schedule-calendar");
   });


### PR DESCRIPTION
## What changed

- stop generating fragment hrefs for section calendar events with no rendered target
- render chips without destinations as focusable tooltip-backed static elements
- keep real dashboard calendar destinations as anchors
- add a no-navigation regression check for the section calendar

## Why

The previous chips looked actionable but only changed the URL to fragment IDs that did not exist.

## Validation

- all four seeded section events render without `href`
- clicking a static chip leaves the URL unchanged
- keyboard focus remains available for tooltip details
- existing dashboard E2E coverage preserves section and exam link navigation
- Svelte diagnostics, TypeScript, Biome, build, and focused E2E passed

Closes #375