### PR TITLE
fix(calendar): serialize DTSTAMP in UTC

### DIFF
--- a/docs/contracts/ical.json
+++ b/docs/contracts/ical.json
@@ -9,6 +9,7 @@
   "rules": {
     "copyable-links": "iCal links should be presented as copyable links rather than requiring users to manually construct them.",
     "no-second-model": "iCal is an export / subscription capability and should not carry a second business model.",
+    "rfc5545-dtstamp-utc": "Every VEVENT in section, multi-section, and personal feeds serializes DTSTAMP as a UTC DATE-TIME with a Z suffix while retaining Asia/Shanghai TZID values for event start and end times.",
     "personal-feed-cache": "Personal feed responses may be served from a short-lived private server-side cache, include ETag, return 304 Not Modified for matching If-None-Match, and write cache hit/miss Cloudflare Analytics Engine datapoints without user IDs or feed tokens.",
     "static-json-resilient": "Calendar location and building image enhancements only read static JSON published at https://static.life-ustc.tiankaima.dev; when loading fails or data is corrupted, diagnostic information should be logged and a valid iCal should still be returned."
   },

--- a/src/features/calendar/server/ical.ts
+++ b/src/features/calendar/server/ical.ts
@@ -1,4 +1,4 @@
-import { ICalCalendar } from "ical-generator";
+import { formatDate, ICalCalendar } from "ical-generator";
 import {
   appendSectionEvents,
   type CalendarHomework,
@@ -33,8 +33,22 @@ const SHANGHAI_TZ_CONFIG = {
   generator: generateShanghaiVTimezone,
 };
 
+export class Rfc5545Calendar extends ICalCalendar {
+  override toString(): string {
+    const events = this.events();
+    let eventIndex = 0;
+
+    // ical-generator applies the calendar timezone to DTSTAMP, but RFC 5545
+    // requires that property to be serialized as UTC for every VEVENT.
+    return super.toString().replace(/^DTSTAMP:[^\r\n]*/gm, (line) => {
+      const event = events[eventIndex++];
+      return event ? `DTSTAMP:${formatDate(null, event.stamp())}` : line;
+    });
+  }
+}
+
 function createCalendar(name: string, description: string, url: string) {
-  return new ICalCalendar({
+  return new Rfc5545Calendar({
     name,
     description,
     timezone: SHANGHAI_TZ_CONFIG,

--- a/tests/e2e/src/app/_shared/api-contract.ts
+++ b/tests/e2e/src/app/_shared/api-contract.ts
@@ -8,6 +8,17 @@ type ApiContractCase = {
   baseURL?: string;
 };
 
+export function expectCalendarDtstampsAreUtc(calendar: string) {
+  const dtstamps = calendar
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("DTSTAMP:"));
+
+  expect(dtstamps.length).toBeGreaterThan(0);
+  for (const dtstamp of dtstamps) {
+    expect(dtstamp).toMatch(/^DTSTAMP:\d{8}T\d{6}Z$/);
+  }
+}
+
 const probeOnlyRoutes = new Set([
   "/api/admin/comments",
   "/api/admin/comments/[id]",
@@ -62,7 +73,9 @@ async function expectCalendarResponse(
 ) {
   expect(response.status()).toBe(200);
   expect(response.headers()["content-type"]).toContain("text/calendar");
-  expect(await response.text()).toContain("BEGIN:VCALENDAR");
+  const calendar = await response.text();
+  expect(calendar).toContain("BEGIN:VCALENDAR");
+  expectCalendarDtstampsAreUtc(calendar);
 }
 
 async function expectProbeRoute(

--- a/tests/e2e/src/app/api/users/[userId]/calendar.ics/test.ts
+++ b/tests/e2e/src/app/api/users/[userId]/calendar.ics/test.ts
@@ -33,7 +33,10 @@ import {
   ensureUserCalendarFeedFixture,
   getCurrentSessionUser,
 } from "../../../../../../utils/e2e-db";
-import { assertApiContract } from "../../../../_shared/api-contract";
+import {
+  assertApiContract,
+  expectCalendarDtstampsAreUtc,
+} from "../../../../_shared/api-contract";
 
 const ROUTE_PATH = "/api/users/[userId]/calendar.ics";
 
@@ -112,6 +115,7 @@ test.describe("GET /api/users/[userId]/calendar.ics", () => {
       const unfoldedBody = unfoldICalendar(body);
       expect(body.trim().length).toBeGreaterThan(0);
       expect(unfoldedBody).toContain("BEGIN:VCALENDAR");
+      expectCalendarDtstampsAreUtc(body);
 
       // Seed data should include homework, todos, and exam events
       expect(unfoldedBody).toContain(DEV_SEED.homeworks.title);

--- a/tests/unit/ical-rfc5545.test.ts
+++ b/tests/unit/ical-rfc5545.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { Rfc5545Calendar } from "@/features/calendar/server/ical";
+import { APP_TIME_ZONE } from "@/lib/time/parse-date-input";
+import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
+
+describe("RFC 5545 calendar serialization", () => {
+  test("serializes each DTSTAMP in UTC without changing event time zones", () => {
+    const calendar = new Rfc5545Calendar({
+      timezone: {
+        name: APP_TIME_ZONE,
+        generator: () =>
+          ["BEGIN:VTIMEZONE", `TZID:${APP_TIME_ZONE}`, "END:VTIMEZONE"].join(
+            "\r\n",
+          ),
+      },
+    });
+    const stamps = [
+      new Date("2026-07-13T15:09:41.000Z"),
+      new Date("2026-07-13T16:10:42.000Z"),
+    ];
+
+    for (const [index, stamp] of stamps.entries()) {
+      calendar.createEvent({
+        id: `event-${index}`,
+        stamp,
+        start: shanghaiDayjs(stamp),
+        timezone: APP_TIME_ZONE,
+        summary: `Event ${index}`,
+      });
+    }
+
+    const output = calendar.toString();
+    const dtstamps = [...output.matchAll(/^DTSTAMP:([^\r\n]+)$/gm)].map(
+      (match) => match[1],
+    );
+
+    expect(dtstamps).toEqual(["20260713T150941Z", "20260713T161042Z"]);
+    expect(output).toContain("BEGIN:VTIMEZONE");
+    expect(output).toContain(`DTSTART;TZID=${APP_TIME_ZONE}:20260713T230941`);
+  });
+});


### PR DESCRIPTION
## What changed

- serialize each event's original `DTSTAMP` as a UTC RFC 5545 `DATE-TIME` with a `Z` suffix
- retain the embedded `VTIMEZONE` and `Asia/Shanghai` event start/end values
- document the feed contract
- extend the shared Playwright calendar assertion across single-section, multi-section, and personal feeds
- add a focused unit regression with two distinct event timestamps

## Validation

- `app:prepare`
- full Biome check
- `svelte-check` (0 errors, 0 warnings)
- all three TypeScript no-emit configurations
- full Vitest: 146 files / 750 tests
- focused test confirms distinct UTC stamps, VTIMEZONE, and Shanghai DTSTART
- PR CI will run all database-backed calendar endpoint tests

Closes #404