### PR TITLE
fix(build): emit font assets for CSP

### DIFF
--- a/docs/contracts/comment.json
+++ b/docs/contracts/comment.json
@@ -10,6 +10,7 @@
     "attached-to-object": "Comments must be attached to a specific object; no decontextualized public feed entry is provided.",
     "attached-object-types": "Attached objects include courses, sections, teachers, homework, and section-teacher relationships.",
     "rich-content": "Supports Markdown, math formulas, emoji, tables, replies, and reactions.",
+    "markdown-font-csp": "Production builds emit Markdown and KaTeX font files as same-origin assets instead of data URIs so every required math glyph can load under the configured font-src Content Security Policy.",
     "visibility-modes": "Supports public and signed-in-only audience visibility; anonymous posting is represented by comment.isAnonymous and hides identity from regular users while remaining traceable by admins in governance scenarios.",
     "shared-read-policy": "Web, REST, and MCP comment reads share the same target resolution, thread serialization, visibility filtering, author masking, reaction, attachment, and viewer action-flag logic; read-only paths must not create durable comment targets and valid empty section-teacher targets load as empty threads.",
     "interaction-gate": "Edits, deletes, replies, and reaction changes require an authenticated, unsuspended viewer and an active visible comment target; deleted or softbanned comments must not expose canEdit/canDelete/canReply/canReact or accept those write actions. Admin moderation affordances require an unsuspended admin."

--- a/tests/e2e/src/app/guides/markdown-support/test.ts
+++ b/tests/e2e/src/app/guides/markdown-support/test.ts
@@ -8,6 +8,7 @@ import {
   gotoAndWaitForReady,
   waitForUiSettled,
 } from "../../../../utils/page-ready";
+import { captureStepScreenshot } from "../../../../utils/screenshot";
 import { assertPageContract } from "../../_shared/page-contract";
 
 test.describe("/guides/markdown-support Markdown 支持页", () => {
@@ -30,5 +31,46 @@ test.describe("/guides/markdown-support Markdown 支持页", () => {
 
     // Should contain a table
     await expect(page.locator("table").first()).toBeVisible();
+  });
+
+  test("KaTeX Size3 字体在 CSP 下可加载", async ({ page }, testInfo) => {
+    const fontConsoleErrors: string[] = [];
+    page.on("console", (message) => {
+      const text = message.text();
+      if (
+        message.type() === "error" &&
+        /data:font|font-src|KaTeX_Size3/i.test(text)
+      ) {
+        fontConsoleErrors.push(text);
+      }
+    });
+
+    await gotoAndWaitForReady(page, "/guides/markdown-support", {
+      waitUntil: "load",
+    });
+    await waitForUiSettled(page);
+    await expect(page.locator(".katex-display").first()).toBeVisible();
+
+    const fontLoaded = await page.evaluate(async () => {
+      const probe = document.createElement("span");
+      probe.style.fontFamily = "KaTeX_Size3";
+      probe.style.fontSize = "32px";
+      probe.style.position = "absolute";
+      probe.style.visibility = "hidden";
+      probe.textContent = "∫";
+      document.body.append(probe);
+
+      try {
+        await document.fonts.load("32px KaTeX_Size3", probe.textContent);
+        await document.fonts.ready;
+        return document.fonts.check("32px KaTeX_Size3", probe.textContent);
+      } finally {
+        probe.remove();
+      }
+    });
+
+    expect(fontLoaded).toBe(true);
+    expect(fontConsoleErrors).toEqual([]);
+    await captureStepScreenshot(page, testInfo, "katex-size3-font-loaded");
   });
 });

--- a/tests/unit/vite-font-assets.test.ts
+++ b/tests/unit/vite-font-assets.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vitest";
+import { assetInlineDecision } from "../../vite.config";
+
+describe("Vite font asset handling", () => {
+  test.each([
+    "woff",
+    "woff2",
+    "ttf",
+    "otf",
+    "eot",
+  ])("keeps .%s fonts as same-origin files", (extension) => {
+    expect(
+      assetInlineDecision(`/node_modules/katex/fonts/KaTeX_Size3.${extension}`),
+    ).toBe(false);
+  });
+
+  test("leaves non-font assets on Vite's default threshold", () => {
+    expect(assetInlineDecision("/src/images/icon.svg")).toBeUndefined();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,16 @@ function prismaWasmModulePlugin() {
   };
 }
 
+const FONT_ASSET_PATTERN = /\.(?:eot|otf|ttf|woff2?)(?:\?.*)?$/i;
+
+export function assetInlineDecision(filePath: string) {
+  return FONT_ASSET_PATTERN.test(filePath) ? false : undefined;
+}
+
 export default defineConfig({
+  build: {
+    assetsInlineLimit: assetInlineDecision,
+  },
   plugins: [prismaWasmModulePlugin(), tailwindcss(), sveltekit()],
   ssr: {
     resolve: {


### PR DESCRIPTION
## What changed

- opt every common web-font extension out of Vite asset inlining
- keep non-font assets on Vite's default inline threshold
- retain the strict existing `font-src 'self'` CSP instead of allowing arbitrary `data:` fonts
- document the Markdown/KaTeX font contract
- add config-unit coverage and a Playwright test that forces `KaTeX_Size3` to load, watches browser console errors, and captures a screenshot

## Validation

- full Biome, Svelte, and three TypeScript checks
- full Vitest: 148 files / 757 tests
- production Cloudflare build
- before: one `data:font/woff2;base64` reference and no emitted Size3 woff2
- after: zero `data:font` references and emitted `KaTeX_Size3-Regular.*.woff2`
- PR CI will provide the final browser/CSP load result and screenshot

Closes #397