### PR TITLE
docs(dev): align fresh-clone workflow

### DIFF
--- a/.agents/skills/life-ustc-dev-loop/SKILL.md
+++ b/.agents/skills/life-ustc-dev-loop/SKILL.md
@@ -16,7 +16,13 @@ This skill records the canonical order of commands for developing, checking, and
 
 ## 1. Start dev environment
 
+Install the Bun version pinned in `.bun-version`, Docker Compose, and the
+PostgreSQL client first. The Prisma seed command delegates to host `psql`
+through `prisma/seed.sh`.
+
 ```bash
+bun install --frozen-lockfile
+cp .env.example .env
 docker compose -f docker-compose.dev.yml up -d
 bun run app:prepare
 bun run db:migrate:deploy

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Core app
-# Host-native dev (`bun run dev`) uses 127.0.0.1 endpoints below and auto-runs
-# `prisma generate` + `prisma migrate deploy` before starting SvelteKit.
+# Host-native dev (`bun run dev`) uses the 127.0.0.1 endpoints below. Before
+# first start, run app:prepare, db:migrate:deploy, and `bunx prisma db seed`;
+# the dev command itself only starts Vite.
 DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev"
 # Optional when running multiple worktrees at once: set a unique
 # COMPOSE_PROJECT_NAME, POSTGRES_PORT, POSTGRES_DB, and DATABASE_URL per

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,9 +72,9 @@ Docker runtime is the static loader.
 ## Shared Test Seed
 
 - Canonical seeded fixture data lives in `tests/e2e/fixtures/scenario.json`; `tests/fixtures/dev-seed.ts` exports the named constants used by tests.
-- `prisma/seed.sql` is currently a minimal placeholder (two dev users). E2E/integration tests that depend on the full legacy scenario will fail until the seed SQL is expanded.
+- `prisma/seed.sql` contains the executable canonical scenario, including the shared users, catalog, schedule, bus, and collaboration records used by E2E/integration tests.
 - The shared anchor comes from `DEV_SEED_ANCHOR` in `tests/fixtures/dev-seed.ts`. Use `.date` for bare date filters, `.recommendedAtTime` for time-sensitive tool calls, and `.startOfDayAtTime` when a test needs the seed day boundary.
-- `$life-ustc-dev-loop` seeds the minimal placeholder; if you invoke integration specs directly, run `bunx prisma db seed` first.
+- `$life-ustc-dev-loop` loads that canonical scenario; if you invoke integration specs directly, run `bunx prisma db seed` first. The seed runner invokes host `psql`, so install the PostgreSQL client locally.
 - Scoped `tests/**/AGENTS.md` files should only add layer-specific caveats and link shared commands/setup back here or to helper files such as `tests/integration/utils/mcp-harness.ts`.
 
 ## Local Dev Environment
@@ -85,7 +85,9 @@ Docker runtime is the static loader.
 - `bun run dev` starts Vite directly; run `bun run app:prepare` and `bun run db:migrate:deploy` (or follow `$life-ustc-dev-loop`) before the first start. It no longer auto-runs OpenAPI generation or migrations.
 - Host-native `bun run dev` is pinned to `127.0.0.1:3000`.
 - Prefer these flows for pain-free setup:
-  1. `docker compose -f docker-compose.dev.yml up -d && bun run dev` for host-native app dev
+  1. Start Postgres with `docker compose -f docker-compose.dev.yml up -d`.
+  2. Run `bun run app:prepare`, `bun run db:migrate:deploy`, and `bunx prisma db seed`.
+  3. Run `bun run dev` for the host-native app.
 
 ## Production Deployment
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,24 @@ contracts live in [docs/contracts/](./docs/contracts/).
 
 ## 快速开始
 
+准备 `.bun-version` 指定的 Bun、Docker Compose 和 PostgreSQL 客户端（seed
+脚本会在宿主机调用 `psql`），然后按同一顺序初始化本地环境：
+
 ```bash
 bun install --frozen-lockfile
 cp .env.example .env
 docker compose -f docker-compose.dev.yml up -d
+bun run app:prepare
+bun run db:migrate:deploy
+bunx prisma db seed
 bun run dev
 ```
 
-首次本地启动前先从 `.env.example` 创建 `.env`，因为 `bun run dev` 会在启动 Vite 前运行 Prisma 迁移并读取 `DATABASE_URL`。本地数据库由 Docker Compose 管理；需要数据库时先启动本地 infra，再运行应用。上传存储使用 Cloudflare `R2_UPLOADS` 绑定，需通过 Wrangler 相关流程本地验证。生产应用由 Cloudflare Git integration 发布，Docker 只保留静态数据加载环境。
+`bun run dev` 只启动 Vite，不会生成 Prisma 客户端、运行迁移或写入 seed。
+本地数据库由 Docker Compose 管理；首次启动及 schema/seed 更新后，先完成上述
+prepare、migrate、seed 步骤。上传存储使用 Cloudflare `R2_UPLOADS` 绑定，需通过
+Wrangler 相关流程本地验证。生产应用由 Cloudflare Git integration 发布，Docker
+只保留静态数据加载环境。
 
 生产 Workers Builds 配置：
 - Build command: `bun install --frozen-lockfile && bun run app:prepare && bun run build`

--- a/prisma/AGENTS.md
+++ b/prisma/AGENTS.md
@@ -51,7 +51,7 @@ Start Postgres first for local migration work:
 
 ```bash
 docker compose -f docker-compose.dev.yml up -d postgres
-bun run db migrate dev # Create migration
+bunx prisma migrate dev # Create migration
 bun run build # Generate artifacts and verify the production build
 # Update seed scenarios
 # Update E2E tests

--- a/tests/unit/AGENTS.md
+++ b/tests/unit/AGENTS.md
@@ -5,7 +5,7 @@ Unit tests for pure helpers.
 ## Run
 
 Use the canonical command list in the repo root `AGENTS.md`; for this layer that
-is `bun run test`.
+is `bunx vitest run tests/unit`.
 
 ## Scope
 


### PR DESCRIPTION
## What changed

- make README and the canonical dev-loop skill use the same fresh-clone sequence: install, create `.env`, start Postgres, prepare, migrate, seed, then start Vite
- state accurately that `bun run dev` only starts Vite
- document the host PostgreSQL client / `psql` prerequisite used by the seed runner
- describe the current canonical 852-line scenario seed instead of the stale two-user placeholder
- replace the nonexistent unit-test and Prisma migration commands in scoped guidance
- reference the Bun pin through `.bun-version` to avoid duplicated version drift

## Validation

- stale-claim and broken-command repository scan
- `git diff --check`
- documented unit command: 148 files / 758 tests
- `app:prepare`
- full Biome check
- `svelte-check` (0 errors / 0 warnings)
- all three TypeScript no-emit configurations
- independent issue-surface review

Closes #364