### PR TITLE
fix(uploads): keep list reads side-effect free

### DIFF
--- a/docs/contracts/upload.json
+++ b/docs/contracts/upload.json
@@ -9,6 +9,7 @@
   "rules": {
     "comment-attachments-only": "Uploads serve only comment attachments; they are not an independent file space.",
     "permission-and-quota": "Permission and quota checks are required before upload.",
+    "pure-upload-reads": "GET upload-list requests never delete pending reservations. Expired reservations are excluded from quota calculations, while cleanup remains confined to upload create and completion write paths.",
     "write-auth-unsuspended": "Upload write routes require an unsuspended signed-in user; suspended users receive 403 before upload metadata or object state changes.",
     "three-step-upload": "Web comment attachment uploads follow a three-step flow — create upload session on-site → browser PUT to an on-site Cloudflare Workers upload object route backed by R2 → confirm completion on-site.",
     "r2-backend": "Upload object create/read/head/delete operations use the Cloudflare R2 binding. The app runtime does not use S3-compatible signed URL fallbacks.",

--- a/src/features/uploads/server/upload-service.ts
+++ b/src/features/uploads/server/upload-service.ts
@@ -266,7 +266,6 @@ export async function completeUploadSession(
 
 export async function listUploads(userId: string) {
   const now = new Date();
-  await deleteExpiredPendingUploads(prisma, userId, now);
 
   const [uploads, usage, pendingUsage] = await Promise.all([
     prisma.upload.findMany({

--- a/tests/e2e/src/app/api/uploads/test.ts
+++ b/tests/e2e/src/app/api/uploads/test.ts
@@ -20,8 +20,8 @@
  */
 import { expect, test } from "@playwright/test";
 import { uploadConfig } from "@/features/uploads/lib/upload-config";
-import { prisma } from "@/lib/db/prisma";
 import { signInAsDebugUser } from "../../../../utils/auth";
+import { withE2ePrisma } from "../../../../utils/e2e-db/prisma";
 import { createUploadedFileViaApi } from "../../../../utils/uploads";
 
 test("/api/uploads GET 未登录返回 401", async ({ request }) => {
@@ -61,16 +61,18 @@ test("/api/uploads GET 忽略过期预留但不执行清理写入", async ({ pag
   const beforeResponse = await page.request.get("/api/uploads");
   const before = (await beforeResponse.json()) as { usedBytes?: number };
   const key = `uploads/${userId}/expired-read-${Date.now()}.txt`;
-  const pending = await prisma.uploadPending.create({
-    data: {
-      contentType: "text/plain",
-      expiresAt: new Date(Date.now() - 60_000),
-      filename: "expired-read.txt",
-      key,
-      size: 12_345,
-      userId,
-    },
-  });
+  const pending = await withE2ePrisma((prisma) =>
+    prisma.uploadPending.create({
+      data: {
+        contentType: "text/plain",
+        expiresAt: new Date(Date.now() - 60_000),
+        filename: "expired-read.txt",
+        key,
+        size: 12_345,
+        userId,
+      },
+    }),
+  );
 
   try {
     const response = await page.request.get("/api/uploads");
@@ -78,10 +80,14 @@ test("/api/uploads GET 忽略过期预留但不执行清理写入", async ({ pag
     const body = (await response.json()) as { usedBytes?: number };
     expect(body.usedBytes).toBe(before.usedBytes);
     await expect(
-      prisma.uploadPending.findUnique({ where: { id: pending.id } }),
+      withE2ePrisma((prisma) =>
+        prisma.uploadPending.findUnique({ where: { id: pending.id } }),
+      ),
     ).resolves.not.toBeNull();
   } finally {
-    await prisma.uploadPending.deleteMany({ where: { id: pending.id } });
+    await withE2ePrisma((prisma) =>
+      prisma.uploadPending.deleteMany({ where: { id: pending.id } }),
+    );
   }
 });
 

--- a/tests/e2e/src/app/api/uploads/test.ts
+++ b/tests/e2e/src/app/api/uploads/test.ts
@@ -4,7 +4,7 @@
  * ## GET /api/uploads
  * - Response: { maxFileSizeBytes, quotaBytes, uploads[], usedBytes }
  * - Auth required (401 if unauthenticated)
- * - Cleans up expired pending uploads before listing
+ * - Ignores expired pending uploads for quota without mutating them
  *
  * ## POST /api/uploads
  * - Body: { filename, size, contentType? }
@@ -20,6 +20,7 @@
  */
 import { expect, test } from "@playwright/test";
 import { uploadConfig } from "@/features/uploads/lib/upload-config";
+import { prisma } from "@/lib/db/prisma";
 import { signInAsDebugUser } from "../../../../utils/auth";
 import { createUploadedFileViaApi } from "../../../../utils/uploads";
 
@@ -44,6 +45,44 @@ test("/api/uploads GET 返回上传列表与配额元数据", async ({ page }) =
   expect(typeof body.quotaBytes).toBe("number");
   expect(typeof body.usedBytes).toBe("number");
   expect(Array.isArray(body.uploads)).toBe(true);
+});
+
+test("/api/uploads GET 忽略过期预留但不执行清理写入", async ({ page }) => {
+  await signInAsDebugUser(page, "/");
+
+  const sessionResponse = await page.request.get("/api/auth/get-session");
+  const session = (await sessionResponse.json()) as {
+    user?: { id?: string };
+  };
+  const userId = session.user?.id;
+  expect(userId).toBeTruthy();
+  if (!userId) throw new Error("Expected signed-in E2E user id");
+
+  const beforeResponse = await page.request.get("/api/uploads");
+  const before = (await beforeResponse.json()) as { usedBytes?: number };
+  const key = `uploads/${userId}/expired-read-${Date.now()}.txt`;
+  const pending = await prisma.uploadPending.create({
+    data: {
+      contentType: "text/plain",
+      expiresAt: new Date(Date.now() - 60_000),
+      filename: "expired-read.txt",
+      key,
+      size: 12_345,
+      userId,
+    },
+  });
+
+  try {
+    const response = await page.request.get("/api/uploads");
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as { usedBytes?: number };
+    expect(body.usedBytes).toBe(before.usedBytes);
+    await expect(
+      prisma.uploadPending.findUnique({ where: { id: pending.id } }),
+    ).resolves.not.toBeNull();
+  } finally {
+    await prisma.uploadPending.deleteMany({ where: { id: pending.id } });
+  }
 });
 
 test("/api/uploads POST 未登录返回 401", async ({ request }) => {

--- a/tests/unit/upload-list-service.test.ts
+++ b/tests/unit/upload-list-service.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  pendingAggregateMock,
+  pendingDeleteManyMock,
+  uploadAggregateMock,
+  uploadFindManyMock,
+} = vi.hoisted(() => ({
+  pendingAggregateMock: vi.fn(),
+  pendingDeleteManyMock: vi.fn(),
+  uploadAggregateMock: vi.fn(),
+  uploadFindManyMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    upload: {
+      aggregate: uploadAggregateMock,
+      findMany: uploadFindManyMock,
+    },
+    uploadPending: {
+      aggregate: pendingAggregateMock,
+      deleteMany: pendingDeleteManyMock,
+    },
+  },
+}));
+
+import { listUploads } from "@/features/uploads/server/upload-service";
+
+describe("listUploads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    uploadFindManyMock.mockResolvedValue([]);
+    uploadAggregateMock.mockResolvedValue({ _sum: { size: 80 } });
+    pendingAggregateMock.mockResolvedValue({ _sum: { size: 20 } });
+  });
+
+  it("keeps GET read-only while excluding expired reservations from usage", async () => {
+    await expect(listUploads("user-1")).resolves.toEqual(
+      expect.objectContaining({ uploads: [], usedBytes: 100 }),
+    );
+
+    expect(pendingDeleteManyMock).not.toHaveBeenCalled();
+    expect(pendingAggregateMock).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        expiresAt: { gt: expect.any(Date) },
+      },
+      _sum: { size: true },
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- remove expired-pending cleanup from `listUploads()`, making GET/list reads side-effect free
- continue excluding expired reservations from quota through the existing `expiresAt > now` aggregate
- keep cleanup on upload creation/completion write paths
- document the read-purity contract
- add a unit regression proving list reads never call `uploadPending.deleteMany`
- add database E2E coverage proving an expired reservation survives GET while contributing zero quota bytes

## Validation

- focused upload service tests: 2 files / 7 tests
- full pinned-Bun gate: 149 files / 759 tests
- Biome, Svelte, and all three TypeScript checks
- production Cloudflare build
- PR CI will run the database-backed upload E2E

Closes #412