### PR TITLE
test(e2e): publish named visual checkpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
       webhook-secret: e2e-ci-secret
       extra-env: |
         NO_PROXY=127.0.0.1,localhost,::1
+        CAPTURE_STEP_SCREENSHOTS=1
       download-artifact-name: e2e-svelte-kit
       download-artifact-path: .svelte-kit
       job-phase: ci:e2e:test

--- a/tests/e2e/AGENTS.md
+++ b/tests/e2e/AGENTS.md
@@ -13,7 +13,11 @@ For a focused local Playwright run after setup:
 bunx playwright test path/to/test
 bunx playwright test --headed path/to/test
 bunx playwright test --ui
+CAPTURE_STEP_SCREENSHOTS=1 bunx playwright test path/to/test
 ```
+
+Named step screenshots are compressed JPEG report attachments. They are enabled
+in CI and opt-in locally through `CAPTURE_STEP_SCREENSHOTS=1`.
 
 ## Local Setup
 

--- a/tests/e2e/mobile-screenshots/screenshots.spec.ts
+++ b/tests/e2e/mobile-screenshots/screenshots.spec.ts
@@ -1,7 +1,16 @@
-import { test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { DEV_SEED } from "../../fixtures/dev-seed";
 import { signInAsDebugUser, signInAsDevAdmin } from "../utils/auth";
+import {
+  getCurrentSessionUser,
+  getUserProfileById,
+  updateUserProfileById,
+} from "../utils/e2e-db";
 import { gotoAndWaitForReady } from "../utils/page-ready";
+import {
+  captureStepScreenshot,
+  isStepScreenshotCaptureEnabled,
+} from "../utils/screenshot";
 
 function screenshotRoute(name: string, path: string) {
   test(name, async ({ page }) => {
@@ -19,7 +28,6 @@ test.describe("移动端截图", () => {
       `/sections/${DEV_SEED.section.jwId}`,
       "/teachers",
       "/bus-map",
-      "/welcome",
       "/comments/guide",
       "/guides/markdown-support",
       "/privacy",
@@ -62,6 +70,50 @@ test.describe("移动端截图", () => {
       const userId = session.user?.id ?? "";
       await gotoAndWaitForReady(page, `/u/id/${userId}`);
     });
+
+    test.describe("welcome 共享用户状态", () => {
+      test.describe.configure({ mode: "serial" });
+
+      test("/welcome 页面截图", async ({ page }) => {
+        const sessionUser = await getCurrentSessionUser(page);
+        const originalUser = await getUserProfileById(sessionUser.id);
+        await updateUserProfileById(sessionUser.id, {
+          name: null,
+          username: null,
+        });
+
+        try {
+          await gotoAndWaitForReady(page, "/welcome");
+          await expect(page).toHaveURL(/\/welcome(?:\?.*)?$/);
+          await expect(
+            page.getByRole("textbox", { name: /^(姓名|Name)\b/i }),
+          ).toBeVisible();
+        } finally {
+          await updateUserProfileById(sessionUser.id, {
+            name: originalUser.name ?? DEV_SEED.debugName,
+            username: originalUser.username ?? DEV_SEED.debugUsername,
+            image: originalUser.image ?? null,
+          });
+        }
+      });
+    });
+  });
+
+  test("命名步骤截图会写入报告附件", async ({ page }, testInfo) => {
+    test.skip(
+      !isStepScreenshotCaptureEnabled(),
+      "Set CAPTURE_STEP_SCREENSHOTS=1 for visual evidence runs.",
+    );
+
+    await gotoAndWaitForReady(page, "/");
+    const attachmentName = "evidence/named-checkpoint";
+    await captureStepScreenshot(page, testInfo, attachmentName);
+
+    const attachment = testInfo.attachments.find(
+      (candidate) => candidate.name === attachmentName,
+    );
+    expect(attachment?.contentType).toBe("image/jpeg");
+    expect(attachment?.body?.byteLength).toBeGreaterThan(0);
   });
 
   test.describe("管理员页面", () => {

--- a/tests/e2e/utils/screenshot.ts
+++ b/tests/e2e/utils/screenshot.ts
@@ -1,6 +1,8 @@
 import type { Page, TestInfo } from "@playwright/test";
 
-const CAPTURE_STEP_SCREENSHOTS = false;
+export function isStepScreenshotCaptureEnabled() {
+  return process.env.CAPTURE_STEP_SCREENSHOTS === "1";
+}
 
 /**
  * Captures a screenshot and attaches it to the test report.
@@ -14,13 +16,17 @@ export async function captureStepScreenshot(
   testInfo: TestInfo,
   name: string,
 ) {
-  if (!CAPTURE_STEP_SCREENSHOTS) return;
+  if (!isStepScreenshotCaptureEnabled()) return;
 
-  const screenshot = await page.screenshot({ fullPage: true });
+  const screenshot = await page.screenshot({
+    fullPage: true,
+    type: "jpeg",
+    quality: 65,
+  });
 
   await testInfo.attach(name, {
     body: screenshot,
-    contentType: "image/png",
+    contentType: "image/jpeg",
   });
 }
 


### PR DESCRIPTION
## What changed

- replace the hard-coded no-op with an explicit `CAPTURE_STEP_SCREENSHOTS=1` policy
- enable named visual checkpoint attachments in every CI E2E shard
- attach compressed full-page JPEG evidence so dialogs, empty/error states, updates, and scrolled states survive into the merged HTML report
- add an E2E assertion for attachment name, MIME type, and non-empty bytes
- move `/welcome` out of the signed-out mobile sweep and capture the real onboarding page using a signed-in user with temporarily incomplete profile data
- restore the shared user in `finally`, and isolate only that mutation in serial mode
- document the local opt-in command

## Validation

- independent configuration/report-chain review: no blockers
- Playwright `--list`: mobile sweep and evidence test selected for mobile-chrome
- focused Biome and E2E TypeScript checks
- full pinned-Bun gate: 148 files / 758 Vitest tests; Svelte 0/0; all three TypeScript checks
- production Cloudflare build
- actual database-backed Chromium run and published attachment are the PR CI merge gate

Closes #371