### PR TITLE
feat(api): return 201 for created resources

### DIFF
--- a/docs/contracts/comment.json
+++ b/docs/contracts/comment.json
@@ -33,6 +33,7 @@
           {
             "path": "/api/comments",
             "method": "POST",
+            "status": 201,
             "returns": "{ id: String }",
             "auth": "user",
             "notes": [
@@ -184,6 +185,7 @@
           {
             "path": "/api/admin/suspensions",
             "method": "POST",
+            "status": 201,
             "returns": "{ suspension: Suspension }"
           },
           {

--- a/docs/contracts/homework.json
+++ b/docs/contracts/homework.json
@@ -83,6 +83,7 @@
           {
             "path": "/api/homeworks",
             "method": "POST",
+            "status": 201,
             "returns": "{ id: String, homework: HomeworkItem }",
             "auth": "user",
             "notes": [

--- a/docs/contracts/openapi.json
+++ b/docs/contracts/openapi.json
@@ -15,7 +15,8 @@
     "generated-client-required": "CLI and Bot business calls must use generated OpenAPI clients and generated request/response types whenever the server OpenAPI covers the endpoint. Allowed exceptions are explicit raw request escape hatches, presigned upload object PUTs, OAuth protocol plumbing, external school/QQ/NapCat APIs, and documented non-OpenAPI endpoints such as OAuth userinfo fallback.",
     "openapi-drift-gate": "After server OpenAPI changes, regenerate public/openapi.generated.json and sync api/openapi.json plus generated Go clients in CLI and Bot before publishing. Cross-repo CI should fail if copied OpenAPI files drift from the server-generated contract.",
     "rest-observability": "REST API handling records production-safe structured request-start/request-finish logs with request ID, method, status, auth mode, duration, and normalized route template; when the Cloudflare Analytics Engine binding is present it also writes sanitized request finish/error datapoints with normalized route, method, status class, auth mode, and duration; it does not log request bodies, credentials, raw query strings, or high-cardinality resource IDs.",
-    "unknown-api-json-errors": "Unknown paths under /api return the standard JSON { error } envelope with status 404 instead of falling through to the HTML application error page."
+    "unknown-api-json-errors": "Unknown paths under /api return the standard JSON { error } envelope with status 404 instead of falling through to the HTML application error page.",
+    "created-resource-status": "POST /api/todos, /api/comments, /api/homeworks, and /api/admin/suspensions return 201 Created with a relative Location header for the new resource. Idempotent upserts and state-setting operations continue to return 200."
   },
   "capabilities": {
     "api-docs-page": {

--- a/docs/contracts/todo.json
+++ b/docs/contracts/todo.json
@@ -73,6 +73,7 @@
           {
             "path": "/api/todos",
             "method": "POST",
+            "status": 201,
             "returns": "{ id: String }"
           },
           {

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -640,8 +640,16 @@
           }
         },
         "responses": {
-          "200": {
+          "201": {
             "description": "Successful response",
+            "headers": {
+              "Location": {
+                "description": "Relative URL of the created resource",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1072,8 +1080,16 @@
           }
         },
         "responses": {
-          "200": {
+          "201": {
             "description": "Successful response",
+            "headers": {
+              "Location": {
+                "description": "Relative URL of the created resource",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -1888,8 +1904,16 @@
           }
         },
         "responses": {
-          "200": {
+          "201": {
             "description": "Successful response",
+            "headers": {
+              "Location": {
+                "description": "Relative URL of the created resource",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -2333,8 +2357,16 @@
           }
         },
         "responses": {
-          "200": {
+          "201": {
             "description": "Successful response",
+            "headers": {
+              "Location": {
+                "description": "Relative URL of the created resource",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {

--- a/scripts/openapi/route-collector.ts
+++ b/scripts/openapi/route-collector.ts
@@ -453,6 +453,16 @@ function buildResponse(
   const statusNum = Number.parseInt(status, 10);
   return {
     description: statusNum >= 400 ? "Error response" : "Successful response",
+    ...(status === "201"
+      ? {
+          headers: {
+            Location: {
+              description: "Relative URL of the created resource",
+              schema: { type: "string" },
+            },
+          },
+        }
+      : {}),
     content: {
       "application/json": { schema: schemaRef(target) },
     },

--- a/src/lib/api/responses.ts
+++ b/src/lib/api/responses.ts
@@ -26,6 +26,13 @@ export function jsonResponse(body: unknown, init?: ResponseInit) {
   });
 }
 
+export function createdJsonResponse(body: unknown, location: string) {
+  return jsonResponse(body, {
+    status: 201,
+    headers: { Location: location },
+  });
+}
+
 export function getRequestSearchParams(request: Request) {
   return new URL(request.url).searchParams;
 }

--- a/src/lib/api/routes/admin-suspensions.ts
+++ b/src/lib/api/routes/admin-suspensions.ts
@@ -5,6 +5,7 @@ import {
 } from "@/features/admin/server/admin-api-service";
 import {
   badRequest,
+  createdJsonResponse,
   jsonResponse,
   notFound,
   parseRouteJsonBody,
@@ -43,7 +44,10 @@ export async function postAdminSuspensionRoute(request: Request) {
         return notFound("User not found");
       }
 
-      return jsonResponse({ suspension: result.suspension });
+      return createdJsonResponse(
+        { suspension: result.suspension },
+        `/api/admin/suspensions/${encodeURIComponent(result.suspension.id)}`,
+      );
     },
     { requireActive: true },
   );

--- a/src/lib/api/routes/comments-create-route.ts
+++ b/src/lib/api/routes/comments-create-route.ts
@@ -1,9 +1,9 @@
 import { createComment } from "@/features/comments/server/comment-mutations";
 import {
   badRequest,
+  createdJsonResponse,
   forbidden,
   handleRouteError,
-  jsonResponse,
   notFound,
   parseRouteJsonBody,
   suspensionForbidden,
@@ -75,7 +75,10 @@ export async function postCommentRoute(request: Request) {
       return forbidden();
     }
 
-    return jsonResponse({ id: result.comment.id });
+    return createdJsonResponse(
+      { id: result.comment.id },
+      `/api/comments/${encodeURIComponent(result.comment.id)}`,
+    );
   } catch (error) {
     return handleRouteError("Failed to create comment", error);
   }

--- a/src/lib/api/routes/homework-mutation-routes.ts
+++ b/src/lib/api/routes/homework-mutation-routes.ts
@@ -2,9 +2,9 @@ import { createHomeworkForSection } from "@/features/homeworks/server/homework-c
 import { requireHomeworkItemById } from "@/features/homeworks/server/homework-read-model";
 import {
   badRequest,
+  createdJsonResponse,
   forbidden,
   handleRouteError,
-  jsonResponse,
   notFound,
   parseRouteJsonBody,
   suspensionForbidden,
@@ -62,7 +62,10 @@ export async function postHomeworkRoute(request: Request) {
       locale: getRequestLocale(request),
       userId,
     });
-    return jsonResponse({ id: homework.id, homework: homeworkItem });
+    return createdJsonResponse(
+      { id: homework.id, homework: homeworkItem },
+      `/api/homeworks/${encodeURIComponent(homework.id)}`,
+    );
   } catch (error) {
     return handleRouteError("Failed to create homework", error);
   }

--- a/src/lib/api/routes/todo-actions.ts
+++ b/src/lib/api/routes/todo-actions.ts
@@ -8,6 +8,7 @@ import {
 } from "@/features/todos/server/todo-service";
 import {
   badRequest,
+  createdJsonResponse,
   forbidden,
   jsonResponse,
   notFound,
@@ -38,7 +39,10 @@ export async function createTodoAction(
     dueAt,
   });
 
-  return jsonResponse({ id: todo.id });
+  return createdJsonResponse(
+    { id: todo.id },
+    `/api/todos/${encodeURIComponent(todo.id)}`,
+  );
 }
 
 export async function updateTodoAction(

--- a/src/routes/api/admin/suspensions/+server.ts
+++ b/src/routes/api/admin/suspensions/+server.ts
@@ -16,7 +16,7 @@ export const GET = svelteRequestHandler(
 /**
  * Create suspension for one user.
  * @body adminCreateSuspensionRequestSchema
- * @response adminSuspensionResponseSchema
+ * @response 201:adminSuspensionResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
  * @response 403:openApiErrorSchema

--- a/src/routes/api/comments/+server.ts
+++ b/src/routes/api/comments/+server.ts
@@ -13,7 +13,7 @@ export const GET = svelteRequestHandler(observedApiRoute(getCommentsRoute));
 /**
  * Create one comment.
  * @body commentCreateRequestSchema
- * @response idResponseSchema
+ * @response 201:idResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
  * @response 403:openApiErrorSchema

--- a/src/routes/api/homeworks/+server.ts
+++ b/src/routes/api/homeworks/+server.ts
@@ -16,7 +16,7 @@ export const GET = svelteRequestHandler(observedApiRoute(getHomeworksRoute));
 /**
  * Create one homework.
  * @body homeworkCreateRequestSchema
- * @response homeworkCreateResponseSchema
+ * @response 201:homeworkCreateResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
  * @response 403:openApiErrorSchema

--- a/src/routes/api/todos/+server.ts
+++ b/src/routes/api/todos/+server.ts
@@ -13,7 +13,7 @@ export const GET = svelteRequestHandler(observedApiRoute(getTodosRoute));
 /**
  * Create a todo.
  * @body todoCreateRequestSchema
- * @response idResponseSchema
+ * @response 201:idResponseSchema
  * @response 400:openApiErrorSchema
  * @response 401:openApiErrorSchema
  */

--- a/tests/e2e/src/app/_shared/page-contract.ts
+++ b/tests/e2e/src/app/_shared/page-contract.ts
@@ -318,7 +318,7 @@ export async function assertPageContract(
           body: "e2e mapped route comment",
         },
       });
-      expect(createResponse.status()).toBe(200);
+      expect(createResponse.status()).toBe(201);
       const createBody = (await createResponse.json()) as { id?: string };
       expect(createBody.id).toBeTruthy();
 

--- a/tests/e2e/src/app/admin/moderation/test.ts
+++ b/tests/e2e/src/app/admin/moderation/test.ts
@@ -156,7 +156,7 @@ test("/admin/moderation 可更新评论状态与备注", async ({ page }, testIn
       visibility: "public",
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
   const createdComment = (await createResponse.json()) as { id?: string };
   expect(createdComment.id).toBeTruthy();
 
@@ -211,7 +211,7 @@ test("/admin/moderation 目标链接可跳转到原页面锚点", async ({
     (response) =>
       response.url().includes("/api/comments") &&
       response.request().method() === "POST" &&
-      response.status() === 200,
+      response.status() === 201,
   );
   await page.getByRole("button", { name: /发布评论|Post comment/i }).click();
   const created = await createResponse;
@@ -293,7 +293,7 @@ test("/admin/moderation 封禁列表可解除封禁", async ({ page }, testInfo)
       },
     },
   );
-  expect(createSuspensionResponse.status()).toBe(200);
+  expect(createSuspensionResponse.status()).toBe(201);
   const createdBody = (await createSuspensionResponse.json()) as {
     suspension?: { id?: string };
   };
@@ -334,7 +334,7 @@ test("/admin/moderation 可从评论弹窗封禁并解除用户", async ({
         visibility: "public",
       },
     });
-    expect(createCommentResponse.status()).toBe(200);
+    expect(createCommentResponse.status()).toBe(201);
     commentId = ((await createCommentResponse.json()) as { id?: string }).id;
     expect(commentId).toBeTruthy();
 
@@ -364,7 +364,7 @@ test("/admin/moderation 可从评论弹窗封禁并解除用户", async ({
     );
     await dialog.getByRole("button", { name: /封禁|Suspend/i }).click();
     const created = await suspendResponse;
-    expect(created.status()).toBe(200);
+    expect(created.status()).toBe(201);
     const createdBody = (await created.json()) as {
       suspension?: { id?: string };
     };

--- a/tests/e2e/src/app/admin/users/test.ts
+++ b/tests/e2e/src/app/admin/users/test.ts
@@ -261,7 +261,7 @@ test("/admin/users 可创建默认时长封禁并通过 API 解除", async ({
       (response) =>
         response.url().includes("/api/admin/suspensions") &&
         response.request().method() === "POST" &&
-        response.status() === 200,
+        response.status() === 201,
     );
     await suspendButton.click({ force: true });
     const response = await responsePromise;

--- a/tests/e2e/src/app/api/admin/homeworks/[id]/test.ts
+++ b/tests/e2e/src/app/api/admin/homeworks/[id]/test.ts
@@ -57,7 +57,7 @@ test.describe("DELETE /api/admin/homeworks/[id] 作业管理", () => {
         submissionDueAt: new Date(now.getTime() + 86400000).toISOString(),
       },
     });
-    expect(createResponse.status()).toBe(200);
+    expect(createResponse.status()).toBe(201);
     const createBody = (await createResponse.json()) as {
       id?: string;
     };

--- a/tests/e2e/src/app/api/admin/suspensions/[id]/test.ts
+++ b/tests/e2e/src/app/api/admin/suspensions/[id]/test.ts
@@ -63,7 +63,7 @@ test.describe("PATCH /api/admin/suspensions/[id] 解除封禁", () => {
           reason: `e2e-lift-suspension-${Date.now()}`,
         },
       });
-      expect(createResponse.status()).toBe(200);
+      expect(createResponse.status()).toBe(201);
       const createBody = (await createResponse.json()) as {
         suspension?: { id?: string };
       };

--- a/tests/e2e/src/app/api/admin/suspensions/test.ts
+++ b/tests/e2e/src/app/api/admin/suspensions/test.ts
@@ -144,7 +144,7 @@ test.describe("GET/POST /api/admin/suspensions 封禁管理", () => {
           note: "automated test",
         },
       });
-      expect(postResponse.status()).toBe(200);
+      expect(postResponse.status()).toBe(201);
       const postBody = (await postResponse.json()) as {
         suspension?: {
           expiresAt?: string | null;
@@ -154,6 +154,9 @@ test.describe("GET/POST /api/admin/suspensions 封禁管理", () => {
         };
       };
       expect(postBody.suspension?.userId).toBe(userId);
+      expect(postResponse.headers().location).toBe(
+        `/api/admin/suspensions/${postBody.suspension?.id}`,
+      );
       expect(postBody.suspension?.reason).toBe("e2e suspension test");
       expect(postBody.suspension?.expiresAt).toBeNull();
 
@@ -163,7 +166,7 @@ test.describe("GET/POST /api/admin/suspensions 封禁管理", () => {
           reason: "e2e suspension replacement",
         },
       });
-      expect(replacementResponse.status()).toBe(200);
+      expect(replacementResponse.status()).toBe(201);
       const replacementBody = (await replacementResponse.json()) as {
         suspension?: {
           id?: string;

--- a/tests/e2e/src/app/api/comments/[id]/reactions/test.ts
+++ b/tests/e2e/src/app/api/comments/[id]/reactions/test.ts
@@ -163,7 +163,7 @@ test("/api/comments/[id]/reactions POST 对失效评论返回 403", async ({
       visibility: "public",
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
   const commentId = ((await createResponse.json()) as { id?: string }).id;
   expect(commentId).toBeTruthy();
   if (!commentId) {
@@ -218,7 +218,7 @@ test("/api/comments/[id]/reactions DELETE 对失效评论返回 403", async ({
       visibility: "public",
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
   const commentId = ((await createResponse.json()) as { id?: string }).id;
   expect(commentId).toBeTruthy();
   if (!commentId) {

--- a/tests/e2e/src/app/api/comments/[id]/test.ts
+++ b/tests/e2e/src/app/api/comments/[id]/test.ts
@@ -125,7 +125,7 @@ test("/api/comments/[id] GET 隐藏聚焦线程返回 403", async ({
       visibility: "logged_in_only",
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
   const commentId = ((await createResponse.json()) as { id?: string }).id;
   expect(commentId).toBeTruthy();
   if (!commentId) {
@@ -167,7 +167,7 @@ test("/api/comments/[id] PATCH 拒绝匿名可见性", async ({ page }) => {
       visibility: "public",
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
   const commentId = ((await createResponse.json()) as { id?: string }).id;
   expect(commentId).toBeTruthy();
 
@@ -204,7 +204,7 @@ test("/api/comments/[id] PATCH 可修改评论并 DELETE 清理", async ({ page 
       visibility: "public",
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
   const commentId = ((await createResponse.json()) as { id?: string }).id;
   expect(commentId).toBeTruthy();
 
@@ -264,7 +264,7 @@ test("/api/comments/[id] PATCH 非所有者管理员被拒绝", async ({ browser
       visibility: "public",
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
   const commentId = ((await createResponse.json()) as { id?: string }).id;
   expect(commentId).toBeTruthy();
   if (!commentId) {
@@ -313,7 +313,7 @@ test("/api/comments/[id] PATCH 拒绝绑定到其他评论的上传文件", asyn
         attachmentIds: [uploaded.uploadId],
       },
     });
-    expect(firstResponse.status()).toBe(200);
+    expect(firstResponse.status()).toBe(201);
 
     const secondResponse = await page.request.post("/api/comments", {
       data: {
@@ -323,7 +323,7 @@ test("/api/comments/[id] PATCH 拒绝绑定到其他评论的上传文件", asyn
         visibility: "public",
       },
     });
-    expect(secondResponse.status()).toBe(200);
+    expect(secondResponse.status()).toBe(201);
     const secondCommentId = ((await secondResponse.json()) as { id?: string })
       .id;
     expect(secondCommentId).toBeTruthy();
@@ -364,7 +364,7 @@ test("/api/comments/[id] PATCH 对失效评论返回 403", async ({ page }) => {
       visibility: "public",
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
   const commentId = ((await createResponse.json()) as { id?: string }).id;
   expect(commentId).toBeTruthy();
   if (!commentId) {

--- a/tests/e2e/src/app/api/comments/test.ts
+++ b/tests/e2e/src/app/api/comments/test.ts
@@ -309,9 +309,10 @@ test("/api/comments POST 登录后可发布新评论并清理", async ({ page })
       visibility: "public",
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
   const createdId = ((await createResponse.json()) as { id?: string }).id;
   expect(createdId).toBeTruthy();
+  expect(createResponse.headers().location).toBe(`/api/comments/${createdId}`);
 
   try {
     const listResponse = await page.request.get(
@@ -343,7 +344,7 @@ test("/api/comments POST 接受公开 section JW id", async ({ page }) => {
       visibility: "public",
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
   const createdId = ((await createResponse.json()) as { id?: string }).id;
   expect(createdId).toBeTruthy();
 
@@ -416,7 +417,7 @@ test("/api/comments POST 拒绝复用已上传附件", async ({ page }) => {
         attachmentIds: [uploaded.uploadId],
       },
     });
-    expect(firstResponse.status()).toBe(200);
+    expect(firstResponse.status()).toBe(201);
 
     const secondResponse = await page.request.post("/api/comments", {
       data: {
@@ -469,7 +470,7 @@ test("/api/comments POST 可创建回复评论", async ({ page }) => {
       parentId: seedCommentId,
     },
   });
-  expect(replyResponse.status()).toBe(200);
+  expect(replyResponse.status()).toBe(201);
   const replyId = ((await replyResponse.json()) as { id?: string }).id;
   expect(replyId).toBeTruthy();
 
@@ -510,7 +511,7 @@ test("/api/comments POST 拒绝对失效父评论回复", async ({ page }) => {
       visibility: "public",
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
   const commentId = ((await createResponse.json()) as { id?: string }).id;
   expect(commentId).toBeTruthy();
   if (!commentId) {

--- a/tests/e2e/src/app/api/homeworks/[id]/test.ts
+++ b/tests/e2e/src/app/api/homeworks/[id]/test.ts
@@ -57,7 +57,7 @@ async function createTempHomework(
       submissionDueAt: new Date(now.getTime() + 86400000).toISOString(),
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
   const body = (await createResponse.json()) as {
     homework?: { id?: string; title?: string } | null;
     id?: string;

--- a/tests/e2e/src/app/api/homeworks/completions/test.ts
+++ b/tests/e2e/src/app/api/homeworks/completions/test.ts
@@ -43,7 +43,7 @@ async function createTempHomework(
       submissionDueAt: new Date(now.getTime() + 86_400_000).toISOString(),
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
 
   const listResponse = await request.get(
     `/api/homeworks?sectionId=${sectionId}`,

--- a/tests/e2e/src/app/api/homeworks/test.ts
+++ b/tests/e2e/src/app/api/homeworks/test.ts
@@ -157,12 +157,15 @@ test("/api/homeworks POST 登录后可创建作业并清理", async ({ page }) =
       submissionDueAt: new Date(now.getTime() + 86400000).toISOString(),
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
   const createBody = (await createResponse.json()) as {
     homework?: { commentCount?: number; id?: string; title?: string } | null;
     id?: string;
   };
   expect(createBody.id).toBeTruthy();
+  expect(createResponse.headers().location).toBe(
+    `/api/homeworks/${createBody.id}`,
+  );
   expect(createBody.homework?.id).toBe(createBody.id);
   expect(createBody.homework?.title).toBe(title);
   expect(createBody.homework?.commentCount).toBe(0);

--- a/tests/e2e/src/app/api/todos/[id]/test.ts
+++ b/tests/e2e/src/app/api/todos/[id]/test.ts
@@ -29,7 +29,7 @@ async function createTodo(page: Page, title: string) {
       priority: "medium",
     },
   });
-  expect(response.status()).toBe(200);
+  expect(response.status()).toBe(201);
   const id = ((await response.json()) as { id?: string }).id;
   expect(id).toBeTruthy();
   return id as string;

--- a/tests/e2e/src/app/api/todos/test.ts
+++ b/tests/e2e/src/app/api/todos/test.ts
@@ -144,10 +144,11 @@ test("/api/todos POST 登录后可创建新待办并清理", async ({ page }) =>
       priority: "high",
     },
   });
-  expect(createResponse.status()).toBe(200);
+  expect(createResponse.status()).toBe(201);
 
   const createdId = ((await createResponse.json()) as { id?: string }).id;
   expect(createdId).toBeTruthy();
+  expect(createResponse.headers().location).toBe(`/api/todos/${createdId}`);
 
   try {
     const listResponse = await page.request.get("/api/todos");

--- a/tests/e2e/src/app/api/uploads/[id]/download/test.ts
+++ b/tests/e2e/src/app/api/uploads/[id]/download/test.ts
@@ -115,7 +115,7 @@ test("/api/uploads/[id]/download GET 允许下载可见评论附件", async ({
         visibility: "public",
       },
     });
-    expect(createCommentResponse.status()).toBe(200);
+    expect(createCommentResponse.status()).toBe(201);
     const commentId = ((await createCommentResponse.json()) as { id?: string })
       .id;
     expect(commentId).toBeTruthy();
@@ -170,7 +170,7 @@ test("/api/uploads/[id]/download GET 拒绝下载已删除评论附件", async (
         visibility: "public",
       },
     });
-    expect(createCommentResponse.status()).toBe(200);
+    expect(createCommentResponse.status()).toBe(201);
     const commentId = ((await createCommentResponse.json()) as { id?: string })
       .id;
     expect(commentId).toBeTruthy();

--- a/tests/e2e/src/app/courses/[jwId]/test.ts
+++ b/tests/e2e/src/app/courses/[jwId]/test.ts
@@ -299,7 +299,7 @@ test.describe("/courses/[jwId] 课程详情", () => {
         (r) =>
           r.url().includes("/api/comments") &&
           r.request().method() === "POST" &&
-          r.status() === 200,
+          r.status() === 201,
       );
       await page
         .getByRole("button", { name: /发布评论|Post comment/i })

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -657,7 +657,7 @@ test.describe("/sections/[jwId] 班级详情页", () => {
         (r) =>
           r.url().includes("/api/homeworks") &&
           r.request().method() === "POST" &&
-          r.status() === 200,
+          r.status() === 201,
       );
       await createDialog
         .getByRole("button", { name: /创建作业|Create homework/i })
@@ -755,7 +755,7 @@ test.describe("/sections/[jwId] 班级详情页", () => {
           title,
         },
       });
-      expect(createResponse.status()).toBe(200);
+      expect(createResponse.status()).toBe(201);
       const createBody = (await createResponse.json()) as {
         homework?: { id?: string };
         id?: string;
@@ -846,7 +846,7 @@ test.describe("/sections/[jwId] 班级详情页", () => {
           title,
         },
       });
-      expect(homeworkResponse.status()).toBe(200);
+      expect(homeworkResponse.status()).toBe(201);
       const homeworkBody = (await homeworkResponse.json()) as {
         homework?: { id?: string };
         id?: string;
@@ -862,7 +862,7 @@ test.describe("/sections/[jwId] 班级详情页", () => {
           targetType: "homework",
         },
       });
-      expect(commentResponse.status()).toBe(200);
+      expect(commentResponse.status()).toBe(201);
       const commentBody = (await commentResponse.json()) as { id?: string };
       commentId = commentBody.id;
       expect(commentId).toBeTruthy();
@@ -919,7 +919,7 @@ test.describe("/sections/[jwId] 班级详情页", () => {
         (r) =>
           r.url().includes("/api/comments") &&
           r.request().method() === "POST" &&
-          r.status() === 200,
+          r.status() === 201,
       );
       await page
         .getByRole("button", { name: /发布评论|Post comment/i })
@@ -1017,7 +1017,7 @@ test.describe("/sections/[jwId] 班级详情页", () => {
         (r) =>
           r.url().includes("/api/comments") &&
           r.request().method() === "POST" &&
-          r.status() === 200,
+          r.status() === 201,
       );
       await replyEditor.getByRole("button", { name: /回复|Reply/i }).click();
       const createdReplyResponse = await replyResponse;
@@ -1085,7 +1085,7 @@ test.describe("/sections/[jwId] 班级详情页", () => {
         (r) =>
           r.url().includes("/api/comments") &&
           r.request().method() === "POST" &&
-          r.status() === 200,
+          r.status() === 201,
       );
       await composerCard
         .getByRole("button", { name: /发布评论|Post comment/i })
@@ -1231,7 +1231,7 @@ test.describe("/sections/[jwId] 班级详情页", () => {
         (r) =>
           r.url().includes("/api/comments") &&
           r.request().method() === "POST" &&
-          r.status() === 200,
+          r.status() === 201,
       );
       await postButton.click();
       const createCommentResponse = await createComment;

--- a/tests/e2e/src/app/teachers/[id]/test.ts
+++ b/tests/e2e/src/app/teachers/[id]/test.ts
@@ -324,7 +324,7 @@ test.describe("/teachers/[id] 教师详情页", () => {
         (r) =>
           r.url().includes("/api/comments") &&
           r.request().method() === "POST" &&
-          r.status() === 200,
+          r.status() === 201,
       );
       await page
         .getByRole("button", { name: /发布评论|Post comment/i })

--- a/tests/unit/admin-user-routes.test.ts
+++ b/tests/unit/admin-user-routes.test.ts
@@ -132,4 +132,27 @@ describe("admin 用户路由", () => {
     });
     expect(response.status).toBe(400);
   });
+
+  it("创建封禁时返回 201 与资源位置", async () => {
+    createAdminSuspensionMock.mockResolvedValue({
+      ok: true,
+      suspension: { id: "suspension-1", userId: "user-1" },
+    });
+    const { postAdminSuspensionRoute } = await import(
+      "@/lib/api/routes/admin-suspensions"
+    );
+
+    const response = await postAdminSuspensionRoute(
+      new Request("https://example.test/api/admin/suspensions", {
+        body: JSON.stringify({ userId: "user-1" }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(response.headers.get("Location")).toBe(
+      "/api/admin/suspensions/suspension-1",
+    );
+  });
 });

--- a/tests/unit/api-created-response.test.ts
+++ b/tests/unit/api-created-response.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { createdJsonResponse } from "@/lib/api/responses";
+
+describe("createdJsonResponse", () => {
+  it("returns 201 with the relative resource location", async () => {
+    const response = createdJsonResponse({ id: "todo-1" }, "/api/todos/todo-1");
+
+    expect(response.status).toBe(201);
+    expect(response.headers.get("Location")).toBe("/api/todos/todo-1");
+    await expect(response.json()).resolves.toEqual({ id: "todo-1" });
+  });
+});

--- a/tests/unit/openapi-collectors.test.ts
+++ b/tests/unit/openapi-collectors.test.ts
@@ -89,6 +89,34 @@ export const GET = () => new Response();
     ).toBeDefined();
   });
 
+  it("documents a relative Location header for 201 responses", () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    project.createSourceFile(
+      "src/routes/api/todos/+server.ts",
+      `
+/**
+ * Create a todo.
+ * @response 201:idResponseSchema
+ */
+export const POST = () => new Response();
+`,
+      { overwrite: true },
+    );
+
+    const schemas = new SchemaCollector();
+    const paths = collectPaths(project, schemas);
+    const responses = (paths["/api/todos"].post as Record<string, unknown>)
+      .responses as Record<string, Record<string, unknown>>;
+
+    expect(responses["200"]).toBeUndefined();
+    expect(responses["201"].headers).toEqual({
+      Location: {
+        description: "Relative URL of the created resource",
+        schema: { type: "string" },
+      },
+    });
+  });
+
   it("parses path parameters and request body", () => {
     const project = new Project({ useInMemoryFileSystem: true });
     project.createSourceFile(

--- a/tests/unit/openapi-generator.test.ts
+++ b/tests/unit/openapi-generator.test.ts
@@ -14,4 +14,29 @@ describe("openapi generator", () => {
     expect(doc.components?.securitySchemes).toBeDefined();
     expect(doc.components?.schemas).toBeDefined();
   }, 15_000);
+
+  it("publishes true creates as 201 responses with Location", () => {
+    const doc = generateOpenApiDocument();
+    const paths = doc.paths as Record<
+      string,
+      {
+        post?: {
+          responses?: Record<string, { headers?: Record<string, unknown> }>;
+        };
+      }
+    >;
+
+    for (const path of [
+      "/api/todos",
+      "/api/comments",
+      "/api/homeworks",
+      "/api/admin/suspensions",
+    ]) {
+      const responses = paths[path]?.post?.responses;
+      expect(responses?.["200"], path).toBeUndefined();
+      expect(responses?.["201"]?.headers, path).toHaveProperty("Location");
+    }
+
+    expect(paths["/api/descriptions"]?.post?.responses?.["200"]).toBeDefined();
+  }, 15_000);
 });


### PR DESCRIPTION
## Goal

Return `201 Created` for POST endpoints that always create a new resource, while preserving `200 OK` for idempotent upserts and state-setting operations.

Closes #411

## Changed Surfaces

- add a shared JSON-created response with relative `Location`
- return 201 + Location from todo, comment, homework, and admin suspension creates
- keep descriptions, reactions, subscriptions, preferences, completion, and upload lifecycle operations at 200
- publish the status/header behavior in route annotations, contract JSON, and generated OpenAPI
- update direct API tests and browser journeys that wait for creation responses

MCP parity: MCP tools do not expose HTTP status codes, so their payload behavior is intentionally unchanged.

## Evidence

- independent semantic review: all true-create paths use 201; upsert/state operations remain 200
- `bun run app:prepare`
- `bunx biome check` (only the existing static-loader unused warning)
- `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors / 0 warnings
- all three TypeScript typecheck projects
- `bunx vitest run` — 151 files / 764 tests
- `bun run openapi:check`
- generated OpenAPI inspected: four creates expose 201 + Location; description upsert remains 200
- `git diff --check`

Database-backed Playwright is deferred to this PR's CI because this runner has no local PostgreSQL/Docker.

## Docs / Contracts

Updated todo, comment/admin-suspension, homework, and OpenAPI contract sources plus `public/openapi.generated.json`.

## Risk Areas

The externally visible status code changes can affect clients that hard-code 200. Repository E2E callers were exhaustively updated; CI is the merge gate for real browser/database flows.

## Cleanup

No scratch reports, traces, generated drift, or unrelated source rewrites remain.