### PR TITLE
fix(api): align pagination query names

### DIFF
--- a/docs/contracts/course.json
+++ b/docs/contracts/course.json
@@ -29,7 +29,7 @@
             "path": "/api/courses",
             "returns": "PaginatedResponse<Course>",
             "notes": [
-              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+              "REST pageSize accepts 1-100; the deprecated limit alias remains accepted and pageSize wins when both are supplied. Out-of-range values are rejected instead of clamped."
             ]
           }
         ]
@@ -41,7 +41,7 @@
             "returns": "PaginatedResponse<Course>",
             "rest_equivalent": "GET /api/courses",
             "notes": [
-              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+              "MCP limit accepts 1-100 and rejects out-of-range values instead of clamping."
             ]
           }
         ]

--- a/docs/contracts/openapi.json
+++ b/docs/contracts/openapi.json
@@ -16,6 +16,7 @@
     "openapi-drift-gate": "After server OpenAPI changes, regenerate public/openapi.generated.json and sync api/openapi.json plus generated Go clients in CLI and Bot before publishing. Cross-repo CI should fail if copied OpenAPI files drift from the server-generated contract.",
     "rest-observability": "REST API handling records production-safe structured request-start/request-finish logs with request ID, method, status, auth mode, duration, and normalized route template; when the Cloudflare Analytics Engine binding is present it also writes sanitized request finish/error datapoints with normalized route, method, status class, auth mode, and duration; it does not log request bodies, credentials, raw query strings, or high-cardinality resource IDs.",
     "unknown-api-json-errors": "Unknown paths under /api return the standard JSON { error } envelope with status 404 instead of falling through to the HTML application error page.",
+    "pagination-query-parameter": "Paginated REST endpoints use pageSize as the canonical request parameter. The deprecated limit alias remains accepted during migration, and pageSize takes precedence when both are supplied.",
     "created-resource-status": "POST /api/todos, /api/comments, /api/homeworks, and /api/admin/suspensions return 201 Created with a relative Location header for the new resource. Idempotent upserts and state-setting operations continue to return 200."
   },
   "capabilities": {

--- a/docs/contracts/schedule.json
+++ b/docs/contracts/schedule.json
@@ -76,7 +76,7 @@
             "notes": [
               "Supports filtering by section, teacher, room, date range, and day of week.",
               "REST/MCP both accept exact JW/code-style filters for schedules so callers do not need to resolve internal numeric IDs first.",
-              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping.",
+              "REST pageSize accepts 1-100; the deprecated limit alias remains accepted and pageSize wins when both are supplied. Out-of-range values are rejected instead of clamped.",
               "REST localizes nested schedule labels from the request locale; MCP accepts an explicit locale input."
             ]
           }
@@ -89,7 +89,7 @@
             "returns": "PaginatedResponse<ScheduleEntry>",
             "rest_equivalent": "GET /api/schedules",
             "notes": [
-              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+              "MCP limit accepts 1-100 and rejects out-of-range values instead of clamping."
             ]
           }
         ]

--- a/docs/contracts/section.json
+++ b/docs/contracts/section.json
@@ -29,7 +29,7 @@
             "path": "/api/sections",
             "returns": "PaginatedResponse<SectionSummary>",
             "notes": [
-              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+              "REST pageSize accepts 1-100; the deprecated limit alias remains accepted and pageSize wins when both are supplied. Out-of-range values are rejected instead of clamped."
             ]
           }
         ]
@@ -41,7 +41,7 @@
             "returns": "PaginatedResponse<SectionSummary>",
             "rest_equivalent": "GET /api/sections",
             "notes": [
-              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+              "MCP limit accepts 1-100 and rejects out-of-range values instead of clamping."
             ]
           }
         ]

--- a/docs/contracts/semester.json
+++ b/docs/contracts/semester.json
@@ -25,7 +25,7 @@
             "path": "/api/semesters",
             "returns": "PaginatedResponse<SemesterSummary>",
             "notes": [
-              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+              "REST pageSize accepts 1-100; the deprecated limit alias remains accepted and pageSize wins when both are supplied. Out-of-range values are rejected instead of clamped."
             ]
           }
         ]
@@ -37,7 +37,7 @@
             "returns": "PaginatedResponse<SemesterSummary>",
             "rest_equivalent": "GET /api/semesters",
             "notes": [
-              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+              "MCP limit accepts 1-100 and rejects out-of-range values instead of clamping."
             ]
           }
         ]

--- a/docs/contracts/teacher.json
+++ b/docs/contracts/teacher.json
@@ -28,7 +28,7 @@
             "path": "/api/teachers",
             "returns": "PaginatedResponse<TeacherSummary>",
             "notes": [
-              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+              "REST pageSize accepts 1-100; the deprecated limit alias remains accepted and pageSize wins when both are supplied. Out-of-range values are rejected instead of clamped."
             ]
           }
         ]
@@ -40,7 +40,7 @@
             "returns": "PaginatedResponse<TeacherSummary>",
             "rest_equivalent": "GET /api/teachers",
             "notes": [
-              "Pagination limit accepts 1-100; REST and MCP reject out-of-range values instead of clamping."
+              "MCP limit accepts 1-100 and rejects out-of-range values instead of clamping."
             ]
           }
         ]

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -750,13 +750,26 @@
           },
           {
             "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "description": "Number of items per page."
+          },
+          {
+            "in": "query",
             "name": "limit",
             "schema": {
               "type": "integer",
               "format": "int64",
               "minimum": 1,
               "maximum": 100
-            }
+            },
+            "deprecated": true,
+            "description": "Deprecated alias for pageSize. pageSize takes precedence when both are supplied."
           }
         ],
         "responses": {
@@ -1492,13 +1505,26 @@
           },
           {
             "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "description": "Number of items per page."
+          },
+          {
+            "in": "query",
             "name": "limit",
             "schema": {
               "type": "integer",
               "format": "int64",
               "minimum": 1,
               "maximum": 100
-            }
+            },
+            "deprecated": true,
+            "description": "Deprecated alias for pageSize. pageSize takes precedence when both are supplied."
           }
         ],
         "responses": {
@@ -1628,13 +1654,26 @@
           },
           {
             "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "description": "Number of items per page."
+          },
+          {
+            "in": "query",
             "name": "limit",
             "schema": {
               "type": "integer",
               "format": "int64",
               "minimum": 1,
               "maximum": 100
-            }
+            },
+            "deprecated": true,
+            "description": "Deprecated alias for pageSize. pageSize takes precedence when both are supplied."
           }
         ],
         "responses": {
@@ -1679,13 +1718,26 @@
           },
           {
             "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "description": "Number of items per page."
+          },
+          {
+            "in": "query",
             "name": "limit",
             "schema": {
               "type": "integer",
               "format": "int64",
               "minimum": 1,
               "maximum": 100
-            }
+            },
+            "deprecated": true,
+            "description": "Deprecated alias for pageSize. pageSize takes precedence when both are supplied."
           }
         ],
         "responses": {
@@ -1745,13 +1797,26 @@
           },
           {
             "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "description": "Number of items per page."
+          },
+          {
+            "in": "query",
             "name": "limit",
             "schema": {
               "type": "integer",
               "format": "int64",
               "minimum": 1,
               "maximum": 100
-            }
+            },
+            "deprecated": true,
+            "description": "Deprecated alias for pageSize. pageSize takes precedence when both are supplied."
           }
         ],
         "responses": {
@@ -2091,11 +2156,22 @@
           },
           {
             "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "Number of items per page."
+          },
+          {
+            "in": "query",
             "name": "limit",
             "schema": {
               "type": "integer",
               "format": "int64"
-            }
+            },
+            "deprecated": true,
+            "description": "Deprecated alias for pageSize. pageSize takes precedence when both are supplied."
           }
         ],
         "responses": {
@@ -2181,11 +2257,22 @@
           },
           {
             "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "Number of items per page."
+          },
+          {
+            "in": "query",
             "name": "limit",
             "schema": {
               "type": "integer",
               "format": "int64"
-            }
+            },
+            "deprecated": true,
+            "description": "Deprecated alias for pageSize. pageSize takes precedence when both are supplied."
           }
         ],
         "responses": {
@@ -2257,11 +2344,22 @@
           },
           {
             "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "Number of items per page."
+          },
+          {
+            "in": "query",
             "name": "limit",
             "schema": {
               "type": "integer",
               "format": "int64"
-            }
+            },
+            "deprecated": true,
+            "description": "Deprecated alias for pageSize. pageSize takes precedence when both are supplied."
           }
         ],
         "responses": {
@@ -2449,11 +2547,22 @@
           },
           {
             "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "Number of items per page."
+          },
+          {
+            "in": "query",
             "name": "limit",
             "schema": {
               "type": "integer",
               "format": "int64"
-            }
+            },
+            "deprecated": true,
+            "description": "Deprecated alias for pageSize. pageSize takes precedence when both are supplied."
           }
         ],
         "responses": {

--- a/src/lib/api/pagination.ts
+++ b/src/lib/api/pagination.ts
@@ -24,6 +24,7 @@ export type PaginationOptions = Pick<
 > & {
   pageParam?: string;
   pageSizeParam?: string;
+  pageSizeAliasParam?: string;
 };
 
 /**

--- a/src/lib/api/route-query-parsing.ts
+++ b/src/lib/api/route-query-parsing.ts
@@ -51,11 +51,15 @@ export function parseRouteQuery<TSchema extends z.ZodObject>(
     return query;
   }
 
+  const pageSizeParam = options?.pagination?.pageSizeParam ?? "pageSize";
+  const pageSizeAliasParam = options?.pagination?.pageSizeAliasParam ?? "limit";
+
   return {
     query,
     pagination: normalizePagination({
       page: searchParams.get(options?.pagination?.pageParam ?? "page"),
-      pageSize: searchParams.get(options?.pagination?.pageSizeParam ?? "limit"),
+      pageSize:
+        searchParams.get(pageSizeParam) ?? searchParams.get(pageSizeAliasParam),
       defaultPage: options?.pagination?.defaultPage,
       defaultPageSize: options?.pagination?.defaultPageSize,
       maxPageSize: options?.pagination?.maxPageSize,

--- a/src/lib/api/schemas/admin-query-schemas.ts
+++ b/src/lib/api/schemas/admin-query-schemas.ts
@@ -1,22 +1,29 @@
 import * as z from "zod";
 import { ADMIN_COMMENT_STATUS_FILTERS } from "@/features/admin/lib/admin-moderation-filters";
-import { integerStringSchema } from "./request-schema-primitives";
+import {
+  deprecatedPaginationLimitParam,
+  integerStringSchema,
+  paginationPageSizeParam,
+} from "./request-schema-primitives";
 
 export const adminUsersQuerySchema = z.object({
   search: z.string().trim().optional(),
   page: integerStringSchema.optional(),
-  limit: integerStringSchema.optional(),
+  pageSize: paginationPageSizeParam(integerStringSchema),
+  limit: deprecatedPaginationLimitParam(integerStringSchema),
 });
 
 export const adminCommentsQuerySchema = z.object({
   status: z.enum(ADMIN_COMMENT_STATUS_FILTERS).optional(),
-  limit: integerStringSchema.optional(),
+  pageSize: paginationPageSizeParam(integerStringSchema),
+  limit: deprecatedPaginationLimitParam(integerStringSchema),
 });
 
 export const adminHomeworksQuerySchema = z.object({
   status: z.enum(["all", "active", "deleted"]).optional(),
   search: z.string().trim().optional(),
-  limit: integerStringSchema.optional(),
+  pageSize: paginationPageSizeParam(integerStringSchema),
+  limit: deprecatedPaginationLimitParam(integerStringSchema),
 });
 
 export const adminDescriptionsQuerySchema = z.object({
@@ -25,5 +32,6 @@ export const adminDescriptionsQuerySchema = z.object({
     .optional(),
   hasContent: z.enum(["all", "withContent", "empty"]).optional(),
   search: z.string().trim().optional(),
-  limit: integerStringSchema.optional(),
+  pageSize: paginationPageSizeParam(integerStringSchema),
+  limit: deprecatedPaginationLimitParam(integerStringSchema),
 });

--- a/src/lib/api/schemas/catalog-query-schemas.ts
+++ b/src/lib/api/schemas/catalog-query-schemas.ts
@@ -1,14 +1,16 @@
 import * as z from "zod";
 import {
   dateInputStringSchema,
+  deprecatedPaginationLimitParam,
   integerStringRangeSchema,
   integerStringSchema,
+  paginationPageSizeParam,
 } from "./request-schema-primitives";
 
-const catalogPaginationLimitSchema = integerStringRangeSchema({
+const catalogPaginationPageSizeSchema = integerStringRangeSchema({
   minimum: 1,
   maximum: 100,
-  message: "Limit must be between 1 and 100",
+  message: "pageSize must be between 1 and 100",
 });
 
 const weekdayStringSchema = integerStringSchema
@@ -48,7 +50,8 @@ export const sectionsQuerySchema = z.object({
   ids: z.string().trim().optional(),
   jwIds: z.string().trim().optional(),
   page: integerStringSchema.optional(),
-  limit: catalogPaginationLimitSchema.optional(),
+  pageSize: paginationPageSizeParam(catalogPaginationPageSizeSchema),
+  limit: deprecatedPaginationLimitParam(catalogPaginationPageSizeSchema),
 });
 
 export const schedulesQuerySchema = z.object({
@@ -63,7 +66,8 @@ export const schedulesQuerySchema = z.object({
   dateFrom: dateInputStringSchema.optional(),
   dateTo: dateInputStringSchema.optional(),
   page: integerStringSchema.optional(),
-  limit: catalogPaginationLimitSchema.optional(),
+  pageSize: paginationPageSizeParam(catalogPaginationPageSizeSchema),
+  limit: deprecatedPaginationLimitParam(catalogPaginationPageSizeSchema),
 });
 
 export const sectionSchedulesQuerySchema = z.object({
@@ -76,7 +80,8 @@ export const teachersQuerySchema = z.object({
   departmentId: integerStringSchema.optional(),
   search: z.string().trim().optional(),
   page: integerStringSchema.optional(),
-  limit: catalogPaginationLimitSchema.optional(),
+  pageSize: paginationPageSizeParam(catalogPaginationPageSizeSchema),
+  limit: deprecatedPaginationLimitParam(catalogPaginationPageSizeSchema),
 });
 
 export const coursesQuerySchema = z.object({
@@ -85,5 +90,6 @@ export const coursesQuerySchema = z.object({
   categoryId: integerStringSchema.optional(),
   classTypeId: integerStringSchema.optional(),
   page: integerStringSchema.optional(),
-  limit: catalogPaginationLimitSchema.optional(),
+  pageSize: paginationPageSizeParam(catalogPaginationPageSizeSchema),
+  limit: deprecatedPaginationLimitParam(catalogPaginationPageSizeSchema),
 });

--- a/src/lib/api/schemas/misc-query-schemas.ts
+++ b/src/lib/api/schemas/misc-query-schemas.ts
@@ -2,8 +2,10 @@ import * as z from "zod";
 import { APP_LOCALES } from "@/i18n/config";
 import {
   dateInputStringSchema,
+  deprecatedPaginationLimitParam,
   integerStringRangeSchema,
   integerStringSchema,
+  paginationPageSizeParam,
   todoPrioritySchema,
 } from "./request-schema-primitives";
 
@@ -13,10 +15,10 @@ const busNextDeparturesLimitSchema = integerStringRangeSchema({
   message: "limit must be between 1 and 50",
 });
 
-const publicPaginationLimitSchema = integerStringRangeSchema({
+const publicPaginationPageSizeSchema = integerStringRangeSchema({
   minimum: 1,
   maximum: 100,
-  message: "limit must be between 1 and 100",
+  message: "pageSize must be between 1 and 100",
 });
 
 const subscribedSchedulesWeekdaySchema = integerStringRangeSchema({
@@ -100,7 +102,8 @@ export const dashboardLinkVisitQuerySchema = z.object({
 
 export const semestersQuerySchema = z.object({
   page: integerStringSchema.optional(),
-  limit: publicPaginationLimitSchema.optional(),
+  pageSize: paginationPageSizeParam(publicPaginationPageSizeSchema),
+  limit: deprecatedPaginationLimitParam(publicPaginationPageSizeSchema),
 });
 
 export const subscribedSchedulesQuerySchema = z.object({

--- a/src/lib/api/schemas/request-schema-primitives.ts
+++ b/src/lib/api/schemas/request-schema-primitives.ts
@@ -61,6 +61,26 @@ export function integerStringRangeSchema({
     });
 }
 
+export function paginationPageSizeParam<TSchema extends z.ZodType>(
+  schema: TSchema,
+) {
+  return schema.optional().meta({
+    param: { description: "Number of items per page." },
+  });
+}
+
+export function deprecatedPaginationLimitParam<TSchema extends z.ZodType>(
+  schema: TSchema,
+) {
+  return schema.optional().meta({
+    param: {
+      deprecated: true,
+      description:
+        "Deprecated alias for pageSize. pageSize takes precedence when both are supplied.",
+    },
+  });
+}
+
 export const dateInputStringSchema = z
   .string()
   .trim()

--- a/tests/e2e/src/app/api/admin/comments/test.ts
+++ b/tests/e2e/src/app/api/admin/comments/test.ts
@@ -47,7 +47,7 @@ test.describe("GET /api/admin/comments 评论列表", () => {
 
   test("管理员可无状态筛选列出活跃评论", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
-    const response = await page.request.get(`${BASE}?limit=5`);
+    const response = await page.request.get(`${BASE}?pageSize=5`);
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
       comments?: Array<{ id?: string; status?: string }>;

--- a/tests/e2e/src/app/api/admin/descriptions/test.ts
+++ b/tests/e2e/src/app/api/admin/descriptions/test.ts
@@ -136,9 +136,9 @@ test.describe("GET /api/admin/descriptions 课程简介管理", () => {
     ).toBe(true);
   });
 
-  test("管理员可使用 limit 参数限制返回数量", async ({ page }) => {
+  test("管理员可使用 pageSize 参数限制返回数量", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
-    const response = await page.request.get(`${BASE}?limit=1`);
+    const response = await page.request.get(`${BASE}?pageSize=1`);
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
       descriptions?: Array<unknown>;

--- a/tests/e2e/src/app/api/admin/homeworks/test.ts
+++ b/tests/e2e/src/app/api/admin/homeworks/test.ts
@@ -130,9 +130,9 @@ test.describe("GET /api/admin/homeworks 作业 moderation 列表", () => {
     ).toBe(true);
   });
 
-  test("管理员可使用 limit 参数限制返回数量", async ({ page }) => {
+  test("管理员可使用 pageSize 参数限制返回数量", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
-    const response = await page.request.get(`${BASE}?limit=1`);
+    const response = await page.request.get(`${BASE}?pageSize=1`);
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
       homeworks?: Array<unknown>;

--- a/tests/e2e/src/app/api/admin/users/test.ts
+++ b/tests/e2e/src/app/api/admin/users/test.ts
@@ -6,7 +6,7 @@
  * - GET returns `{ data, pagination }` with user objects
  *   containing id, name, username, isAdmin, email, createdAt
  * - Supports `search` query for filtering by id, name, username, or email
- * - Supports `page` and `limit` pagination parameters (max limit 100)
+ * - Supports `page` and `pageSize` pagination parameters (deprecated `limit` alias, max 100)
  * - Returns 401 for unauthenticated or non-admin requests
  * - Returns 400 for invalid query parameters
  */
@@ -59,9 +59,9 @@ test.describe("GET /api/admin/users 用户列表", () => {
     expect(typeof body.pagination?.total).toBe("number");
   });
 
-  test("管理员可使用 limit=1 分页用户", async ({ page }) => {
+  test("管理员可使用 pageSize=1 分页用户", async ({ page }) => {
     await signInAsDevAdmin(page, "/admin");
-    const response = await page.request.get(`${BASE}?page=1&limit=1`);
+    const response = await page.request.get(`${BASE}?page=1&pageSize=1`);
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
       data?: unknown[];

--- a/tests/e2e/src/app/api/courses/test.ts
+++ b/tests/e2e/src/app/api/courses/test.ts
@@ -6,7 +6,7 @@
  *
  * ## Request
  * - Query: `search` (optional, matches nameCn/nameEn/code, case-insensitive),
- *          `page` (optional, default 1), `limit` (optional, default pageSize)
+ *          `page` (optional, default 1), `pageSize` (optional), and deprecated `limit` alias
  *
  * ## Response
  * - 200: `{ data: Course[], pagination: { page, pageSize, total, totalPages } }`
@@ -137,8 +137,8 @@ test.describe("GET /api/courses 接口", () => {
     expect(body.pagination?.page).toBe(1);
   });
 
-  test("limit 参数控制分页大小", async ({ request }) => {
-    const response = await request.get("/api/courses?limit=1");
+  test("pageSize 控制分页大小并优先于 limit 别名", async ({ request }) => {
+    const response = await request.get("/api/courses?pageSize=1&limit=2");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
       data?: unknown[];

--- a/tests/e2e/src/app/api/schedules/test.ts
+++ b/tests/e2e/src/app/api/schedules/test.ts
@@ -8,7 +8,7 @@
  * - Query: `sectionId` (optional, int), `teacherId` (optional, int),
  *          `roomId` (optional, int), `dateFrom` (optional, date string),
  *          `dateTo` (optional, date string), `weekday` (optional, int 1-7),
- *          `page` (optional), `limit` (optional)
+ *          `page` (optional), `pageSize` (optional), and deprecated `limit` alias
  *
  * ## Response
  * - 200: `{ data: Schedule[], pagination: { page, pageSize, total, totalPages } }`
@@ -166,8 +166,8 @@ test.describe("GET /api/schedules - 排课列表", () => {
     expect(response.status()).toBe(400);
   });
 
-  test("limit 参数控制页大小", async ({ request }) => {
-    const response = await request.get("/api/schedules?limit=1");
+  test("pageSize 参数控制页大小", async ({ request }) => {
+    const response = await request.get("/api/schedules?pageSize=1");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
       data?: unknown[];

--- a/tests/e2e/src/app/api/sections/test.ts
+++ b/tests/e2e/src/app/api/sections/test.ts
@@ -53,8 +53,8 @@ test("班级列表项包含教师数组", async ({ request }) => {
   expect(Array.isArray(section?.teachers)).toBe(true);
 });
 
-test("limit 参数控制班级列表页大小", async ({ request }) => {
-  const response = await request.get("/api/sections?limit=1");
+test("pageSize 参数控制班级列表页大小", async ({ request }) => {
+  const response = await request.get("/api/sections?pageSize=1");
   expect(response.status()).toBe(200);
   const body = (await response.json()) as {
     data?: unknown[];

--- a/tests/e2e/src/app/api/semesters/test.ts
+++ b/tests/e2e/src/app/api/semesters/test.ts
@@ -5,7 +5,7 @@
  * - `GET /api/semesters` — List semesters with pagination, ordered by startDate descending.
  *
  * ## Request
- * - Query: `page` (optional), `limit` (optional, max 100)
+ * - Query: `page` (optional), `pageSize` (optional, max 100), deprecated `limit` alias
  *
  * ## Response
  * - 200: `{ data: Semester[], pagination: { page, pageSize, total, totalPages } }`
@@ -16,7 +16,7 @@
  *
  * ## Edge Cases
  * - Results ordered by startDate descending (most recent first)
- * - limit param directly controls page size
+ * - pageSize directly controls page size; limit remains a compatible alias
  */
 import { expect, test } from "@playwright/test";
 import { DEV_SEED } from "../../../../utils/dev-seed";
@@ -61,8 +61,8 @@ test.describe("GET /api/semesters", () => {
     expect(typeof semester?.nameCn).toBe("string");
   });
 
-  test("limit 参数控制页大小", async ({ request }) => {
-    const response = await request.get("/api/semesters?limit=1");
+  test("pageSize 参数控制页大小", async ({ request }) => {
+    const response = await request.get("/api/semesters?pageSize=1");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
       data?: unknown[];

--- a/tests/e2e/src/app/api/teachers/test.ts
+++ b/tests/e2e/src/app/api/teachers/test.ts
@@ -6,7 +6,7 @@
  *
  * ## Request
  * - Query: `departmentId` (optional, integer), `search` (optional, matches nameCn/nameEn/code),
- *          `page` (optional), `limit` (optional)
+ *          `page` (optional), `pageSize` (optional), and deprecated `limit` alias
  *
  * ## Response
  * - 200: `{ data: Teacher[], pagination: { page, pageSize, total, totalPages } }`
@@ -106,8 +106,8 @@ test.describe("GET /api/teachers", () => {
     expect(body.pagination?.page).toBe(1);
   });
 
-  test("limit 参数控制页大小", async ({ request }) => {
-    const response = await request.get("/api/teachers?limit=1");
+  test("pageSize 参数控制页大小", async ({ request }) => {
+    const response = await request.get("/api/teachers?pageSize=1");
     expect(response.status()).toBe(200);
     const body = (await response.json()) as {
       data?: unknown[];

--- a/tests/unit/api-helpers.test.ts
+++ b/tests/unit/api-helpers.test.ts
@@ -67,12 +67,13 @@ describe("API 辅助函数", () => {
     });
   });
 
-  it("解析路由查询参数并规范化分页", () => {
+  it("优先使用规范的 pageSize 查询参数", () => {
     const result = parseRouteQuery(
-      new URLSearchParams("search=math&page=3&limit=250"),
+      new URLSearchParams("search=math&page=3&pageSize=25&limit=80"),
       z.object({
         search: z.string().optional(),
         page: z.string().optional(),
+        pageSize: z.string().optional(),
         limit: z.string().optional(),
       }),
       "Invalid query",
@@ -81,7 +82,31 @@ describe("API 辅助函数", () => {
 
     expect(result).not.toBeInstanceOf(Response);
     expect(result).toEqual({
-      query: { search: "math", page: "3", limit: "250" },
+      query: {
+        search: "math",
+        page: "3",
+        pageSize: "25",
+        limit: "80",
+      },
+      pagination: { page: 3, pageSize: 25, skip: 50 },
+    });
+  });
+
+  it("在 pageSize 缺失时接受废弃的 limit 别名", () => {
+    const result = parseRouteQuery(
+      new URLSearchParams("page=3&limit=250"),
+      z.object({
+        page: z.string().optional(),
+        pageSize: z.string().optional(),
+        limit: z.string().optional(),
+      }),
+      "Invalid query",
+      { pagination: { maxPageSize: 100 } },
+    );
+
+    expect(result).not.toBeInstanceOf(Response);
+    expect(result).toEqual({
+      query: { page: "3", pageSize: undefined, limit: "250" },
       pagination: { page: 3, pageSize: 100, skip: 200 },
     });
   });

--- a/tests/unit/api-route-query-validation.test.ts
+++ b/tests/unit/api-route-query-validation.test.ts
@@ -14,10 +14,10 @@ async function expectInvalidQueryResponse(
 }
 
 describe("API 路由查询校验", () => {
-  it("在限制前拒绝过大的公开分页限制", async () => {
+  it("在查询前拒绝过大的 pageSize 与 limit 别名", async () => {
     await expectInvalidQueryResponse(
       getCoursesRoute(
-        new Request("https://example.test/api/courses?limit=101"),
+        new Request("https://example.test/api/courses?pageSize=101"),
       ),
       "Invalid course query",
     );

--- a/tests/unit/api-schemas.test.ts
+++ b/tests/unit/api-schemas.test.ts
@@ -6,6 +6,10 @@ import {
 import { HOMEWORK_DESCRIPTION_MAX_LENGTH } from "@/features/homeworks/lib/homework-limits";
 import { TODO_CONTENT_MAX_LENGTH } from "@/features/todos/lib/todo-limits";
 import {
+  adminCommentsQuerySchema,
+  adminDescriptionsQuerySchema,
+  adminHomeworksQuerySchema,
+  adminUsersQuerySchema,
   busNextDeparturesQuerySchema,
   calendarSubscriptionAppendRequestSchema,
   calendarSubscriptionBatchRequestSchema,
@@ -522,17 +526,31 @@ describe("其他请求 schema", () => {
     ).toBe(false);
   });
 
-  it("校验文档中记录的查询 limit 边界", () => {
-    for (const schema of [
+  it("校验分页 pageSize 与废弃 limit 别名的边界", () => {
+    const paginatedSchemas = [
       coursesQuerySchema,
       sectionsQuerySchema,
       schedulesQuerySchema,
       teachersQuerySchema,
       semestersQuerySchema,
-    ]) {
+    ];
+    for (const schema of paginatedSchemas) {
+      expect(schema.safeParse({ pageSize: "100" }).success).toBe(true);
+      expect(schema.safeParse({ pageSize: "101" }).success).toBe(false);
+      expect(schema.safeParse({ pageSize: "0" }).success).toBe(false);
       expect(schema.safeParse({ limit: "100" }).success).toBe(true);
       expect(schema.safeParse({ limit: "101" }).success).toBe(false);
       expect(schema.safeParse({ limit: "0" }).success).toBe(false);
+    }
+
+    for (const schema of [
+      adminCommentsQuerySchema,
+      adminDescriptionsQuerySchema,
+      adminHomeworksQuerySchema,
+      adminUsersQuerySchema,
+    ]) {
+      expect(schema.safeParse({ pageSize: "50" }).success).toBe(true);
+      expect(schema.safeParse({ limit: "50" }).success).toBe(true);
     }
 
     const validBusNextQuery = {

--- a/tests/unit/openapi-generator.test.ts
+++ b/tests/unit/openapi-generator.test.ts
@@ -15,6 +15,47 @@ describe("openapi generator", () => {
     expect(doc.components?.schemas).toBeDefined();
   }, 15_000);
 
+  it("publishes pageSize and marks limit as its deprecated alias", () => {
+    const doc = generateOpenApiDocument();
+    const paths = doc.paths as Record<
+      string,
+      {
+        get?: {
+          parameters?: Array<{
+            deprecated?: boolean;
+            description?: string;
+            name?: string;
+          }>;
+        };
+      }
+    >;
+
+    for (const path of [
+      "/api/courses",
+      "/api/sections",
+      "/api/schedules",
+      "/api/teachers",
+      "/api/semesters",
+      "/api/admin/users",
+      "/api/admin/comments",
+      "/api/admin/homeworks",
+      "/api/admin/descriptions",
+    ]) {
+      const parameters = paths[path]?.get?.parameters ?? [];
+      const pageSize = parameters.find((parameter) => {
+        return parameter.name === "pageSize";
+      });
+      const limit = parameters.find((parameter) => {
+        return parameter.name === "limit";
+      });
+
+      expect(pageSize, path).toBeDefined();
+      expect(pageSize?.deprecated, path).not.toBe(true);
+      expect(limit?.deprecated, path).toBe(true);
+      expect(limit?.description, path).toContain("pageSize");
+    }
+  }, 15_000);
+
   it("publishes true creates as 201 responses with Location", () => {
     const doc = generateOpenApiDocument();
     const paths = doc.paths as Record<


### PR DESCRIPTION
## Summary

- make `pageSize` the canonical query parameter for the nine paginated REST collection endpoints
- keep `limit` as a deprecated compatibility alias, with `pageSize` taking precedence when both are provided
- publish both parameters and deprecation metadata in generated OpenAPI and contract docs while preserving MCP and non-pagination `limit` semantics
- update unit and end-to-end coverage for canonical input, alias fallback, validation, and precedence

## Verification

- `bun run app:prepare`
- `bunx biome check` (only the existing unused-parameter warning)
- `bunx svelte-check --tsconfig ./tsconfig.json` (0 errors, 0 warnings)
- all three `tsc --noEmit` projects
- `bunx vitest run` (151 files, 766 tests)
- `bun run build`
- `bun run openapi:check`
- independent semantic review of all nine endpoints, MCP isolation, non-pagination limits, and generated OpenAPI stability

Database-backed Playwright coverage is left to GitHub Actions before merge.

Closes #413