### PR TITLE
fix(subscriptions): prevent cross-semester history loss

### DIFF
--- a/docs/contracts/ical.json
+++ b/docs/contracts/ical.json
@@ -60,7 +60,8 @@
             "returns": "text/calendar",
             "notes": [
               "Same-user session or bearer access is accepted.",
-              "Anonymous feed access is accepted with either ?token=... or the userId:token path segment form."
+              "Anonymous feed access is accepted with either ?token=... or the userId:token path segment form.",
+              "An existing user with a valid feed token receives a valid empty VCALENDAR when no items are currently available, so calendar clients can keep the subscription active."
             ]
           },
           {

--- a/docs/contracts/subscription.json
+++ b/docs/contracts/subscription.json
@@ -79,7 +79,8 @@
             "notes": [
               "Preferred mutation endpoint for batch subscribe, unsubscribe, and replace/update flows.",
               "Accepts action plus sectionIds and/or mixed section/course codes.",
-              "action=set may omit sectionIds/codes to clear the caller's section subscriptions."
+              "action=set replaces only the requested semester when semesterId is present, preserving subscriptions from every other semester; without semesterId it retains the compatibility behavior of replacing the full set.",
+              "A semester-scoped action=set may omit sectionIds/codes to clear only that semester."
             ]
           },
           {

--- a/src/features/calendar/server/calendar-export-service.ts
+++ b/src/features/calendar/server/calendar-export-service.ts
@@ -33,18 +33,6 @@ function userCalendarTodoItems(
   );
 }
 
-function hasUserCalendarItems(input: {
-  homeworks: unknown[];
-  sections: unknown[];
-  todos: unknown[];
-}) {
-  return (
-    input.sections.length > 0 ||
-    input.homeworks.length > 0 ||
-    input.todos.length > 0
-  );
-}
-
 export async function buildUserCalendarExport(
   user: UserCalendarRecord,
   userId: string,
@@ -55,16 +43,6 @@ export async function buildUserCalendarExport(
     sectionIds,
   );
   const todos = userCalendarTodoItems(user.todos);
-
-  if (
-    !hasUserCalendarItems({
-      homeworks,
-      sections: user.subscribedSections,
-      todos,
-    })
-  ) {
-    return null;
-  }
 
   const calendar = await createUserCalendar({
     sections: user.subscribedSections,

--- a/src/features/subscriptions/server/subscription-section-resolver.ts
+++ b/src/features/subscriptions/server/subscription-section-resolver.ts
@@ -39,17 +39,20 @@ export async function resolveCalendarSubscriptionSections({
   const requestedSectionIds = uniqueSectionIds(sectionIds);
   const requestedCodes = uniqueCodes(codes);
   const semester =
-    requestedCodes.length > 0
+    requestedCodes.length > 0 || semesterId !== undefined
       ? await resolveSectionCodeMatchSemester(semesterId)
       : null;
 
-  if (requestedCodes.length > 0 && !semester) {
+  if ((requestedCodes.length > 0 || semesterId !== undefined) && !semester) {
     return null;
   }
 
   const where: Prisma.SectionWhereInput[] = [];
   if (requestedSectionIds.length > 0) {
-    where.push({ id: { in: requestedSectionIds } });
+    where.push({
+      id: { in: requestedSectionIds },
+      ...(semester ? { semesterId: semester.id } : {}),
+    });
   }
   if (semester && requestedCodes.length > 0) {
     where.push({

--- a/src/features/subscriptions/server/subscription-write-model.ts
+++ b/src/features/subscriptions/server/subscription-write-model.ts
@@ -23,6 +23,28 @@ async function replaceUserSectionIds(
   });
 }
 
+async function replaceUserSectionIdsInSemester(
+  userId: string,
+  currentIds: readonly number[],
+  nextIds: readonly number[],
+) {
+  const currentIdSet = new Set(currentIds);
+  const nextIdSet = new Set(nextIds);
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      subscribedSections: {
+        connect: uniqueSectionIds(nextIds)
+          .filter((id) => !currentIdSet.has(id))
+          .map((id) => ({ id })),
+        disconnect: uniqueSectionIds(currentIds)
+          .filter((id) => !nextIdSet.has(id))
+          .map((id) => ({ id })),
+      },
+    },
+  });
+}
+
 async function getExistingSectionIds(sectionIds: readonly number[]) {
   if (sectionIds.length === 0) {
     return [];
@@ -49,7 +71,7 @@ async function getMutableUserSubscriptions(userId: string) {
     select: {
       id: true,
       subscribedSections: {
-        select: { id: true, jwId: true },
+        select: { id: true, jwId: true, semesterId: true },
       },
     },
   });
@@ -263,10 +285,26 @@ export async function batchUpdateUserSectionSubscriptions({
     unchangedCount = targetIds.length - removedCount;
     await disconnectUserSectionIds(userId, removedIds);
   } else {
+    const currentIdsInScope =
+      semesterId === undefined
+        ? currentIds
+        : user.subscribedSections
+            .filter((section) => section.semesterId === semesterId)
+            .map((section) => section.id);
     addedCount = targetIds.filter((id) => !currentIdSet.has(id)).length;
-    removedCount = currentIds.filter((id) => !targetIdSet.has(id)).length;
+    removedCount = currentIdsInScope.filter(
+      (id) => !targetIdSet.has(id),
+    ).length;
     unchangedCount = targetIds.length - addedCount;
-    await replaceUserSectionIds(userId, targetIds);
+    if (semesterId === undefined) {
+      await replaceUserSectionIds(userId, targetIds);
+    } else {
+      await replaceUserSectionIdsInSemester(
+        userId,
+        currentIdsInScope,
+        targetIds,
+      );
+    }
   }
 
   return {

--- a/tests/e2e/src/app/api/calendar-subscriptions/test.ts
+++ b/tests/e2e/src/app/api/calendar-subscriptions/test.ts
@@ -27,10 +27,12 @@
 import { expect, test } from "@playwright/test";
 import { signInAsDebugUser } from "../../../../utils/auth";
 import { DEV_SEED } from "../../../../utils/dev-seed";
+import { getSeedSectionSemesterFixture } from "../../../../utils/e2e-db";
 import { resolveSeedSectionMatches } from "../../../../utils/seed-lookups";
 import { assertApiContract } from "../../_shared/api-contract";
 
 const BASE = "/api/calendar-subscriptions";
+const BATCH_BASE = "/api/calendar-subscriptions/batch";
 const IMPORT_BASE = "/api/calendar-subscriptions/import-codes";
 
 test.describe("日历订阅 API", () => {
@@ -202,6 +204,84 @@ test.describe("日历订阅 API", () => {
       };
       expect(repeatBody.addedCount).toBe(0);
       expect(repeatBody.alreadySubscribedCount).toBe(1);
+    } finally {
+      await page.request.post(BASE, {
+        data: { sectionIds: originalIds },
+      });
+    }
+  });
+
+  test("set 只替换指定学期并保留往期订阅", async ({ page }) => {
+    await signInAsDebugUser(page, "/");
+    const [currentSection, previousSection] = await Promise.all([
+      getSeedSectionSemesterFixture(DEV_SEED.section.jwId),
+      getSeedSectionSemesterFixture(DEV_SEED.previousSection.jwId),
+    ]);
+    if (
+      currentSection.semesterId === null ||
+      previousSection.semesterId === null
+    ) {
+      throw new Error("Expected seed sections to belong to semesters");
+    }
+    expect(currentSection.semesterId).not.toBe(previousSection.semesterId);
+
+    const currentRes = await page.request.get(
+      "/api/calendar-subscriptions/current",
+    );
+    const currentBody = (await currentRes.json()) as {
+      subscription?: { sections?: Array<{ id?: number }> } | null;
+    };
+    const originalIds =
+      currentBody.subscription?.sections?.map(
+        (section) => section.id as number,
+      ) ?? [];
+
+    try {
+      const setupResponse = await page.request.post(BASE, {
+        data: { sectionIds: [currentSection.id, previousSection.id] },
+      });
+      expect(setupResponse.status()).toBe(200);
+      const currentSemesterId = currentSection.semesterId;
+
+      const response = await page.request.post(BATCH_BASE, {
+        data: {
+          action: "set",
+          sectionIds: [],
+          semesterId: currentSemesterId,
+        },
+      });
+      expect(response.status()).toBe(200);
+      const body = (await response.json()) as {
+        removedCount?: number;
+        subscription?: { sections?: Array<{ id?: number }> };
+      };
+      const subscribedIds =
+        body.subscription?.sections?.map((section) => section.id) ?? [];
+
+      expect(body.removedCount).toBe(1);
+      expect(subscribedIds).not.toContain(currentSection.id);
+      expect(subscribedIds).toContain(previousSection.id);
+
+      const wrongSemesterResponse = await page.request.post(BATCH_BASE, {
+        data: {
+          action: "set",
+          sectionIds: [previousSection.id],
+          semesterId: currentSemesterId,
+        },
+      });
+      expect(wrongSemesterResponse.status()).toBe(200);
+      const wrongSemesterBody = (await wrongSemesterResponse.json()) as {
+        matchedSectionIds?: number[];
+        unmatchedSectionIds?: number[];
+        subscription?: { sections?: Array<{ id?: number }> };
+      };
+      expect(wrongSemesterBody.matchedSectionIds).toEqual([]);
+      expect(wrongSemesterBody.unmatchedSectionIds).toEqual([
+        previousSection.id,
+      ]);
+      expect(
+        wrongSemesterBody.subscription?.sections?.map((section) => section.id),
+      ).toContain(previousSection.id);
     } finally {
       await page.request.post(BASE, {
         data: { sectionIds: originalIds },

--- a/tests/e2e/src/app/api/users/[userId]/calendar.ics/test.ts
+++ b/tests/e2e/src/app/api/users/[userId]/calendar.ics/test.ts
@@ -30,6 +30,8 @@ import { expect, test } from "@playwright/test";
 import { signInAsDebugUser } from "../../../../../../utils/auth";
 import { DEV_SEED } from "../../../../../../utils/dev-seed";
 import {
+  createTempUsersFixture,
+  deleteUsersByPrefix,
   ensureUserCalendarFeedFixture,
   getCurrentSessionUser,
 } from "../../../../../../utils/e2e-db";
@@ -177,5 +179,28 @@ test.describe("GET /api/users/[userId]/calendar.ics", () => {
       `/api/users/${userId}/calendar.ics?token=bogus-token-e2e`,
     );
     expect(response.status()).toBe(403);
+  });
+
+  test("有效 token 在没有日历项目时返回空 iCalendar", async ({ request }) => {
+    const prefix = `e2e-empty-calendar-${Date.now()}`;
+    const { userIds } = await createTempUsersFixture({ prefix, count: 1 });
+    const userId = userIds[0];
+    if (!userId) {
+      throw new Error("Expected temporary calendar user");
+    }
+
+    try {
+      const feed = await ensureUserCalendarFeedFixture(userId);
+      const response = await request.get(feed.path);
+
+      expect(response.status()).toBe(200);
+      expect(response.headers()["content-type"]).toContain("text/calendar");
+      const body = await response.text();
+      expect(body).toContain("BEGIN:VCALENDAR");
+      expect(body).toContain("END:VCALENDAR");
+      expect(body).not.toContain("BEGIN:VEVENT");
+    } finally {
+      await deleteUsersByPrefix(prefix);
+    }
   });
 });

--- a/tests/e2e/utils/e2e-db.ts
+++ b/tests/e2e/utils/e2e-db.ts
@@ -136,10 +136,12 @@ export const getSeedTeacherDepartmentFixture = (code: string) =>
   );
 
 export const getSeedSectionSemesterFixture = (jwId: number) =>
-  runDbFixture<{ semesterId: number | null; semesterName: string | null }>(
-    "getSeedSectionSemesterFixture",
-    [jwId],
-  );
+  runDbFixture<{
+    code: string;
+    id: number;
+    semesterId: number | null;
+    semesterName: string | null;
+  }>("getSeedSectionSemesterFixture", [jwId]);
 
 export const getUserProfileById = (userId: string) =>
   runDbFixture<UserProfileFixture>("getUserProfileById", [userId]);
@@ -168,7 +170,10 @@ export const createTempUsersFixture = (options: {
   prefix: string;
   count: number;
 }) =>
-  runDbFixture<{ usernames: string[] }>("createTempUsersFixture", [options]);
+  runDbFixture<{ userIds: string[]; usernames: string[] }>(
+    "createTempUsersFixture",
+    [options],
+  );
 
 export const deleteUsersByPrefix = (prefix: string) =>
   runDbFixture<null>("deleteUsersByPrefix", [prefix]);

--- a/tests/e2e/utils/e2e-db/seed.ts
+++ b/tests/e2e/utils/e2e-db/seed.ts
@@ -47,6 +47,8 @@ export async function getSeedSectionSemesterFixture(jwId: number) {
     prisma.section.findUniqueOrThrow({
       where: { jwId },
       select: {
+        id: true,
+        code: true,
         semesterId: true,
         semester: { select: { nameCn: true } },
       },
@@ -54,6 +56,8 @@ export async function getSeedSectionSemesterFixture(jwId: number) {
   );
 
   return {
+    id: section.id,
+    code: section.code,
     semesterId: section.semesterId,
     semesterName: section.semester?.nameCn ?? null,
   };

--- a/tests/e2e/utils/e2e-db/users.ts
+++ b/tests/e2e/utils/e2e-db/users.ts
@@ -107,6 +107,7 @@ export async function createTempUsersFixture(options: {
   count: number;
 }) {
   const usernames: string[] = [];
+  const userIds: string[] = [];
 
   await withE2ePrisma(async (prisma) => {
     for (let index = 0; index < options.count; index += 1) {
@@ -126,6 +127,7 @@ export async function createTempUsersFixture(options: {
           name: `E2E ${username}`,
         },
       });
+      userIds.push(user.id);
       await prisma.verifiedEmail.upsert({
         where: {
           provider_email: {
@@ -145,7 +147,7 @@ export async function createTempUsersFixture(options: {
     }
   });
 
-  return { usernames };
+  return { userIds, usernames };
 }
 
 export async function deleteUsersByPrefix(prefix: string) {


### PR DESCRIPTION
## Root cause

PR #432 assumed historical `User.subscribedSections` relations were still present. In production the affected user has zero such relations, so Dashboard, Bot schedules, and the personal iCalendar feed all read the same empty state.

The batch subscription endpoint accepted `semesterId` but `action=set` still replaced the user's global relation. A semester-scoped client update could therefore delete every other semester. Direct `sectionIds` were also not constrained to the requested semester.

## Changes

- Make `action=set` semester-scoped when `semesterId` is supplied.
- Use nested connect/disconnect for the scoped mutation so unrelated semesters and concurrent additions are retained.
- Reject cross-semester section IDs from the scoped target as unmatched.
- Keep the existing global replace behavior only when `semesterId` is omitted.
- Return a valid empty `VCALENDAR` for an existing user with valid feed access and no current items, so calendar clients keep the feed active.
- Add Playwright regressions for past-term preservation, cross-semester ID rejection, and empty personal feeds.

## Impact

This prevents current-term sync/set operations from deleting historical homework and schedule discovery. It does not reconstruct relations that were already deleted; production recovery is tracked in #431 and requires an explicit data repair after deployment.

## Validation

- `bun run app:prepare`
- `bunx biome check .` (one pre-existing unused-parameter warning)
- `svelte-check` (0 errors, 0 warnings)
- TypeScript app/operational/test configs
- `bunx vitest run` (153 files, 774 tests)
- `bun run build`
- Focused Playwright: semester-scoped set preservation (passed)
- Focused Playwright: valid empty personal iCalendar (passed)
- Bot `go test ./...` (passed)
- CLI `go test ./...` (passed)

Refs #431
