### PR TITLE
fix(subscriptions): reject unscoped batch replacement

### DIFF
--- a/docs/contracts/subscription.json
+++ b/docs/contracts/subscription.json
@@ -79,7 +79,7 @@
             "notes": [
               "Preferred mutation endpoint for batch subscribe, unsubscribe, and replace/update flows.",
               "Accepts action plus sectionIds and/or mixed section/course codes.",
-              "action=set replaces only the requested semester when semesterId is present, preserving subscriptions from every other semester; without semesterId it retains the compatibility behavior of replacing the full set.",
+              "action=set requires semesterId and replaces only the requested semester, preserving subscriptions from every other semester.",
               "A semester-scoped action=set may omit sectionIds/codes to clear only that semester."
             ]
           },

--- a/src/lib/api/schemas/request-user-mutation-schemas.ts
+++ b/src/lib/api/schemas/request-user-mutation-schemas.ts
@@ -63,7 +63,18 @@ export const calendarSubscriptionBatchRequestSchema =
       action: calendarSubscriptionBatchActionSchema,
     })
     .superRefine((input, context) => {
-      if (input.action === "set" || hasCalendarSubscriptionSelection(input)) {
+      if (input.action === "set") {
+        if (input.semesterId === undefined) {
+          context.addIssue({
+            code: "custom",
+            message: "semesterId is required when action is set",
+            path: ["semesterId"],
+          });
+        }
+        return;
+      }
+
+      if (hasCalendarSubscriptionSelection(input)) {
         return;
       }
 

--- a/tests/e2e/src/app/api/calendar-subscriptions/test.ts
+++ b/tests/e2e/src/app/api/calendar-subscriptions/test.ts
@@ -241,6 +241,22 @@ test.describe("日历订阅 API", () => {
         data: { sectionIds: [currentSection.id, previousSection.id] },
       });
       expect(setupResponse.status()).toBe(200);
+
+      const unscopedSetResponse = await page.request.post(BATCH_BASE, {
+        data: { action: "set", sectionIds: [] },
+      });
+      expect(unscopedSetResponse.status()).toBe(400);
+      const preservedBody = (await (
+        await page.request.get("/api/calendar-subscriptions/current")
+      ).json()) as {
+        subscription?: { sections?: Array<{ id?: number }> } | null;
+      };
+      const preservedIds =
+        preservedBody.subscription?.sections?.map((section) => section.id) ??
+        [];
+      expect(preservedIds).toContain(currentSection.id);
+      expect(preservedIds).toContain(previousSection.id);
+
       const currentSemesterId = currentSection.semesterId;
 
       const response = await page.request.post(BATCH_BASE, {

--- a/tests/unit/api-schemas.test.ts
+++ b/tests/unit/api-schemas.test.ts
@@ -452,9 +452,18 @@ describe("其他请求 schema", () => {
       }).success,
     ).toBe(true);
     expect(
-      calendarSubscriptionBatchRequestSchema.safeParse({ action: "set" })
-        .success,
+      calendarSubscriptionBatchRequestSchema.safeParse({
+        action: "set",
+        semesterId: 12,
+      }).success,
     ).toBe(true);
+    const unscopedSet = calendarSubscriptionBatchRequestSchema.safeParse({
+      action: "set",
+    });
+    expect(unscopedSet.success).toBe(false);
+    if (!unscopedSet.success) {
+      expect(unscopedSet.error.issues[0]?.path).toEqual(["semesterId"]);
+    }
     expect(
       calendarSubscriptionBatchRequestSchema.safeParse({ action: "remove" })
         .success,


### PR DESCRIPTION
## Goal

Prevent an unscoped batch `action=set` request from replacing every historical section subscription. Production logs for #431 correlate the July 10 deletion with an automated CLI sweep that ran `workspace calendar set 999999` using a production credential; the invalid section resolved to an empty target and the compatibility branch replaced the full relation.

## Changed Surfaces

- Reject batch `action=set` unless `semesterId` is present.
- Preserve the existing scoped behavior: an empty selection may still clear only the named semester.
- Add schema and public-route regression coverage proving the rejected request does not mutate either semester.
- Update the subscription contract.

## Evidence

Static/unit/build:

- `bun run app:prepare`
- `bunx biome check`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- all three repository `tsc --noEmit` checks
- `bunx vitest run` — 154 files / 782 tests
- `bun run build`
- `bun run openapi:check`

Isolated database/API:

- 40 migrations and seed completed in a disposable local database
- related MCP integration: 11/11
- focused Playwright regression: 1 passed; both DATABASE_URL and local Hyperdrive override targeted the disposable database

## Docs / Contracts

Updated `docs/contracts/subscription.json` to require `semesterId` for `action=set`. Generated OpenAPI has no drift because the conditional Zod refinement is enforced at runtime; the companion CLI guard is Life-USTC/cli#9.

REST/MCP parity was checked. MCP exposes add/remove/append only and has no replace tool. Bot has an unused internal replace wrapper, but no callers; this server guard makes any future unscoped use fail safely.

## Risk Areas

This intentionally breaks clients that relied on unscoped batch replacement; they must select a semester. The separate legacy `POST /api/calendar-subscriptions` compatibility endpoint still supports explicit whole-set replacement and is not changed here because removing it is a broader public API break. It was not the caller in this incident.

No production data restoration is included. #431 remains open until the affected relations are restored with explicit authorization and the exposed calendar credential is rotated.

## Cleanup

No scratch artifacts, Playwright output, generated drift, or unrelated rewrites remain.