### PR TITLE
fix(oauth): clarify device code entry

### DIFF
--- a/docs/contracts/oauth.json
+++ b/docs/contracts/oauth.json
@@ -248,7 +248,9 @@
       "mcp": "unavailable",
       "display": {
         "fields": [
-          "User code entry form",
+          "One page-level title and description",
+          "One segmented user-code input labelled Device Code",
+          "One verify action",
           "Approval/result screens",
           "Requested scopes[] on approval screen",
           "Requested resources[] on approval screen",

--- a/src/features/oauth/components/DeviceCodeForm.svelte
+++ b/src/features/oauth/components/DeviceCodeForm.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { REGEXP_ONLY_DIGITS_AND_CHARS } from "bits-ui";
-import { Badge } from "$lib/components/ui/badge/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
 import * as Field from "$lib/components/ui/field/index.js";
 import * as InputOTP from "$lib/components/ui/input-otp/index.js";
@@ -20,12 +19,6 @@ function sanitizeDeviceCode(value: string) {
     .slice(0, 8);
 }
 </script>
-
-<header class="text-center">
-  <Badge class="mb-3" variant="ghost">{copy.deviceTitle}</Badge>
-  <h2 class="font-semibold text-2xl tracking-normal">{copy.deviceTitle}</h2>
-  <p class="mt-2 text-muted-foreground">{copy.deviceCodeHint}</p>
-</header>
 
 <form method="GET" action="/oauth/device">
   <input type="hidden" name="step" value="approve" />

--- a/src/features/oauth/components/DeviceSidePanel.svelte
+++ b/src/features/oauth/components/DeviceSidePanel.svelte
@@ -1,29 +1,17 @@
 <script lang="ts">
-import ShieldAlert from "@lucide/svelte/icons/shield-alert";
-import * as Alert from "$lib/components/ui/alert/index.js";
 import { Badge } from "$lib/components/ui/badge/index.js";
 import * as Card from "$lib/components/ui/card/index.js";
 import * as Item from "$lib/components/ui/item/index.js";
-
-export let deviceTitle: string;
-export let sideNoteLabel: string;
 </script>
 
-<Card.Header class="content-between gap-8 bg-subtle p-6">
-  <div class="grid gap-5">
-    <Item.Root variant="muted">
-      <Item.Media class="size-12" variant="image">
-        <img class="size-full object-cover" src="/images/icon.png" alt="Life@USTC" />
-      </Item.Media>
-      <Item.Content class="gap-1">
-        <Badge class="w-fit" variant="secondary">OAuth</Badge>
-        <Item.Title>{deviceTitle}</Item.Title>
-      </Item.Content>
-    </Item.Root>
-  </div>
-
-  <Alert.Root>
-    <ShieldAlert />
-    <Alert.Description class="break-words">{sideNoteLabel}</Alert.Description>
-  </Alert.Root>
+<Card.Header class="bg-subtle p-6">
+  <Item.Root variant="muted">
+    <Item.Media class="size-12" variant="image">
+      <img class="size-full object-cover" src="/images/icon.png" alt="" />
+    </Item.Media>
+    <Item.Content class="gap-1">
+      <Badge class="w-fit" variant="secondary">OAuth</Badge>
+      <Item.Title>Life@USTC</Item.Title>
+    </Item.Content>
+  </Item.Root>
 </Card.Header>

--- a/src/features/oauth/components/OAuthDevicePage.svelte
+++ b/src/features/oauth/components/OAuthDevicePage.svelte
@@ -43,9 +43,6 @@ function deviceDecisionAction(decision: "approve" | "deny"): SubmitFunction {
 
 $: approvalRequest = data.state === "approval" ? data.request : null;
 $: deviceResult = data.result === "approved" ? "approved" : "denied";
-$: sideNoteLabel = approvalRequest
-  ? data.copy.deviceRequestedPermissions
-  : data.copy.deviceCodeLabel;
 </script>
 
 <svelte:head><title>{data.copy.deviceTitle} - Life@USTC</title></svelte:head>
@@ -54,7 +51,7 @@ $: sideNoteLabel = approvalRequest
   <PageHeader title={data.copy.deviceTitle} description={data.copy.deviceCodeHint} eyebrow="OAuth" />
 
   <Card.Root class="grid gap-0 p-0 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
-    <DeviceSidePanel deviceTitle={data.copy.deviceTitle} {sideNoteLabel} />
+    <DeviceSidePanel />
 
     <Card.Content class="grid gap-5 p-6">
       {#if data.state === "result"}

--- a/tests/e2e/src/app/oauth/device/test.ts
+++ b/tests/e2e/src/app/oauth/device/test.ts
@@ -200,19 +200,53 @@ async function exchangeDeviceToken(
   };
 }
 
-test("/oauth/device 页面渲染用户代码输入表单", async ({ page }, testInfo) => {
+test("/oauth/device 移动端只呈现一个标题和一个代码输入", async ({
+  page,
+}, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 844 });
   await gotoAndWaitForReady(page, "/oauth/device");
 
   await expect(
-    page.locator('input#code, input[type="text"][name="code"]').first(),
-  ).toBeVisible();
+    page.getByRole("heading", {
+      name: /设备登录|Device Login/i,
+      exact: true,
+    }),
+  ).toHaveCount(1);
   await expect(
-    page
-      .getByRole("button", { name: /Verify|确认|Confirm|Submit|提交|验证/i })
-      .first(),
-  ).toBeVisible();
+    page.getByText(/^(设备登录|Device Login)$/, { exact: true }),
+  ).toHaveCount(1);
+  await expect(
+    page.getByText(
+      /输入设备上显示的验证码。|Enter the code displayed on your device\./i,
+      { exact: true },
+    ),
+  ).toHaveCount(1);
 
-  await captureStepScreenshot(page, testInfo, "oauth/device/form");
+  const codeInputs = page.locator('input[name="code"]');
+  await expect(codeInputs).toHaveCount(1);
+  await expect(codeInputs).toBeVisible();
+  await expect(page.locator('label[for="code"]')).toHaveCount(1);
+  await expect(
+    page.getByText(/^(设备验证码|Device Code)$/, { exact: true }),
+  ).toHaveCount(1);
+  await expect(page.locator('[data-slot="input-otp-slot"]')).toHaveCount(8);
+  const verifyButton = page.getByRole("button", {
+    name: /^(验证|Verify)$/i,
+    exact: true,
+  });
+  await expect(verifyButton).toHaveCount(1);
+  await expect(verifyButton).toBeVisible();
+  await expect(verifyButton).toBeInViewport();
+
+  expect(
+    await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth <=
+        document.documentElement.clientWidth,
+    ),
+  ).toBe(true);
+
+  await captureStepScreenshot(page, testInfo, "oauth/device/form-mobile");
 });
 
 test("/oauth/device 无效用户代码显示公开错误", async ({ page }, testInfo) => {


### PR DESCRIPTION
## Goal

Make `/oauth/device` present one clear device-code entry path instead of repeating the title three times and rendering a second input-like “Device Code” panel.

Closes #400

## Changed Surfaces

- Keep the page-level OAuth / Device Login title and description as the single entry heading.
- Reduce the card side panel to Life@USTC application identity; remove the duplicate Device Login title and input-like alert.
- Keep only the labelled 8-slot OTP input and one Verify action in the entry form.
- Treat the adjacent app icon as decorative so assistive technology does not announce the Life@USTC brand twice.
- Add a 390×844 E2E contract for unique visible title/description/label, one real code input, eight slots, one in-viewport Verify action, no horizontal overflow, and a named mobile screenshot.

## Evidence

Final head: `695d77bf4f28be4216e1f3e424316b6e4ceeb6a6`

- [GitHub Actions run 29435330127](https://github.com/Life-USTC/server/actions/runs/29435330127): all jobs passed; public-web E2E **160 passed, 0 failed, 0 flaky**.
- [Published Playwright report](https://life-ustc.github.io/e2e-snapshot-artifacts/reports/29435330127/index.html)
- [Cloudflare commit preview](https://b54441d9-life-ustc.tiankaima.workers.dev): deployment successful for the final head.
- Local: app preparation, Biome, Svelte check (0/0), all three TypeScript projects, focused contract-schema test (1/1), production build, and OpenAPI parity passed.
- Fresh independent contract/source review: passed.
- Fresh independent visual review of the current-head entry and approval screenshots: **passed**.
  - At 390×844, title, description, Device Code, eight slots, and Verify are singular and fully visible in the first viewport with no horizontal overflow.
  - The brand panel reads as application identity rather than a competing input.
  - The desktop approval screen retains client identity, requested permissions, and Deny/Approve actions.
- Full local Vitest was not clean in this constrained workspace: unrelated comment batch-route mock failures appeared before the process was terminated with SIGTERM. The clean repository CI Check passed the final head.

## Docs / Contracts

Updated `docs/contracts/oauth.json` to specify one page-level title/description, one segmented Device Code input, and one verify action.

No message, REST, MCP, OpenAPI, database, or protocol contract changes.

## Risk Areas

- Entry-state presentation only; device authorization, approval/deny, result, error, token, scope, and resource behavior are unchanged.
- The reviewed approval screenshot used a permissions-only request; resource rendering remains covered by component source and the passing resource-bound E2E journey.
- No separate screen-reader hardware audit was performed.

## Cleanup

- Based on `main` release `c0484342`.
- Local and published branch trees are byte-identical.
- No screenshots, traces, generated outputs, or scratch probes are committed.
