### PR TITLE
fix(dashboard): add semantic page identity

### DIFF
--- a/docs/contracts/_ui.json
+++ b/docs/contracts/_ui.json
@@ -11,6 +11,7 @@
   "Context Tabs": "* Used for multi-context switching within detail pages.\n* Common combinations: sections — homework, calendar, comments; courses — sections, comments; teachers — sections, comments.",
   "Calendar Export Dialog": "* Used to display single-object iCal and personal subscription iCal.\n* Presented as a copyable link; users are not required to manually construct the URL.",
   "Shell Layout": "* Desktop shell uses independent scroll regions: the sidebar navigation scrolls separately from the main content column.\n* Shell density favors dashboard-style spacing: compact topbar, compact sidebar links, and tighter page padding.\n* Theme selection is explicit through a dropdown menu with system, light, and dark radio choices.",
+  "Dashboard Page Identity": "* Every signed-in dashboard branch exposes exactly one localized level-one heading.\n* The main content landmark uses the same localized branch label.\n* The document title identifies the active branch before the Life@USTC suffix.\n* Identity follows the normalized dashboard tab across root, path, and query-parameter aliases.",
   "Localized Count Copy": "* User-visible English count copy distinguishes singular from plural forms; Chinese may share one count template when its grammar does not change.",
   "Navigation Landmarks": "* The application sidebar is a real navigation landmark labelled Primary navigation / 主导航.\n* Footer links use one distinct Footer navigation / 页脚导航 landmark so assistive technology can distinguish the two regions."
 }

--- a/src/features/dashboard/components/DashboardPageController.svelte
+++ b/src/features/dashboard/components/DashboardPageController.svelte
@@ -160,6 +160,10 @@ $: sectionCopy = copy.sectionDetail;
 $: subscriptionsCopy = copy.subscriptions;
 $: todosCopy = copy.todos;
 $: commentsCopy = copy.comments;
+$: pageTitle =
+  data.signedIn && data.mainContentLabel
+    ? data.mainContentLabel
+    : copy.metadata.home;
 $: todoPriorityOptions = buildTodoPriorityOptions(todoPriorityOrder, todosCopy);
 $: calendarWeekdayLabels = buildCalendarWeekdayLabels(sectionCopy);
 $: dashboardLinkGroupLabels = dashboardCopy.linkHub.groups;
@@ -520,10 +524,14 @@ onMount(() => {
 </script>
 
 <svelte:head>
-  <title>{copy.metadata.home} - Life@USTC</title>
+  <title>{pageTitle} - Life@USTC</title>
 </svelte:head>
 
 <div class="mx-auto grid w-full max-w-7xl gap-6">
+  {#if data.signedIn && data.mainContentLabel}
+    <h1 class="sr-only">{data.mainContentLabel}</h1>
+  {/if}
+
   <DashboardStatusAlerts
     {actionError}
     {calendarCopyError}

--- a/src/features/dashboard/lib/dashboard-controller-types.ts
+++ b/src/features/dashboard/lib/dashboard-controller-types.ts
@@ -455,6 +455,7 @@ export type DashboardPageData = DashboardRecord & {
   homeworks?: DashboardHomeworksData | null;
   links?: DashboardLinksData | null;
   locale: string;
+  mainContentLabel?: string | null;
   navStats?: DashboardNavStats | null;
   overview?: DashboardOverviewData | null;
   publicLinks?: DashboardLinkItem[] | null;
@@ -473,6 +474,7 @@ export type DashboardActionData =
   | undefined;
 
 export type SignedDashboardData = DashboardPageData & {
+  mainContentLabel: string;
   signedIn: true;
   userMissing?: false;
   navStats: NonNullable<DashboardPageData["navStats"]>;

--- a/src/features/dashboard/server/dashboard-page-load.ts
+++ b/src/features/dashboard/server/dashboard-page-load.ts
@@ -1,3 +1,4 @@
+import { isSignedDashboardTab } from "@/features/dashboard/lib/dashboard-nav";
 import { getDashboardPageCopy } from "@/features/dashboard/server/dashboard-page-copy";
 import { loadAnonymousDashboardPageData } from "@/features/dashboard/server/dashboard-page-load-public";
 import { loadSignedDashboardPageData } from "@/features/dashboard/server/dashboard-page-load-signed";
@@ -91,6 +92,7 @@ export async function loadDashboardPage({
     return data;
   }
 
+  const signedTab = isSignedDashboardTab(tab) ? tab : "overview";
   const [publicSummary, signedData] = await Promise.all([
     publicSummaryPromise,
     loadSignedDashboardPageData({
@@ -120,5 +122,6 @@ export async function loadDashboardPage({
     ...signedData,
     counts: publicSummary.counts,
     currentTermName: publicSummary.currentTermName,
+    mainContentLabel: pageCopy.dashboard.nav[signedTab].title,
   };
 }

--- a/src/lib/components/shell/AppShell.svelte
+++ b/src/lib/components/shell/AppShell.svelte
@@ -66,10 +66,16 @@ $: navGroups = buildShellNavGroups(
   $page.data,
 );
 $: detailWorkspace = isDetailWorkspacePath($page.url.pathname);
+$: mainContentLabel = resolveMainContentLabel($page.data);
 const footerLinks = buildFooterLinks(data.copy.footer);
 
 function isDetailWorkspacePath(pathname: string) {
   return /^\/(courses|sections|teachers)\/[^/]+/.test(pathname);
+}
+
+function resolveMainContentLabel(pageData: Record<string, unknown>) {
+  const label = pageData.mainContentLabel;
+  return typeof label === "string" && label.trim() ? label : undefined;
 }
 
 function buildShellNavGroups(
@@ -365,6 +371,7 @@ afterNavigate(({ from, to }) => {
     />
 
     <Sidebar.Inset
+      aria-label={mainContentLabel}
       id="main-content"
       class="relative flex w-full min-w-0 flex-1 flex-col lg:h-screen lg:min-h-0 lg:overflow-hidden"
     >

--- a/tests/e2e/src/app/dashboard/[tab]/test.ts
+++ b/tests/e2e/src/app/dashboard/[tab]/test.ts
@@ -1,7 +1,11 @@
 /**
  * E2E tests for dashboard route variants (`/dashboard/<tab>`).
  */
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
+import {
+  type SignedTabId,
+  signedTabIds,
+} from "@/features/dashboard/lib/dashboard-nav";
 import {
   expectRequiresSignIn,
   signInAsDebugUser,
@@ -9,6 +13,64 @@ import {
 import { sidebarDashboardLink } from "../../../../utils/locators";
 import { gotoAndWaitForReady } from "../../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
+
+const dashboardTabRoutes = {
+  overview: "/dashboard",
+  calendar: "/dashboard/calendar",
+  homeworks: "/dashboard/homeworks",
+  todos: "/dashboard/todos",
+  exams: "/dashboard/exams",
+  subscriptions: "/dashboard/subscriptions",
+  bus: "/dashboard/bus",
+  links: "/dashboard/links",
+} satisfies Record<SignedTabId, string>;
+
+const dashboardTabTitles = {
+  "en-us": {
+    overview: "Overview",
+    calendar: "Calendar",
+    homeworks: "Homework",
+    todos: "Todos",
+    exams: "Exams",
+    subscriptions: "Section Management",
+    bus: "Shuttle Bus",
+    links: "Websites",
+  },
+  "zh-cn": {
+    overview: "总览",
+    calendar: "日历",
+    homeworks: "作业",
+    todos: "待办",
+    exams: "考试",
+    subscriptions: "关注班级",
+    bus: "校车",
+    links: "网站",
+  },
+} satisfies Record<"en-us" | "zh-cn", Record<SignedTabId, string>>;
+
+async function setLocale(page: Page, locale: "en-us" | "zh-cn") {
+  const response = await page.request.post("/api/locale", {
+    data: { locale },
+  });
+  expect(response.status()).toBe(200);
+}
+
+async function expectDashboardPageIdentity(
+  page: Page,
+  locale: "en-us" | "zh-cn",
+  title: string,
+) {
+  await expect(page.locator("html")).toHaveAttribute("lang", locale);
+  await expect(page).toHaveTitle(`${title} - Life@USTC`);
+  await expect(page.getByRole("heading", { level: 1 })).toHaveCount(1);
+  await expect(
+    page.getByRole("heading", { level: 1, name: title, exact: true }),
+  ).toHaveCount(1);
+  await expect(page.getByRole("main")).toHaveCount(1);
+  await expect(
+    page.getByRole("main", { name: title, exact: true }),
+  ).toHaveCount(1);
+}
 
 test("/dashboard 别名需要登录", async ({ page }, testInfo) => {
   await expectRequiresSignIn(page, "/dashboard/homeworks");
@@ -27,4 +89,45 @@ test("/dashboard/homeworks 加载登录标签", async ({ page }, testInfo) => {
     sidebarDashboardLink(page, /^(工作台任务|Workspace assignments)$/i),
   ).toHaveAttribute("aria-current", "page");
   await captureStepScreenshot(page, testInfo, "dashboard-homeworks");
+});
+
+for (const locale of ["zh-cn", "en-us"] as const) {
+  test(`登录工作台各分支提供唯一页面身份（${locale}）`, async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(60_000);
+    if (locale === "zh-cn") {
+      await page.setViewportSize({ width: 390, height: 844 });
+    }
+    await setLocale(page, locale);
+    await signInAsDebugUser(page, dashboardTabRoutes.overview);
+
+    for (const tab of signedTabIds) {
+      await gotoAndWaitForReady(page, dashboardTabRoutes[tab]);
+      await expectDashboardPageIdentity(
+        page,
+        locale,
+        dashboardTabTitles[locale][tab],
+      );
+
+      if (
+        (locale === "zh-cn" && tab === "todos") ||
+        (locale === "en-us" && tab === "calendar")
+      ) {
+        await captureStepScreenshot(
+          page,
+          testInfo,
+          `dashboard-page-identity-${locale}-${tab}`,
+        );
+      }
+    }
+  });
+}
+
+test("查询参数别名使用规范化后的工作台页面身份", async ({ page }) => {
+  await setLocale(page, "zh-cn");
+  await signInAsDebugUser(page, "/dashboard?tab=todos");
+  await gotoAndWaitForReady(page, "/dashboard?tab=todos");
+
+  await expectDashboardPageIdentity(page, "zh-cn", "待办");
 });

--- a/tests/e2e/src/app/dashboard/test.ts
+++ b/tests/e2e/src/app/dashboard/test.ts
@@ -65,7 +65,16 @@ test.describe("仪表盘", () => {
     });
 
     await expect(page).toHaveURL(/\/(?:\?.*)?$/);
-    await expect(page.locator("#main-content")).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: /^(总览|Overview)$/,
+      }),
+    ).toHaveCount(1);
+    await expect(
+      page.getByRole("main", { name: /^(总览|Overview)$/ }),
+    ).toHaveCount(1);
+    await expect(page).toHaveTitle(/^(总览|Overview) - Life@USTC$/);
     await expect(page.locator("#app-user-menu")).toBeVisible();
 
     // Dashboard sidebar group can be expanded to show the auth-only sub-pages


### PR DESCRIPTION
## Summary

- add one localized level-one heading to every signed-in dashboard branch
- label the main landmark with the same normalized branch name
- use the active branch name in the document title across root, path, and query aliases
- document the UI contract and cover all eight signed-in tabs in both locales

Closes #376

## Verification

Exact PR head: `188c50cd14a2519dc9bf39b585a542abc9f1a965`  
Exact tree: `6f8aa95277f84146d535531edf002b893a73973a`  
Actions run: [29443694797](https://github.com/Life-USTC/server/actions/runs/29443694797)

- [x] independent full-check and diff review — PASS, no blocker
- [x] Biome check — only the pre-existing `src/static-loader/import.ts:1325` warning
- [x] `svelte-check --tsconfig ./tsconfig.json` — 0 errors, 0 warnings
- [x] application, test, and operational TypeScript projects
- [x] UI contract schema test
- [x] production build and OpenAPI parity
- [x] GitHub Actions: all workflow jobs green on the exact head
- [x] Playwright: public 161/161, signed-in 96/96, API/MCP 343/343, admin/comments 44/44
- [x] zero Playwright failures, retries, or flaky results
- [x] Cloudflare preview deployed from `188c50cd`
- [x] independent screenshot review — PASS, no blocker

The added signed-in cases passed on their first attempt:

- Chinese and English eight-tab identity matrices: 4.5s / 4.6s
- normalized query alias: 1.2s

Screenshot evidence from the exact-head signed-in artifact:

- Chinese mobile Todos, 390×1144, SHA-256 `b0db5a45d3d143f3b1793240a15d6b3b27c9ff08d2d370dc455e1198e7fc4840`
- English desktop Calendar, 1280×720, SHA-256 `01ba07a68f666772f58288fc361d3e2fb3fa6cded3d50d2b5fc24eba7b946991`

The independent visual review found no visible duplicate heading, blank space, clipping, overlap, or locale regression.

The independent local full Vitest run hit fixed 15-second timeouts in unchanged CPU-heavy modules; focused reruns, production build, OpenAPI parity, and the exact-head GitHub main check all passed. Local Docker/PostgreSQL were unavailable, so the exact-head Actions browser run is the DB-backed evidence.

## Scope

No REST, MCP, OpenAPI, database, or migration changes.