### PR TITLE
fix(static-loader): preserve campus and room meetings

### DIFF
--- a/src/static-loader/import.ts
+++ b/src/static-loader/import.ts
@@ -18,6 +18,7 @@ import {
   mapAdminClass,
   mapBuilding,
   mapCampus,
+  mapCampusFromSection,
   mapCourse,
   mapExam,
   mapExamBatch,
@@ -120,8 +121,14 @@ export async function runImport(
 
   const { teachers } = loadTeachers(snapshot);
 
-  const { campuses, roomTypes, buildings, rooms, adminClasses } =
-    loadScheduleInfrastructure(snapshot);
+  const {
+    campuses,
+    campusNameByJwId,
+    roomTypes,
+    buildings,
+    rooms,
+    adminClasses,
+  } = loadScheduleInfrastructure(snapshot);
 
   const { sections, placeholderDepartments: sectionPlaceholderDepartments } =
     loadSections(
@@ -209,13 +216,13 @@ export async function runImport(
       upsertTeachers(tx, teachers, departmentMap, teacherTitleMap),
     );
     const campusMap = await logStep("upsertCampuses", campuses.length, () =>
-      upsertCampuses(tx, campuses),
+      upsertCampuses(tx, campuses, campusNameByJwId),
     );
     const roomTypeMap = await logStep("upsertRoomTypes", roomTypes.length, () =>
       upsertRoomTypes(tx, roomTypes),
     );
     const buildingMap = await logStep("upsertBuildings", buildings.length, () =>
-      upsertBuildings(tx, buildings, campusMap),
+      upsertBuildings(tx, buildings, campusMap.byJwId),
     );
     const roomMap = await logStep("upsertRooms", rooms.length, () =>
       upsertRooms(tx, rooms, buildingMap, roomTypeMap),
@@ -638,13 +645,54 @@ function loadScheduleInfrastructure(snapshot: Snapshot) {
   const adminClassRows = snapshot.queryAll(
     "jw_ws_schedule_table_datum_result_lessonList_adminclasses",
   );
+  const catalogLessonRows = snapshot.queryAll(
+    "catalog_teach_lesson_list_for_teach",
+  );
+  const catalogCampusRows = snapshot.queryGrouped(
+    "catalog_teach_lesson_list_for_teach_campus",
+  );
+  const scheduleLessonRows = snapshot.queryAll(
+    "jw_ws_schedule_table_datum_result_lessonList",
+  );
+  const scheduleLessonById = new Map<number, SnapshotRow>();
+  for (const row of scheduleLessonRows) {
+    const lessonId = asInt(row.id);
+    if (lessonId != null) scheduleLessonById.set(lessonId, row);
+  }
 
   const campuses = new Map<string, CampusBuild>();
+  const campusNameByJwId = new Map<number, string>();
   const buildings = new Map<number, BuildingBuild>();
   const rooms = new Map<number, RoomBuild>();
   const roomTypes = new Map<number, RoomTypeBuild>();
   const adminClasses = new Map<number, AdminClassBuild>();
   const adminClassNames = new Set<string>();
+
+  function addCampus(campus: CampusBuild) {
+    if (campus.jwId != null) {
+      const existingName = campusNameByJwId.get(campus.jwId);
+      if (existingName != null && existingName !== campus.nameCn) {
+        throw new Error(
+          `Campus jwId ${campus.jwId} has conflicting names: ${existingName} vs ${campus.nameCn}`,
+        );
+      }
+      campusNameByJwId.set(campus.jwId, campus.nameCn);
+    }
+
+    const existing = campuses.get(campus.nameCn);
+    if (existing == null) {
+      campuses.set(campus.nameCn, campus);
+      return;
+    }
+    if (campus.jwId != null) {
+      existing.jwId =
+        existing.jwId == null
+          ? campus.jwId
+          : Math.min(existing.jwId, campus.jwId);
+    }
+    existing.nameEn ??= campus.nameEn;
+    existing.code ??= campus.code;
+  }
 
   for (const row of roomRows) {
     const parentId = asInt(row.store_id);
@@ -660,8 +708,7 @@ function loadScheduleInfrastructure(snapshot: Snapshot) {
       if (campus) {
         const c = mapCampus(campus);
         if (c != null) {
-          const key = c.nameCn;
-          if (!campuses.has(key)) campuses.set(key, c);
+          addCampus(c);
         }
       }
       const b = mapBuilding(building, campus);
@@ -674,6 +721,17 @@ function loadScheduleInfrastructure(snapshot: Snapshot) {
     }
   }
 
+  for (const lesson of catalogLessonRows) {
+    const lessonId = asInt(lesson.id);
+    const parentId = asInt(lesson.store_id);
+    if (lessonId == null || parentId == null) continue;
+    const campus = mapCampusFromSection(
+      scheduleLessonById.get(lessonId),
+      firstChild(catalogCampusRows, parentId),
+    );
+    if (campus != null) addCampus(campus);
+  }
+
   for (const row of adminClassRows) {
     const ac = mapAdminClass(row);
     if (ac == null || adminClasses.has(ac.jwId)) continue;
@@ -684,6 +742,7 @@ function loadScheduleInfrastructure(snapshot: Snapshot) {
 
   return {
     campuses: Array.from(campuses.values()),
+    campusNameByJwId,
     roomTypes: Array.from(roomTypes.values()),
     buildings: Array.from(buildings.values()),
     rooms: Array.from(rooms.values()),
@@ -865,19 +924,17 @@ function loadScheduleData(
   for (const row of scheduleListRows) {
     const lessonJwId = asInt(row.lessonId);
     if (lessonJwId == null || !importedSectionJwIds.has(lessonJwId)) continue;
-    const key = scheduleKey(row);
+    const room = firstChild(roomMap, asInt(row.store_id) ?? -1);
+    const roomJwId = asInt(room?.id) ?? asInt(row.roomId);
+    const key = scheduleKey(row, roomJwId);
     const personId = asInt(row.personId);
     const existing = schedules.get(key);
     if (existing) {
-      mergeSchedule(existing, row, personId ?? undefined);
+      mergeSchedule(existing, row, personId ?? undefined, roomJwId);
       continue;
     }
 
-    const room = firstChild(roomMap, asInt(row.store_id) ?? -1);
-    const schedule = mapSchedule(row, personId ?? undefined);
-    if (room && schedule.roomJwId == null) {
-      schedule.roomJwId = asInt(room.id);
-    }
+    const schedule = mapSchedule(row, personId ?? undefined, roomJwId);
     schedules.set(key, schedule);
   }
 
@@ -1524,41 +1581,46 @@ function resolveTeacherId(
 async function upsertCampuses(
   tx: Prisma.TransactionClient,
   builds: CampusBuild[],
-): Promise<Map<number, number>> {
-  const map = new Map<number, number>();
+  campusNameByJwId: Map<number, string>,
+): Promise<CampusMap> {
+  const map: CampusMap = {
+    byJwId: new Map<number, number>(),
+    byName: new Map<string, number>(),
+  };
 
   for (const build of builds) {
-    if (build.jwId != null) {
-      const result = await tx.campus.upsert({
-        where: { jwId: build.jwId },
-        create: {
-          jwId: build.jwId,
-          nameCn: build.nameCn,
-          nameEn: build.nameEn,
-          code: build.code,
-        },
-        update: {
-          nameCn: build.nameCn,
-          nameEn: build.nameEn,
-          code: build.code,
-        },
-      });
-      map.set(build.jwId, result.id);
-    } else {
-      await tx.campus.upsert({
-        where: { nameCn: build.nameCn },
-        create: {
-          nameCn: build.nameCn,
-          nameEn: build.nameEn,
-          code: build.code,
-        },
-        update: { nameEn: build.nameEn, code: build.code },
-      });
+    const result = await tx.campus.upsert({
+      where: { nameCn: build.nameCn },
+      create: {
+        jwId: build.jwId,
+        nameCn: build.nameCn,
+        nameEn: build.nameEn,
+        code: build.code,
+      },
+      update: {
+        jwId: build.jwId,
+        nameEn: build.nameEn,
+        code: build.code,
+      },
+    });
+    map.byName.set(build.nameCn, result.id);
+  }
+
+  for (const [jwId, nameCn] of campusNameByJwId) {
+    const campusId = map.byName.get(nameCn);
+    if (campusId == null) {
+      throw new Error(`Campus ${nameCn} for jwId ${jwId} was not upserted`);
     }
+    map.byJwId.set(jwId, campusId);
   }
 
   return map;
 }
+
+type CampusMap = {
+  byJwId: Map<number, number>;
+  byName: Map<string, number>;
+};
 
 async function upsertRoomTypes(
   tx: Prisma.TransactionClient,
@@ -1725,7 +1787,7 @@ async function upsertSections(
   departmentMap: Map<string, number>,
   courseMap: Map<string, number>,
   lookupMaps: LookupMaps,
-  campusMap: Map<number, number>,
+  campusMap: CampusMap,
   roomTypeMap: Map<number, number>,
 ): Promise<Map<number, number>> {
   const columns = [
@@ -1774,6 +1836,21 @@ async function upsertSections(
     const openDepartmentId = build.openDepartmentCode
       ? departmentMap.get(build.openDepartmentCode)
       : null;
+    const campusId =
+      (build.campusId != null
+        ? campusMap.byJwId.get(build.campusId)
+        : undefined) ??
+      (build.campusName != null
+        ? campusMap.byName.get(build.campusName)
+        : undefined);
+    if (
+      campusId == null &&
+      (build.campusId != null || build.campusName != null)
+    ) {
+      throw new Error(
+        `Campus did not resolve for section jwId ${build.jwId}: ${build.campusId ?? build.campusName}`,
+      );
+    }
     records.push({
       key: build.jwId,
       values: [
@@ -1810,7 +1887,7 @@ async function upsertSections(
         build.scheduleRemark,
         courseId,
         semesterId,
-        build.campusId != null ? campusMap.get(build.campusId) : null,
+        campusId,
         build.examModeName ? lookupMaps.examMode.get(build.examModeName) : null,
         openDepartmentId,
         build.teachLanguageName
@@ -2070,8 +2147,15 @@ async function writeSchedules(
       const sectionId = sectionMap.get(build.lessonJwId);
       const scheduleGroupId = scheduleGroupMap.get(build.scheduleGroupJwId);
       if (sectionId == null || scheduleGroupId == null) return undefined;
+      const roomId =
+        build.roomJwId != null ? roomMap.get(build.roomJwId) : undefined;
+      if (build.roomJwId != null && roomId == null) {
+        throw new Error(
+          `Room jwId ${build.roomJwId} did not resolve for section jwId ${build.lessonJwId}`,
+        );
+      }
       return {
-        periods: build.periods,
+        periods: build.periods ?? 0,
         date: build.date,
         weekday: build.weekday,
         startTime: build.startTime,
@@ -2083,22 +2167,24 @@ async function writeSchedules(
         exerciseClass: build.exerciseClass,
         startUnit: build.startUnit,
         endUnit: build.endUnit,
-        roomId:
-          build.roomJwId != null ? roomMap.get(build.roomJwId) : undefined,
+        roomId,
         sectionId,
         scheduleGroupId,
-        key: [
-          sectionId,
-          scheduleGroupId,
-          build.dateStr ?? "",
-          build.weekday,
-          build.startTime,
-          build.endTime,
-          build.startUnit,
-          build.endUnit,
-          build.customPlace ?? "",
-          build.weekIndex,
-        ].join("|"),
+        key: scheduleKey(
+          {
+            lessonId: sectionId,
+            scheduleGroupId,
+            date: build.dateStr,
+            weekday: build.weekday,
+            startTime: build.startTime,
+            endTime: build.endTime,
+            startUnit: build.startUnit,
+            endUnit: build.endUnit,
+            customPlace: build.customPlace,
+            weekIndex: build.weekIndex,
+          },
+          roomId,
+        ),
         teacherPersonIds: build.teacherPersonIds,
       };
     })
@@ -2139,23 +2225,27 @@ async function writeSchedules(
       endUnit: true,
       customPlace: true,
       weekIndex: true,
+      roomId: true,
     },
   });
 
   const scheduleKeyToId = new Map<string, number>();
   for (const row of scheduleRows) {
-    const key = [
-      row.sectionId,
-      row.scheduleGroupId,
-      row.date == null ? "" : formatLocalDate(row.date),
-      row.weekday,
-      row.startTime,
-      row.endTime,
-      row.startUnit,
-      row.endUnit,
-      row.customPlace ?? "",
-      row.weekIndex,
-    ].join("|");
+    const key = scheduleKey(
+      {
+        lessonId: row.sectionId,
+        scheduleGroupId: row.scheduleGroupId,
+        date: row.date == null ? undefined : formatLocalDate(row.date),
+        weekday: row.weekday,
+        startTime: row.startTime,
+        endTime: row.endTime,
+        startUnit: row.startUnit,
+        endUnit: row.endUnit,
+        customPlace: row.customPlace,
+        weekIndex: row.weekIndex,
+      },
+      row.roomId ?? undefined,
+    );
     if (!scheduleKeyToId.has(key)) scheduleKeyToId.set(key, row.id);
   }
 

--- a/src/static-loader/mappers.ts
+++ b/src/static-loader/mappers.ts
@@ -6,7 +6,7 @@ import {
   asInt,
   asString,
   type SnapshotRow,
-} from "./snapshot";
+} from "./snapshot-values";
 
 export type SemesterBuild = {
   jwId: number;
@@ -90,6 +90,7 @@ export type SectionBuild = {
   courseSourceKey: string;
   semesterCode: number;
   campusId?: number;
+  campusName?: string;
   examModeName?: string;
   openDepartmentCode?: string;
   teachLanguageName?: string;
@@ -107,7 +108,7 @@ export type ScheduleGroupBuild = {
 };
 
 export type ScheduleBuild = {
-  periods: number;
+  periods?: number;
   date?: Date;
   dateStr?: string;
   weekday: number;
@@ -465,6 +466,7 @@ export function mapSection(
     courseSourceKey,
     semesterCode,
     campusId: scheduleLesson ? asInt(scheduleLesson.campusId) : undefined,
+    campusName: asString(catalogLookups.campus?.cn),
     examModeName: asString(catalogLookups.examMode?.cn),
     openDepartmentCode: asString(catalogLookups.openDepartment?.code),
     teachLanguageName: asString(catalogLookups.teachLanguage?.cn),
@@ -489,38 +491,88 @@ export function mapScheduleGroup(
   };
 }
 
-export function scheduleKey(row: SnapshotRow): string {
+export function scheduleKey(
+  row: SnapshotRow,
+  roomJwId = asInt(row.roomId),
+): string {
   return [
-    row.lessonId,
-    row.scheduleGroupId,
-    row.date,
-    row.weekday,
-    row.startTime,
-    row.endTime,
-    row.startUnit,
-    row.endUnit,
-    row.customPlace ?? "",
-    row.weekIndex,
+    asInt(row.lessonId) ?? "",
+    asInt(row.scheduleGroupId) ?? "",
+    asString(row.date) ?? "",
+    asInt(row.weekday) ?? "",
+    asInt(row.startTime) ?? "",
+    asInt(row.endTime) ?? "",
+    asInt(row.startUnit) ?? "",
+    asInt(row.endUnit) ?? "",
+    asString(row.customPlace) ?? "",
+    asInt(row.weekIndex) ?? "",
+    roomJwId ?? "",
   ].join("|");
+}
+
+function mergeScheduleValue<T extends string | number | boolean>(
+  field: string,
+  existing: T | undefined,
+  incoming: T | undefined,
+  key: string,
+): T | undefined {
+  if (existing == null) return incoming;
+  if (incoming == null || existing === incoming) return existing;
+  const values = [JSON.stringify(existing), JSON.stringify(incoming)].sort();
+  throw new Error(
+    `Conflicting schedule ${field} for ${key}: ${values.join(" vs ")}`,
+  );
 }
 
 export function mergeSchedule(
   existing: ScheduleBuild,
-  _row: SnapshotRow,
+  row: SnapshotRow,
   personId?: number,
+  roomJwId = asInt(row.roomId),
 ): ScheduleBuild {
-  if (personId != null && !existing.teacherPersonIds.includes(personId)) {
-    existing.teacherPersonIds.push(personId);
+  const incoming = mapSchedule(row, personId, roomJwId);
+  const key = scheduleKey(row, roomJwId);
+  if (existing.roomJwId !== incoming.roomJwId) {
+    throw new Error(`Cannot merge schedules from different rooms for ${key}`);
   }
+  existing.periods =
+    existing.periods == null
+      ? incoming.periods
+      : incoming.periods == null
+        ? existing.periods
+        : Math.max(existing.periods, incoming.periods);
+  existing.experiment = mergeScheduleValue(
+    "experiment",
+    existing.experiment,
+    incoming.experiment,
+    key,
+  );
+  existing.lessonType = mergeScheduleValue(
+    "lessonType",
+    existing.lessonType,
+    incoming.lessonType,
+    key,
+  );
+  existing.exerciseClass = mergeScheduleValue(
+    "exerciseClass",
+    existing.exerciseClass,
+    incoming.exerciseClass,
+    key,
+  );
+  existing.teacherPersonIds = Array.from(
+    new Set([...existing.teacherPersonIds, ...incoming.teacherPersonIds]),
+  ).sort((a, b) => a - b);
   return existing;
 }
 
 export function mapSchedule(
   row: SnapshotRow,
   personId?: number,
+  roomJwId = asInt(row.roomId),
 ): ScheduleBuild {
+  const periods = asFloat(row.periods);
   return {
-    periods: Math.round(asFloat(row.periods) ?? 0),
+    periods: periods == null ? undefined : Math.round(periods),
     date: asDate(row.date),
     dateStr: asString(row.date),
     weekday: asInt(row.weekday) ?? 0,
@@ -530,10 +582,10 @@ export function mapSchedule(
     customPlace: asString(row.customPlace),
     lessonType: asString(row.lessonType),
     weekIndex: asInt(row.weekIndex) ?? 0,
-    exerciseClass: asBoolean(row.exerciseClass),
+    exerciseClass: asBoolean(row.exerciseClass) ?? false,
     startUnit: asInt(row.startUnit) ?? 0,
     endUnit: asInt(row.endUnit) ?? 0,
-    roomJwId: asInt(row.roomId),
+    roomJwId,
     lessonJwId: asInt(row.lessonId) ?? 0,
     scheduleGroupJwId: asInt(row.scheduleGroupId) ?? 0,
     teacherPersonIds: personId == null ? [] : [personId],
@@ -589,6 +641,19 @@ export function mapCampus(row: SnapshotRow): CampusBuild | undefined {
     nameCn,
     nameEn: asString(row.nameEn),
     code: asString(row.code),
+  };
+}
+
+export function mapCampusFromSection(
+  scheduleLesson: SnapshotRow | undefined,
+  catalogCampus: SnapshotRow | undefined,
+): CampusBuild | undefined {
+  const nameCn = asString(catalogCampus?.cn);
+  if (!nameCn) return undefined;
+  return {
+    jwId: asInt(scheduleLesson?.campusId),
+    nameCn,
+    nameEn: asString(catalogCampus?.en),
   };
 }
 

--- a/src/static-loader/snapshot-values.ts
+++ b/src/static-loader/snapshot-values.ts
@@ -1,0 +1,50 @@
+export type SnapshotRow = Record<string, unknown>;
+
+export function asInt(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value === "number")
+    return Number.isFinite(value) ? Math.trunc(value) : undefined;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? Math.trunc(parsed) : undefined;
+  }
+  return undefined;
+}
+
+export function asFloat(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value === "number")
+    return Number.isFinite(value) ? value : undefined;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+export function asString(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  const str = String(value).trim();
+  return str === "" ? undefined : str;
+}
+
+export function asBoolean(value: unknown): boolean | undefined {
+  if (value == null) return undefined;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+  if (typeof value === "string") {
+    const lower = value.trim().toLowerCase();
+    if (lower === "1" || lower === "true") return true;
+    if (lower === "0" || lower === "false") return false;
+  }
+  return undefined;
+}
+
+export function asDate(value: unknown): Date | undefined {
+  if (value == null) return undefined;
+  const str = String(value).trim();
+  if (str === "") return undefined;
+  const date = new Date(str);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}

--- a/src/static-loader/snapshot.ts
+++ b/src/static-loader/snapshot.ts
@@ -1,6 +1,14 @@
 import { Database } from "bun:sqlite";
+import { asInt, type SnapshotRow } from "./snapshot-values";
 
-export type SnapshotRow = Record<string, unknown>;
+export {
+  asBoolean,
+  asDate,
+  asFloat,
+  asInt,
+  asString,
+  type SnapshotRow,
+} from "./snapshot-values";
 
 export class Snapshot {
   private readonly db: Database;
@@ -49,53 +57,4 @@ export class Snapshot {
   ): Map<number, SnapshotRow[]> {
     return this.groupByParent(this.queryAll(tableName), parentColumn);
   }
-}
-
-export function asInt(value: unknown): number | undefined {
-  if (value == null) return undefined;
-  if (typeof value === "number")
-    return Number.isFinite(value) ? Math.trunc(value) : undefined;
-  if (typeof value === "bigint") return Number(value);
-  if (typeof value === "string" && value.trim() !== "") {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? Math.trunc(parsed) : undefined;
-  }
-  return undefined;
-}
-
-export function asFloat(value: unknown): number | undefined {
-  if (value == null) return undefined;
-  if (typeof value === "number")
-    return Number.isFinite(value) ? value : undefined;
-  if (typeof value === "string" && value.trim() !== "") {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : undefined;
-  }
-  return undefined;
-}
-
-export function asString(value: unknown): string | undefined {
-  if (value == null) return undefined;
-  const str = String(value).trim();
-  return str === "" ? undefined : str;
-}
-
-export function asBoolean(value: unknown): boolean | undefined {
-  if (value == null) return undefined;
-  if (typeof value === "boolean") return value;
-  if (typeof value === "number") return value === 1;
-  if (typeof value === "string") {
-    const lower = value.trim().toLowerCase();
-    if (lower === "1" || lower === "true") return true;
-    if (lower === "0" || lower === "false") return false;
-  }
-  return undefined;
-}
-
-export function asDate(value: unknown): Date | undefined {
-  if (value == null) return undefined;
-  const str = String(value).trim();
-  if (str === "") return undefined;
-  const date = new Date(str);
-  return Number.isNaN(date.getTime()) ? undefined : date;
 }

--- a/tests/unit/static-schedule-mappers.test.ts
+++ b/tests/unit/static-schedule-mappers.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapCampusFromSection,
+  mapSchedule,
+  mapSection,
+  mergeSchedule,
+  scheduleKey,
+} from "@/static-loader/mappers";
+import type { SnapshotRow } from "@/static-loader/snapshot-values";
+
+function scheduleRow(overrides: SnapshotRow = {}): SnapshotRow {
+  return {
+    lessonId: 1001,
+    scheduleGroupId: 2001,
+    periods: 2,
+    date: "2026-09-01",
+    weekday: 2,
+    startTime: 800,
+    endTime: 940,
+    customPlace: null,
+    experiment: false,
+    lessonType: "理论",
+    weekIndex: 1,
+    exerciseClass: false,
+    startUnit: 1,
+    endUnit: 2,
+    ...overrides,
+  };
+}
+
+describe("static schedule meeting mapping", () => {
+  it("keeps otherwise identical meetings in different rooms separate", () => {
+    const row = scheduleRow();
+
+    expect(scheduleKey(row, 5301)).not.toBe(scheduleKey(row, 5302));
+  });
+
+  it("merges teachers only for the same room meeting", () => {
+    const row = scheduleRow();
+    const existing = mapSchedule(row, 11, 5301);
+
+    mergeSchedule(existing, row, 12, 5301);
+
+    expect(existing.teacherPersonIds).toEqual([11, 12]);
+    expect(existing.roomJwId).toBe(5301);
+  });
+
+  it("refuses to merge teachers from different rooms", () => {
+    const row = scheduleRow();
+
+    expect(() =>
+      mergeSchedule(mapSchedule(row, 11, 5301), row, 12, 5302),
+    ).toThrow(/different rooms/);
+  });
+
+  it("uses the maximum teacher periods regardless of input order", () => {
+    const shorter = scheduleRow({ periods: 3 });
+    const longer = scheduleRow({ periods: 4 });
+    const forward = mapSchedule(shorter, 11, 5301);
+    const reverse = mapSchedule(longer, 12, 5301);
+
+    mergeSchedule(forward, longer, 12, 5301);
+    mergeSchedule(reverse, shorter, 11, 5301);
+
+    expect(forward).toEqual(reverse);
+    expect(forward.periods).toBe(4);
+  });
+
+  it.each([
+    ["experiment", { experiment: true }],
+    ["lessonType", { lessonType: "实验" }],
+    ["exerciseClass", { exerciseClass: true }],
+  ])("rejects conflicting %s regardless of input order", (_field, conflict) => {
+    const first = scheduleRow();
+    const second = scheduleRow(conflict);
+
+    expect(() =>
+      mergeSchedule(mapSchedule(first, 11, 5301), second, 12, 5301),
+    ).toThrow(/Conflicting schedule/);
+    expect(() =>
+      mergeSchedule(mapSchedule(second, 12, 5301), first, 11, 5301),
+    ).toThrow(/Conflicting schedule/);
+  });
+
+  it("uses the defined optional payload regardless of input order", () => {
+    const withoutOptional = scheduleRow({
+      experiment: null,
+      lessonType: null,
+      exerciseClass: null,
+    });
+    const withOptional = scheduleRow({
+      experiment: true,
+      lessonType: "理论",
+      exerciseClass: false,
+    });
+
+    const forward = mapSchedule(withoutOptional, 12, 5301);
+    mergeSchedule(forward, withOptional, 11, 5301);
+    const reverse = mapSchedule(withOptional, 11, 5301);
+    mergeSchedule(reverse, withoutOptional, 12, 5301);
+
+    expect(forward).toEqual(reverse);
+  });
+
+  it("treats null and false exerciseClass as the same false value", () => {
+    const row = scheduleRow({ exerciseClass: null });
+    const existing = mapSchedule(row, 11, 5301);
+
+    expect(() =>
+      mergeSchedule(existing, scheduleRow({ exerciseClass: false }), 12, 5301),
+    ).not.toThrow();
+    expect(existing.exerciseClass).toBe(false);
+  });
+});
+
+describe("static section campus mapping", () => {
+  it("builds a Campus from the JW campus ID and Catalog names", () => {
+    expect(
+      mapCampusFromSection(
+        { campusId: 901 },
+        { cn: "国际金融研究院", en: "International Institute" },
+      ),
+    ).toEqual({
+      jwId: 901,
+      nameCn: "国际金融研究院",
+      nameEn: "International Institute",
+    });
+  });
+
+  it("builds a name-only Campus when the JW lesson is missing", () => {
+    expect(
+      mapCampusFromSection(undefined, {
+        cn: "国际金融研究院",
+        en: "International Institute",
+      }),
+    ).toEqual({
+      jwId: undefined,
+      nameCn: "国际金融研究院",
+      nameEn: "International Institute",
+    });
+  });
+
+  it("retains the Catalog campus name when the JW lesson is missing", () => {
+    const section = mapSection(
+      { id: 1001, code: "MATH1001.01", semester_id: 401 },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        course: { id: 3001 },
+        courseSourceKey: "course-source-key",
+        campus: { cn: "国际金融研究院", en: "International Institute" },
+      },
+    );
+
+    expect(section).toMatchObject({
+      campusId: undefined,
+      campusName: "国际金融研究院",
+    });
+  });
+});


### PR DESCRIPTION
## Goal

Make static imports preserve every Section campus and every distinct room meeting.

Closes #448.
Closes #449.

## Changed Surfaces

- Build Campus aliases from both room infrastructure and JW lesson campus IDs paired with Catalog names.
- Fall back to Catalog campus names for the three lessons absent from JW data; fail if a provided campus cannot resolve.
- Include room identity in source and persisted Schedule meeting keys.
- Merge teacher rows only within the same room meeting.
- Canonicalize teacher-specific `periods` with `max`, normalize `exerciseClass` null/false, and reject true shared-field conflicts.
- Move snapshot scalar conversion helpers into a pure module so mapper behavior is unit-testable under Node Vitest.

## Evidence

- `bunx biome check` — passed with the pre-existing unused `build` warning only.
- `bunx svelte-check --tsconfig ./tsconfig.json` — passed.
- All three repository TypeScript checks — passed.
- `bunx vitest run` — 163 files / 890 tests passed.
- Current production snapshot dry-run — passed.
- Current snapshot imported twice into disposable PostgreSQL — stable at 7,927 Sections, 0 missing campuses, and 130,581 Schedules (84 room-specific meetings restored).

## Docs / Contracts

No REST/MCP schema or public contract changed; this corrects imported records only.

## Risk Areas

Campus aliases are canonicalized by `nameCn` while retaining every JW ID mapping. Optional schedule fields use explicit order-independent merge rules; conflicting shared meeting payloads fail closed.

## Cleanup

Disposable database and temporary snapshot used by the subagent were removed. No generated scratch artifacts or unrelated rewrites remain.