### PR TITLE
fix(static): harden static snapshot imports

### DIFF
--- a/scripts/load-static-sqlite.sh
+++ b/scripts/load-static-sqlite.sh
@@ -4,7 +4,11 @@ set -eu
 : "${DATABASE_URL:?DATABASE_URL is required}"
 : "${STATIC_SNAPSHOT_URL:=https://static.life-ustc.tiankaima.dev/life-ustc-static.sqlite}"
 
-if [ -n "${STATIC_SNAPSHOT_PATH:-}" ] && [ -f "$STATIC_SNAPSHOT_PATH" ]; then
+if [ -n "${STATIC_SNAPSHOT_PATH:-}" ]; then
+  if [ ! -f "$STATIC_SNAPSHOT_PATH" ]; then
+    echo "Local snapshot not found: ${STATIC_SNAPSHOT_PATH}" >&2
+    exit 1
+  fi
   echo "Using local snapshot: ${STATIC_SNAPSHOT_PATH}"
   STATIC_SNAPSHOT_PATH="$STATIC_SNAPSHOT_PATH" bun run static:load
   exit 0

--- a/scripts/load-static-sqlite.sh
+++ b/scripts/load-static-sqlite.sh
@@ -4,8 +4,8 @@ set -eu
 : "${DATABASE_URL:?DATABASE_URL is required}"
 : "${STATIC_SNAPSHOT_URL:=https://static.life-ustc.tiankaima.dev/life-ustc-static.sqlite}"
 
-if [ -n "${STATIC_SNAPSHOT_PATH:-}" ]; then
-  if [ ! -f "$STATIC_SNAPSHOT_PATH" ]; then
+if [ "${STATIC_SNAPSHOT_PATH+x}" = x ]; then
+  if [ -z "$STATIC_SNAPSHOT_PATH" ] || [ ! -f "$STATIC_SNAPSHOT_PATH" ]; then
     echo "Local snapshot not found: ${STATIC_SNAPSHOT_PATH}" >&2
     exit 1
   fi

--- a/src/static-loader/cli.ts
+++ b/src/static-loader/cli.ts
@@ -4,6 +4,7 @@ import { writeFile } from "node:fs/promises";
 import { runImport } from "./import";
 import { createPrismaClient } from "./prisma";
 import { Snapshot } from "./snapshot";
+import { parseBooleanSetting, parsePositiveIntegerSetting } from "./validation";
 
 function getEnv(name: string, defaultValue?: string): string {
   const value = process.env[name] ?? defaultValue;
@@ -13,23 +14,6 @@ function getEnv(name: string, defaultValue?: string): string {
   return value;
 }
 
-function parseBool(value: string | undefined, defaultValue: boolean): boolean {
-  if (value === undefined) return defaultValue;
-  const lower = value.trim().toLowerCase();
-  if (lower === "true" || lower === "1") return true;
-  if (lower === "false" || lower === "0") return false;
-  return defaultValue;
-}
-
-function parseIntDefault(
-  value: string | undefined,
-  defaultValue: number,
-): number {
-  if (value === undefined) return defaultValue;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isNaN(parsed) ? defaultValue : parsed;
-}
-
 function maskDatabaseUrl(url: string): string {
   return url.replace(/:\/\/([^:@]+)(:[^@]+)?@/, "://***@");
 }
@@ -37,11 +21,16 @@ function maskDatabaseUrl(url: string): string {
 async function main() {
   const databaseUrl = getEnv("DATABASE_URL");
   const snapshotPath = getEnv("STATIC_SNAPSHOT_PATH");
-  const minSemester = parseIntDefault(
+  const minSemester = parsePositiveIntegerSetting(
+    "STATIC_LOADER_MIN_SEMESTER",
     process.env.STATIC_LOADER_MIN_SEMESTER,
     401,
   );
-  const dryRun = parseBool(process.env.STATIC_LOADER_DRY_RUN, false);
+  const dryRun = parseBooleanSetting(
+    "STATIC_LOADER_DRY_RUN",
+    process.env.STATIC_LOADER_DRY_RUN,
+    false,
+  );
 
   if (!existsSync(snapshotPath)) {
     throw new Error(`Snapshot not found: ${snapshotPath}`);

--- a/src/static-loader/import.ts
+++ b/src/static-loader/import.ts
@@ -59,6 +59,10 @@ import {
   requireCourseSourceKey,
   sectionConflictUpdateColumns,
 } from "./upsert-policy";
+import {
+  missingSnapshotRowsWhere,
+  validateSnapshotCompleteness,
+} from "./validation";
 
 export type ImportConfig = {
   snapshotPath: string;
@@ -88,10 +92,26 @@ export async function runImport(
   const snapshot = new Snapshot(config.snapshotPath);
   const metadata = snapshot.metadata();
   const schemaVersion = metadata.schema_version;
-  if (schemaVersion !== "5") {
-    throw new Error(
-      `Unsupported snapshot schema version: ${schemaVersion ?? "unknown"}`,
+  try {
+    if (schemaVersion !== "5") {
+      throw new Error(
+        `Unsupported snapshot schema version: ${schemaVersion ?? "unknown"}`,
+      );
+    }
+    validateSnapshotCompleteness(
+      {
+        metadata,
+        semesterRows: snapshot.queryAll("catalog_teach_semester_list"),
+        catalogLessonRows: snapshot.queryAll(
+          "catalog_teach_lesson_list_for_teach",
+        ),
+        fetchRows: snapshot.queryAll("upstream_fetches"),
+      },
+      config.minSemester,
     );
+  } catch (error) {
+    snapshot.close();
+    throw error;
   }
 
   const allSectionJwIds = new Set<number>();
@@ -291,6 +311,26 @@ export async function runImport(
     );
     await logStep("writeExamRooms", exams.length, () =>
       writeExamRooms(tx, exams, examMap),
+    );
+    await logStep(
+      "reconcileRemovedSnapshotRows",
+      scheduleGroups.length + exams.length,
+      async () => {
+        const scheduleGroupWhere = missingSnapshotRowsWhere(
+          sectionDbIds,
+          scheduleGroups.map((group) => group.jwId),
+        );
+        if (scheduleGroupWhere != null) {
+          await tx.scheduleGroup.deleteMany({ where: scheduleGroupWhere });
+        }
+        const examWhere = missingSnapshotRowsWhere(
+          sectionDbIds,
+          exams.map((exam) => exam.jwId),
+        );
+        if (examWhere != null) {
+          await tx.exam.deleteMany({ where: examWhere });
+        }
+      },
     );
 
     if (config.dryRun) {

--- a/src/static-loader/validation.ts
+++ b/src/static-loader/validation.ts
@@ -1,0 +1,241 @@
+const CATALOG_LESSON_SOURCE = "catalog_teach_lesson_list_for_teach";
+const CATALOG_EXAM_SOURCE = "catalog_teach_exam_list";
+const JW_SCHEDULE_SOURCE = "jw_ws_schedule_table_datum";
+const SEMESTER_SOURCES = new Set([
+  CATALOG_LESSON_SOURCE,
+  CATALOG_EXAM_SOURCE,
+  JW_SCHEDULE_SOURCE,
+]);
+
+type SnapshotRow = Record<string, unknown>;
+
+function rowString(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  const normalized = String(value).trim();
+  return normalized === "" ? undefined : normalized;
+}
+
+function rowInteger(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? Math.trunc(value) : undefined;
+  }
+  const normalized = rowString(value);
+  if (normalized == null || !/^-?\d+$/.test(normalized)) return undefined;
+  const parsed = Number(normalized);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+function rowBoolean(value: unknown): boolean | undefined {
+  if (value === true || value === 1 || value === "1") return true;
+  if (value === false || value === 0 || value === "0") return false;
+  const normalized = rowString(value)?.toLowerCase();
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  return undefined;
+}
+
+export function parseBooleanSetting(
+  name: string,
+  value: string | undefined,
+  defaultValue: boolean,
+): boolean {
+  if (value === undefined) return defaultValue;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true" || normalized === "1") return true;
+  if (normalized === "false" || normalized === "0") return false;
+  throw new Error(`${name} must be one of: true, false, 1, 0`);
+}
+
+export function parsePositiveIntegerSetting(
+  name: string,
+  value: string | undefined,
+  defaultValue: number,
+): number {
+  if (value === undefined) return defaultValue;
+  if (!/^[1-9]\d*$/.test(value)) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`${name} must be a safe positive integer`);
+  }
+  return parsed;
+}
+
+function optionalNonNegativeIntegerMetadata(
+  name: string,
+  value: string | undefined,
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`snapshot metadata ${name} must be a non-negative integer`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`snapshot metadata ${name} must be a safe integer`);
+  }
+  return parsed;
+}
+
+type SnapshotCompletenessInput = {
+  metadata: Record<string, string>;
+  semesterRows: SnapshotRow[];
+  catalogLessonRows: SnapshotRow[];
+  fetchRows: SnapshotRow[];
+};
+
+type SemesterFetchState = {
+  catalogLessonFetches: number;
+  catalogExamFetches: number;
+  jwChunks: number[];
+};
+
+function fetchContext(row: SnapshotRow): URLSearchParams {
+  const context = rowString(row.context);
+  if (context == null) {
+    throw new Error(
+      `Snapshot fetch ${rowString(row.source) ?? "unknown"} has no context`,
+    );
+  }
+  return new URLSearchParams(context);
+}
+
+function contextInteger(
+  source: string,
+  context: URLSearchParams,
+  name: string,
+): number {
+  const value = context.get(name);
+  if (value == null || !/^\d+$/.test(value)) {
+    throw new Error(`Snapshot fetch ${source} has invalid ${name}`);
+  }
+  return Number(value);
+}
+
+export function validateSnapshotCompleteness(
+  input: SnapshotCompletenessInput,
+  minSemester: number,
+): void {
+  const chunkSize = parsePositiveIntegerSetting(
+    "snapshot metadata jw_schedule_chunk_size",
+    input.metadata.jw_schedule_chunk_size,
+    100,
+  );
+  const examMinSemester = parsePositiveIntegerSetting(
+    "snapshot metadata catalog_exam_min_semester_id",
+    input.metadata.catalog_exam_min_semester_id,
+    381,
+  );
+
+  const targetSemesters = new Set(
+    input.semesterRows
+      .map((row) => rowInteger(row.id))
+      .filter(
+        (semesterId): semesterId is number =>
+          semesterId != null && semesterId >= minSemester,
+      ),
+  );
+  const lessonCounts = new Map<number, number>();
+  const fetchState = new Map<number, SemesterFetchState>();
+  for (const semesterId of targetSemesters) {
+    lessonCounts.set(semesterId, 0);
+    fetchState.set(semesterId, {
+      catalogLessonFetches: 0,
+      catalogExamFetches: 0,
+      jwChunks: [],
+    });
+  }
+
+  for (const row of input.catalogLessonRows) {
+    const semesterId = rowInteger(row.semester_id);
+    if (semesterId == null || !targetSemesters.has(semesterId)) continue;
+    lessonCounts.set(semesterId, (lessonCounts.get(semesterId) ?? 0) + 1);
+  }
+
+  for (const row of input.fetchRows) {
+    const source = rowString(row.source);
+    if (source == null || !SEMESTER_SOURCES.has(source)) continue;
+    const context = fetchContext(row);
+    const semesterId = contextInteger(source, context, "semester_id");
+    if (!targetSemesters.has(semesterId)) continue;
+    if (rowBoolean(row.ok) !== true) {
+      throw new Error(
+        `Snapshot fetch ${source} for semester ${semesterId} failed`,
+      );
+    }
+
+    const state = fetchState.get(semesterId);
+    if (state == null) continue;
+    if (source === CATALOG_LESSON_SOURCE) {
+      state.catalogLessonFetches += 1;
+    } else if (source === CATALOG_EXAM_SOURCE) {
+      state.catalogExamFetches += 1;
+    } else {
+      state.jwChunks.push(contextInteger(source, context, "chunk_index"));
+    }
+  }
+
+  for (const semesterId of targetSemesters) {
+    const state = fetchState.get(semesterId);
+    if (state == null) continue;
+    if (state.catalogLessonFetches === 0) {
+      throw new Error(
+        `Snapshot semester ${semesterId} has no successful ${CATALOG_LESSON_SOURCE} fetch`,
+      );
+    }
+    if (semesterId >= examMinSemester && state.catalogExamFetches === 0) {
+      throw new Error(
+        `Snapshot semester ${semesterId} has no successful ${CATALOG_EXAM_SOURCE} fetch`,
+      );
+    }
+
+    const expectedChunkCount = Math.ceil(
+      (lessonCounts.get(semesterId) ?? 0) / chunkSize,
+    );
+    const expectedChunkMetadataName = `jw_schedule_expected_chunk_count_${semesterId}`;
+    const recordedExpectedChunkCount = optionalNonNegativeIntegerMetadata(
+      expectedChunkMetadataName,
+      input.metadata[expectedChunkMetadataName],
+    );
+    if (
+      recordedExpectedChunkCount != null &&
+      recordedExpectedChunkCount !== expectedChunkCount
+    ) {
+      throw new Error(
+        `Snapshot semester ${semesterId} expected chunk metadata ${recordedExpectedChunkCount} contradicts catalog-derived count ${expectedChunkCount}`,
+      );
+    }
+    const expectedChunks = Array.from(
+      { length: expectedChunkCount },
+      (_, index) => index,
+    );
+    const actualChunks = [...state.jwChunks].sort((a, b) => a - b);
+    if (
+      expectedChunks.length !== actualChunks.length ||
+      expectedChunks.some((chunk, index) => chunk !== actualChunks[index])
+    ) {
+      throw new Error(
+        `Snapshot semester ${semesterId} expected JW chunks ${expectedChunks.join(",")} but found ${actualChunks.join(",")}`,
+      );
+    }
+  }
+}
+
+export type MissingSnapshotRowsWhere = {
+  sectionId: { in: number[] };
+  jwId?: { notIn: number[] };
+};
+
+export function missingSnapshotRowsWhere(
+  sectionIds: number[],
+  currentJwIds: number[],
+): MissingSnapshotRowsWhere | undefined {
+  if (sectionIds.length === 0) return undefined;
+  const where: MissingSnapshotRowsWhere = {
+    sectionId: { in: [...sectionIds] },
+  };
+  if (currentJwIds.length > 0) {
+    where.jwId = { notIn: [...currentJwIds] };
+  }
+  return where;
+}

--- a/tests/unit/static-loader-validation.test.ts
+++ b/tests/unit/static-loader-validation.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import {
+  missingSnapshotRowsWhere,
+  parseBooleanSetting,
+  parsePositiveIntegerSetting,
+  validateSnapshotCompleteness,
+} from "@/static-loader/validation";
+
+function semesterRows(...ids: number[]) {
+  return ids.map((id) => ({ id }));
+}
+
+function lessonRows(semesterId: number, count: number) {
+  return Array.from({ length: count }, () => ({ semester_id: semesterId }));
+}
+
+function fetchRow(
+  source: string,
+  semesterId: number,
+  options: { chunkIndex?: number; ok?: boolean } = {},
+) {
+  const context = new URLSearchParams();
+  if (options.chunkIndex != null) {
+    context.set("chunk_index", String(options.chunkIndex));
+  }
+  context.set("semester_id", String(semesterId));
+  return {
+    source,
+    context: context.toString(),
+    ok: options.ok === false ? 0 : 1,
+  };
+}
+
+function completeFetches(semesterId: number, chunkCount: number) {
+  return [
+    fetchRow("catalog_teach_lesson_list_for_teach", semesterId),
+    fetchRow("catalog_teach_exam_list", semesterId),
+    ...Array.from({ length: chunkCount }, (_, chunkIndex) =>
+      fetchRow("jw_ws_schedule_table_datum", semesterId, { chunkIndex }),
+    ),
+  ];
+}
+
+describe("static loader configuration", () => {
+  it.each([
+    [undefined, false, false],
+    [undefined, true, true],
+    ["true", false, true],
+    ["1", false, true],
+    ["FALSE", true, false],
+    ["0", true, false],
+  ])("parses boolean setting %s with default %s", (value, defaultValue, expected) => {
+    expect(
+      parseBooleanSetting("STATIC_LOADER_DRY_RUN", value, defaultValue),
+    ).toBe(expected);
+  });
+
+  it("rejects an invalid boolean instead of falling back to a write-enabled default", () => {
+    expect(() =>
+      parseBooleanSetting("STATIC_LOADER_DRY_RUN", "treu", false),
+    ).toThrow("STATIC_LOADER_DRY_RUN");
+  });
+
+  it.each([
+    [undefined, 401],
+    ["401", 401],
+    ["461", 461],
+  ])("parses positive integer setting %s", (value, expected) => {
+    expect(
+      parsePositiveIntegerSetting("STATIC_LOADER_MIN_SEMESTER", value, 401),
+    ).toBe(expected);
+  });
+
+  it.each([
+    "",
+    "401x",
+    "401.5",
+    "0",
+    "-1",
+  ])("rejects invalid positive integer %s", (value) => {
+    expect(() =>
+      parsePositiveIntegerSetting("STATIC_LOADER_MIN_SEMESTER", value, 401),
+    ).toThrow("STATIC_LOADER_MIN_SEMESTER");
+  });
+});
+
+describe("snapshot completeness validation", () => {
+  const metadata = {
+    catalog_exam_min_semester_id: "381",
+    jw_schedule_chunk_size: "100",
+  };
+
+  it("accepts all expected JW chunks and a zero-lesson semester", () => {
+    expect(() =>
+      validateSnapshotCompleteness(
+        {
+          metadata,
+          semesterRows: semesterRows(381, 401, 421),
+          catalogLessonRows: [...lessonRows(401, 101), ...lessonRows(421, 0)],
+          fetchRows: [...completeFetches(401, 2), ...completeFetches(421, 0)],
+        },
+        401,
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects a failed JW chunk", () => {
+    expect(() =>
+      validateSnapshotCompleteness(
+        {
+          metadata,
+          semesterRows: semesterRows(401),
+          catalogLessonRows: lessonRows(401, 101),
+          fetchRows: [
+            ...completeFetches(401, 1),
+            fetchRow("jw_ws_schedule_table_datum", 401, {
+              chunkIndex: 1,
+              ok: false,
+            }),
+          ],
+        },
+        401,
+      ),
+    ).toThrow("failed");
+  });
+
+  it("rejects a missing JW chunk", () => {
+    expect(() =>
+      validateSnapshotCompleteness(
+        {
+          metadata,
+          semesterRows: semesterRows(401),
+          catalogLessonRows: lessonRows(401, 201),
+          fetchRows: completeFetches(401, 2),
+        },
+        401,
+      ),
+    ).toThrow("expected JW chunks 0,1,2");
+  });
+
+  it("rejects duplicate or extra JW chunks", () => {
+    expect(() =>
+      validateSnapshotCompleteness(
+        {
+          metadata,
+          semesterRows: semesterRows(401),
+          catalogLessonRows: lessonRows(401, 1),
+          fetchRows: [
+            ...completeFetches(401, 1),
+            fetchRow("jw_ws_schedule_table_datum", 401, { chunkIndex: 1 }),
+          ],
+        },
+        401,
+      ),
+    ).toThrow("expected JW chunks 0");
+  });
+
+  it("rejects expected-chunk metadata that contradicts catalog lessons", () => {
+    expect(() =>
+      validateSnapshotCompleteness(
+        {
+          metadata: {
+            ...metadata,
+            jw_schedule_expected_chunk_count_401: "2",
+          },
+          semesterRows: semesterRows(401),
+          catalogLessonRows: lessonRows(401, 1),
+          fetchRows: completeFetches(401, 1),
+        },
+        401,
+      ),
+    ).toThrow("expected chunk metadata");
+  });
+
+  it.each([
+    "catalog_teach_lesson_list_for_teach",
+    "catalog_teach_exam_list",
+  ])("rejects a missing successful %s fetch", (missingSource) => {
+    expect(() =>
+      validateSnapshotCompleteness(
+        {
+          metadata,
+          semesterRows: semesterRows(401),
+          catalogLessonRows: lessonRows(401, 1),
+          fetchRows: completeFetches(401, 1).filter(
+            (row) => row.source !== missingSource,
+          ),
+        },
+        401,
+      ),
+    ).toThrow(missingSource);
+  });
+
+  it("ignores semesters below the configured import boundary", () => {
+    expect(() =>
+      validateSnapshotCompleteness(
+        {
+          metadata,
+          semesterRows: semesterRows(381, 401),
+          catalogLessonRows: lessonRows(401, 1),
+          fetchRows: completeFetches(401, 1),
+        },
+        401,
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("snapshot reconciliation scope", () => {
+  it("limits deletion to imported sections and preserves current IDs", () => {
+    expect(missingSnapshotRowsWhere([10, 20], [101, 102])).toEqual({
+      sectionId: { in: [10, 20] },
+      jwId: { notIn: [101, 102] },
+    });
+  });
+
+  it("deletes every scoped row when the current snapshot set is empty", () => {
+    expect(missingSnapshotRowsWhere([10, 20], [])).toEqual({
+      sectionId: { in: [10, 20] },
+    });
+  });
+
+  it("skips reconciliation when no sections are in scope", () => {
+    expect(missingSnapshotRowsWhere([], [101])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Goal

Make destructive static imports fail closed, reconcile removed snapshot children, and reject ambiguous operator configuration.

Closes #450.
Closes #451.
Closes #452.

## Changed Surfaces

- Validate schema-v5 curriculum fetch metadata before opening the database transaction.
- Require successful Catalog lesson/exam fetches and the exact contiguous JW chunk set derived from lesson count; compare new expected-chunk metadata when present while remaining compatible with older v5 snapshots.
- Reconcile ScheduleGroup and Exam rows absent from the new snapshot, scoped only to Sections included by `minSemester`.
- Reject invalid boolean/integer loader settings.
- Treat an explicitly empty or missing local snapshot path as an error instead of downloading a different remote snapshot.

## Evidence

- Full repository check sequence passed: app prepare, Biome (one pre-existing unused `build` warning), Svelte check, three TypeScript checks, and Vitest (163 files / 904 tests).
- Current production v5 snapshot without new chunk metadata passed validation using the existing 100-course contract.
- A copy with a failed JW chunk was rejected before writes; Schedule count remained 130,497.
- Current snapshot imported twice into disposable PostgreSQL successfully.
- Injected stale ScheduleGroup+Schedule and Exam+ExamRoom rows were removed on the next import.
- Injected semester 381 rows below `minSemester=401` were retained across all five related tables.
- Invalid dry-run values plus empty/missing local snapshot paths exited non-zero.

## Docs / Contracts

No REST/MCP schema or public contract changed. Static schema remains v5; validation accepts both existing metadata and the new optional producer metadata.

## Risk Areas

Reconciliation is intentionally limited to database Section IDs present in the selected snapshot, so it does not broaden deletion to older semesters or entirely absent Sections. Validation runs before the Prisma transaction and closes the read-only SQLite handle on failure.

## Cleanup

Disposable PostgreSQL and mutation probes were cleaned. No snapshot, logs, generated scratch artifacts, or unrelated rewrites are committed.