### PR TITLE
feat(db): add course alias storage

### DIFF
--- a/prisma/migrations/20260717143000_add_course_alias/migration.sql
+++ b/prisma/migrations/20260717143000_add_course_alias/migration.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "CourseAlias" (
+  "jwId" INTEGER NOT NULL,
+  "courseId" INTEGER NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "CourseAlias_pkey" PRIMARY KEY ("jwId")
+);
+
+CREATE INDEX "CourseAlias_courseId_idx" ON "CourseAlias"("courseId");
+
+ALTER TABLE "CourseAlias"
+  ADD CONSTRAINT "CourseAlias_courseId_fkey"
+  FOREIGN KEY ("courseId") REFERENCES "Course"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -163,6 +163,7 @@ model Course {
   sections Section[]
   comments Comment[]
   description Description?
+  aliases CourseAlias[]
 
   @@index([jwId])
   @@index([code])
@@ -174,6 +175,17 @@ model Course {
   @@index([educationLevelId])
   @@index([gradationId])
   @@index([typeId])
+}
+
+model CourseAlias {
+  jwId Int @id
+
+  courseId Int
+  course   Course @relation(fields: [courseId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+
+  @@index([courseId])
 }
 
 model CourseCategory {


### PR DESCRIPTION
## Goal

Add the expand-only `CourseAlias` storage before the behavior in #458 is deployed, so the production Worker never queries a table that has not been migrated yet.

Refs #395.

## Changed Surfaces

- Add the `Course.aliases` relation and `CourseAlias` Prisma model.
- Add migration `20260717143000_add_course_alias` with its primary key, `courseId` index, and cascading foreign key.
- No seed, resolver, static-loader, REST, MCP, or web behavior is included.

## Evidence

- `bunx prisma validate` — passed.
- Fresh PostgreSQL database: `bun run db:migrate:deploy` — all 42 migrations passed, including `20260717143000_add_course_alias`; table columns, primary key, `courseId` index, and cascading FK were inspected.
- `bun run app:prepare` — SvelteKit sync and both Prisma clients generated successfully.
- `bunx tsc --noEmit -p tsconfig.typecheck.json` — passed.
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json` — passed.
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json` — passed.
- `bunx vitest run` — 168 files / 952 tests passed.

## Docs / Contracts

No contract or OpenAPI change: this PR exposes no behavior. #458 owns the alias behavior and its contract updates.

## Risk Areas

This is an additive migration only. It does not modify existing rows. Deploy this migration before #458 so app code cannot race ahead of the table.

## Cleanup

The branch contains exactly the Prisma schema change and migration; no generated clients, seed changes, probes, or unrelated files are committed.