### PR TITLE
feat(db): add section lifecycle storage

### DIFF
--- a/prisma/migrations/20260718023000_add_section_source_lifecycle/migration.sql
+++ b/prisma/migrations/20260718023000_add_section_source_lifecycle/migration.sql
@@ -1,0 +1,9 @@
+ALTER TYPE "AuditAction" ADD VALUE 'section_retire';
+ALTER TYPE "AuditAction" ADD VALUE 'section_reactivate';
+
+ALTER TABLE "Section"
+ADD COLUMN "sourceLastSeenAt" TIMESTAMP(3),
+ADD COLUMN "retiredAt" TIMESTAMP(3);
+
+CREATE INDEX "Section_semesterId_retiredAt_idx"
+ON "Section"("semesterId", "retiredAt");


### PR DESCRIPTION
## Goal

Add the database storage required for Section source-lifecycle reconciliation without changing application behavior. This is phase 1 of the rollout so the nullable columns, index, and audit enum values can exist before any code starts reading or writing them.

## Changed Surfaces

- Adds one additive Prisma migration only.
- Adds `AuditAction` values `section_retire` and `section_reactivate`.
- Adds nullable `Section.sourceLastSeenAt` and `Section.retiredAt` columns.
- Adds the `Section(semesterId, retiredAt)` index.
- Intentionally does not change `prisma/schema.prisma`, application code, workflows, or generated clients. A follow-up PR will add those surfaces after this storage migration is deployed.

## Evidence

- Fresh PostgreSQL 16: `bun run app:prepare`
- Fresh PostgreSQL 16: `bun run db:migrate:deploy` (all 43 migrations applied)
- `bunx prisma db seed` twice (idempotent)
- PostgreSQL catalog inspection confirmed both columns are nullable with no defaults, the composite index exists, and both enum values exist.
- Default CI-equivalent checks: `bunx biome check`, `bunx svelte-check --tsconfig ./tsconfig.json`, all three `tsc --noEmit` projects, and `bunx vitest run` (182 files / 1091 tests passed).
- Integration: migrate deploy + seed + `bunx vitest run --config vitest.integration.config.ts` (27 files / 174 tests passed).
- Local E2E not run because this phase changes no Prisma schema or application behavior; PR CI will run all E2E shards against a fresh migrated database.

## Docs / Contracts

No docs or contract changes: this PR exposes no behavior or public data shape. The follow-up application PR will update contracts with the lifecycle behavior.

## Risk Areas

- Additive PostgreSQL migration only; existing clients ignore the nullable columns and cannot emit the new enum values.
- No backfill, retirement, deletion, or production data mutation beyond DDL occurs in this phase.
- `prisma/schema.prisma` is intentionally one phase behind the deployed database. CI has no schema/migration drift gate; all existing generated clients and seeds remain compatible. The follow-up PR must restore schema parity before using the new fields.

## Cleanup

Only `prisma/migrations/20260718023000_add_section_source_lifecycle/migration.sql` is committed. No generated files, scratch artifacts, or unrelated rewrites are included.