### PR TITLE
fix(db): align section lifecycle schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,12 +50,12 @@ enum AuditAction {
   comment_react
   description_edit
   upload_delete
-  section_retire
-  section_reactivate
   admin_user_suspend
   admin_user_unsuspend
   admin_comment_moderate
   admin_description_moderate
+  section_retire
+  section_reactivate
 }
 
 enum TodoPriority {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,8 @@ enum AuditAction {
   comment_react
   description_edit
   upload_delete
+  section_retire
+  section_reactivate
   admin_user_suspend
   admin_user_unsuspend
   admin_comment_moderate
@@ -375,6 +377,9 @@ model Section {
   id   Int @id @default(autoincrement())
   jwId Int @unique
 
+  sourceLastSeenAt DateTime?
+  retiredAt        DateTime?
+
   code                    String
   bizTypeId               Int?
   credits                 Float?
@@ -439,6 +444,7 @@ model Section {
   @@index([graduateAndPostgraduate])
   @@index([courseId])
   @@index([semesterId])
+  @@index([semesterId, retiredAt])
   @@index([examModeId])
   @@index([campusId])
   @@index([openDepartmentId])


### PR DESCRIPTION
## Goal

Restore Prisma schema parity after #473 was applied to production, without enabling any stale-Section behavior.

## Change

`prisma/schema.prisma` only (+6 lines):

- append `section_retire` and `section_reactivate` in the same PostgreSQL enum order produced by the migration
- declare nullable `Section.sourceLastSeenAt` and `Section.retiredAt`
- declare `@@index([semesterId, retiredAt])`

No migration, loader, query, workflow, generated client, backfill, retirement, or delete behavior is included.

## Why urgent

The expand-only migration is already recorded in production. Leaving the Prisma schema behind makes introspection/drift tooling describe destructive drops of the new storage. Deleting the applied migration or dropping the storage is unsafe; schema parity is the surgical fix.

## Verification

- `prisma validate` and client generation passed
- full migrations -> schema diff reported no field/type/index differences
- PostgreSQL 16 introspection confirmed exact enum ordering
- Svelte check, all three TypeScript projects, Biome, and `git diff --check` passed
- independent re-review APPROVE; final diff is only `prisma/schema.prisma` +6/-0

#468 behavior remains blocked by #471. This PR does not satisfy or close the recovery evidence gate.

Refs #471
Refs #468