### PR TITLE
fix(static-loader): avoid unchanged row rewrites

### DIFF
--- a/src/static-loader/import.ts
+++ b/src/static-loader/import.ts
@@ -2262,16 +2262,13 @@ export async function writeSectionTeachers(
     resolved.push({ sectionId, teacherId });
   }
 
-  await deleteByColumn(tx, "_SectionTeachers", "A", sectionDbIds);
-
-  for (const chunk of chunks(resolved, 1000)) {
-    const values = chunk
-      .map((p) => `(${p.sectionId},${p.teacherId})`)
-      .join(",");
-    await tx.$executeRawUnsafe(
-      `INSERT INTO "_SectionTeachers" ("A","B") VALUES ${values} ON CONFLICT DO NOTHING`,
-    );
-  }
+  await syncJoinPairs(
+    tx,
+    "_SectionTeachers",
+    "A",
+    sectionDbIds,
+    resolved.map((pair) => ({ a: pair.sectionId, b: pair.teacherId })),
+  );
 
   const now = new Date();
   for (const chunk of chunks(resolved, 1000)) {
@@ -2279,7 +2276,7 @@ export async function writeSectionTeachers(
       .map((p) => `(${p.sectionId},${p.teacherId})`)
       .join(",");
     await tx.$executeRawUnsafe(
-      `UPDATE "SectionTeacher" SET "retiredAt" = NULL, "updatedAt" = $1 WHERE ("sectionId","teacherId") IN (${tuples})`,
+      `UPDATE "SectionTeacher" SET "retiredAt" = NULL, "updatedAt" = $1 WHERE ("sectionId","teacherId") IN (${tuples}) AND "retiredAt" IS NOT NULL`,
       now,
     );
   }
@@ -2357,7 +2354,7 @@ async function writeTeacherAssignments(
   }
 }
 
-async function writeAdminClassSections(
+export async function writeAdminClassSections(
   tx: Prisma.TransactionClient,
   pairs: AdminClassSectionPair[],
   sectionMap: Map<number, number>,
@@ -2375,22 +2372,16 @@ async function writeAdminClassSections(
     resolved.push({ a: adminClassId, b: sectionId });
   }
 
-  await deleteByColumn(
+  await syncJoinPairs(
     tx,
     "_SectionAdminClasses",
     "B",
     Array.from(sectionMap.values()),
+    resolved,
   );
-
-  for (const chunk of chunks(resolved, 1000)) {
-    const values = chunk.map((p) => `(${p.a},${p.b})`).join(",");
-    await tx.$executeRawUnsafe(
-      `INSERT INTO "_SectionAdminClasses" ("A","B") VALUES ${values} ON CONFLICT DO NOTHING`,
-    );
-  }
 }
 
-async function writeSchedules(
+export async function writeSchedules(
   tx: Prisma.TransactionClient,
   builds: ScheduleBuild[],
   sectionMap: Map<number, number>,
@@ -2399,8 +2390,6 @@ async function writeSchedules(
   teacherMap: TeacherMap,
   sectionDbIds: number[],
 ): Promise<void> {
-  await tx.schedule.deleteMany({ where: { sectionId: { in: sectionDbIds } } });
-
   const resolved = builds
     .map((build) => {
       const sectionId = sectionMap.get(build.lessonJwId);
@@ -2449,25 +2438,75 @@ async function writeSchedules(
     })
     .filter((s): s is NonNullable<typeof s> => s != null);
 
-  for (const chunk of chunks(resolved, 1000)) {
-    const data = chunk.map((c) => ({
-      periods: c.periods,
-      date: c.date,
-      weekday: c.weekday,
-      startTime: c.startTime,
-      endTime: c.endTime,
-      experiment: c.experiment,
-      customPlace: c.customPlace,
-      lessonType: c.lessonType,
-      weekIndex: c.weekIndex,
-      exerciseClass: c.exerciseClass,
-      startUnit: c.startUnit,
-      endUnit: c.endUnit,
-      roomId: c.roomId,
-      sectionId: c.sectionId,
-      scheduleGroupId: c.scheduleGroupId,
-    }));
-    await tx.schedule.createMany({ data });
+  const existingRows = await tx.schedule.findMany({
+    where: { sectionId: { in: sectionDbIds } },
+    select: {
+      id: true,
+      periods: true,
+      date: true,
+      weekday: true,
+      startTime: true,
+      endTime: true,
+      experiment: true,
+      customPlace: true,
+      lessonType: true,
+      weekIndex: true,
+      exerciseClass: true,
+      startUnit: true,
+      endUnit: true,
+      roomId: true,
+      sectionId: true,
+      scheduleGroupId: true,
+    },
+  });
+
+  const existingByKey = new Map<string, (typeof existingRows)[number]>();
+  const staleIds: number[] = [];
+  for (const row of existingRows) {
+    const key = scheduleRowKey(row);
+    if (existingByKey.has(key)) {
+      staleIds.push(row.id);
+    } else {
+      existingByKey.set(key, row);
+    }
+  }
+
+  const desiredKeys = new Set(resolved.map((schedule) => schedule.key));
+  const inserts: typeof resolved = [];
+  const updates: Array<{ id: number; values: ColumnValue[] }> = [];
+  for (const schedule of resolved) {
+    const existing = existingByKey.get(schedule.key);
+    if (existing == null) {
+      inserts.push(schedule);
+      continue;
+    }
+    if (!scheduleRowMatches(existing, schedule)) {
+      updates.push({
+        id: existing.id,
+        values: scheduleColumnValues(schedule),
+      });
+    }
+  }
+  for (const [key, row] of existingByKey) {
+    if (!desiredKeys.has(key)) staleIds.push(row.id);
+  }
+
+  if (staleIds.length > 0) {
+    await tx.schedule.deleteMany({ where: { id: { in: staleIds } } });
+  }
+
+  await bulkUpdate(
+    tx,
+    "Schedule",
+    SCHEDULE_COLUMNS,
+    SCHEDULE_COLUMN_TYPES,
+    updates,
+  );
+
+  for (const chunk of chunks(inserts, 1000)) {
+    await tx.schedule.createMany({
+      data: chunk.map(scheduleCreateData),
+    });
   }
 
   const scheduleRows = await tx.schedule.findMany({
@@ -2490,22 +2529,7 @@ async function writeSchedules(
 
   const scheduleKeyToId = new Map<string, number>();
   for (const row of scheduleRows) {
-    const key = scheduleKey(
-      {
-        lessonId: row.sectionId,
-        scheduleGroupId: row.scheduleGroupId,
-        date: row.date == null ? undefined : formatLocalDate(row.date),
-        weekday: row.weekday,
-        startTime: row.startTime,
-        endTime: row.endTime,
-        startUnit: row.startUnit,
-        endUnit: row.endUnit,
-        customPlace: row.customPlace,
-        weekIndex: row.weekIndex,
-      },
-      row.roomId ?? undefined,
-    );
-    if (!scheduleKeyToId.has(key)) scheduleKeyToId.set(key, row.id);
+    scheduleKeyToId.set(scheduleRowKey(row), row.id);
   }
 
   const joinPairs: Array<{ scheduleId: number; teacherId: number }> = [];
@@ -2523,14 +2547,169 @@ async function writeSchedules(
     }
   }
 
-  for (const chunk of chunks(joinPairs, 1000)) {
-    const values = chunk
-      .map((p) => `(${p.scheduleId},${p.teacherId})`)
-      .join(",");
-    await tx.$executeRawUnsafe(
-      `INSERT INTO "_ScheduleTeachers" ("A","B") VALUES ${values} ON CONFLICT DO NOTHING`,
-    );
-  }
+  await syncJoinPairs(
+    tx,
+    "_ScheduleTeachers",
+    "A",
+    scheduleRows.map((row) => row.id),
+    joinPairs.map((pair) => ({ a: pair.scheduleId, b: pair.teacherId })),
+  );
+}
+
+const SCHEDULE_COLUMNS = [
+  "periods",
+  "date",
+  "weekday",
+  "startTime",
+  "endTime",
+  "experiment",
+  "customPlace",
+  "lessonType",
+  "weekIndex",
+  "exerciseClass",
+  "startUnit",
+  "endUnit",
+  "roomId",
+  "sectionId",
+  "scheduleGroupId",
+];
+
+const SCHEDULE_COLUMN_TYPES = [
+  "int",
+  "date",
+  "int",
+  "int",
+  "int",
+  "text",
+  "text",
+  "text",
+  "int",
+  "boolean",
+  "int",
+  "int",
+  "int",
+  "int",
+  "int",
+];
+
+type ResolvedSchedule = {
+  periods: number;
+  date: Date | undefined;
+  weekday: number;
+  startTime: number;
+  endTime: number;
+  experiment: string | undefined;
+  customPlace: string | undefined;
+  lessonType: string | undefined;
+  weekIndex: number;
+  exerciseClass: boolean | undefined;
+  startUnit: number;
+  endUnit: number;
+  roomId: number | undefined;
+  sectionId: number;
+  scheduleGroupId: number;
+};
+
+function scheduleColumnValues(schedule: ResolvedSchedule): ColumnValue[] {
+  return [
+    schedule.periods,
+    schedule.date,
+    schedule.weekday,
+    schedule.startTime,
+    schedule.endTime,
+    schedule.experiment,
+    schedule.customPlace,
+    schedule.lessonType,
+    schedule.weekIndex,
+    schedule.exerciseClass,
+    schedule.startUnit,
+    schedule.endUnit,
+    schedule.roomId,
+    schedule.sectionId,
+    schedule.scheduleGroupId,
+  ];
+}
+
+function scheduleCreateData(schedule: ResolvedSchedule) {
+  return {
+    periods: schedule.periods,
+    date: schedule.date,
+    weekday: schedule.weekday,
+    startTime: schedule.startTime,
+    endTime: schedule.endTime,
+    experiment: schedule.experiment,
+    customPlace: schedule.customPlace,
+    lessonType: schedule.lessonType,
+    weekIndex: schedule.weekIndex,
+    exerciseClass: schedule.exerciseClass,
+    startUnit: schedule.startUnit,
+    endUnit: schedule.endUnit,
+    roomId: schedule.roomId,
+    sectionId: schedule.sectionId,
+    scheduleGroupId: schedule.scheduleGroupId,
+  };
+}
+
+function scheduleRowKey(row: {
+  sectionId: number;
+  scheduleGroupId: number;
+  date: Date | null;
+  weekday: number;
+  startTime: number;
+  endTime: number;
+  startUnit: number;
+  endUnit: number;
+  customPlace: string | null;
+  weekIndex: number;
+  roomId: number | null;
+}): string {
+  return scheduleKey(
+    {
+      lessonId: row.sectionId,
+      scheduleGroupId: row.scheduleGroupId,
+      date: row.date == null ? undefined : formatLocalDate(row.date),
+      weekday: row.weekday,
+      startTime: row.startTime,
+      endTime: row.endTime,
+      startUnit: row.startUnit,
+      endUnit: row.endUnit,
+      customPlace: row.customPlace,
+      weekIndex: row.weekIndex,
+    },
+    row.roomId ?? undefined,
+  );
+}
+
+function scheduleRowMatches(
+  row: Parameters<typeof scheduleRowKey>[0] & {
+    periods: number;
+    experiment: string | null;
+    lessonType: string | null;
+    exerciseClass: boolean | null;
+  },
+  schedule: ResolvedSchedule,
+): boolean {
+  const rowValues = [
+    row.periods,
+    row.date?.getTime(),
+    row.weekday,
+    row.startTime,
+    row.endTime,
+    row.experiment ?? undefined,
+    row.customPlace ?? undefined,
+    row.lessonType ?? undefined,
+    row.weekIndex,
+    row.exerciseClass ?? undefined,
+    row.startUnit,
+    row.endUnit,
+    row.roomId ?? undefined,
+    row.sectionId,
+    row.scheduleGroupId,
+  ];
+  const scheduleValues = scheduleColumnValues(schedule).map((value) =>
+    value instanceof Date ? value.getTime() : value,
+  );
+  return rowValues.every((value, index) => value === scheduleValues[index]);
 }
 
 function formatLocalDate(date: Date): string {
@@ -2646,16 +2825,33 @@ function mergePlaceholderDepartments(
   return result;
 }
 
-async function deleteByColumn(
+async function syncJoinPairs(
   tx: Prisma.TransactionClient,
   table: string,
-  column: string,
-  ids: number[],
+  scopeColumn: "A" | "B",
+  scopeIds: number[],
+  pairs: Array<{ a: number; b: number }>,
 ): Promise<void> {
-  for (const chunk of chunks(ids, 1000)) {
-    const values = chunk.join(",");
+  for (const scopeChunk of chunks(scopeIds, 1000)) {
+    const scopeSet = new Set(scopeChunk);
+    const scopedPairs = pairs.filter((pair) =>
+      scopeSet.has(scopeColumn === "A" ? pair.a : pair.b),
+    );
+    const keepClause =
+      scopedPairs.length === 0
+        ? ""
+        : ` AND ("A","B") NOT IN (${scopedPairs
+            .map((pair) => `(${pair.a},${pair.b})`)
+            .join(",")})`;
     await tx.$executeRawUnsafe(
-      `DELETE FROM "${table}" WHERE "${column}" IN (${values})`,
+      `DELETE FROM "${table}" WHERE "${scopeColumn}" IN (${scopeChunk.join(",")})${keepClause}`,
+    );
+  }
+
+  for (const pairChunk of chunks(pairs, 1000)) {
+    const values = pairChunk.map((pair) => `(${pair.a},${pair.b})`).join(",");
+    await tx.$executeRawUnsafe(
+      `INSERT INTO "${table}" ("A","B") VALUES ${values} ON CONFLICT DO NOTHING`,
     );
   }
 }
@@ -2681,7 +2877,7 @@ type BulkUpsertOptions = {
   updateColumns?: string[];
 };
 
-async function bulkUpsert<K extends string | number>(
+export async function bulkUpsert<K extends string | number>(
   tx: Prisma.TransactionClient,
   table: string,
   uniqueColumn: string,
@@ -2724,6 +2920,8 @@ async function bulkUpsert<K extends string | number>(
       VALUES ${valuePlaceholders.join(",")}
       ON CONFLICT ("${uniqueColumn}") DO UPDATE SET
         ${updateColumns.map((c) => `"${c}" = EXCLUDED."${c}"`).join(",\n        ")}
+      WHERE ROW(${updateColumns.map((c) => `"${table}"."${c}"`).join(",")})
+        IS DISTINCT FROM ROW(${updateColumns.map((c) => `EXCLUDED."${c}"`).join(",")})
       RETURNING "id", "${uniqueColumn}"
     `;
 
@@ -2732,6 +2930,21 @@ async function bulkUpsert<K extends string | number>(
     >(sql, ...params);
     for (const row of rows) {
       map.set(row[uniqueColumn] as K, row.id);
+    }
+
+    const missing = batch.filter((record) => !map.has(record.key));
+    if (missing.length > 0) {
+      const missingRows = await tx.$queryRawUnsafe<
+        Array<{ id: number } & Record<string, unknown>>
+      >(
+        `SELECT "id", "${uniqueColumn}" FROM "${table}" WHERE "${uniqueColumn}" IN (${missing
+          .map((_, index) => `$${index + 1}::${uniqueColumnType}`)
+          .join(",")})`,
+        ...missing.map((record) => record.key),
+      );
+      for (const row of missingRows) {
+        map.set(row[uniqueColumn] as K, row.id);
+      }
     }
   }
 

--- a/tests/integration/static-import-write-churn.test.ts
+++ b/tests/integration/static-import-write-churn.test.ts
@@ -1,0 +1,375 @@
+/// <reference path="../../src/static-loader/bun-sqlite.d.ts" />
+
+import { afterAll, describe, expect, it, vi } from "vitest";
+import type { ScheduleBuild } from "@/static-loader/mappers";
+import { createTestPrisma, disconnectTestPrisma } from "../shared/prisma";
+
+vi.mock("bun:sqlite", () => ({ Database: class {} }));
+const {
+  bulkUpsert,
+  writeAdminClassSections,
+  writeSchedules,
+  writeSectionTeachers,
+} = await import("@/static-loader/import");
+
+const prisma = createTestPrisma();
+
+afterAll(async () => {
+  await disconnectTestPrisma(prisma);
+});
+
+async function tupleId(
+  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  table: string,
+  where: string,
+): Promise<string> {
+  const [row] = await tx.$queryRawUnsafe<Array<{ tupleId: string }>>(
+    `SELECT ctid::text AS "tupleId" FROM "${table}" WHERE ${where}`,
+  );
+  if (row == null) throw new Error(`Missing ${table} test row`);
+  return row.tupleId;
+}
+
+describe("static import write churn", () => {
+  it("skips unchanged bulk upserts while still returning their ids", async () => {
+    const rollback = new Error("ROLLBACK_BULK_UPSERT_CHURN_TEST");
+    const marker = 1_700_000_000 + (Date.now() % 100_000_000);
+
+    try {
+      await prisma.$transaction(async (tx) => {
+        const record = {
+          key: marker,
+          values: [`${marker}-code`, `${marker}-name`],
+        };
+        const first = await bulkUpsert(
+          tx,
+          "Course",
+          "jwId",
+          "int",
+          ["code", "nameCn"],
+          ["text", "text"],
+          [record],
+        );
+        const firstTuple = await tupleId(tx, "Course", `"jwId" = ${marker}`);
+
+        const second = await bulkUpsert(
+          tx,
+          "Course",
+          "jwId",
+          "int",
+          ["code", "nameCn"],
+          ["text", "text"],
+          [record],
+        );
+        const secondTuple = await tupleId(tx, "Course", `"jwId" = ${marker}`);
+
+        expect(second.get(marker)).toBe(first.get(marker));
+        expect(secondTuple).toBe(firstTuple);
+
+        await bulkUpsert(
+          tx,
+          "Course",
+          "jwId",
+          "int",
+          ["code", "nameCn"],
+          ["text", "text"],
+          [{ ...record, values: [`${marker}-code`, `${marker}-changed`] }],
+        );
+        expect(await tupleId(tx, "Course", `"jwId" = ${marker}`)).not.toBe(
+          firstTuple,
+        );
+
+        throw rollback;
+      });
+    } catch (error) {
+      if (error !== rollback) throw error;
+    }
+  });
+
+  it("preserves unchanged schedules and joins, then applies real changes", async () => {
+    const rollback = new Error("ROLLBACK_SCHEDULE_CHURN_TEST");
+    const marker = 1_800_000_000 + (Date.now() % 100_000_000);
+
+    try {
+      await prisma.$transaction(async (tx) => {
+        const course = await tx.course.create({
+          data: {
+            jwId: marker,
+            code: `${marker}`,
+            nameCn: `${marker}`,
+          },
+        });
+        const section = await tx.section.create({
+          data: {
+            jwId: marker,
+            code: `${marker}`,
+            courseId: course.id,
+          },
+        });
+        const group = await tx.scheduleGroup.create({
+          data: {
+            jwId: marker,
+            no: 1,
+            limitCount: 1,
+            stdCount: 1,
+            actualPeriods: 1,
+            isDefault: true,
+            sectionId: section.id,
+          },
+        });
+        const department = await tx.department.create({
+          data: { code: `${marker}`, nameCn: `${marker}` },
+        });
+        const firstTeacher = await tx.teacher.create({
+          data: {
+            personId: marker,
+            code: `${marker}`,
+            nameCn: `${marker}`,
+            departmentId: department.id,
+          },
+        });
+        const secondTeacher = await tx.teacher.create({
+          data: {
+            personId: marker + 1,
+            code: `${marker + 1}`,
+            nameCn: `${marker + 1}`,
+            departmentId: department.id,
+          },
+        });
+        const sectionMap = new Map([[section.jwId, section.id]]);
+        const groupMap = new Map([[group.jwId, group.id]]);
+        const teacherMap = {
+          byPersonId: new Map([
+            [marker, firstTeacher.id],
+            [marker + 1, secondTeacher.id],
+          ]),
+          byTeacherId: new Map<number, number>(),
+          byCode: new Map<string, number>(),
+          byNameDept: new Map<string, number>(),
+        };
+        const schedule: ScheduleBuild = {
+          periods: 2,
+          weekday: 1,
+          startTime: 800,
+          endTime: 940,
+          customPlace: `${marker}`,
+          lessonType: "lecture",
+          weekIndex: 1,
+          exerciseClass: false,
+          startUnit: 1,
+          endUnit: 2,
+          lessonJwId: section.jwId,
+          scheduleGroupJwId: group.jwId,
+          teacherPersonIds: [marker],
+        };
+
+        await writeSchedules(
+          tx,
+          [schedule],
+          sectionMap,
+          groupMap,
+          new Map(),
+          teacherMap,
+          [section.id],
+        );
+        const firstRow = await tx.schedule.findFirstOrThrow({
+          where: { sectionId: section.id },
+          include: { teachers: true },
+        });
+        const firstTuple = await tupleId(
+          tx,
+          "Schedule",
+          `"id" = ${firstRow.id}`,
+        );
+        const firstJoinTuple = await tupleId(
+          tx,
+          "_ScheduleTeachers",
+          `"A" = ${firstRow.id}`,
+        );
+
+        await writeSchedules(
+          tx,
+          [schedule],
+          sectionMap,
+          groupMap,
+          new Map(),
+          teacherMap,
+          [section.id],
+        );
+        const unchanged = await tx.schedule.findFirstOrThrow({
+          where: { sectionId: section.id },
+          include: { teachers: true },
+        });
+
+        expect(unchanged.id).toBe(firstRow.id);
+        expect(await tupleId(tx, "Schedule", `"id" = ${firstRow.id}`)).toBe(
+          firstTuple,
+        );
+        expect(
+          await tupleId(tx, "_ScheduleTeachers", `"A" = ${firstRow.id}`),
+        ).toBe(firstJoinTuple);
+
+        await writeSchedules(
+          tx,
+          [
+            {
+              ...schedule,
+              periods: 3,
+              lessonType: "seminar",
+              teacherPersonIds: [marker + 1],
+            },
+          ],
+          sectionMap,
+          groupMap,
+          new Map(),
+          teacherMap,
+          [section.id],
+        );
+        const changed = await tx.schedule.findFirstOrThrow({
+          where: { sectionId: section.id },
+          include: { teachers: true },
+        });
+
+        expect(changed).toMatchObject({
+          id: firstRow.id,
+          periods: 3,
+          lessonType: "seminar",
+          teachers: [{ id: secondTeacher.id }],
+        });
+        expect(await tupleId(tx, "Schedule", `"id" = ${firstRow.id}`)).not.toBe(
+          firstTuple,
+        );
+
+        await writeSchedules(
+          tx,
+          [{ ...schedule, customPlace: `${marker}-replacement` }],
+          sectionMap,
+          groupMap,
+          new Map(),
+          teacherMap,
+          [section.id],
+        );
+        const replacement = await tx.schedule.findMany({
+          where: { sectionId: section.id },
+        });
+        expect(replacement).toHaveLength(1);
+        expect(replacement[0]).toMatchObject({
+          customPlace: `${marker}-replacement`,
+        });
+        expect(replacement[0]?.id).not.toBe(firstRow.id);
+
+        throw rollback;
+      });
+    } catch (error) {
+      if (error !== rollback) throw error;
+    }
+  });
+
+  it("does not rebuild unchanged section relation rows", async () => {
+    const rollback = new Error("ROLLBACK_SECTION_JOIN_CHURN_TEST");
+    const marker = 1_900_000_000 + (Date.now() % 100_000_000);
+
+    try {
+      await prisma.$transaction(async (tx) => {
+        const course = await tx.course.create({
+          data: {
+            jwId: marker,
+            code: `${marker}`,
+            nameCn: `${marker}`,
+          },
+        });
+        const section = await tx.section.create({
+          data: {
+            jwId: marker,
+            code: `${marker}`,
+            courseId: course.id,
+          },
+        });
+        const department = await tx.department.create({
+          data: { code: `${marker}`, nameCn: `${marker}` },
+        });
+        const teacher = await tx.teacher.create({
+          data: {
+            personId: marker,
+            code: `${marker}`,
+            nameCn: `${marker}`,
+            departmentId: department.id,
+          },
+        });
+        const adminClass = await tx.adminClass.create({
+          data: { jwId: marker, nameCn: `${marker}` },
+        });
+        const sectionMap = new Map([[section.jwId, section.id]]);
+        const teacherMap = {
+          byPersonId: new Map([[marker, teacher.id]]),
+          byTeacherId: new Map<number, number>(),
+          byCode: new Map<string, number>(),
+          byNameDept: new Map<string, number>(),
+        };
+        const teacherPairs = [
+          {
+            sectionJwId: section.jwId,
+            personId: marker,
+            nameCn: `${marker}`,
+          },
+        ];
+        const adminPairs = [
+          {
+            sectionJwId: section.jwId,
+            adminClassJwId: marker,
+          },
+        ];
+
+        await writeSectionTeachers(tx, sectionMap, teacherMap, teacherPairs, [
+          section.id,
+        ]);
+        await writeAdminClassSections(
+          tx,
+          adminPairs,
+          sectionMap,
+          new Map([[marker, adminClass.id]]),
+        );
+        const status = await tx.sectionTeacher.findFirstOrThrow({
+          where: { sectionId: section.id, teacherId: teacher.id },
+        });
+        const teacherJoinTuple = await tupleId(
+          tx,
+          "_SectionTeachers",
+          `"A" = ${section.id}`,
+        );
+        const adminJoinTuple = await tupleId(
+          tx,
+          "_SectionAdminClasses",
+          `"B" = ${section.id}`,
+        );
+
+        await writeSectionTeachers(tx, sectionMap, teacherMap, teacherPairs, [
+          section.id,
+        ]);
+        await writeAdminClassSections(
+          tx,
+          adminPairs,
+          sectionMap,
+          new Map([[marker, adminClass.id]]),
+        );
+
+        await expect(
+          tx.sectionTeacher.findFirstOrThrow({
+            where: { sectionId: section.id, teacherId: teacher.id },
+            select: { updatedAt: true },
+          }),
+        ).resolves.toEqual({ updatedAt: status.updatedAt });
+        expect(
+          await tupleId(tx, "_SectionTeachers", `"A" = ${section.id}`),
+        ).toBe(teacherJoinTuple);
+        expect(
+          await tupleId(tx, "_SectionAdminClasses", `"B" = ${section.id}`),
+        ).toBe(adminJoinTuple);
+
+        throw rollback;
+      });
+    } catch (error) {
+      if (error !== rollback) throw error;
+    }
+  });
+});


### PR DESCRIPTION
## Goal

Stop the scheduled static loader from rewriting unchanged catalog, schedule, and relation rows. Closes #484.

## Changed Surfaces

- `src/static-loader/import.ts`: add `IS DISTINCT FROM` guards to bulk upserts and resolve IDs for unchanged conflicts; reconcile schedules by stable key; diff schedule, section-teacher, and admin-class join rows; only reactivate retired `SectionTeacher` rows.
- `tests/integration/static-import-write-churn.test.ts`: verify PostgreSQL tuple identity and schedule IDs remain stable across identical writes while real field, teacher, and key changes still reconcile.

## Evidence

- Full default gate: app prepare, Biome, Svelte check, all three TypeScript configs, and Vitest (192 files / 1,146 tests).
- Seeded integration suite: 32 files / 183 tests.
- Production Cloudflare build.
- Full Playwright suite against an isolated PostgreSQL database: 680 passed, 1 intentional skip, including desktop flows and mobile screenshot coverage.
- Focused PostgreSQL assertions compare `ctid` before and after identical imports to prove zero tuple replacement.

## Docs / Contracts

No public API, MCP, data schema, permission, or user-visible workflow changed; contract updates are not applicable.

## Risk Areas

- Static import persistence only. Schedule identity continues to use the existing `scheduleKey`; non-key field changes update the existing row, key changes replace it, and duplicate legacy keys are removed.
- No migration or generated file changes.

## Cleanup

Only the importer and its focused integration test are committed. Local reports, test databases, and scratch artifacts are excluded; the isolated Docker service was stopped.
