### PR TITLE
perf(sitemap): cache generated document

### DIFF
--- a/src/features/catalog/server/sitemap-cache.ts
+++ b/src/features/catalog/server/sitemap-cache.ts
@@ -1,0 +1,73 @@
+import { sha256Base64Url } from "@/lib/crypto/web-crypto";
+
+export const SITEMAP_RUNTIME_CACHE_TTL_MS = 60 * 60 * 1_000;
+
+type SitemapDocument = {
+  body: string;
+  etag: string;
+};
+
+type SitemapCacheEntry = {
+  document: SitemapDocument;
+  expiresAtMs: number;
+};
+
+let cachedSitemap: SitemapCacheEntry | undefined;
+let sitemapGeneration: Promise<SitemapDocument> | undefined;
+
+export function buildSitemapXml(urls: readonly string[]) {
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.map((loc) => `  <url><loc>${loc}</loc></url>`).join("\n")}\n</urlset>\n`;
+}
+
+async function generateSitemap(
+  loadUrls: () => Promise<readonly string[]>,
+): Promise<SitemapDocument> {
+  const body = buildSitemapXml(await loadUrls());
+  return {
+    body,
+    etag: `"sha256-${await sha256Base64Url(body)}"`,
+  };
+}
+
+export async function getCachedSitemap(
+  loadUrls: () => Promise<readonly string[]>,
+) {
+  const nowMs = Date.now();
+  if (cachedSitemap && cachedSitemap.expiresAtMs > nowMs) {
+    return cachedSitemap.document;
+  }
+  cachedSitemap = undefined;
+
+  if (!sitemapGeneration) {
+    sitemapGeneration = generateSitemap(loadUrls);
+  }
+
+  const generation = sitemapGeneration;
+  try {
+    const document = await generation;
+    cachedSitemap = {
+      document,
+      expiresAtMs: Date.now() + SITEMAP_RUNTIME_CACHE_TTL_MS,
+    };
+    return document;
+  } finally {
+    if (sitemapGeneration === generation) {
+      sitemapGeneration = undefined;
+    }
+  }
+}
+
+export function requestMatchesSitemapEtag(request: Request, etag: string) {
+  const ifNoneMatch = request.headers.get("If-None-Match");
+  if (!ifNoneMatch) return false;
+
+  return ifNoneMatch.split(",").some((token) => {
+    const normalized = token.trim().replace(/^W\//, "");
+    return normalized === "*" || normalized === etag;
+  });
+}
+
+export function resetSitemapCacheForTest() {
+  cachedSitemap = undefined;
+  sitemapGeneration = undefined;
+}

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,6 +1,17 @@
+import {
+  getCachedSitemap,
+  requestMatchesSitemapEtag,
+} from "@/features/catalog/server/sitemap-cache";
 import { prisma } from "@/lib/db/prisma";
 import { getCanonicalOrigin } from "@/lib/site-url";
 import type { RequestHandler } from "./$types";
+
+const RESPONSE_HEADERS = {
+  "Cache-Control": "public, max-age=0, must-revalidate",
+  "Cloudflare-CDN-Cache-Control":
+    "public, max-age=3600, stale-while-revalidate=21600",
+  "Content-Type": "application/xml; charset=utf-8",
+};
 
 const STATIC_ROUTES = [
   "/",
@@ -30,16 +41,27 @@ async function getEntityUrls(origin: string) {
   return [...courseUrls, ...sectionUrls, ...teacherUrls];
 }
 
-export const GET: RequestHandler = async () => {
+async function loadSitemapUrls() {
   const origin = getCanonicalOrigin();
   const entityUrls = await getEntityUrls(origin);
-  const urls = [
-    ...STATIC_ROUTES.map((route) => `${origin}${route}`),
-    ...entityUrls,
-  ];
+  return [...STATIC_ROUTES.map((route) => `${origin}${route}`), ...entityUrls];
+}
 
-  const body = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.map((loc) => `  <url><loc>${loc}</loc></url>`).join("\n")}\n</urlset>\n`;
-  return new Response(body, {
-    headers: { "Content-Type": "application/xml; charset=utf-8" },
+export const GET: RequestHandler = async ({ request }) => {
+  const sitemap = await getCachedSitemap(loadSitemapUrls);
+  const headers = {
+    ...RESPONSE_HEADERS,
+    ETag: sitemap.etag,
+  };
+
+  if (requestMatchesSitemapEtag(request, sitemap.etag)) {
+    return new Response(null, {
+      headers,
+      status: 304,
+    });
+  }
+
+  return new Response(sitemap.body, {
+    headers,
   });
 };

--- a/tests/unit/sitemap-route.test.ts
+++ b/tests/unit/sitemap-route.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetSitemapCacheForTest,
+  SITEMAP_RUNTIME_CACHE_TTL_MS,
+} from "@/features/catalog/server/sitemap-cache";
+
+const { courseFindManyMock, sectionFindManyMock, teacherFindManyMock } =
+  vi.hoisted(() => ({
+    courseFindManyMock: vi.fn(),
+    sectionFindManyMock: vi.fn(),
+    teacherFindManyMock: vi.fn(),
+  }));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    course: { findMany: courseFindManyMock },
+    section: { findMany: sectionFindManyMock },
+    teacher: { findMany: teacherFindManyMock },
+  },
+}));
+
+vi.mock("@/lib/site-url", () => ({
+  getCanonicalOrigin: () => "https://life.example",
+}));
+
+import { GET } from "@/routes/sitemap.xml/+server";
+
+function getSitemap(headers?: HeadersInit) {
+  return GET({
+    request: new Request("https://life.example/sitemap.xml", { headers }),
+  } as never) as Promise<Response>;
+}
+
+describe("sitemap route", () => {
+  beforeEach(() => {
+    resetSitemapCacheForTest();
+    courseFindManyMock.mockReset().mockResolvedValue([{ jwId: "CS100" }]);
+    sectionFindManyMock.mockReset().mockResolvedValue([{ jwId: "CS100-01" }]);
+    teacherFindManyMock.mockReset().mockResolvedValue([{ id: 42 }]);
+  });
+
+  afterEach(() => {
+    resetSitemapCacheForTest();
+    vi.useRealTimers();
+  });
+
+  it("preserves canonical URLs and excludes retired Sections", async () => {
+    const response = await getSitemap();
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(
+      Array.from(body.matchAll(/<loc>(.+)<\/loc>/g), (match) => match[1]),
+    ).toEqual([
+      "https://life.example/",
+      "https://life.example/courses",
+      "https://life.example/sections",
+      "https://life.example/teachers",
+      "https://life.example/bus-map",
+      "https://life.example/api/docs/tag/sections",
+      "https://life.example/privacy",
+      "https://life.example/terms",
+      "https://life.example/courses/CS100",
+      "https://life.example/sections/CS100-01",
+      "https://life.example/teachers/42",
+    ]);
+    expect(sectionFindManyMock).toHaveBeenCalledWith({
+      where: { retiredAt: null },
+      select: { jwId: true },
+    });
+  });
+
+  it("reuses a successful generation within the runtime TTL", async () => {
+    await getSitemap();
+    await getSitemap();
+
+    expect(courseFindManyMock).toHaveBeenCalledTimes(1);
+    expect(sectionFindManyMock).toHaveBeenCalledTimes(1);
+    expect(teacherFindManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces concurrent cache misses", async () => {
+    let resolveCourses: ((courses: { jwId: string }[]) => void) | undefined;
+    courseFindManyMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCourses = resolve;
+      }),
+    );
+
+    const first = getSitemap();
+    const second = getSitemap();
+    resolveCourses?.([{ jwId: "CS100" }]);
+    await Promise.all([first, second]);
+
+    expect(courseFindManyMock).toHaveBeenCalledTimes(1);
+    expect(sectionFindManyMock).toHaveBeenCalledTimes(1);
+    expect(teacherFindManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("regenerates after the runtime TTL", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-19T00:00:00.000Z"));
+
+    await getSitemap();
+    vi.setSystemTime(
+      new Date(
+        new Date("2026-07-19T00:00:00.000Z").getTime() +
+          SITEMAP_RUNTIME_CACHE_TTL_MS +
+          1,
+      ),
+    );
+    await getSitemap();
+
+    expect(courseFindManyMock).toHaveBeenCalledTimes(2);
+    expect(sectionFindManyMock).toHaveBeenCalledTimes(2);
+    expect(teacherFindManyMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache failed generations", async () => {
+    courseFindManyMock
+      .mockRejectedValueOnce(new Error("database unavailable"))
+      .mockResolvedValueOnce([{ jwId: "CS100" }]);
+
+    await expect(getSitemap()).rejects.toThrow("database unavailable");
+    await expect(getSitemap()).resolves.toHaveProperty("status", 200);
+
+    expect(courseFindManyMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns edge cache headers and supports conditional requests", async () => {
+    const first = await getSitemap();
+    const etag = first.headers.get("ETag");
+
+    expect(etag).toMatch(/^"sha256-[A-Za-z0-9_-]+"$/);
+    expect(first.headers.get("Cache-Control")).toBe(
+      "public, max-age=0, must-revalidate",
+    );
+    expect(first.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
+      "public, max-age=3600, stale-while-revalidate=21600",
+    );
+    expect(first.headers.get("Content-Type")).toBe(
+      "application/xml; charset=utf-8",
+    );
+
+    const conditional = await getSitemap({
+      "If-None-Match": `"other", W/${etag}`,
+    });
+
+    expect(conditional.status).toBe(304);
+    expect(await conditional.text()).toBe("");
+    expect(conditional.headers.get("ETag")).toBe(etag);
+    expect(courseFindManyMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Goal

Stop rebuilding the full sitemap for every crawler request while preserving the existing URL set.

Closes #505.

## Changed Surfaces

- Add a one-hour per-isolate sitemap document cache with concurrent-miss coalescing and failure-safe retries.
- Add SHA-256 ETags and conditional `If-None-Match` / `304` responses.
- Add browser revalidation and Cloudflare edge-cache directives (`1h` fresh, `6h` stale-while-revalidate).
- Preserve all current static/entity URLs and the retired-section filter.

## Evidence

- `bun run app:prepare`
- `bunx biome check`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` — 193 files / 1152 tests passed
- `bun run build` — Cloudflare production build passed

## Docs Contracts

No REST, MCP, schema, auth, or product contract changes.

## Risk Areas

- Runtime caching is per isolate; cross-colo reuse relies on Cloudflare's edge cache.
- Sitemap freshness is eventual: 1 hour fresh plus up to 6 hours stale-while-revalidate.

## Cleanup

No unrelated cleanup.