### PR TITLE
feat(seo): add AI discovery policy

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -18,6 +18,7 @@ import {
   createScriptNonce,
   formActionSourceFromOAuthRedirectUri,
 } from "@/lib/security/csp";
+import { setContentSignal } from "@/lib/seo/content-signal";
 
 const SECURITY_HEADERS = {
   "X-Content-Type-Options": "nosniff",
@@ -227,6 +228,7 @@ const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
     if (!mutableResponse.headers.has("Cache-Control")) {
       mutableResponse.headers.set("Cache-Control", "no-store");
     }
+    setContentSignal(mutableResponse.headers);
     mutableResponse.headers.set(
       "Content-Security-Policy",
       buildContentSecurityPolicy(nonce, {

--- a/src/lib/auth/auth-routing.ts
+++ b/src/lib/auth/auth-routing.ts
@@ -108,6 +108,7 @@ function isNonPageRequestPath(pathname: string): boolean {
     pathname.startsWith("/api/") ||
     pathname.startsWith("/.well-known/") ||
     pathname.startsWith("/_app/") ||
+    pathname === "/llms.txt" ||
     pathname === "/robots.txt" ||
     pathname === "/sitemap.xml"
   );

--- a/src/lib/seo/content-signal.ts
+++ b/src/lib/seo/content-signal.ts
@@ -1,0 +1,5 @@
+export const CONTENT_SIGNAL = "search=yes, ai-input=yes, ai-train=no";
+
+export function setContentSignal(headers: Headers) {
+  headers.set("Content-Signal", CONTENT_SIGNAL);
+}

--- a/src/routes/llms.txt/+server.ts
+++ b/src/routes/llms.txt/+server.ts
@@ -1,0 +1,34 @@
+import { CONTENT_SIGNAL } from "@/lib/seo/content-signal";
+import { getCanonicalOrigin } from "@/lib/site-url";
+import type { RequestHandler } from "./$types";
+
+export const GET: RequestHandler = () => {
+  const origin = getCanonicalOrigin();
+  const body = `# Life@USTC
+
+> Public course, section, teacher, and campus information for the University of Science and Technology of China community.
+
+## Catalog
+
+- [Courses](${origin}/courses)
+- [Sections](${origin}/sections)
+- [Teachers](${origin}/teachers)
+
+## Developer interfaces
+
+- [REST API documentation](${origin}/api/docs/tag/sections)
+- [MCP protected resource metadata](${origin}/.well-known/oauth-protected-resource/api/mcp)
+- [MCP endpoint](${origin}/api/mcp)
+
+## Discovery
+
+- [Sitemap](${origin}/sitemap.xml)
+`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Signal": CONTENT_SIGNAL,
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+};

--- a/src/routes/robots.txt/+server.ts
+++ b/src/routes/robots.txt/+server.ts
@@ -1,20 +1,36 @@
+import { CONTENT_SIGNAL } from "@/lib/seo/content-signal";
+import { getCanonicalOrigin } from "@/lib/site-url";
 import type { RequestHandler } from "./$types";
 
-export const GET: RequestHandler = () =>
-  new Response(
+export const GET: RequestHandler = () => {
+  const origin = getCanonicalOrigin();
+
+  return new Response(
     [
       "User-agent: *",
       "Allow: /",
+      "Allow: /api/docs$",
+      "Allow: /api/docs/",
+      "Disallow: /admin$",
       "Disallow: /admin/",
+      "Disallow: /api$",
       "Disallow: /api/",
+      "Disallow: /oauth$",
       "Disallow: /oauth/",
+      "Disallow: /settings$",
       "Disallow: /settings/",
+      "Disallow: /signin$",
       "Disallow: /signin/",
+      "Disallow: /welcome$",
       "Disallow: /welcome/",
-      "Sitemap: /sitemap.xml",
+      `Sitemap: ${origin}/sitemap.xml`,
       "",
     ].join("\n"),
     {
-      headers: { "Content-Type": "text/plain; charset=utf-8" },
+      headers: {
+        "Content-Signal": CONTENT_SIGNAL,
+        "Content-Type": "text/plain; charset=utf-8",
+      },
     },
   );
+};

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db/prisma";
+import { CONTENT_SIGNAL } from "@/lib/seo/content-signal";
 import { getCanonicalOrigin } from "@/lib/site-url";
 import type { RequestHandler } from "./$types";
 
@@ -40,6 +41,9 @@ export const GET: RequestHandler = async () => {
 
   const body = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.map((loc) => `  <url><loc>${loc}</loc></url>`).join("\n")}\n</urlset>\n`;
   return new Response(body, {
-    headers: { "Content-Type": "application/xml; charset=utf-8" },
+    headers: {
+      "Content-Signal": CONTENT_SIGNAL,
+      "Content-Type": "application/xml; charset=utf-8",
+    },
   });
 };

--- a/tests/unit/seo-discovery-routes.test.ts
+++ b/tests/unit/seo-discovery-routes.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setContentSignal } from "@/lib/seo/content-signal";
+import { GET as getLlmsTxt } from "@/routes/llms.txt/+server";
+import { GET as getRobotsTxt } from "@/routes/robots.txt/+server";
+import { GET as getSitemapXml } from "@/routes/sitemap.xml/+server";
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    course: {
+      findMany: vi.fn(async () => [{ jwId: "course-1" }]),
+    },
+    section: {
+      findMany: vi.fn(async () => [{ jwId: "section-1" }]),
+    },
+    teacher: {
+      findMany: vi.fn(async () => [{ id: 1 }]),
+    },
+  },
+}));
+
+const ORIGIN = "https://life.example";
+const CONTENT_SIGNAL = "search=yes, ai-input=yes, ai-train=no";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("crawler discovery routes", () => {
+  it("sets the shared content-use policy", () => {
+    const headers = new Headers();
+    setContentSignal(headers);
+
+    expect(headers.get("Content-Signal")).toBe(CONTENT_SIGNAL);
+  });
+
+  it("generates a precise robots policy with an absolute sitemap", async () => {
+    vi.stubEnv("APP_CANONICAL_ORIGIN", ORIGIN);
+
+    const response = await getRobotsTxt({} as never);
+    const body = await response.text();
+
+    expect(response.headers.get("Content-Signal")).toBe(CONTENT_SIGNAL);
+    expect(body).toContain("Allow: /api/docs$\nAllow: /api/docs/");
+    expect(body).toContain("Disallow: /api$\nDisallow: /api/");
+    for (const path of ["admin", "oauth", "settings", "signin", "welcome"]) {
+      expect(body).toContain(`Disallow: /${path}$\nDisallow: /${path}/`);
+    }
+    expect(body).toContain(`Sitemap: ${ORIGIN}/sitemap.xml`);
+    expect(body).not.toContain("Sitemap: /sitemap.xml");
+  });
+
+  it("lists only stable public discovery and protocol links", async () => {
+    vi.stubEnv("APP_CANONICAL_ORIGIN", ORIGIN);
+
+    const response = await getLlmsTxt({} as never);
+    const body = await response.text();
+
+    expect(response.headers.get("Content-Signal")).toBe(CONTENT_SIGNAL);
+    expect(body).toContain(`${ORIGIN}/courses`);
+    expect(body).toContain(`${ORIGIN}/sections`);
+    expect(body).toContain(`${ORIGIN}/teachers`);
+    expect(body).toContain(`${ORIGIN}/api/docs/tag/sections`);
+    expect(body).toContain(
+      `${ORIGIN}/.well-known/oauth-protected-resource/api/mcp`,
+    );
+    expect(body).toContain(`${ORIGIN}/api/mcp`);
+    expect(body).toContain(`${ORIGIN}/sitemap.xml`);
+    expect(body).not.toMatch(/\/(?:admin|settings|signin|welcome)(?:[/)\s]|$)/);
+  });
+
+  it("adds the content-use policy to the sitemap", async () => {
+    vi.stubEnv("APP_CANONICAL_ORIGIN", ORIGIN);
+
+    const response = await getSitemapXml({} as never);
+    const body = await response.text();
+
+    expect(response.headers.get("Content-Signal")).toBe(CONTENT_SIGNAL);
+    expect(body).toContain(`<loc>${ORIGIN}/api/docs/tag/sections</loc>`);
+    expect(body).toContain(`<loc>${ORIGIN}/courses/course-1</loc>`);
+    expect(body).toContain(`<loc>${ORIGIN}/sections/section-1</loc>`);
+    expect(body).toContain(`<loc>${ORIGIN}/teachers/1</loc>`);
+  });
+});

--- a/tests/unit/welcome-redirect.test.ts
+++ b/tests/unit/welcome-redirect.test.ts
@@ -26,6 +26,7 @@ describe("欢迎页重定向策略", () => {
     expect(shouldRedirect("/api/me")).toBe(false);
     expect(shouldRedirect("/.well-known/openid-configuration")).toBe(false);
     expect(shouldRedirect("/_app/immutable/start.js")).toBe(false);
+    expect(shouldRedirect("/llms.txt")).toBe(false);
     expect(shouldRedirect("/robots.txt")).toBe(false);
     expect(shouldRedirect("/sitemap.xml")).toBe(false);
   });


### PR DESCRIPTION
## Goal

Make crawler discovery and permitted AI use explicit without exposing private application surfaces.

Closes #504.

## Changed Surfaces

- Tighten `robots.txt` with exact/descendant rules, an explicit API-docs allow rule, and an absolute canonical sitemap URL.
- Add `Content-Signal: search=yes, ai-input=yes, ai-train=no` to SSR HTML and crawler discovery responses.
- Add a concise `/llms.txt` linking the public catalog, REST docs, MCP metadata/endpoint, and sitemap.
- Exempt `/llms.txt` from incomplete-profile redirects.
- Add focused discovery-policy tests.

## Evidence

- `bun run app:prepare`
- `bunx biome check`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` — 193 files / 1150 tests passed
- `bun run build` — Cloudflare production build passed
- Local HTTP checks for `robots.txt`, `llms.txt`, and public SSR HTML passed

## Docs Contracts

No REST/MCP response shape, permissions, schema, or workflow changes.

## Risk Areas

- `Content-Signal` is an emerging convention; crawler behavior may vary, while `robots.txt` remains the access-discovery control.
- The policy permits search and AI input but explicitly denies model training.

## Cleanup

No unrelated cleanup.