### PR TITLE
feat(seo): add catalog structured data

### DIFF
--- a/src/features/catalog/components/CourseDetailPageController.svelte
+++ b/src/features/catalog/components/CourseDetailPageController.svelte
@@ -66,6 +66,7 @@ type PageData = {
   descriptionData: CatalogDetailDescriptionData;
   detailSection: "overview" | "introduction" | "sections" | "comments";
   locale: string;
+  structuredDataJson: string;
 };
 
 export let data: PageData;
@@ -117,6 +118,7 @@ $: activeNavItem =
 
 <svelte:head>
   <title>{formatMessage(copy.metadata.pages.courseDetail, { name: displayName })} - Life@USTC</title>
+  {@html `<script type="application/ld+json">${data.structuredDataJson}</script>`}
 </svelte:head>
 
 <section class="grid min-h-full grid-rows-[auto_minmax(0,1fr)] bg-card lg:h-full lg:min-h-0">

--- a/src/features/catalog/components/TeacherDetailPageController.svelte
+++ b/src/features/catalog/components/TeacherDetailPageController.svelte
@@ -54,6 +54,7 @@ type PageData = {
   descriptionData: CatalogDetailDescriptionData;
   detailSection: "overview" | "introduction" | "sections" | "comments";
   locale: string;
+  structuredDataJson: string;
   teacher: TeacherDetailData;
 };
 
@@ -109,6 +110,7 @@ $: activeNavItem =
 
 <svelte:head>
   <title>{formatMessage(copy.metadata.pages.teacherDetail, { name: displayName })} - Life@USTC</title>
+  {@html `<script type="application/ld+json">${data.structuredDataJson}</script>`}
 </svelte:head>
 
 <section class="grid min-h-full grid-rows-[auto_minmax(0,1fr)] bg-card lg:h-full lg:min-h-0">

--- a/src/features/catalog/lib/catalog-structured-data.ts
+++ b/src/features/catalog/lib/catalog-structured-data.ts
@@ -1,0 +1,195 @@
+type BreadcrumbLabels = {
+  collection: string;
+  home: string;
+};
+
+type StructuredDataGraph = {
+  "@context": "https://schema.org";
+  "@graph": Record<string, unknown>[];
+};
+
+const USTC_PROVIDER = {
+  "@type": "CollegeOrUniversity",
+  name: "University of Science and Technology of China",
+} as const;
+
+function breadcrumbList({
+  canonicalUrl,
+  entityName,
+  labels,
+  listPath,
+}: {
+  canonicalUrl: string;
+  entityName: string;
+  labels: BreadcrumbLabels;
+  listPath: string;
+}) {
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        item: new URL("/", canonicalUrl).href,
+        name: labels.home,
+        position: 1,
+      },
+      {
+        "@type": "ListItem",
+        item: new URL(listPath, canonicalUrl).href,
+        name: labels.collection,
+        position: 2,
+      },
+      {
+        "@type": "ListItem",
+        item: canonicalUrl,
+        name: entityName,
+        position: 3,
+      },
+    ],
+  };
+}
+
+function graph(
+  entity: Record<string, unknown>,
+  breadcrumbs: Record<string, unknown>,
+): StructuredDataGraph {
+  return {
+    "@context": "https://schema.org",
+    "@graph": [entity, breadcrumbs],
+  };
+}
+
+function addDescription(
+  entity: Record<string, unknown>,
+  description: string | null | undefined,
+) {
+  const value = description?.trim();
+  return value ? { ...entity, description: value } : entity;
+}
+
+export function buildCourseStructuredData({
+  canonicalUrl,
+  code,
+  description,
+  labels,
+  name,
+}: {
+  canonicalUrl: string;
+  code: string;
+  description?: string | null;
+  labels: BreadcrumbLabels;
+  name: string;
+}) {
+  const entity = addDescription(
+    {
+      "@id": `${canonicalUrl}#course`,
+      "@type": "Course",
+      courseCode: code,
+      name,
+      provider: USTC_PROVIDER,
+      url: canonicalUrl,
+    },
+    description,
+  );
+
+  return graph(
+    entity,
+    breadcrumbList({
+      canonicalUrl,
+      entityName: name,
+      labels,
+      listPath: "/courses",
+    }),
+  );
+}
+
+export function buildSectionStructuredData({
+  canonicalUrl,
+  course,
+  description,
+  instructors,
+  labels,
+  name,
+}: {
+  canonicalUrl: string;
+  course: { jwId: number | string; name: string };
+  description?: string | null;
+  instructors: Array<{ id: number | string; name: string }>;
+  labels: BreadcrumbLabels;
+  name: string;
+}) {
+  const instructor = instructors
+    .filter((teacher) => teacher.name)
+    .map((teacher) => ({
+      "@id": `${new URL(`/teachers/${teacher.id}`, canonicalUrl).href}#person`,
+      "@type": "Person",
+      name: teacher.name,
+      url: new URL(`/teachers/${teacher.id}`, canonicalUrl).href,
+    }));
+  const entity = addDescription(
+    {
+      "@id": `${canonicalUrl}#course-instance`,
+      "@type": "CourseInstance",
+      ...(instructor.length > 0 ? { instructor } : {}),
+      isPartOf: {
+        "@id": `${new URL(`/courses/${course.jwId}`, canonicalUrl).href}#course`,
+        "@type": "Course",
+        name: course.name,
+        url: new URL(`/courses/${course.jwId}`, canonicalUrl).href,
+      },
+      name,
+      url: canonicalUrl,
+    },
+    description,
+  );
+
+  return graph(
+    entity,
+    breadcrumbList({
+      canonicalUrl,
+      entityName: name,
+      labels,
+      listPath: "/sections",
+    }),
+  );
+}
+
+export function buildTeacherStructuredData({
+  canonicalUrl,
+  labels,
+  name,
+}: {
+  canonicalUrl: string;
+  labels: BreadcrumbLabels;
+  name: string;
+}) {
+  return graph(
+    {
+      "@id": `${canonicalUrl}#person`,
+      "@type": "Person",
+      name,
+      url: canonicalUrl,
+    },
+    breadcrumbList({
+      canonicalUrl,
+      entityName: name,
+      labels,
+      listPath: "/teachers",
+    }),
+  );
+}
+
+const jsonLdEscapes: Record<string, string> = {
+  "&": "\\u0026",
+  "<": "\\u003c",
+  ">": "\\u003e",
+  "\u2028": "\\u2028",
+  "\u2029": "\\u2029",
+};
+
+export function serializeStructuredData(value: StructuredDataGraph) {
+  return JSON.stringify(value).replace(
+    /[<>&\u2028\u2029]/g,
+    (character) => jsonLdEscapes[character] ?? character,
+  );
+}

--- a/src/features/catalog/server/catalog-detail-page-server.ts
+++ b/src/features/catalog/server/catalog-detail-page-server.ts
@@ -1,5 +1,10 @@
 import { error, redirect } from "@sveltejs/kit";
 import { catalogPrimaryName } from "@/features/catalog/lib/catalog-list-display";
+import {
+  buildCourseStructuredData,
+  buildTeacherStructuredData,
+  serializeStructuredData,
+} from "@/features/catalog/lib/catalog-structured-data";
 import { getCoursePage } from "@/features/catalog/server/course-page-data";
 import { getTeacherPage } from "@/features/catalog/server/teacher-page-data";
 import {
@@ -71,6 +76,17 @@ export async function loadCourseDetailPage({
       viewer,
     },
   );
+  const socialMetadata = buildSocialMetadata({
+    canonicalPath: `/courses/${course.jwId}`,
+    description: formatSocialMetadataMessage(
+      copy.metadata.social.courseDescription,
+      { code: course.code, name: displayName },
+    ),
+    imageAlt: copy.metadata.social.imageAlt,
+    locale: locals.locale,
+    origin: url.origin,
+    title: `${displayName} (${course.code}) - Life@USTC`,
+  });
   return {
     course,
     locale: locals.locale,
@@ -78,17 +94,19 @@ export async function loadCourseDetailPage({
     descriptionData,
     commentsData,
     detailSection,
-    socialMetadata: buildSocialMetadata({
-      canonicalPath: `/courses/${course.jwId}`,
-      description: formatSocialMetadataMessage(
-        copy.metadata.social.courseDescription,
-        { code: course.code, name: displayName },
-      ),
-      imageAlt: copy.metadata.social.imageAlt,
-      locale: locals.locale,
-      origin: url.origin,
-      title: `${displayName} (${course.code}) - Life@USTC`,
-    }),
+    socialMetadata,
+    structuredDataJson: serializeStructuredData(
+      buildCourseStructuredData({
+        canonicalUrl: socialMetadata.canonicalUrl,
+        code: course.code,
+        description: descriptionData.description.content,
+        labels: {
+          collection: copy.common.courses,
+          home: copy.common.home,
+        },
+        name: displayName,
+      }),
+    ),
   };
 }
 
@@ -119,6 +137,19 @@ export async function loadTeacherDetailPage({
       viewer,
     },
   );
+  const socialMetadata = buildSocialMetadata({
+    canonicalPath: `/teachers/${teacher.id}`,
+    description: formatSocialMetadataMessage(
+      copy.metadata.social.teacherDescription,
+      { name: displayName },
+    ),
+    imageAlt: copy.metadata.social.imageAlt,
+    locale: locals.locale,
+    origin: url.origin,
+    title: `${formatSocialMetadataMessage(copy.metadata.pages.teacherDetail, {
+      name: displayName,
+    })} - Life@USTC`,
+  });
   return {
     teacher,
     locale: locals.locale,
@@ -126,18 +157,16 @@ export async function loadTeacherDetailPage({
     descriptionData,
     commentsData,
     detailSection,
-    socialMetadata: buildSocialMetadata({
-      canonicalPath: `/teachers/${teacher.id}`,
-      description: formatSocialMetadataMessage(
-        copy.metadata.social.teacherDescription,
-        { name: displayName },
-      ),
-      imageAlt: copy.metadata.social.imageAlt,
-      locale: locals.locale,
-      origin: url.origin,
-      title: `${formatSocialMetadataMessage(copy.metadata.pages.teacherDetail, {
+    socialMetadata,
+    structuredDataJson: serializeStructuredData(
+      buildTeacherStructuredData({
+        canonicalUrl: socialMetadata.canonicalUrl,
+        labels: {
+          collection: copy.common.teachers,
+          home: copy.common.home,
+        },
         name: displayName,
-      })} - Life@USTC`,
-    }),
+      }),
+    ),
   };
 }

--- a/src/features/section-detail/components/SectionDetailPageController.svelte
+++ b/src/features/section-detail/components/SectionDetailPageController.svelte
@@ -337,6 +337,7 @@ onMount(() => {
   code={data.section.code}
   courseName={_courseName}
   formatMessage={_formatMessage}
+  structuredDataJson={data.structuredDataJson}
   titleTemplate={_copy.metadata.pages.sectionDetail}
 />
 

--- a/src/features/section-detail/components/SectionDetailPageHead.svelte
+++ b/src/features/section-detail/components/SectionDetailPageHead.svelte
@@ -5,6 +5,7 @@ export let formatMessage: (
   template: string,
   values: Record<string, string>,
 ) => string;
+export let structuredDataJson: string;
 export let titleTemplate: string;
 
 $: pageTitle = formatMessage(titleTemplate, { code, name: courseName });
@@ -12,4 +13,5 @@ $: pageTitle = formatMessage(titleTemplate, { code, name: courseName });
 
 <svelte:head>
   <title>{pageTitle} - Life@USTC</title>
+  {@html `<script type="application/ld+json">${structuredDataJson}</script>`}
 </svelte:head>

--- a/src/features/section-detail/lib/section-detail-controller-types.ts
+++ b/src/features/section-detail/lib/section-detail-controller-types.ts
@@ -346,6 +346,7 @@ export type SectionDetailPageData = {
   locale: AppLocale;
   section: SectionDetailSection;
   showSubscribeDialog: boolean;
+  structuredDataJson: string;
   todayCalendarKey: string;
   viewer: {
     isSubscribed?: boolean;

--- a/src/features/section-detail/server/section-detail-page-server.ts
+++ b/src/features/section-detail/server/section-detail-page-server.ts
@@ -1,5 +1,9 @@
 import { error } from "@sveltejs/kit";
 import {
+  buildSectionStructuredData,
+  serializeStructuredData,
+} from "@/features/catalog/lib/catalog-structured-data";
+import {
   formatMessage,
   primaryName,
 } from "@/features/section-detail/lib/display";
@@ -77,6 +81,24 @@ export async function loadSectionDetailPage({
       getSectionDetailDescriptionAndComments(section, userId),
       getSectionHomeworkData(section.id, userId),
     ]);
+  const socialMetadata = buildSocialMetadata({
+    canonicalPath: `/sections/${jwId}`,
+    description: formatSocialMetadataMessage(
+      copy.metadata.social.sectionDescription,
+      { code: section.code, name: courseName },
+    ),
+    imageAlt: copy.metadata.social.imageAlt,
+    locale: locals.locale,
+    origin: url.origin,
+    title: `${formatMessage(copy.metadata.pages.sectionDetail, {
+      code: section.code,
+      name: courseName,
+    })} - Life@USTC`,
+  });
+  const sectionName = formatMessage(copy.metadata.pages.sectionDetail, {
+    code: section.code,
+    name: courseName,
+  });
   return {
     section,
     locale: locals.locale,
@@ -91,20 +113,26 @@ export async function loadSectionDetailPage({
       url.searchParams.get("homeworkView") === "list" ? "list" : "cards",
     showSubscribeDialog:
       section.retiredAt === null && url.searchParams.get("subscribe") === "1",
-    socialMetadata: buildSocialMetadata({
-      canonicalPath: `/sections/${jwId}`,
-      description: formatSocialMetadataMessage(
-        copy.metadata.social.sectionDescription,
-        { code: section.code, name: courseName },
-      ),
-      imageAlt: copy.metadata.social.imageAlt,
-      locale: locals.locale,
-      origin: url.origin,
-      title: `${formatMessage(copy.metadata.pages.sectionDetail, {
-        code: section.code,
-        name: courseName,
-      })} - Life@USTC`,
-    }),
+    socialMetadata,
+    structuredDataJson: serializeStructuredData(
+      buildSectionStructuredData({
+        canonicalUrl: socialMetadata.canonicalUrl,
+        course: {
+          jwId: section.course.jwId,
+          name: courseName,
+        },
+        description: descriptionAndComments.descriptionData.description.content,
+        instructors: section.teachers.map((teacher) => ({
+          id: teacher.id,
+          name: primaryName(teacher),
+        })),
+        labels: {
+          collection: copy.common.sections,
+          home: copy.common.home,
+        },
+        name: sectionName,
+      }),
+    ),
     viewer: {
       signedIn: Boolean(userId),
       isSubscribed: Boolean(

--- a/tests/e2e/src/app/courses/social-metadata.test.ts
+++ b/tests/e2e/src/app/courses/social-metadata.test.ts
@@ -32,6 +32,11 @@ type RawSocialMetadata = {
   values: Record<MetadataKey, string[]>;
 };
 
+type StructuredDataGraph = {
+  "@context": string;
+  "@graph": Array<Record<string, unknown>>;
+};
+
 async function setLocale(page: Page, locale: "en-us" | "zh-cn") {
   const response = await page.request.post("/api/locale", {
     data: { locale },
@@ -117,6 +122,23 @@ function expectCompleteSocialMetadata(
   expect(metadata.values.twitterImageAlt[0]).toBe(expected.imageAlt);
 }
 
+async function readRawStructuredData(page: Page, path: string) {
+  const response = await page.request.get(path);
+  expect(response.status()).toBe(200);
+  const html = await response.text();
+
+  return await page.evaluate((markup) => {
+    const document = new DOMParser().parseFromString(markup, "text/html");
+    const scripts = Array.from(
+      document.querySelectorAll('script[type="application/ld+json"]'),
+    );
+    return {
+      data: scripts.map((script) => JSON.parse(script.textContent ?? "")),
+      count: scripts.length,
+    } as { count: number; data: StructuredDataGraph[] };
+  }, html);
+}
+
 test("首页原始 SSR HTML 输出双语且唯一的完整分享元数据", async ({ page }) => {
   const cases = [
     {
@@ -196,6 +218,82 @@ test("教师详情原始 SSR HTML 使用实体根路径与本地化摘要", asyn
     locale: "en-us",
     title: `Teacher: ${DEV_SEED.teacher.nameEn} - Life@USTC`,
   });
+});
+
+test("公开实体的原始 SSR HTML 输出双语 JSON-LD 且不包含用户字段", async ({
+  page,
+}) => {
+  await setLocale(page, "zh-cn");
+  const courseResult = await readRawStructuredData(
+    page,
+    `/courses/${DEV_SEED.course.jwId}/introduction`,
+  );
+  expect(courseResult.count).toBe(1);
+  expect(courseResult.data[0]?.["@context"]).toBe("https://schema.org");
+  expect(courseResult.data[0]?.["@graph"]).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        "@type": "Course",
+        courseCode: DEV_SEED.course.code,
+        name: DEV_SEED.course.nameCn,
+      }),
+      expect.objectContaining({ "@type": "BreadcrumbList" }),
+    ]),
+  );
+
+  await setLocale(page, "en-us");
+  const sectionResult = await readRawStructuredData(
+    page,
+    `/sections/${DEV_SEED.section.jwId}/teachers`,
+  );
+  expect(sectionResult.count).toBe(1);
+  expect(sectionResult.data[0]?.["@graph"]).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        "@type": "CourseInstance",
+        instructor: expect.arrayContaining([
+          expect.objectContaining({
+            "@type": "Person",
+            name: DEV_SEED.teacher.nameEn,
+          }),
+        ]),
+        isPartOf: expect.objectContaining({
+          "@type": "Course",
+          name: DEV_SEED.course.nameEn,
+        }),
+      }),
+      expect.objectContaining({ "@type": "BreadcrumbList" }),
+    ]),
+  );
+
+  await gotoAndWaitForReady(
+    page,
+    `/teachers?search=${encodeURIComponent(DEV_SEED.teacher.code)}`,
+  );
+  const teacherHref = await page
+    .locator("#main-content a[href^='/teachers/']:visible")
+    .first()
+    .getAttribute("href");
+  expect(teacherHref).toMatch(/^\/teachers\/\d+$/);
+  const teacherResult = await readRawStructuredData(page, teacherHref ?? "");
+  expect(teacherResult.count).toBe(1);
+  expect(teacherResult.data[0]?.["@graph"]).toEqual(
+    expect.arrayContaining([
+      {
+        "@id": `${teacherResult.data[0]?.["@graph"][0]?.url}#person`,
+        "@type": "Person",
+        name: DEV_SEED.teacher.nameEn,
+        url: teacherResult.data[0]?.["@graph"][0]?.url,
+      },
+      expect.objectContaining({ "@type": "BreadcrumbList" }),
+    ]),
+  );
+
+  for (const result of [courseResult, sectionResult, teacherResult]) {
+    expect(JSON.stringify(result.data)).not.toMatch(
+      /"viewer"|"session"|"email"|"telephone"|"mobile"|"address"/i,
+    );
+  }
 });
 
 test("社交分享图片是可抓取的 1200×630 8-bit RGBA PNG", async ({ request }) => {

--- a/tests/unit/catalog-structured-data.test.ts
+++ b/tests/unit/catalog-structured-data.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildCourseStructuredData,
+  buildSectionStructuredData,
+  buildTeacherStructuredData,
+  serializeStructuredData,
+} from "@/features/catalog/lib/catalog-structured-data";
+
+describe("catalog structured data", () => {
+  test("builds a Chinese Course and breadcrumbs from public page fields", () => {
+    const data = buildCourseStructuredData({
+      canonicalUrl: "https://life.example.edu/courses/9901001",
+      code: "MATH1001",
+      description: "  数值方法课程简介。  ",
+      labels: { collection: "课程", home: "首页" },
+      name: "数值分析",
+    });
+
+    expect(data).toEqual({
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@id": "https://life.example.edu/courses/9901001#course",
+          "@type": "Course",
+          courseCode: "MATH1001",
+          description: "数值方法课程简介。",
+          name: "数值分析",
+          provider: {
+            "@type": "CollegeOrUniversity",
+            name: "University of Science and Technology of China",
+          },
+          url: "https://life.example.edu/courses/9901001",
+        },
+        {
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            {
+              "@type": "ListItem",
+              item: "https://life.example.edu/",
+              name: "首页",
+              position: 1,
+            },
+            {
+              "@type": "ListItem",
+              item: "https://life.example.edu/courses",
+              name: "课程",
+              position: 2,
+            },
+            {
+              "@type": "ListItem",
+              item: "https://life.example.edu/courses/9901001",
+              name: "数值分析",
+              position: 3,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  test("builds an English CourseInstance with only public instructors", () => {
+    const data = buildSectionStructuredData({
+      canonicalUrl: "https://life.example.edu/sections/8802002",
+      course: { jwId: 9901001, name: "Numerical Analysis" },
+      instructors: [
+        { id: 42, name: "Ada Lovelace" },
+        { id: 43, name: "" },
+      ],
+      labels: { collection: "Sections", home: "Home" },
+      name: "Numerical Analysis · Section 01",
+    });
+
+    expect(data["@graph"][0]).toEqual({
+      "@id": "https://life.example.edu/sections/8802002#course-instance",
+      "@type": "CourseInstance",
+      instructor: [
+        {
+          "@id": "https://life.example.edu/teachers/42#person",
+          "@type": "Person",
+          name: "Ada Lovelace",
+          url: "https://life.example.edu/teachers/42",
+        },
+      ],
+      isPartOf: {
+        "@id": "https://life.example.edu/courses/9901001#course",
+        "@type": "Course",
+        name: "Numerical Analysis",
+        url: "https://life.example.edu/courses/9901001",
+      },
+      name: "Numerical Analysis · Section 01",
+      url: "https://life.example.edu/sections/8802002",
+    });
+    expect(data["@graph"][1]).toMatchObject({
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { name: "Home", position: 1 },
+        { name: "Sections", position: 2 },
+        { name: "Numerical Analysis · Section 01", position: 3 },
+      ],
+    });
+  });
+
+  test("keeps Person data minimal and safely serializes script-sensitive text", () => {
+    const data = buildTeacherStructuredData({
+      canonicalUrl: "https://life.example.edu/teachers/42",
+      labels: { collection: "教师", home: "首页" },
+      name: "</script><script>alert('xss')</script>&\u2028",
+    });
+    const serialized = serializeStructuredData(data);
+
+    expect(serialized).not.toContain("<");
+    expect(serialized).not.toContain(">");
+    expect(serialized).not.toContain("&");
+    expect(serialized).not.toContain("\u2028");
+    expect(JSON.parse(serialized)).toEqual(data);
+    expect(serialized).not.toMatch(
+      /viewer|session|email|telephone|mobile|address/i,
+    );
+  });
+});


### PR DESCRIPTION
## Goal

Expose machine-readable public catalog entities in SSR HTML for search engines and AI clients.

Closes #506.

## Changed Surfaces

- Add `Course`, `CourseInstance`, and `Person` JSON-LD to course, section, and teacher detail pages.
- Add localized `BreadcrumbList` data to each entity page.
- Build JSON-LD only from public page fields and safely escape script-sensitive characters.
- Identify USTC as the course provider without claiming Life@USTC is an official university service.
- Add bilingual builder/security tests and raw SSR rendering coverage.

## Evidence

- `bun run app:prepare`
- `bunx biome check`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` — 193 files / 1149 tests passed
- `bun run build` — Cloudflare production build passed
- Focused raw-SSR Playwright suite — 6/6 passed

## Docs Contracts

No API shape, permission, schema, or workflow changes.

## Risk Areas

- Rich-result eligibility remains controlled by individual search engines; this PR provides valid Schema.org entities but does not guarantee a rich result.
- Public descriptions retain their source Markdown text in the JSON-LD description field.

## Cleanup

No unrelated cleanup.