### PR TITLE
perf(infra): trim detail page SSR critical paths

### DIFF
--- a/src/features/catalog/components/CourseDetailPageController.svelte
+++ b/src/features/catalog/components/CourseDetailPageController.svelte
@@ -108,7 +108,7 @@ $: sectionNavItems = [
     icon: MessageSquareIcon,
     key: "comments" as const,
     label: copy.courseDetail.tabs.comments,
-    meta: commentsCount,
+    meta: data.commentsData ? commentsCount : undefined,
   },
 ];
 $: activeNavItem =

--- a/src/features/catalog/components/TeacherDetailPageController.svelte
+++ b/src/features/catalog/components/TeacherDetailPageController.svelte
@@ -100,7 +100,7 @@ $: sectionNavItems = [
     icon: MessageSquareIcon,
     key: "comments" as const,
     label: copy.comments.title,
-    meta: commentsCount,
+    meta: data.commentsData ? commentsCount : undefined,
   },
 ];
 $: activeNavItem =

--- a/src/features/catalog/server/catalog-detail-comments.ts
+++ b/src/features/catalog/server/catalog-detail-comments.ts
@@ -3,25 +3,31 @@ import { getDescriptionPayload } from "@/features/descriptions/server/descriptio
 import type { ViewerContext } from "@/lib/auth/viewer-context";
 
 export async function loadCatalogDetailCommentsData({
+  includeComments,
   targetId,
   type,
   viewer,
 }: {
+  includeComments: boolean;
   targetId: number;
   type: "course" | "teacher";
   viewer: ViewerContext;
 }) {
   const [descriptionData, comments] = await Promise.all([
     getDescriptionPayload(type, targetId, viewer),
-    getCommentsPayload({ type, targetId }, viewer),
+    includeComments
+      ? getCommentsPayload({ type, targetId }, viewer)
+      : Promise.resolve(null),
   ]);
 
   return {
-    commentsData: {
-      commentMap: { [type]: comments.comments },
-      hiddenCount: comments.hiddenCount,
-      viewer,
-    },
+    commentsData: comments
+      ? {
+          commentMap: { [type]: comments.comments },
+          hiddenCount: comments.hiddenCount,
+          viewer,
+        }
+      : null,
     descriptionData,
   };
 }

--- a/src/features/catalog/server/catalog-detail-page-server.ts
+++ b/src/features/catalog/server/catalog-detail-page-server.ts
@@ -61,16 +61,19 @@ export async function loadCourseDetailPage({
   if (!detailSection) error(404, copy.notFound.description);
   const jwId = Number(params.jwId);
   if (!Number.isInteger(jwId)) error(404, copy.notFound.description);
-  const course = await getCoursePage(jwId, locals.locale);
+  const [course, viewer] = await Promise.all([
+    getCoursePage(jwId, locals.locale),
+    currentCatalogViewer(request),
+  ]);
   if (!course) error(404, copy.notFound.description);
   if (course.jwId !== jwId) {
     const sectionPath = detailSection === "overview" ? "" : `/${detailSection}`;
     redirect(308, `/courses/${course.jwId}${sectionPath}${url.search}`);
   }
   const displayName = catalogPrimaryName(course) || course.code;
-  const viewer = await currentCatalogViewer(request);
   const { commentsData, descriptionData } = await loadCatalogDetailCommentsData(
     {
+      includeComments: detailSection === "comments",
       targetId: course.id,
       type: "course",
       viewer,
@@ -126,12 +129,15 @@ export async function loadTeacherDetailPage({
   if (!detailSection) error(404, copy.notFound.description);
   const id = Number(params.id);
   if (!Number.isInteger(id)) error(404, copy.notFound.description);
-  const teacher = await getTeacherPage(id, locals.locale);
+  const [teacher, viewer] = await Promise.all([
+    getTeacherPage(id, locals.locale),
+    currentCatalogViewer(request),
+  ]);
   if (!teacher) error(404, copy.notFound.description);
   const displayName = catalogPrimaryName(teacher);
-  const viewer = await currentCatalogViewer(request);
   const { commentsData, descriptionData } = await loadCatalogDetailCommentsData(
     {
+      includeComments: detailSection === "comments",
       targetId: teacher.id,
       type: "teacher",
       viewer,

--- a/src/features/section-detail/components/SectionDetailMainContent.svelte
+++ b/src/features/section-detail/components/SectionDetailMainContent.svelte
@@ -113,7 +113,7 @@ $: sectionNavItems = [
     icon: ClipboardListIcon,
     key: "homework" as const,
     label: sectionCopy.tabs.homeworks,
-    meta: homeworks.length,
+    meta: data.detailSection === "homework" ? homeworks.length : undefined,
   },
   {
     href: `${sectionBaseHref}/teachers`,
@@ -127,7 +127,7 @@ $: sectionNavItems = [
     icon: MessageSquareIcon,
     key: "comments" as const,
     label: sectionCopy.tabs.comments,
-    meta: commentsCount,
+    meta: data.commentsData ? commentsCount : undefined,
   },
 ];
 $: activeNavItem =

--- a/src/features/section-detail/components/SectionDetailPageController.svelte
+++ b/src/features/section-detail/components/SectionDetailPageController.svelte
@@ -329,6 +329,7 @@ onMount(() => {
     setOrigin: (origin) => {
       _origin = origin;
     },
+    shouldLoadHomeworks: data.detailSection === "homework",
   });
 });
 </script>

--- a/src/features/section-detail/lib/section-detail-controller-mount.ts
+++ b/src/features/section-detail/lib/section-detail-controller-mount.ts
@@ -9,12 +9,15 @@ export function mountSectionDetailController(input: {
   loadHomeworks: () => unknown;
   setHomeworkView: (view: SectionHomeworkView) => void;
   setOrigin: (origin: string) => void;
+  shouldLoadHomeworks: boolean;
 }) {
   input.setOrigin(window.location.origin);
   input.setHomeworkView(
     initialSectionHomeworkViewFromBrowser(input.getHomeworkView()),
   );
-  void input.loadHomeworks();
+  if (input.shouldLoadHomeworks) {
+    void input.loadHomeworks();
+  }
 
   return () => {
     input.clearClipboardTimer();

--- a/src/features/section-detail/server/section-detail-comments-data.ts
+++ b/src/features/section-detail/server/section-detail-comments-data.ts
@@ -9,12 +9,24 @@ export async function getSectionDetailDescriptionAndComments(
     teachers: { id: number }[];
   },
   userId: string | null,
+  { includeComments }: { includeComments: boolean },
 ) {
   const descriptionViewer = await getViewerContext({ userId });
+  const descriptionDataPromise = getDescriptionPayload(
+    "section",
+    section.id,
+    descriptionViewer,
+  );
+  if (!includeComments) {
+    return {
+      commentsData: null,
+      descriptionData: await descriptionDataPromise,
+    };
+  }
   const firstCommentTeacher = section.teachers[0] ?? null;
   const [descriptionData, sectionComments, courseComments, teacherComments] =
     await Promise.all([
-      getDescriptionPayload("section", section.id, descriptionViewer),
+      descriptionDataPromise,
       getCommentsPayload(
         { type: "section", targetId: section.id },
         descriptionViewer,

--- a/src/features/section-detail/server/section-detail-page-server.ts
+++ b/src/features/section-detail/server/section-detail-page-server.ts
@@ -66,11 +66,13 @@ export async function loadSectionDetailPage({
   if (!detailSection) error(404, "Section not found");
   const jwId = parseSectionJwId(params.jwId);
   if (jwId === null) error(404, "Section not found");
-  const section = await getSectionPage(jwId, locals.locale);
+  const [section, userId] = await Promise.all([
+    getSectionPage(jwId, locals.locale),
+    getSectionDetailUserId(request),
+  ]);
   if (!section) error(404, "Section not found");
   const copy = getSectionDetailPageCopy(locals.locale);
   const courseName = primaryName(section.course) || section.code;
-  const userId = await getSectionDetailUserId(request);
   const [subscriptionState, descriptionAndComments, homeworkData] =
     await Promise.all([
       userId
@@ -78,8 +80,21 @@ export async function loadSectionDetailPage({
             await import("@/features/subscriptions/server/subscriptions")
           ).getUserSectionSubscriptionState(userId)
         : null,
-      getSectionDetailDescriptionAndComments(section, userId),
-      getSectionHomeworkData(section.id, userId),
+      getSectionDetailDescriptionAndComments(section, userId, {
+        includeComments: detailSection === "comments",
+      }),
+      detailSection === "homework"
+        ? getSectionHomeworkData(section.id, userId)
+        : {
+            auditLogs: [],
+            homeworks: [],
+            viewer: {
+              isAdmin: false,
+              isAuthenticated: Boolean(userId),
+              isSuspended: false,
+              userId,
+            },
+          },
     ]);
   const socialMetadata = buildSocialMetadata({
     canonicalPath: `/sections/${jwId}`,

--- a/tests/unit/detail-page-loader-critical-path.test.ts
+++ b/tests/unit/detail-page-loader-critical-path.test.ts
@@ -1,0 +1,326 @@
+/// <reference path="../../src/app.d.ts" />
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  currentCatalogViewerMock,
+  getCommentsPayloadMock,
+  getCoursePageMock,
+  getDescriptionPayloadMock,
+  getSectionDetailUserIdMock,
+  getSectionHomeworkDataMock,
+  getSectionPageMock,
+  getTeacherPageMock,
+  getUserSectionSubscriptionStateMock,
+  getViewerContextMock,
+} = vi.hoisted(() => ({
+  currentCatalogViewerMock: vi.fn(),
+  getCommentsPayloadMock: vi.fn(),
+  getCoursePageMock: vi.fn(),
+  getDescriptionPayloadMock: vi.fn(),
+  getSectionDetailUserIdMock: vi.fn(),
+  getSectionHomeworkDataMock: vi.fn(),
+  getSectionPageMock: vi.fn(),
+  getTeacherPageMock: vi.fn(),
+  getUserSectionSubscriptionStateMock: vi.fn(),
+  getViewerContextMock: vi.fn(),
+}));
+
+vi.mock("@/features/catalog/server/course-page-data", () => ({
+  getCoursePage: getCoursePageMock,
+}));
+
+vi.mock("@/features/catalog/server/teacher-page-data", () => ({
+  getTeacherPage: getTeacherPageMock,
+}));
+
+vi.mock("@/features/catalog/server/catalog-detail-viewer", () => ({
+  currentCatalogViewer: currentCatalogViewerMock,
+}));
+
+vi.mock("@/features/comments/server/comments-server", () => ({
+  getCommentsPayload: getCommentsPayloadMock,
+}));
+
+vi.mock("@/features/descriptions/server/descriptions-server", () => ({
+  getDescriptionPayload: getDescriptionPayloadMock,
+}));
+
+vi.mock("@/features/section-detail/server/section-page-data", () => ({
+  getSectionPage: getSectionPageMock,
+}));
+
+vi.mock("@/features/section-detail/server/section-detail-session", () => ({
+  getSectionDetailUserId: getSectionDetailUserIdMock,
+}));
+
+vi.mock(
+  "@/features/section-detail/server/section-detail-homework-data",
+  () => ({
+    getSectionHomeworkData: getSectionHomeworkDataMock,
+  }),
+);
+
+vi.mock("@/features/subscriptions/server/subscriptions", () => ({
+  getUserSectionSubscriptionState: getUserSectionSubscriptionStateMock,
+}));
+
+vi.mock("@/lib/auth/viewer-context", () => ({
+  getViewerContext: getViewerContextMock,
+}));
+
+const anonymousViewer = {
+  image: null,
+  isAdmin: false,
+  isAuthenticated: false,
+  isSuspended: false,
+  name: null,
+  suspensionExpiresAt: null,
+  suspensionReason: null,
+  userId: null,
+};
+
+const descriptionData = {
+  description: {
+    content: "Primary SSR description",
+    id: "description-1",
+    lastEditedAt: null,
+    lastEditedBy: null,
+    updatedAt: null,
+  },
+  history: [],
+  viewer: anonymousViewer,
+};
+
+const course = {
+  code: "MATH1001",
+  id: 11,
+  jwId: 101,
+  namePrimary: "Calculus",
+  sections: [],
+};
+
+const teacher = {
+  id: 21,
+  namePrimary: "Ada",
+  sections: [],
+};
+
+const section = {
+  code: "001",
+  course: {
+    id: course.id,
+    jwId: course.jwId,
+    namePrimary: course.namePrimary,
+  },
+  id: 31,
+  jwId: 301,
+  retiredAt: null,
+  teachers: [{ id: teacher.id, namePrimary: teacher.namePrimary }],
+};
+
+function locals(): App.Locals {
+  return {
+    authUser: null,
+    locale: "en-us",
+    requestId: "detail-loader-test",
+  };
+}
+
+function request(path: string) {
+  return new Request(`https://example.test${path}`);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  currentCatalogViewerMock.mockResolvedValue(anonymousViewer);
+  getCommentsPayloadMock.mockResolvedValue({
+    comments: [],
+    hiddenCount: 0,
+    viewer: anonymousViewer,
+  });
+  getCoursePageMock.mockResolvedValue(course);
+  getDescriptionPayloadMock.mockResolvedValue(descriptionData);
+  getSectionDetailUserIdMock.mockResolvedValue(null);
+  getSectionHomeworkDataMock.mockResolvedValue({
+    auditLogs: [],
+    homeworks: [],
+    viewer: anonymousViewer,
+  });
+  getSectionPageMock.mockResolvedValue(section);
+  getTeacherPageMock.mockResolvedValue(teacher);
+  getUserSectionSubscriptionStateMock.mockResolvedValue({
+    subscribedSections: [],
+    subscriptionIcsUrl: null,
+  });
+  getViewerContextMock.mockResolvedValue(anonymousViewer);
+});
+
+describe("catalog detail loader critical path", () => {
+  it("starts course and viewer work together and skips comments outside the comments section", async () => {
+    let resolveCourse: ((value: typeof course) => void) | undefined;
+    getCoursePageMock.mockReturnValue(
+      new Promise<typeof course>((resolve) => {
+        resolveCourse = resolve;
+      }),
+    );
+    const { loadCourseDetailPage } = await import(
+      "@/features/catalog/server/catalog-detail-page-server"
+    );
+
+    const resultPromise = loadCourseDetailPage({
+      locals: locals(),
+      params: { jwId: String(course.jwId) },
+      request: request(`/courses/${course.jwId}`),
+      url: new URL(`https://example.test/courses/${course.jwId}`),
+    });
+
+    await vi.waitFor(() => {
+      expect(currentCatalogViewerMock).toHaveBeenCalledOnce();
+    });
+    expect(getDescriptionPayloadMock).not.toHaveBeenCalled();
+
+    resolveCourse?.(course);
+    const result = await resultPromise;
+
+    expect(result.descriptionData).toBe(descriptionData);
+    expect(result.structuredDataJson).toContain("Primary SSR description");
+    expect(result.commentsData).toBeNull();
+    expect(getCommentsPayloadMock).not.toHaveBeenCalled();
+  });
+
+  it("loads comments only for the course comments section", async () => {
+    const { loadCourseDetailPage } = await import(
+      "@/features/catalog/server/catalog-detail-page-server"
+    );
+
+    const result = await loadCourseDetailPage({
+      locals: locals(),
+      params: { jwId: String(course.jwId), section: "comments" },
+      request: request(`/courses/${course.jwId}/comments`),
+      url: new URL(`https://example.test/courses/${course.jwId}/comments`),
+    });
+
+    expect(result.commentsData).not.toBeNull();
+    expect(getCommentsPayloadMock).toHaveBeenCalledOnce();
+    expect(getCommentsPayloadMock).toHaveBeenCalledWith(
+      { targetId: course.id, type: "course" },
+      anonymousViewer,
+    );
+  });
+
+  it("skips comments outside the teacher comments section", async () => {
+    const { loadTeacherDetailPage } = await import(
+      "@/features/catalog/server/catalog-detail-page-server"
+    );
+
+    const result = await loadTeacherDetailPage({
+      locals: locals(),
+      params: { id: String(teacher.id), section: "sections" },
+      request: request(`/teachers/${teacher.id}/sections`),
+      url: new URL(`https://example.test/teachers/${teacher.id}/sections`),
+    });
+
+    expect(result.descriptionData).toBe(descriptionData);
+    expect(result.commentsData).toBeNull();
+    expect(getCommentsPayloadMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("section detail loader critical path", () => {
+  it("starts section and session work together and skips comments and homework on overview", async () => {
+    let resolveSection: ((value: typeof section) => void) | undefined;
+    getSectionPageMock.mockReturnValue(
+      new Promise<typeof section>((resolve) => {
+        resolveSection = resolve;
+      }),
+    );
+    const { loadSectionDetailPage } = await import(
+      "@/features/section-detail/server/section-detail-page-server"
+    );
+
+    const resultPromise = loadSectionDetailPage({
+      locals: locals(),
+      params: { jwId: String(section.jwId) },
+      request: request(`/sections/${section.jwId}`),
+      url: new URL(`https://example.test/sections/${section.jwId}`),
+    });
+
+    await vi.waitFor(() => {
+      expect(getSectionDetailUserIdMock).toHaveBeenCalledOnce();
+    });
+    expect(getDescriptionPayloadMock).not.toHaveBeenCalled();
+
+    resolveSection?.(section);
+    const result = await resultPromise;
+
+    expect(result.descriptionData).toBe(descriptionData);
+    expect(result.structuredDataJson).toContain("Primary SSR description");
+    expect(result.commentsData).toBeNull();
+    expect(result.homeworkData.homeworks).toEqual([]);
+    expect(getCommentsPayloadMock).not.toHaveBeenCalled();
+    expect(getSectionHomeworkDataMock).not.toHaveBeenCalled();
+    expect(getUserSectionSubscriptionStateMock).not.toHaveBeenCalled();
+  });
+
+  it("loads homework, but not comments, for the homework section", async () => {
+    const { loadSectionDetailPage } = await import(
+      "@/features/section-detail/server/section-detail-page-server"
+    );
+
+    const result = await loadSectionDetailPage({
+      locals: locals(),
+      params: { jwId: String(section.jwId), section: "homework" },
+      request: request(`/sections/${section.jwId}/homework`),
+      url: new URL(`https://example.test/sections/${section.jwId}/homework`),
+    });
+
+    expect(result.descriptionData).toBe(descriptionData);
+    expect(getSectionHomeworkDataMock).toHaveBeenCalledWith(section.id, null);
+    expect(getCommentsPayloadMock).not.toHaveBeenCalled();
+  });
+
+  it("loads comments, but not homework, for the comments section", async () => {
+    const { loadSectionDetailPage } = await import(
+      "@/features/section-detail/server/section-detail-page-server"
+    );
+
+    const result = await loadSectionDetailPage({
+      locals: locals(),
+      params: { jwId: String(section.jwId), section: "comments" },
+      request: request(`/sections/${section.jwId}/comments`),
+      url: new URL(`https://example.test/sections/${section.jwId}/comments`),
+    });
+
+    expect(result.commentsData).not.toBeNull();
+    expect(getCommentsPayloadMock).toHaveBeenCalledTimes(3);
+    expect(getSectionHomeworkDataMock).not.toHaveBeenCalled();
+  });
+
+  it("retains subscription state on signed-in sections because the fixed header consumes it", async () => {
+    getSectionDetailUserIdMock.mockResolvedValue("user-1");
+    getUserSectionSubscriptionStateMock.mockResolvedValue({
+      subscribedSections: [section.id],
+      subscriptionIcsUrl: "/api/users/user-1/calendar.ics",
+    });
+    const { loadSectionDetailPage } = await import(
+      "@/features/section-detail/server/section-detail-page-server"
+    );
+
+    const result = await loadSectionDetailPage({
+      locals: locals(),
+      params: { jwId: String(section.jwId), section: "teachers" },
+      request: request(`/sections/${section.jwId}/teachers`),
+      url: new URL(`https://example.test/sections/${section.jwId}/teachers`),
+    });
+
+    expect(getUserSectionSubscriptionStateMock).toHaveBeenCalledWith("user-1");
+    expect(result.viewer).toMatchObject({
+      isSubscribed: true,
+      signedIn: true,
+      subscriptionIcsUrl: "/api/users/user-1/calendar.ics",
+    });
+    expect(getCommentsPayloadMock).not.toHaveBeenCalled();
+    expect(getSectionHomeworkDataMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/section-detail-controller-mount.test.ts
+++ b/tests/unit/section-detail-controller-mount.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mountSectionDetailController } from "@/features/section-detail/lib/section-detail-controller-mount";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("mountSectionDetailController", () => {
+  it.each([
+    { expectedCalls: 1, shouldLoadHomeworks: true },
+    { expectedCalls: 0, shouldLoadHomeworks: false },
+  ])("loads homework $expectedCalls time(s) when shouldLoadHomeworks is $shouldLoadHomeworks", ({
+    expectedCalls,
+    shouldLoadHomeworks,
+  }) => {
+    vi.stubGlobal("window", {
+      location: {
+        href: "https://example.test/sections/301",
+        origin: "https://example.test",
+      },
+    });
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn().mockReturnValue(null),
+    });
+    const clearClipboardTimer = vi.fn();
+    const loadHomeworks = vi.fn();
+
+    const cleanup = mountSectionDetailController({
+      clearClipboardTimer,
+      getHomeworkView: () => "cards",
+      loadHomeworks,
+      setHomeworkView: vi.fn(),
+      setOrigin: vi.fn(),
+      shouldLoadHomeworks,
+    });
+
+    expect(loadHomeworks).toHaveBeenCalledTimes(expectedCalls);
+    cleanup();
+    expect(clearClipboardTimer).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Goal

Shorten course, teacher, and section detail SSR critical paths without removing primary SSR content, descriptions used by structured data, or signed-in behavior. Closes #512.

## Changed Surfaces

- Start catalog entity/viewer and section entity/session work in parallel.
- Fetch catalog and section comments only on the `comments` route section.
- Fetch section homework SSR data, and the hydration refresh, only on the `homework` route section.
- Keep course/section descriptions on every route because JSON-LD consumes them; retain teacher description behavior.
- Keep signed-in subscription state on every section route because the fixed header and mobile primary actions consume it.
- Hide unloaded comments/homework navigation counts instead of presenting a misleading zero.
- Add dependency-call tests for route-section loading and controller mount behavior.

## Evidence

- `bunx vitest run tests/unit/detail-page-loader-critical-path.test.ts tests/unit/section-detail-controller-mount.test.ts` — 9 passed.
- Full dev loop: app prepare, Biome, Svelte check, all three TypeScript projects, and Vitest — 197 files / 1168 tests passed; Svelte diagnostics reported 0 errors and 0 warnings. Biome retained one unrelated pre-existing unused-parameter warning in `src/static-loader/import.ts`.
- `bun run build` — production Cloudflare adapter build passed.
- `bunx wrangler deploy --dry-run --outdir /tmp/life-ustc-ssr-critical-wrangler` — passed.
- Focused Playwright detail-page run for course, teacher, and section routes — 57 passed, including description, comments, homework, subscription, mobile navigation, and redirect flows.
- Integration MCP suite not run: no REST/GraphQL/MCP contract or shared domain service behavior changed.

## Docs / Contracts

No docs/contracts change: routes, response shape, permissions, copy, and public API contracts are unchanged; this is loader scheduling and route-scoped data-fetch work.

## Risk Areas

- Non-active comments/homework navigation counts are intentionally omitted until their section is loaded rather than displaying stale or false values.
- Subscription lookup remains on all signed-in section detail routes because current shared header controls require it; changing that would need a separate client-state design.
- Invalid entity requests now start session/viewer resolution concurrently before the not-found result, trading a small amount of 404 work for lower valid-page latency.

## Cleanup

Temporary Playwright reports, traces, the isolated E2E database/container, and ad hoc build output were removed. No generated Prisma files, migrations, contracts, or unrelated source changes are included.

Remote checks: CI, CodeQL, MCP integration, all four E2E shards, static-loader image, report publishing, and Cloudflare Workers Build all passed.