### PR TITLE
fix(api): isolate localized catalog caches

### DIFF
--- a/docs/contracts/course.json
+++ b/docs/contracts/course.json
@@ -15,7 +15,7 @@
     "retired-section-history": "Direct Course detail retains retired Section offerings as historical references; public Section discovery excludes them.",
     "jwid-url-only": "jwId is used only for URLs, APIs, MCP, and backend logic; it should not be directly displayed in ordinary course UI.",
     "education-level-display-casing": "English education-level filter labels uppercase only their initial character for consistent display while preserving all remaining source casing; non-English labels remain unchanged.",
-    "public-list-cache": "Anonymous course list REST responses and server-side list data may use short public runtime/CDN caching because course fact data is read-only; localized HTML pages must not use shared edge caching unless the cache key varies by locale.",
+    "public-list-cache": "Course REST responses may use short shared CDN caching only when a supported locale is explicit in the locale URL query; responses localized from Cookie/Accept-Language fallback are private/no-store. Server-side list data may still use short locale-keyed runtime caching. Localized HTML pages must not use shared edge caching unless the cache key varies by locale.",
     "mobile-detail-hierarchy": "Course detail pages present the public course code before the localized display name on mobile, use a responsive title size, and expose context navigation as a touch-scrollable horizontal row.",
     "static-classification-unsupported": "Static course snapshots do not currently provide CourseClassify source data, so static-loaded courses keep classifyId/classify null and static-loaded metadata may expose courseClassifies as an empty array."
   },

--- a/docs/contracts/schedule.json
+++ b/docs/contracts/schedule.json
@@ -9,7 +9,8 @@
   "rules": {
     "schedule-definition": "Schedule refers to a section's class times, locations, and week patterns.",
     "schedule-as-context": "The schedule within a section detail page is not treated as an isolated table but as an important entry point for understanding the section context.",
-    "personal-calendar-integrates": "The personal calendar integrates subscribed section schedules, homework due dates, exam times, and personal todo due dates."
+    "personal-calendar-integrates": "The personal calendar integrates subscribed section schedules, homework due dates, exam times, and personal todo due dates.",
+    "public-rest-locale-cache": "Localized public schedule REST responses may use short shared CDN caching only when a supported locale is explicit in the locale URL query; responses localized from Cookie/Accept-Language fallback are private/no-store."
   },
   "capabilities": {
     "my-schedule": {

--- a/docs/contracts/section.json
+++ b/docs/contracts/section.json
@@ -15,7 +15,7 @@
     "retired-read-semantics": "Public Section/search/match and public/current calendar collection queries exclude retired rows. Direct Section detail and single-Section calendar access remain available for historical references; the detail page labels the record historical and does not offer a new subscription. Course/Teacher detail histories and the owner's subscribed Sections list also retain retired rows. New subscription discovery/add operations reject retired rows, while an existing owner can still remove one.",
     "subscription-not-enrollment": "Pages involving subscription actions must clearly state this is not official academic course enrollment.",
     "jwid-url-only": "jwId is used only for routing and API endpoints; it should not be directly displayed in ordinary section UI.",
-    "public-list-cache": "Anonymous section list REST responses and server-side list data may use short public runtime/CDN caching because section fact data is read-only; localized HTML pages must not use shared edge caching unless the cache key varies by locale.",
+    "public-list-cache": "Section REST responses may use short shared CDN caching only when a supported locale is explicit in the locale URL query; responses localized from Cookie/Accept-Language fallback are private/no-store. Server-side list data may still use short locale-keyed runtime caching. Localized HTML pages must not use shared edge caching unless the cache key varies by locale.",
     "mobile-detail-actions": "Section detail pages present stable section metadata before a responsive course title, use touch-scrollable horizontal context navigation on mobile, and keep the primary calendar and subscription actions available in a bottom sticky action bar."
   },
   "capabilities": {

--- a/docs/contracts/teacher.json
+++ b/docs/contracts/teacher.json
@@ -9,7 +9,7 @@
   "rules": {
     "identified-by-name": "Teacher objects are naturally identified by name.",
     "section-code-auxiliary": "Section codes retain value on teacher pages but appear only as auxiliary fields in the teaching section list.",
-    "public-list-cache": "Anonymous teacher list REST responses and server-side list data may use short public runtime/CDN caching because teacher fact data is read-only; localized HTML pages must not use shared edge caching unless the cache key varies by locale.",
+    "public-list-cache": "Teacher REST responses may use short shared CDN caching only when a supported locale is explicit in the locale URL query; responses localized from Cookie/Accept-Language fallback are private/no-store. Server-side list data may still use short locale-keyed runtime caching. Localized HTML pages must not use shared edge caching unless the cache key varies by locale.",
     "mobile-detail-hierarchy": "Teacher detail pages use a responsive title size and expose context navigation as a touch-scrollable horizontal row on mobile."
   },
   "capabilities": {

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -894,6 +894,17 @@
         "parameters": [
           {
             "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en-us",
+                "zh-cn"
+              ]
+            }
+          },
+          {
+            "in": "query",
             "name": "search",
             "schema": {
               "type": "string"
@@ -1710,6 +1721,17 @@
         "parameters": [
           {
             "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en-us",
+                "zh-cn"
+              ]
+            }
+          },
+          {
+            "in": "query",
             "name": "sectionId",
             "schema": {
               "type": "integer",
@@ -1856,6 +1878,17 @@
           "Sections"
         ],
         "parameters": [
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en-us",
+                "zh-cn"
+              ]
+            }
+          },
           {
             "in": "query",
             "name": "courseId",
@@ -2069,6 +2102,17 @@
           "Teachers"
         ],
         "parameters": [
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en-us",
+                "zh-cn"
+              ]
+            }
+          },
           {
             "in": "query",
             "name": "departmentId",
@@ -4160,6 +4204,17 @@
               "format": "int64"
             },
             "required": true
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en-us",
+                "zh-cn"
+              ]
+            }
           }
         ],
         "responses": {
@@ -4815,6 +4870,17 @@
               "format": "int64"
             },
             "required": true
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en-us",
+                "zh-cn"
+              ]
+            }
           }
         ],
         "responses": {
@@ -4991,6 +5057,17 @@
               "format": "int64"
             },
             "required": true
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en-us",
+                "zh-cn"
+              ]
+            }
           }
         ],
         "responses": {
@@ -7677,6 +7754,17 @@
               "format": "int64"
             },
             "required": true
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en-us",
+                "zh-cn"
+              ]
+            }
           }
         ],
         "responses": {
@@ -7722,6 +7810,17 @@
               "format": "int64"
             },
             "required": true
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en-us",
+                "zh-cn"
+              ]
+            }
           },
           {
             "in": "query",

--- a/src/lib/api/routes/academic-course-routes.ts
+++ b/src/lib/api/routes/academic-course-routes.ts
@@ -5,9 +5,8 @@ import {
   parseRouteQuery,
 } from "@/lib/api/helpers";
 import { parseJwIdRouteParam } from "@/lib/api/routes/academic-route-helpers";
-import { getRequestLocale } from "@/lib/api/routes/request-locale";
+import { resolvePublicCatalogLocale } from "@/lib/api/routes/request-locale";
 import { coursesQuerySchema } from "@/lib/api/schemas/request-schemas";
-import { PUBLIC_LOCALE_CATALOG_HEADERS } from "@/lib/public-cache-control";
 import {
   cachedPublicRuntimeData,
   publicRuntimeCacheKey,
@@ -16,6 +15,11 @@ import {
 const COURSES_API_CACHE_TTL_MS = 60_000;
 
 export async function getCoursesRoute(request: Request) {
+  const localeResolution = resolvePublicCatalogLocale(request);
+  if (localeResolution instanceof Response) {
+    return localeResolution;
+  }
+
   const searchParams = new URL(request.url).searchParams;
   const parsed = parseRouteQuery(
     searchParams,
@@ -28,7 +32,8 @@ export async function getCoursesRoute(request: Request) {
   }
 
   const { query: parsedQuery, pagination } = parsed;
-  const locale = getRequestLocale(request);
+  const { locale: _locale, ...filters } = parsedQuery;
+  const { cacheHeaders, locale } = localeResolution;
 
   try {
     const result = await cachedPublicRuntimeData(
@@ -39,14 +44,14 @@ export async function getCoursesRoute(request: Request) {
           "@/features/catalog/server/course-section-queries"
         );
         return listCourseSummaries({
-          filters: parsedQuery,
+          filters,
           locale,
           pagination,
         });
       },
     );
     return jsonResponse(result, {
-      headers: PUBLIC_LOCALE_CATALOG_HEADERS,
+      headers: cacheHeaders,
     });
   } catch (error) {
     return handleRouteError("Failed to fetch courses", error);
@@ -61,12 +66,17 @@ export async function getCourseDetailRoute(
     const parsedJwId = parseJwIdRouteParam(params, "course ID");
     if (parsedJwId instanceof Response) return parsedJwId;
 
+    const localeResolution = resolvePublicCatalogLocale(request);
+    if (localeResolution instanceof Response) {
+      return localeResolution;
+    }
+
     const { findCourseDetailByJwId } = await import(
       "@/features/catalog/server/course-section-queries"
     );
     const course = await findCourseDetailByJwId(
       parsedJwId,
-      getRequestLocale(request),
+      localeResolution.locale,
     );
 
     if (!course) {
@@ -74,7 +84,7 @@ export async function getCourseDetailRoute(
     }
 
     return jsonResponse(course, {
-      headers: PUBLIC_LOCALE_CATALOG_HEADERS,
+      headers: localeResolution.cacheHeaders,
     });
   } catch (error) {
     return handleRouteError("Failed to fetch course", error);

--- a/src/lib/api/routes/academic-schedule-routes.ts
+++ b/src/lib/api/routes/academic-schedule-routes.ts
@@ -5,12 +5,16 @@ import {
   jsonResponse,
   parseRouteQuery,
 } from "@/lib/api/helpers";
-import { getRequestLocale } from "@/lib/api/routes/request-locale";
+import { resolvePublicCatalogLocale } from "@/lib/api/routes/request-locale";
 import { schedulesQuerySchema } from "@/lib/api/schemas/request-schemas";
-import { PUBLIC_LOCALE_CATALOG_HEADERS } from "@/lib/public-cache-control";
 
 export async function getSchedulesRoute(request: Request) {
   try {
+    const localeResolution = resolvePublicCatalogLocale(request);
+    if (localeResolution instanceof Response) {
+      return localeResolution;
+    }
+
     const searchParams = new URL(request.url).searchParams;
     const parsed = parseRouteQuery(
       searchParams,
@@ -39,11 +43,11 @@ export async function getSchedulesRoute(request: Request) {
     return jsonResponse(
       await listPublicSchedules({
         filters,
-        locale: getRequestLocale(request),
+        locale: localeResolution.locale,
         page: pagination.page,
         pageSize: pagination.pageSize,
       }),
-      { headers: PUBLIC_LOCALE_CATALOG_HEADERS },
+      { headers: localeResolution.cacheHeaders },
     );
   } catch (error) {
     return handleRouteError("Failed to fetch schedules", error);

--- a/src/lib/api/routes/academic-section-detail-action.ts
+++ b/src/lib/api/routes/academic-section-detail-action.ts
@@ -1,10 +1,10 @@
 import type { AppLocale } from "@/i18n/config";
 import { jsonResponse, notFound } from "@/lib/api/helpers";
-import { PUBLIC_LOCALE_CATALOG_HEADERS } from "@/lib/public-cache-control";
 
 export async function getSectionDetailAction(
   parsedJwId: number,
   locale: AppLocale,
+  cacheHeaders: HeadersInit,
 ) {
   const { findSectionDetailByJwId } = await import(
     "@/features/catalog/server/course-section-queries"
@@ -16,6 +16,6 @@ export async function getSectionDetailAction(
   }
 
   return jsonResponse(section, {
-    headers: PUBLIC_LOCALE_CATALOG_HEADERS,
+    headers: cacheHeaders,
   });
 }

--- a/src/lib/api/routes/academic-section-list-action.ts
+++ b/src/lib/api/routes/academic-section-list-action.ts
@@ -1,6 +1,5 @@
 import type { AppLocale } from "@/i18n/config";
 import { jsonResponse } from "@/lib/api/helpers";
-import { PUBLIC_LOCALE_CATALOG_HEADERS } from "@/lib/public-cache-control";
 import { cachedPublicRuntimeData } from "@/lib/public-runtime-cache";
 
 const SECTION_LIST_API_CACHE_TTL_MS = 60_000;
@@ -24,6 +23,7 @@ export async function listSectionsAction(
     pageSize: number;
   },
   locale: AppLocale,
+  cacheHeaders: HeadersInit,
 ) {
   const result = await cachedPublicRuntimeData(
     `api:sections:${JSON.stringify({ locale, parsedQuery, pagination })}`,
@@ -31,7 +31,7 @@ export async function listSectionsAction(
     () => listUncachedSectionsAction(parsedQuery, pagination, locale),
   );
   return jsonResponse(result, {
-    headers: PUBLIC_LOCALE_CATALOG_HEADERS,
+    headers: cacheHeaders,
   });
 }
 

--- a/src/lib/api/routes/academic-section-routes.ts
+++ b/src/lib/api/routes/academic-section-routes.ts
@@ -12,25 +12,34 @@ import {
   getSectionScheduleGroupsAction,
   getSectionSchedulesAction,
 } from "@/lib/api/routes/academic-section-schedule-actions";
-import { getRequestLocale } from "@/lib/api/routes/request-locale";
+import {
+  getRequestLocale,
+  resolvePublicCatalogLocale,
+} from "@/lib/api/routes/request-locale";
 
 export async function getSectionsRoute(request: Request) {
+  const localeResolution = resolvePublicCatalogLocale(request);
+  if (localeResolution instanceof Response) {
+    return localeResolution;
+  }
+
   const parsed = parseSectionsRouteQuery(request);
   if (parsed instanceof Response) {
     return parsed;
   }
 
   const { query: parsedQuery, pagination } = parsed;
+  const { locale: _locale, ...filters } = parsedQuery;
   try {
-    const locale = getRequestLocale(request);
     return await listSectionsAction(
       {
-        ...parsedQuery,
-        ids: parseIntegerList(parsedQuery.ids),
-        jwIds: parseIntegerList(parsedQuery.jwIds),
+        ...filters,
+        ids: parseIntegerList(filters.ids),
+        jwIds: parseIntegerList(filters.jwIds),
       },
       pagination,
-      locale,
+      localeResolution.locale,
+      localeResolution.cacheHeaders,
     );
   } catch (error) {
     return handleRouteError("Failed to fetch sections", error);
@@ -41,11 +50,20 @@ export async function getSectionDetailRoute(
   request: Request,
   params: { jwId: string },
 ) {
-  const locale = getRequestLocale(request);
+  const localeResolution = resolvePublicCatalogLocale(request);
+  if (localeResolution instanceof Response) {
+    return localeResolution;
+  }
+
   return withParsedSectionJwId(
     params,
     "Failed to fetch section",
-    (parsedJwId) => getSectionDetailAction(parsedJwId, locale),
+    (parsedJwId) =>
+      getSectionDetailAction(
+        parsedJwId,
+        localeResolution.locale,
+        localeResolution.cacheHeaders,
+      ),
   );
 }
 
@@ -53,7 +71,11 @@ export async function getSectionSchedulesRoute(
   request: Request,
   params: { jwId: string },
 ) {
-  const locale = getRequestLocale(request);
+  const localeResolution = resolvePublicCatalogLocale(request);
+  if (localeResolution instanceof Response) {
+    return localeResolution;
+  }
+
   const parsedQuery = parseSectionSchedulesRouteQuery(request);
   if (parsedQuery instanceof Response) return parsedQuery;
 
@@ -61,11 +83,16 @@ export async function getSectionSchedulesRoute(
     params,
     "Failed to fetch section schedules",
     (parsedJwId) =>
-      getSectionSchedulesAction(parsedJwId, locale, {
-        dateFrom: parsedQuery.dateFrom,
-        dateTo: parsedQuery.dateTo,
-        limit: parsedQuery.limit,
-      }),
+      getSectionSchedulesAction(
+        parsedJwId,
+        localeResolution.locale,
+        localeResolution.cacheHeaders,
+        {
+          dateFrom: parsedQuery.dateFrom,
+          dateTo: parsedQuery.dateTo,
+          limit: parsedQuery.limit,
+        },
+      ),
   );
 }
 
@@ -73,11 +100,20 @@ export async function getSectionScheduleGroupsRoute(
   request: Request,
   params: { jwId: string },
 ) {
-  const locale = getRequestLocale(request);
+  const localeResolution = resolvePublicCatalogLocale(request);
+  if (localeResolution instanceof Response) {
+    return localeResolution;
+  }
+
   return withParsedSectionJwId(
     params,
     "Failed to fetch schedule groups",
-    (parsedJwId) => getSectionScheduleGroupsAction(parsedJwId, locale),
+    (parsedJwId) =>
+      getSectionScheduleGroupsAction(
+        parsedJwId,
+        localeResolution.locale,
+        localeResolution.cacheHeaders,
+      ),
   );
 }
 

--- a/src/lib/api/routes/academic-section-schedule-actions.ts
+++ b/src/lib/api/routes/academic-section-schedule-actions.ts
@@ -4,11 +4,11 @@ import {
 } from "@/features/catalog/server/schedule-read-model";
 import type { AppLocale } from "@/i18n/config";
 import { jsonResponse, notFound } from "@/lib/api/helpers";
-import { PUBLIC_LOCALE_CATALOG_HEADERS } from "@/lib/public-cache-control";
 
 export async function getSectionSchedulesAction(
   parsedJwId: number,
   locale: AppLocale,
+  cacheHeaders: HeadersInit,
   filters: { dateFrom?: Date; dateTo?: Date; limit?: number } = {},
 ) {
   const result = await getSectionSchedulesByJwId({
@@ -24,13 +24,14 @@ export async function getSectionSchedulesAction(
   }
 
   return jsonResponse(result.schedules, {
-    headers: PUBLIC_LOCALE_CATALOG_HEADERS,
+    headers: cacheHeaders,
   });
 }
 
 export async function getSectionScheduleGroupsAction(
   parsedJwId: number,
   locale: AppLocale,
+  cacheHeaders: HeadersInit,
 ) {
   const result = await getSectionScheduleGroupsByJwId({
     locale,
@@ -42,6 +43,6 @@ export async function getSectionScheduleGroupsAction(
   }
 
   return jsonResponse(result.scheduleGroups, {
-    headers: PUBLIC_LOCALE_CATALOG_HEADERS,
+    headers: cacheHeaders,
   });
 }

--- a/src/lib/api/routes/academic-teacher-routes.ts
+++ b/src/lib/api/routes/academic-teacher-routes.ts
@@ -5,9 +5,8 @@ import {
   parseRouteQuery,
 } from "@/lib/api/helpers";
 import { parseResourceIdRouteParam } from "@/lib/api/routes/academic-route-helpers";
-import { getRequestLocale } from "@/lib/api/routes/request-locale";
+import { resolvePublicCatalogLocale } from "@/lib/api/routes/request-locale";
 import { teachersQuerySchema } from "@/lib/api/schemas/request-schemas";
-import { PUBLIC_LOCALE_CATALOG_HEADERS } from "@/lib/public-cache-control";
 import {
   cachedPublicRuntimeData,
   publicRuntimeCacheKey,
@@ -16,6 +15,11 @@ import {
 const TEACHERS_API_CACHE_TTL_MS = 60_000;
 
 export async function getTeachersRoute(request: Request) {
+  const localeResolution = resolvePublicCatalogLocale(request);
+  if (localeResolution instanceof Response) {
+    return localeResolution;
+  }
+
   const searchParams = new URL(request.url).searchParams;
   const parsed = parseRouteQuery(
     searchParams,
@@ -28,7 +32,8 @@ export async function getTeachersRoute(request: Request) {
   }
 
   const { query: parsedQuery, pagination } = parsed;
-  const locale = getRequestLocale(request);
+  const { locale: _locale, ...filters } = parsedQuery;
+  const { cacheHeaders, locale } = localeResolution;
 
   try {
     const result = await cachedPublicRuntimeData(
@@ -39,14 +44,14 @@ export async function getTeachersRoute(request: Request) {
           "@/features/catalog/server/course-section-queries"
         );
         return listTeacherSummaries({
-          filters: parsedQuery,
+          filters,
           locale,
           pagination,
         });
       },
     );
     return jsonResponse(result, {
-      headers: PUBLIC_LOCALE_CATALOG_HEADERS,
+      headers: cacheHeaders,
     });
   } catch (error) {
     return handleRouteError("Failed to fetch teachers", error);
@@ -61,12 +66,17 @@ export async function getTeacherDetailRoute(
     const parsedId = parseResourceIdRouteParam(params, "teacher ID");
     if (parsedId instanceof Response) return parsedId;
 
+    const localeResolution = resolvePublicCatalogLocale(request);
+    if (localeResolution instanceof Response) {
+      return localeResolution;
+    }
+
     const { findTeacherDetailById } = await import(
       "@/features/catalog/server/course-section-queries"
     );
     const teacher = await findTeacherDetailById(
       parsedId,
-      getRequestLocale(request),
+      localeResolution.locale,
     );
 
     if (!teacher) {
@@ -74,7 +84,7 @@ export async function getTeacherDetailRoute(
     }
 
     return jsonResponse(teacher, {
-      headers: PUBLIC_LOCALE_CATALOG_HEADERS,
+      headers: localeResolution.cacheHeaders,
     });
   } catch (error) {
     return handleRouteError("Failed to fetch teacher", error);

--- a/src/lib/api/routes/request-locale.ts
+++ b/src/lib/api/routes/request-locale.ts
@@ -1,4 +1,9 @@
-import { LOCALE_COOKIE, negotiateLocale } from "@/i18n/config";
+import { isAppLocale, LOCALE_COOKIE, negotiateLocale } from "@/i18n/config";
+import { jsonResponse } from "@/lib/api/helpers";
+import {
+  PRIVATE_LOCALE_CATALOG_HEADERS,
+  PUBLIC_LOCALE_CATALOG_HEADERS,
+} from "@/lib/public-cache-control";
 
 function getCookieValue(request: Request, name: string) {
   const cookies = request.headers.get("cookie") ?? "";
@@ -20,4 +25,30 @@ export function getRequestLocale(request: Request) {
     getCookieValue(request, LOCALE_COOKIE),
     request.headers.get("accept-language"),
   );
+}
+
+export function resolvePublicCatalogLocale(request: Request) {
+  const explicitLocale = new URL(request.url).searchParams.get("locale");
+
+  if (explicitLocale !== null) {
+    if (!isAppLocale(explicitLocale)) {
+      return jsonResponse(
+        { error: "Invalid locale" },
+        {
+          status: 400,
+          headers: PRIVATE_LOCALE_CATALOG_HEADERS,
+        },
+      );
+    }
+
+    return {
+      cacheHeaders: PUBLIC_LOCALE_CATALOG_HEADERS,
+      locale: explicitLocale,
+    } as const;
+  }
+
+  return {
+    cacheHeaders: PRIVATE_LOCALE_CATALOG_HEADERS,
+    locale: getRequestLocale(request),
+  } as const;
 }

--- a/src/lib/api/schemas/catalog-query-schemas.ts
+++ b/src/lib/api/schemas/catalog-query-schemas.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import { APP_LOCALES } from "@/i18n/config";
 import {
   dateQuerySchema,
   deprecatedPaginationLimitParam,
@@ -27,7 +28,11 @@ const sectionScheduleLimitSchema = integerQueryRangeSchema({
   message: "Limit must be between 1 and 200",
 });
 
-export const sectionsQuerySchema = z.object({
+export const catalogLocaleQuerySchema = z.object({
+  locale: z.enum(APP_LOCALES).optional(),
+});
+
+export const sectionsQuerySchema = catalogLocaleQuerySchema.extend({
   courseId: integerStringSchema.optional(),
   courseJwId: integerStringSchema.optional(),
   semesterId: integerStringSchema.optional(),
@@ -44,7 +49,7 @@ export const sectionsQuerySchema = z.object({
   limit: deprecatedPaginationLimitParam(catalogPaginationPageSizeSchema),
 });
 
-export const schedulesQuerySchema = z.object({
+export const schedulesQuerySchema = catalogLocaleQuerySchema.extend({
   sectionId: integerQuerySchema.optional(),
   sectionJwId: integerQuerySchema.optional(),
   sectionCode: z.string().trim().min(1).optional(),
@@ -60,13 +65,13 @@ export const schedulesQuerySchema = z.object({
   limit: deprecatedPaginationLimitParam(catalogPaginationPageSizeSchema),
 });
 
-export const sectionSchedulesQuerySchema = z.object({
+export const sectionSchedulesQuerySchema = catalogLocaleQuerySchema.extend({
   dateFrom: dateQuerySchema().optional(),
   dateTo: dateQuerySchema().optional(),
   limit: sectionScheduleLimitSchema.optional(),
 });
 
-export const teachersQuerySchema = z.object({
+export const teachersQuerySchema = catalogLocaleQuerySchema.extend({
   departmentId: integerStringSchema.optional(),
   search: z.string().trim().optional(),
   page: integerStringSchema.optional(),
@@ -74,7 +79,7 @@ export const teachersQuerySchema = z.object({
   limit: deprecatedPaginationLimitParam(catalogPaginationPageSizeSchema),
 });
 
-export const coursesQuerySchema = z.object({
+export const coursesQuerySchema = catalogLocaleQuerySchema.extend({
   search: z.string().trim().optional(),
   educationLevelId: integerStringSchema.optional(),
   categoryId: integerStringSchema.optional(),

--- a/src/lib/api/schemas/request-query-schemas.ts
+++ b/src/lib/api/schemas/request-query-schemas.ts
@@ -5,6 +5,7 @@ export {
   adminUsersQuerySchema,
 } from "./admin-query-schemas";
 export {
+  catalogLocaleQuerySchema,
   coursesQuerySchema,
   schedulesQuerySchema,
   sectionSchedulesQuerySchema,

--- a/src/lib/public-cache-control.ts
+++ b/src/lib/public-cache-control.ts
@@ -5,3 +5,9 @@ export const PUBLIC_LOCALE_CATALOG_HEADERS = {
   "Cache-Control": PUBLIC_CATALOG_CACHE_CONTROL,
   Vary: "Accept-Language, Cookie",
 } as const;
+
+export const PRIVATE_LOCALE_CATALOG_HEADERS = {
+  "Cache-Control": "private, no-store",
+  "Cloudflare-CDN-Cache-Control": "no-store",
+  Vary: "Accept-Language, Cookie",
+} as const;

--- a/src/routes/api/courses/[jwId]/+server.ts
+++ b/src/routes/api/courses/[jwId]/+server.ts
@@ -5,6 +5,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
 /**
  * Get course.
  * @pathParams jwIdPathParamsSchema
+ * @params catalogLocaleQuerySchema
  * @response courseDetailSchema
  * @response 400:openApiErrorSchema
  * @response 404:openApiErrorSchema

--- a/src/routes/api/sections/[jwId]/+server.ts
+++ b/src/routes/api/sections/[jwId]/+server.ts
@@ -5,6 +5,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
 /**
  * Get section.
  * @pathParams jwIdPathParamsSchema
+ * @params catalogLocaleQuerySchema
  * @response sectionDetailSchema
  * @response 400:openApiErrorSchema
  * @response 404:openApiErrorSchema

--- a/src/routes/api/sections/[jwId]/schedule-groups/+server.ts
+++ b/src/routes/api/sections/[jwId]/schedule-groups/+server.ts
@@ -5,6 +5,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
 /**
  * Get schedule groups.
  * @pathParams jwIdPathParamsSchema
+ * @params catalogLocaleQuerySchema
  * @response 200:array
  * @response 404:openApiErrorSchema
  */

--- a/src/routes/api/teachers/[id]/+server.ts
+++ b/src/routes/api/teachers/[id]/+server.ts
@@ -5,6 +5,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
 /**
  * Get teacher.
  * @pathParams teacherIdPathParamsSchema
+ * @params catalogLocaleQuerySchema
  * @response teacherDetailSchema
  * @response 400:openApiErrorSchema
  * @response 404:openApiErrorSchema

--- a/tests/e2e/src/app/api/courses/test.ts
+++ b/tests/e2e/src/app/api/courses/test.ts
@@ -5,8 +5,9 @@
  * - `GET /api/courses` — List courses with optional search and pagination.
  *
  * ## Request
- * - Query: `search` (optional, matches nameCn/nameEn/code, case-insensitive),
- *          `page` (optional, default 1), `pageSize` (optional), and deprecated `limit` alias
+ * - Query: `locale` (optional, en-us/zh-cn), `search` (optional, matches
+ *          nameCn/nameEn/code, case-insensitive), `page` (optional, default 1),
+ *          `pageSize` (optional), and deprecated `limit` alias
  *
  * ## Response
  * - 200: `{ data: Course[], pagination: { page, pageSize, total, totalPages } }`
@@ -52,6 +53,31 @@ test.describe("GET /api/courses 接口", () => {
     expect(typeof body.pagination?.total).toBe("number");
     expect(typeof body.pagination?.totalPages).toBe("number");
     expect(body.pagination?.totalPages).toBeGreaterThanOrEqual(1);
+  });
+
+  test("仅显式 locale URL 变体使用共享缓存", async ({ request }) => {
+    const explicit = await request.get("/api/courses?locale=en-us&pageSize=1", {
+      headers: {
+        "accept-language": "zh-CN",
+        cookie: "NEXT_LOCALE=zh-cn",
+      },
+    });
+    expect(explicit.status()).toBe(200);
+    expect(explicit.headers()["cache-control"]).toBe(
+      "public, max-age=0, s-maxage=60, stale-while-revalidate=300",
+    );
+
+    const fallback = await request.get("/api/courses?pageSize=1", {
+      headers: { "accept-language": "en-US" },
+    });
+    expect(fallback.status()).toBe(200);
+    expect(fallback.headers()["cache-control"]).toBe("private, no-store");
+    expect(fallback.headers()["cloudflare-cdn-cache-control"]).toBe("no-store");
+
+    const invalid = await request.get("/api/courses?locale=fr-fr");
+    expect(invalid.status()).toBe(400);
+    expect(invalid.headers()["cache-control"]).toBe("private, no-store");
+    expect(invalid.headers()["cloudflare-cdn-cache-control"]).toBe("no-store");
   });
 
   test("按课程代码搜索返回 seed 课程", async ({ request }) => {

--- a/tests/unit/academic-list-cache.test.ts
+++ b/tests/unit/academic-list-cache.test.ts
@@ -45,10 +45,14 @@ describe("academic 列表路由缓存", () => {
     );
 
     const first = await getCoursesRoute(
-      new Request("https://example.test/api/courses?search=math&page=1"),
+      new Request(
+        "https://example.test/api/courses?locale=en-us&search=math&page=1",
+      ),
     );
     const second = await getCoursesRoute(
-      new Request("https://example.test/api/courses?page=1&search=math"),
+      new Request(
+        "https://example.test/api/courses?page=1&search=math&locale=en-us",
+      ),
     );
 
     expect(first.headers.get("Cache-Control")).toBe(
@@ -65,10 +69,14 @@ describe("academic 列表路由缓存", () => {
     );
 
     const first = await getTeachersRoute(
-      new Request("https://example.test/api/teachers?search=li&page=1"),
+      new Request(
+        "https://example.test/api/teachers?locale=zh-cn&search=li&page=1",
+      ),
     );
     const second = await getTeachersRoute(
-      new Request("https://example.test/api/teachers?page=1&search=li"),
+      new Request(
+        "https://example.test/api/teachers?page=1&search=li&locale=zh-cn",
+      ),
     );
 
     expect(first.headers.get("Cache-Control")).toBe(
@@ -77,5 +85,23 @@ describe("academic 列表路由缓存", () => {
     expect(first.headers.get("Vary")).toBe("Accept-Language, Cookie");
     expect(second.status).toBe(200);
     expect(listTeacherSummariesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not publicly cache a locale negotiated from request headers", async () => {
+    const { getCoursesRoute } = await import(
+      "@/lib/api/routes/academic-course-routes"
+    );
+
+    const response = await getCoursesRoute(
+      new Request("https://example.test/api/courses?page=1", {
+        headers: { "accept-language": "en-US" },
+      }),
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
+      "no-store",
+    );
+    expect(response.headers.get("Vary")).toBe("Accept-Language, Cookie");
   });
 });

--- a/tests/unit/academic-route-locale.test.ts
+++ b/tests/unit/academic-route-locale.test.ts
@@ -304,4 +304,85 @@ describe("academic REST 语言适配器", () => {
       sectionJwId: 123,
     });
   });
+
+  it("仅对 URL 中显式支持的语言返回公共缓存策略", async () => {
+    const [
+      { getCourseDetailRoute, getCoursesRoute },
+      { getSchedulesRoute },
+      {
+        getSectionDetailRoute,
+        getSectionScheduleGroupsRoute,
+        getSectionSchedulesRoute,
+        getSectionsRoute,
+      },
+      { getTeacherDetailRoute, getTeachersRoute },
+    ] = await Promise.all([
+      import("@/lib/api/routes/academic-course-routes"),
+      import("@/lib/api/routes/academic-schedule-routes"),
+      import("@/lib/api/routes/academic-section-routes"),
+      import("@/lib/api/routes/academic-teacher-routes"),
+    ]);
+
+    const responses = [
+      await getCoursesRoute(request("/api/courses?locale=zh-cn")),
+      await getCourseDetailRoute(request("/api/courses/123?locale=zh-cn"), {
+        jwId: "123",
+      }),
+      await getTeachersRoute(request("/api/teachers?locale=zh-cn")),
+      await getTeacherDetailRoute(request("/api/teachers/456?locale=zh-cn"), {
+        id: "456",
+      }),
+      await getSectionsRoute(request("/api/sections?locale=zh-cn")),
+      await getSectionDetailRoute(request("/api/sections/123?locale=zh-cn"), {
+        jwId: "123",
+      }),
+      await getSchedulesRoute(request("/api/schedules?locale=zh-cn")),
+      await getSectionSchedulesRoute(
+        request("/api/sections/123/schedules?locale=zh-cn"),
+        { jwId: "123" },
+      ),
+      await getSectionScheduleGroupsRoute(
+        request("/api/sections/123/schedule-groups?locale=zh-cn"),
+        { jwId: "123" },
+      ),
+    ];
+
+    for (const response of responses) {
+      expect(response.headers.get("Cache-Control")).toBe(
+        "public, max-age=0, s-maxage=60, stale-while-revalidate=300",
+      );
+      expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    }
+
+    expect(findCourseDetailByJwIdMock).toHaveBeenCalledWith(123, "zh-cn");
+    expect(findTeacherDetailByIdMock).toHaveBeenCalledWith(456, "zh-cn");
+    expect(findSectionDetailByJwIdMock).toHaveBeenCalledWith(123, "zh-cn");
+    expect(listPublicSchedulesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: "zh-cn" }),
+    );
+    expect(getSectionSchedulesByJwIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: "zh-cn" }),
+    );
+    expect(getSectionScheduleGroupsByJwIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: "zh-cn" }),
+    );
+  });
+
+  it("在进入目录读取前拒绝无效的显式语言", async () => {
+    const { getCourseDetailRoute } = await import(
+      "@/lib/api/routes/academic-course-routes"
+    );
+
+    const response = await getCourseDetailRoute(
+      request("/api/courses/123?locale=fr-fr"),
+      { jwId: "123" },
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
+      "no-store",
+    );
+    expect(findCourseDetailByJwIdMock).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/public-catalog-locale.test.ts
+++ b/tests/unit/public-catalog-locale.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { resolvePublicCatalogLocale } from "@/lib/api/routes/request-locale";
+import {
+  PRIVATE_LOCALE_CATALOG_HEADERS,
+  PUBLIC_LOCALE_CATALOG_HEADERS,
+} from "@/lib/public-cache-control";
+
+function expectHeaders(
+  headers: Headers,
+  expected: Readonly<Record<string, string>>,
+) {
+  for (const [name, value] of Object.entries(expected)) {
+    expect(headers.get(name)).toBe(value);
+  }
+}
+
+describe("public catalog locale cache policy", () => {
+  it.each([
+    "en-us",
+    "zh-cn",
+  ] as const)("publicly caches explicit %s URL variants", (locale) => {
+    const result = resolvePublicCatalogLocale(
+      new Request(`https://example.test/api/courses?locale=${locale}&page=1`, {
+        headers: {
+          "accept-language": locale === "en-us" ? "zh-CN" : "en-US",
+          cookie: `NEXT_LOCALE=${locale === "en-us" ? "zh-cn" : "en-us"}`,
+        },
+      }),
+    );
+
+    expect(result).not.toBeInstanceOf(Response);
+    if (result instanceof Response) return;
+
+    expect(result.locale).toBe(locale);
+    expect(result.cacheHeaders).toBe(PUBLIC_LOCALE_CATALOG_HEADERS);
+  });
+
+  it("keeps a cookie-derived locale out of browser and CDN caches", () => {
+    const result = resolvePublicCatalogLocale(
+      new Request("https://example.test/api/courses?page=1", {
+        headers: {
+          "accept-language": "en-US",
+          cookie: "NEXT_LOCALE=zh-cn",
+        },
+      }),
+    );
+
+    expect(result).not.toBeInstanceOf(Response);
+    if (result instanceof Response) return;
+
+    expect(result.locale).toBe("zh-cn");
+    expect(result.cacheHeaders).toBe(PRIVATE_LOCALE_CATALOG_HEADERS);
+  });
+
+  it("keeps an Accept-Language-derived locale out of shared caches", () => {
+    const result = resolvePublicCatalogLocale(
+      new Request("https://example.test/api/courses?page=1", {
+        headers: { "accept-language": "en-US,en;q=0.9" },
+      }),
+    );
+
+    expect(result).not.toBeInstanceOf(Response);
+    if (result instanceof Response) return;
+
+    expect(result.locale).toBe("en-us");
+    expect(result.cacheHeaders).toBe(PRIVATE_LOCALE_CATALOG_HEADERS);
+  });
+
+  it("rejects an unsupported explicit locale without caching the error", async () => {
+    const result = resolvePublicCatalogLocale(
+      new Request("https://example.test/api/courses?locale=fr-fr"),
+    );
+
+    expect(result).toBeInstanceOf(Response);
+    if (!(result instanceof Response)) return;
+
+    expect(result.status).toBe(400);
+    await expect(result.json()).resolves.toEqual({ error: "Invalid locale" });
+    expectHeaders(result.headers, PRIVATE_LOCALE_CATALOG_HEADERS);
+  });
+});


### PR DESCRIPTION
## Goal

Prevent Cookie/`Accept-Language`-derived catalog responses from sharing a Cloudflare CDN cache entry while preserving short public caching for locale variants whose identity is explicit in the URL.

Closes #511.

## Changed Surfaces

- Added a shared catalog locale resolver that returns both the selected locale and cache policy.
- `?locale=en-us|zh-cn` overrides request headers and remains publicly cacheable because the query is part of the default cache key.
- Missing `locale` keeps the existing Cookie -> `Accept-Language` -> default negotiation, but returns `Cache-Control: private, no-store` and `Cloudflare-CDN-Cache-Control: no-store`.
- Unsupported explicit locales return 400 with the same browser/CDN no-store policy.
- Applied the policy consistently to course, teacher, section, public schedule, section schedule, and schedule-group GET routes. SSR HTML caching is unchanged.
- Added the supported locale query to route schemas and generated OpenAPI.

## Evidence

- `bunx biome check`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` — 196 files / 1167 tests passed
- `bunx vitest run --config vitest.integration.config.ts` — 31 files / 180 tests passed
- Focused catalog Playwright runs — 35 passed, section API directory 24 passed, final courses/cache-header run 12 passed
- `bun run build`
- `bunx wrangler deploy --dry-run --outdir /tmp/life-ustc-cache-locale-wrangler`
- `bun run openapi:check` after commit

A full 682-test Playwright run was attempted and stopped after the first 93 tests because eight unrelated admin seed/state assertions failed (missing seeded users/suspensions/descriptions/homework and a pre-existing OAuth empty-state assumption); 78 tests had passed and 596 had not run. The affected catalog API suites were then rerun against a freshly migrated and seeded isolated database and passed.

## Docs / Contracts

- Updated course, teacher, section, and schedule contracts with the explicit-locale shared-cache rule.
- Updated route OpenAPI annotations and regenerated `public/openapi.generated.json` with the optional enum locale query on all affected GET routes.
- REST behavior changes only; GraphQL and MCP already take request/tool locale independently and do not use this CDN response policy.

## Risk Areas

- Existing clients without an explicit locale remain behavior-compatible but lose shared CDN caching by design.
- Public caching is retained only for supported locale query values; the response is independent of Cookie/`Accept-Language` in that mode.
- This does not fix or expand SSR HTML caching, nor does it change the separate Cloudflare Browser Cache TTL configuration.
- Production cache behavior still needs the issue acceptance probe after deployment in both locale warming orders.

## Cleanup

No scratch reports, Playwright artifacts, temporary databases, Docker resources, or manual generated-file edits remain. The diff is limited to locale/cache policy, affected adapters/schemas/contracts, generated OpenAPI, and regression tests.
