### PR TITLE
perf(markdown): avoid parser during read hydration

### DIFF
--- a/docs/contracts/comment.json
+++ b/docs/contracts/comment.json
@@ -10,6 +10,7 @@
     "attached-to-object": "Comments must be attached to a specific object; no decontextualized public feed entry is provided.",
     "attached-object-types": "Attached objects include courses, sections, teachers, homework, and section-teacher relationships.",
     "rich-content": "Supports Markdown, math formulas, emoji, tables, replies, and reactions.",
+    "server-rendered-markdown": "Visible comment nodes include body as the source Markdown and renderedBody as sanitized server-rendered HTML. Web read surfaces consume renderedBody without rerunning the Markdown pipeline during hydration; REST and MCP full mode keep the shared serialized comment-node shape, while MCP compact modes omit renderedBody to avoid repeating the source Markdown in AI context.",
     "markdown-font-csp": "Production builds emit Markdown and KaTeX font files as same-origin assets instead of data URIs so every required math glyph can load under the configured font-src Content Security Policy.",
     "visibility-modes": "Supports public and signed-in-only audience visibility; anonymous posting is represented by comment.isAnonymous and hides identity from regular users while remaining traceable by admins in governance scenarios.",
     "shared-read-policy": "Web, REST, and MCP comment reads share the same target resolution, thread serialization, visibility filtering, author masking, reaction, attachment, and viewer action-flag logic; read-only paths must not create durable comment targets and valid empty section-teacher targets load as empty threads.",
@@ -69,7 +70,7 @@
         "routes": [
           {
             "path": "/api/comments",
-            "returns": "{ data: Comment[], pagination, meta: { hiddenCount: Int, viewer, target } }",
+            "returns": "{ data: Comment[] (including body and renderedBody), pagination, meta: { hiddenCount: Int, viewer, target } }",
             "notes": [
               "Accepts REST-compatible internal targetId plus public identifiers such as sectionJwId, courseJwId, teacherId, homeworkId, and sectionTeacherId.",
               "Returns 404 when the attached target entity does not exist.",
@@ -199,6 +200,7 @@
           "comment.author.name",
           "comment.author.image (avatar)",
           "comment.body (markdown-rendered)",
+          "comment.renderedBody (sanitized server-rendered HTML)",
           "comment.createdAt (timestamp)",
           "comment.updatedAt / edited timestamp",
           "comment.visibility badges",

--- a/docs/contracts/description.json
+++ b/docs/contracts/description.json
@@ -9,7 +9,8 @@
   "rules": {
     "supplement-not-comment": "Description is a Markdown supplement on an object, not equivalent to comments expressing personal opinions.",
     "attached-object-types": "Attached objects include courses, sections, teachers, homework, and similar.",
-    "platform-maintained": "When descriptions conflict with personal experiences in comments, descriptions are treated as platform-maintained information by default."
+    "platform-maintained": "When descriptions conflict with personal experiences in comments, descriptions are treated as platform-maintained information by default.",
+    "server-rendered-markdown": "Description payloads include content as the source Markdown and renderedHtml as sanitized server-rendered HTML. Web read surfaces consume renderedHtml without rerunning the Markdown pipeline during hydration; REST and MCP full mode keep the shared description payload, while MCP compact modes omit renderedHtml to avoid repeating the source Markdown in AI context."
   },
   "capabilities": {
     "object-description-section": {
@@ -20,7 +21,7 @@
         "routes": [
           {
             "path": "/api/descriptions",
-            "returns": "{ description, history, viewer }",
+            "returns": "{ description: { content, renderedHtml, ... }, history, viewer }",
             "notes": [
               "Inputs accept targetType plus targetId, or public identifiers such as sectionJwId, courseJwId, teacherId, homeworkId.",
               "Returns 404 when the attached target entity does not exist."
@@ -61,6 +62,7 @@
       "display": {
         "fields": [
           "description.content (markdown-rendered)",
+          "description.renderedHtml (sanitized server-rendered HTML)",
           "description.lastEditedBy.name",
           "description.lastEditedAt / updatedAt",
           "Edit button (if authorized)",

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -7947,6 +7947,9 @@
           "body": {
             "type": "string"
           },
+          "renderedBody": {
+            "type": "string"
+          },
           "visibility": {
             "type": "string"
           },
@@ -8098,6 +8101,7 @@
         "required": [
           "id",
           "body",
+          "renderedBody",
           "visibility",
           "status",
           "author",
@@ -8166,6 +8170,9 @@
             "type": "string"
           },
           "body": {
+            "type": "string"
+          },
+          "renderedBody": {
             "type": "string"
           },
           "visibility": {
@@ -8322,6 +8329,7 @@
         "required": [
           "id",
           "body",
+          "renderedBody",
           "visibility",
           "status",
           "author",
@@ -11653,6 +11661,9 @@
                 "format": "date-time",
                 "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
               },
+              "renderedHtml": {
+                "type": "string"
+              },
               "lastEditedBy": {
                 "nullable": true,
                 "type": "object",
@@ -11687,6 +11698,7 @@
               "content",
               "updatedAt",
               "lastEditedAt",
+              "renderedHtml",
               "lastEditedBy"
             ],
             "additionalProperties": false

--- a/src/features/comments/components/CommentThreadBody.svelte
+++ b/src/features/comments/components/CommentThreadBody.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import type { CommentNode } from "@/features/comments/server/comment-types";
-import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
-import MarkdownPreview from "$lib/components/MarkdownPreview.svelte";
+import RenderedMarkdown from "$lib/components/RenderedMarkdown.svelte";
 import CommentAttachmentCards from "./CommentAttachmentCards.svelte";
 import CommentLinkCards from "./CommentLinkCards.svelte";
 import CommentThreadEditForm from "./CommentThreadEditForm.svelte";
@@ -50,10 +49,9 @@ export let visibilityOptions: CommentSelectOption[];
 {:else if comment.status === "deleted"}
   <p class="text-muted-foreground text-sm">{commentCopy.deletedMessage}</p>
 {:else}
-  <MarkdownPreview
+  <RenderedMarkdown
     class="break-words"
-    content={comment.body}
-    remarkPlugins={campusReferenceMarkdownPlugins}
+    html={comment.renderedBody}
   />
   <CommentLinkCards content={comment.body} copy={commentCopy} />
 {/if}

--- a/src/features/comments/server/comment-serialization-types.ts
+++ b/src/features/comments/server/comment-serialization-types.ts
@@ -31,6 +31,7 @@ export type CommentReactionSummary = {
 export type CommentNode = {
   id: string;
   body: string;
+  renderedBody: string;
   visibility: CommentVisibility;
   status: CommentStatus;
   author: CommentAuthorSummary | null;

--- a/src/features/comments/server/comment-types.ts
+++ b/src/features/comments/server/comment-types.ts
@@ -25,6 +25,7 @@ export type CommentReaction = {
 export type CommentNode = {
   id: string;
   body: string;
+  renderedBody: string;
   visibility: string;
   status: string;
   author: CommentAuthor | null;

--- a/src/features/comments/server/serialized-comment-node.ts
+++ b/src/features/comments/server/serialized-comment-node.ts
@@ -1,3 +1,5 @@
+import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
+import { renderMarkdown } from "@/lib/components/markdown-preview-renderer";
 import { toShanghaiIsoString } from "@/lib/time/serialize-date-output";
 import { canViewerAccessCommentAttachment } from "./comment-attachment-access";
 import { canViewerWriteCommentInteraction } from "./comment-interaction-policy";
@@ -46,6 +48,9 @@ export function buildVisibleCommentNode({
   return {
     id: comment.id,
     body: comment.body,
+    renderedBody: renderMarkdown(comment.body, {
+      remarkPlugins: campusReferenceMarkdownPlugins,
+    }),
     visibility: comment.visibility,
     status,
     author,

--- a/src/features/descriptions/components/DescriptionReadPanel.svelte
+++ b/src/features/descriptions/components/DescriptionReadPanel.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import { formatDescriptionCopy } from "@/features/descriptions/lib/description-card-actions";
-import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
-import MarkdownPreview from "$lib/components/MarkdownPreview.svelte";
+import RenderedMarkdown from "$lib/components/RenderedMarkdown.svelte";
 import * as Empty from "$lib/components/ui/empty/index.js";
 import * as Tabs from "$lib/components/ui/tabs/index.js";
 import DescriptionHistoryList from "./DescriptionHistoryList.svelte";
@@ -42,10 +41,7 @@ function handlePanelTabChange(value: string) {
 
   <Tabs.Content value="description">
     {#if description.content}
-      <MarkdownPreview
-        content={description.content}
-        remarkPlugins={campusReferenceMarkdownPlugins}
-      />
+      <RenderedMarkdown html={description.renderedHtml} />
     {:else}
       <Empty.Root class="min-h-24">
         <Empty.Header>

--- a/src/features/descriptions/lib/description-payload-types.ts
+++ b/src/features/descriptions/lib/description-payload-types.ts
@@ -10,6 +10,7 @@ export type EditorSummary = {
 export type DescriptionData = {
   id: string | null;
   content: string;
+  renderedHtml: string;
   updatedAt: string | null;
   lastEditedAt: string | null;
   lastEditedBy: EditorSummary | null;

--- a/src/features/descriptions/server/description-payload.ts
+++ b/src/features/descriptions/server/description-payload.ts
@@ -5,6 +5,8 @@ import type {
   DescriptionViewer,
   EditorSummary,
 } from "@/features/descriptions/lib/description-payload-types";
+import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
+import { renderMarkdown } from "@/lib/components/markdown-preview-renderer";
 
 export type {
   DescriptionData,
@@ -38,6 +40,7 @@ export function emptyDescriptionData(): DescriptionData {
   return {
     id: null,
     content: "",
+    renderedHtml: "",
     updatedAt: null,
     lastEditedAt: null,
     lastEditedBy: null,
@@ -62,6 +65,9 @@ export function serializeDescriptionRecord(
   return {
     id: description.id,
     content: description.content ?? "",
+    renderedHtml: renderMarkdown(description.content ?? "", {
+      remarkPlugins: campusReferenceMarkdownPlugins,
+    }),
     updatedAt: description.updatedAt
       ? toShanghaiIsoString(description.updatedAt)
       : null,

--- a/src/features/section-detail/components/SectionHomeworkReadOnlySummary.svelte
+++ b/src/features/section-detail/components/SectionHomeworkReadOnlySummary.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
-import MarkdownPreview from "$lib/components/MarkdownPreview.svelte";
+import RenderedMarkdown from "$lib/components/RenderedMarkdown.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
 import * as Item from "$lib/components/ui/item/index.js";
 import type {
@@ -17,10 +16,20 @@ export let homeworkCopy: SectionHomeworkCopy;
 <Item.Root variant="muted" class="items-start">
   <Item.Content>
     {#if homework.description?.content}
-      <MarkdownPreview
-        content={homework.description.content}
-        remarkPlugins={campusReferenceMarkdownPlugins}
-      />
+      {#if homework.description.renderedHtml}
+        <RenderedMarkdown html={homework.description.renderedHtml} />
+      {:else}
+        {#await Promise.all([
+          import("$lib/components/MarkdownPreview.svelte"),
+          import("@/features/markdown/lib/campus-reference-markdown"),
+        ]) then [previewModule, markdownModule]}
+          {@const Preview = previewModule.default}
+          <Preview
+            content={homework.description.content}
+            remarkPlugins={markdownModule.campusReferenceMarkdownPlugins}
+          />
+        {/await}
+      {/if}
     {:else}
       <Item.Description>{homeworkCopy.descriptionEmpty}</Item.Description>
     {/if}

--- a/src/features/section-detail/components/section-homework-display-types.ts
+++ b/src/features/section-detail/components/section-homework-display-types.ts
@@ -49,6 +49,7 @@ export type SectionHomeworkDisplay = {
   completion: { completedAt: string | null } | null;
   description?: {
     content?: string | null;
+    renderedHtml?: string;
   } | null;
   id: string;
   isMajor: boolean;

--- a/src/features/section-detail/lib/section-detail-controller-types.ts
+++ b/src/features/section-detail/lib/section-detail-controller-types.ts
@@ -364,7 +364,7 @@ export type SectionHomework = {
   completion: { completedAt: string | null } | null;
   commentCount?: number;
   createdById?: string | null;
-  description?: { content?: string | null } | null;
+  description?: { content?: string | null; renderedHtml?: string } | null;
   id: string;
   isMajor: boolean;
   publishedAt?: string | Date | null;

--- a/src/features/section-detail/server/section-detail-homework-data.ts
+++ b/src/features/section-detail/server/section-detail-homework-data.ts
@@ -1,5 +1,7 @@
 import { listSectionHomeworksWithAudit } from "@/features/homeworks/server/homework-list-read-model";
+import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import type { SectionDetailPageData } from "@/features/section-detail/lib/section-detail-controller-types";
+import { renderMarkdown } from "@/lib/components/markdown-preview-renderer";
 import {
   serializeDatesDeep,
   toShanghaiIsoString,
@@ -22,6 +24,15 @@ export async function getSectionHomeworkData(
         serializeDatesDeep(homework);
       return {
         ...scopedHomework,
+        description: scopedHomework.description
+          ? {
+              ...scopedHomework.description,
+              renderedHtml: renderMarkdown(
+                scopedHomework.description.content ?? "",
+                { remarkPlugins: campusReferenceMarkdownPlugins },
+              ),
+            }
+          : null,
         completion: homework.completion
           ? {
               completedAt: toShanghaiIsoString(homework.completion.completedAt),

--- a/src/lib/api/schemas/comment-node-response-schema.ts
+++ b/src/lib/api/schemas/comment-node-response-schema.ts
@@ -28,6 +28,7 @@ export const commentReactionSummarySchema = z.object({
 export type CommentNode = {
   id: string;
   body: string;
+  renderedBody: string;
   visibility: string;
   status: string;
   author: z.infer<typeof commentAuthorSummarySchema> | null;
@@ -52,6 +53,7 @@ export const commentNodeSchema: z.ZodType<CommentNode> = z.lazy(() =>
   z.object({
     id: z.string(),
     body: z.string(),
+    renderedBody: z.string(),
     visibility: z.string(),
     status: z.string(),
     author: commentAuthorSummarySchema.nullable(),

--- a/src/lib/api/schemas/descriptions-response-schemas.ts
+++ b/src/lib/api/schemas/descriptions-response-schemas.ts
@@ -46,6 +46,7 @@ export const descriptionDetailSchema = descriptionBaseSchema
   .pick({ id: true, content: true, updatedAt: true, lastEditedAt: true })
   .extend({
     id: z.string().nullable(),
+    renderedHtml: z.string(),
     lastEditedBy: z
       .object({
         id: z.string(),

--- a/src/lib/components/MarkdownEditor.svelte
+++ b/src/lib/components/MarkdownEditor.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import type { ComponentProps } from "svelte";
 import type { PluggableList } from "unified";
-import MarkdownPreview from "$lib/components/MarkdownPreview.svelte";
 import { Button } from "$lib/components/ui/button/index.js";
 import * as InputGroup from "$lib/components/ui/input-group/index.js";
 import * as Tabs from "$lib/components/ui/tabs/index.js";
@@ -102,7 +101,12 @@ function setActiveTab(value: string) {
       </div>
     </Tabs.Content>
     <Tabs.Content value="preview" class="m-0 min-h-32 p-3">
-      <MarkdownPreview content={value} emptyLabel={previewEmptyLabel} {remarkPlugins} />
+      {#if activeTab === "preview"}
+        {#await import("$lib/components/MarkdownPreview.svelte") then previewModule}
+          {@const Preview = previewModule.default}
+          <Preview content={value} emptyLabel={previewEmptyLabel} {remarkPlugins} />
+        {/await}
+      {/if}
     </Tabs.Content>
   </Tabs.Root>
 

--- a/src/lib/components/RenderedMarkdown.svelte
+++ b/src/lib/components/RenderedMarkdown.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+import * as Empty from "$lib/components/ui/empty/index.js";
+import { cn } from "$lib/utils.js";
+import "$lib/components/markdown-preview.css";
+import "katex/dist/katex.min.css";
+
+export let html = "";
+export let emptyLabel = "";
+let className = "";
+
+export { className as class };
+</script>
+
+<div class={cn("markdown-preview grid gap-3 text-sm leading-6", className)} data-slot="markdown-preview">
+  {#if html}
+    {@html html}
+  {:else if emptyLabel}
+    <Empty.Root class="min-h-24">
+      <Empty.Header>
+        <Empty.Description>{emptyLabel}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
+  {/if}
+</div>

--- a/src/lib/mcp/compact-dispatch.ts
+++ b/src/lib/mcp/compact-dispatch.ts
@@ -205,6 +205,8 @@ export const EVENT_PAYLOAD_COMPACTORS: Record<string, (v: unknown) => unknown> =
     todo_due: compactTodo,
   };
 
+const COMPACT_OMITTED_KEYS = new Set(["renderedBody", "renderedHtml"]);
+
 export function compactEvents(
   value: unknown[],
   fallbackCompact: (value: unknown) => unknown,
@@ -231,6 +233,9 @@ export function compactMcpPayload(value: unknown): unknown {
 
   const out: Record<string, unknown> = {};
   for (const [key, fieldValue] of Object.entries(value)) {
+    if (COMPACT_OMITTED_KEYS.has(key)) {
+      continue;
+    }
     if (Object.hasOwn(KEY_COMPACTORS, key)) {
       out[key] = KEY_COMPACTORS[key](fieldValue);
       continue;

--- a/src/lib/mcp/tool-output-schemas.ts
+++ b/src/lib/mcp/tool-output-schemas.ts
@@ -5,14 +5,23 @@ import {
   paginatedSemesterResponseSchema,
   paginatedTeacherResponseSchema,
 } from "@/lib/api/schemas/academic-paginated-response-schemas";
-import { commentNodeSchema } from "@/lib/api/schemas/comment-node-response-schema";
+import {
+  commentAttachmentSummarySchema,
+  commentAuthorSummarySchema,
+  commentReactionSummarySchema,
+} from "@/lib/api/schemas/comment-node-response-schema";
 import { commentsListResponseSchema } from "@/lib/api/schemas/comments-response-schemas";
+import {
+  descriptionDetailSchema,
+  descriptionHistoryEntrySchema,
+} from "@/lib/api/schemas/descriptions-response-schemas";
 import {
   matchSectionCodesResponseSchema,
   meResponseSchema,
   successResponseSchema,
   todoCountsSchema,
   todoItemSchema,
+  viewerContextSchema,
 } from "@/lib/api/schemas/misc-response-schema-core";
 import { dateTimeSchema } from "@/lib/api/schemas/response-schema-primitives";
 import { paginatedScheduleResponseSchema } from "@/lib/api/schemas/schedule-response-schema-core";
@@ -303,12 +312,119 @@ const uploadListMcpSchema = objectOutputSchema({
   meta: uploadsListResponseSchema.shape.meta,
 });
 
-const commentListMcpSchema = objectOutputSchema({
-  found: z.boolean(),
-  data: collectionOutputSchema(commentNodeSchema),
-  pagination: commentsListResponseSchema.shape.pagination,
-  meta: commentsListResponseSchema.shape.meta,
-});
+function createMcpCommentNodeSchema(includeRenderedBody: boolean): z.ZodType {
+  let schema: z.ZodType;
+  schema = z.lazy(() =>
+    z
+      .object({
+        id: z.string(),
+        body: z.string(),
+        ...(includeRenderedBody ? { renderedBody: z.string() } : {}),
+        visibility: z.string(),
+        status: z.string(),
+        author: commentAuthorSummarySchema.nullable(),
+        authorHidden: z.boolean(),
+        isAnonymous: z.boolean(),
+        isAuthor: z.boolean(),
+        createdAt: dateTimeSchema,
+        updatedAt: dateTimeSchema,
+        parentId: z.string().nullable(),
+        rootId: z.string().nullable(),
+        replies: z.array(schema),
+        attachments: z.array(commentAttachmentSummarySchema),
+        reactions: z.array(commentReactionSummarySchema),
+        canReact: z.boolean(),
+        canReply: z.boolean(),
+        canEdit: z.boolean(),
+        canDelete: z.boolean(),
+        canModerate: z.boolean(),
+      })
+      .strict(),
+  );
+  return schema;
+}
+
+const compactCommentNodeSchema = createMcpCommentNodeSchema(false);
+const fullCommentNodeSchema = createMcpCommentNodeSchema(true);
+const commentNodeMcpSchema = z.union([
+  compactCommentNodeSchema,
+  fullCommentNodeSchema,
+]);
+
+const compactDescriptionDetailSchema = descriptionDetailSchema
+  .omit({ renderedHtml: true })
+  .strict();
+const descriptionDetailMcpSchema = z.union([
+  compactDescriptionDetailSchema,
+  descriptionDetailSchema.strict(),
+]);
+
+function commentListOutputSchema(commentSchema: z.ZodType) {
+  return objectOutputSchema({
+    found: z.boolean(),
+    data: collectionOutputSchema(commentSchema),
+    pagination: commentsListResponseSchema.shape.pagination,
+    meta: commentsListResponseSchema.shape.meta,
+  });
+}
+
+function commentThreadOutputSchema(commentSchema: z.ZodType) {
+  return objectOutputSchema({
+    thread: collectionOutputSchema(commentSchema),
+    focusId: z.string(),
+    hiddenCount: z.number().int().nonnegative(),
+    viewer: z.unknown(),
+    target: z.unknown(),
+  });
+}
+
+function descriptionOutputSchema(descriptionSchema: z.ZodType) {
+  return objectOutputSchema({
+    target: z.unknown(),
+    description: descriptionSchema,
+    history: collectionOutputSchema(descriptionHistoryEntrySchema),
+    viewer: viewerContextSchema,
+  });
+}
+
+function descriptionUpsertOutputSchema(descriptionSchema: z.ZodType) {
+  return objectOutputSchema({
+    id: z.string(),
+    updated: z.boolean(),
+    target: z.unknown(),
+    description: descriptionSchema,
+    history: collectionOutputSchema(descriptionHistoryEntrySchema),
+    viewer: viewerContextSchema,
+  });
+}
+
+const commentListMcpSchema = commentListOutputSchema(commentNodeMcpSchema);
+const commentThreadMcpSchema = commentThreadOutputSchema(commentNodeMcpSchema);
+const descriptionMcpSchema = descriptionOutputSchema(
+  descriptionDetailMcpSchema,
+);
+const descriptionUpsertMcpSchema = descriptionUpsertOutputSchema(
+  descriptionDetailMcpSchema,
+);
+
+const MARKDOWN_MODE_OUTPUT_SCHEMAS = {
+  list_comments: {
+    default: commentListOutputSchema(compactCommentNodeSchema),
+    full: commentListOutputSchema(fullCommentNodeSchema),
+  },
+  get_comment_thread: {
+    default: commentThreadOutputSchema(compactCommentNodeSchema),
+    full: commentThreadOutputSchema(fullCommentNodeSchema),
+  },
+  get_description: {
+    default: descriptionOutputSchema(compactDescriptionDetailSchema),
+    full: descriptionOutputSchema(descriptionDetailSchema.strict()),
+  },
+  upsert_description: {
+    default: descriptionUpsertOutputSchema(compactDescriptionDetailSchema),
+    full: descriptionUpsertOutputSchema(descriptionDetailSchema.strict()),
+  },
+} satisfies Record<string, Record<"default" | "full", McpToolOutputSchema>>;
 
 const matchSectionCodesMcpSchema = objectOutputSchema({
   ...matchSectionCodesResponseSchema.shape,
@@ -399,13 +515,7 @@ const TOOL_OUTPUT_SCHEMAS: Record<string, McpToolOutputSchema> = {
   get_my_7days_timeline: topLevelOutputSchema(["range", "total", "events"]),
 
   list_comments: commentListMcpSchema,
-  get_comment_thread: topLevelOutputSchema([
-    "thread",
-    "focusId",
-    "hiddenCount",
-    "viewer",
-    "target",
-  ]),
+  get_comment_thread: commentThreadMcpSchema,
   create_comment: objectOutputSchema({ success: z.boolean(), id: z.string() }),
   update_own_comment: topLevelOutputSchema(["comment"]),
   delete_own_comment: objectOutputSchemaFromApi(successResponseSchema),
@@ -418,20 +528,8 @@ const TOOL_OUTPUT_SCHEMAS: Record<string, McpToolOutputSchema> = {
     changed: z.boolean(),
   }),
 
-  get_description: topLevelOutputSchema([
-    "target",
-    "description",
-    "history",
-    "viewer",
-  ]),
-  upsert_description: topLevelOutputSchema([
-    "id",
-    "updated",
-    "target",
-    "description",
-    "history",
-    "viewer",
-  ]),
+  get_description: descriptionMcpSchema,
+  upsert_description: descriptionUpsertMcpSchema,
 
   list_my_uploads: uploadListMcpSchema,
   rename_my_upload: objectOutputSchema({
@@ -562,6 +660,13 @@ const TOOL_OUTPUT_SCHEMAS: Record<string, McpToolOutputSchema> = {
 
 export function getMcpToolOutputSchema(name: string): McpToolOutputSchema {
   return TOOL_OUTPUT_SCHEMAS[name] ?? STRUCTURED_CONTENT_OUTPUT_SCHEMA;
+}
+
+export function getMarkdownMcpToolOutputSchemaForMode(
+  name: keyof typeof MARKDOWN_MODE_OUTPUT_SCHEMAS,
+  mode: "default" | "full",
+): McpToolOutputSchema {
+  return MARKDOWN_MODE_OUTPUT_SCHEMAS[name][mode];
 }
 
 export function hasMcpToolOutputSchema(name: string): boolean {

--- a/src/routes/_components/LegalDocument.svelte
+++ b/src/routes/_components/LegalDocument.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-import MarkdownPreview from "$lib/components/MarkdownPreview.svelte";
+import RenderedMarkdown from "$lib/components/RenderedMarkdown.svelte";
 import * as Card from "$lib/components/ui/card/index.js";
 
 export let content: {
   title: string;
   mdx: string;
+  renderedHtml: string;
 };
 </script>
 
@@ -12,7 +13,7 @@ export let content: {
 
 <Card.Root class="mx-auto w-full max-w-3xl">
   <Card.Content class="px-6 md:px-8">
-    <MarkdownPreview class="legal-document" content={content.mdx} />
+    <RenderedMarkdown class="legal-document" html={content.renderedHtml} />
   </Card.Content>
 </Card.Root>
 

--- a/src/routes/privacy/+page.server.ts
+++ b/src/routes/privacy/+page.server.ts
@@ -1,6 +1,13 @@
+import { renderMarkdown } from "@/lib/components/markdown-preview-renderer";
 import { getLegalContent } from "@/lib/legal-content";
 import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = ({ locals }) => ({
-  content: getLegalContent(locals.locale, "privacy"),
-});
+export const load: PageServerLoad = ({ locals }) => {
+  const content = getLegalContent(locals.locale, "privacy");
+  return {
+    content: {
+      ...content,
+      renderedHtml: renderMarkdown(content.mdx),
+    },
+  };
+};

--- a/src/routes/terms/+page.server.ts
+++ b/src/routes/terms/+page.server.ts
@@ -1,6 +1,13 @@
+import { renderMarkdown } from "@/lib/components/markdown-preview-renderer";
 import { getLegalContent } from "@/lib/legal-content";
 import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = ({ locals }) => ({
-  content: getLegalContent(locals.locale, "terms"),
-});
+export const load: PageServerLoad = ({ locals }) => {
+  const content = getLegalContent(locals.locale, "terms");
+  return {
+    content: {
+      ...content,
+      renderedHtml: renderMarkdown(content.mdx),
+    },
+  };
+};

--- a/tests/e2e/src/app/courses/[jwId]/test.ts
+++ b/tests/e2e/src/app/courses/[jwId]/test.ts
@@ -297,6 +297,12 @@ test.describe("/courses/[jwId] 课程详情", () => {
         intervals: [250, 500, 1_000],
       });
       await editor.fill(content);
+      await descCard.getByRole("tab", { name: /预览|Preview/i }).click();
+      await expect(
+        descCard
+          .getByRole("tabpanel", { name: /预览|Preview/i })
+          .getByText(content),
+      ).toBeVisible();
 
       const saveResponse = page.waitForResponse(
         (r) =>
@@ -410,5 +416,18 @@ test.describe("/courses/[jwId] 课程详情", () => {
     } finally {
       await cleanupCommentsForE2e([commentId]);
     }
+  });
+});
+
+test.describe("/courses/[jwId]/introduction 无 JavaScript", () => {
+  test.use({ javaScriptEnabled: false });
+
+  test("SSR 保留 sanitized Markdown 简介", async ({ page }) => {
+    await page.goto(COURSE_WITH_DESCRIPTION_URL);
+
+    await expect(page.getByText(COURSE_WITH_DESCRIPTION_TEXT)).toBeVisible();
+    await expect(
+      page.locator("#course-description .markdown-preview"),
+    ).toBeVisible();
   });
 });

--- a/tests/e2e/src/app/privacy/test.ts
+++ b/tests/e2e/src/app/privacy/test.ts
@@ -33,3 +33,15 @@ test.describe("/privacy 隐私政策页", () => {
     expect(await listItems.count()).toBeGreaterThan(0);
   });
 });
+
+test.describe("/privacy 无 JavaScript", () => {
+  test.use({ javaScriptEnabled: false });
+
+  test("SSR 保留完整政策正文", async ({ page }) => {
+    await page.goto("/privacy");
+
+    await expect(page.locator("h1")).toBeVisible();
+    await expect(page.locator("h2").first()).toBeVisible();
+    await expect(page.locator("li").first()).toBeVisible();
+  });
+});

--- a/tests/integration/mcp-02-comments.test.ts
+++ b/tests/integration/mcp-02-comments.test.ts
@@ -6,13 +6,14 @@ const context = fixtures.createMcpToolTestContext();
 
 describe("评论读取工具 — MCP 暴露 REST 评论层级", () => {
   it("list_comments 返回带查看者/操作字段的班级串帖评论", async () => {
-    const result = await context.client.call<{
+    type Result = {
       found?: boolean;
       data?: Array<{
         id?: string;
         body?: string;
+        renderedBody?: string;
         author?: { name?: string | null } | null;
-        replies?: Array<{ body?: string }>;
+        replies?: Array<{ body?: string; renderedBody?: string }>;
         reactions?: Array<{ type?: string; count?: number }>;
         canReact?: boolean;
         canReply?: boolean;
@@ -32,11 +33,20 @@ describe("评论读取工具 — MCP 暴露 REST 评论层级", () => {
         viewer?: { userId?: string | null; isAuthenticated?: boolean };
       };
       pagination?: { page?: number; pageSize?: number; total?: number };
-    }>("list_comments", {
-      targetType: "section",
-      sectionJwId: fixtures.DEV_SEED.section.jwId,
-      mode: "full",
-    });
+    };
+
+    const results = await Promise.all(
+      (["default", "summary", "full"] as const).map(async (mode) => ({
+        mode,
+        result: await context.client.call<Result>("list_comments", {
+          targetType: "section",
+          sectionJwId: fixtures.DEV_SEED.section.jwId,
+          mode,
+        }),
+      })),
+    );
+    const result = results.find(({ mode }) => mode === "full")?.result;
+    if (!result) throw new Error("Missing full-mode list_comments result");
 
     expect(result.found).toBe(true);
     expect(result.meta?.target?.type).toBe("section");
@@ -71,6 +81,19 @@ describe("评论读取工具 — MCP 暴露 REST 评论层级", () => {
         (reaction) => reaction.type === "upvote" && reaction.count === 1,
       ),
     ).toBe(true);
+
+    for (const { mode, result: modeResult } of results) {
+      const modeRoot = modeResult.data?.find((comment) =>
+        comment.body?.includes(fixtures.DEV_SEED.comments.sectionRootBody),
+      );
+      expect(modeRoot).toBeDefined();
+      expect(Object.hasOwn(modeRoot ?? {}, "renderedBody")).toBe(
+        mode === "full",
+      );
+      expect(Object.hasOwn(modeRoot?.replies?.[0] ?? {}, "renderedBody")).toBe(
+        mode === "full",
+      );
+    }
   });
 
   it("get_comment_thread 返回聚焦线程及目标元数据", async () => {
@@ -80,13 +103,14 @@ describe("评论读取工具 — MCP 暴露 REST 评论层级", () => {
     });
     expect(seedComment?.id).toBeTruthy();
 
-    const result = await context.client.call<{
+    type Result = {
       found?: boolean;
       focusId?: string;
       thread?: Array<{
         id?: string;
         body?: string;
-        replies?: Array<{ body?: string }>;
+        renderedBody?: string;
+        replies?: Array<{ body?: string; renderedBody?: string }>;
       }>;
       target?: {
         courseJwId?: number | null;
@@ -94,10 +118,18 @@ describe("评论读取工具 — MCP 暴露 REST 评论层级", () => {
         sectionJwId?: number | null;
         sectionCode?: string | null;
       };
-    }>("get_comment_thread", {
-      commentId: seedComment?.id,
-      mode: "full",
-    });
+    };
+    const results = await Promise.all(
+      (["default", "summary", "full"] as const).map(async (mode) => ({
+        mode,
+        result: await context.client.call<Result>("get_comment_thread", {
+          commentId: seedComment?.id,
+          mode,
+        }),
+      })),
+    );
+    const result = results.find(({ mode }) => mode === "full")?.result;
+    if (!result) throw new Error("Missing full-mode comment thread result");
 
     expect(result.found).toBe(true);
     expect(result.focusId).toBe(seedComment?.id);
@@ -110,6 +142,18 @@ describe("评论读取工具 — MCP 暴露 REST 评论层级", () => {
     expect(result.target?.sectionCode).toBe(fixtures.DEV_SEED.section.code);
     expect(result.target?.courseJwId).toBe(fixtures.DEV_SEED.course.jwId);
     expect(result.target?.courseName).toBe(fixtures.DEV_SEED.course.nameCn);
+
+    for (const { mode, result: modeResult } of results) {
+      expect(Object.hasOwn(modeResult.thread?.[0] ?? {}, "renderedBody")).toBe(
+        mode === "full",
+      );
+      expect(
+        Object.hasOwn(
+          modeResult.thread?.[0]?.replies?.[0] ?? {},
+          "renderedBody",
+        ),
+      ).toBe(mode === "full");
+    }
   });
 
   it("list_comments 报告缺失目标而非返回空成功", async () => {

--- a/tests/integration/mcp-03-descriptions.test.ts
+++ b/tests/integration/mcp-03-descriptions.test.ts
@@ -11,17 +11,29 @@ describe("描述工具 — MCP 暴露 REST 描述载荷", () => {
     });
     expect(section?.id).toBeTruthy();
 
-    const result = await context.client.call<{
+    type Result = {
       found?: boolean;
-      description?: { content?: string; id?: string | null };
+      description?: {
+        content?: string;
+        id?: string | null;
+        renderedHtml?: string;
+      };
       history?: Array<{ id?: string; nextContent?: string }>;
       target?: { targetId?: number; type?: string };
       viewer?: { isAuthenticated?: boolean; userId?: string | null };
-    }>("get_description", {
-      targetType: "section",
-      sectionJwId: fixtures.DEV_SEED.section.jwId,
-      mode: "full",
-    });
+    };
+    const results = await Promise.all(
+      (["default", "summary", "full"] as const).map(async (mode) => ({
+        mode,
+        result: await context.client.call<Result>("get_description", {
+          targetType: "section",
+          sectionJwId: fixtures.DEV_SEED.section.jwId,
+          mode,
+        }),
+      })),
+    );
+    const result = results.find(({ mode }) => mode === "full")?.result;
+    if (!result) throw new Error("Missing full-mode description result");
 
     expect(result.found).toBe(true);
     expect(result.target).toMatchObject({
@@ -35,6 +47,11 @@ describe("描述工具 — MCP 暴露 REST 描述载荷", () => {
       isAuthenticated: true,
       userId: context.devUserId,
     });
+    for (const { mode, result: modeResult } of results) {
+      expect(Object.hasOwn(modeResult.description ?? {}, "renderedHtml")).toBe(
+        mode === "full",
+      );
+    }
   });
 
   it("get_description 报告缺失的公开班级目标", async () => {
@@ -66,18 +83,33 @@ describe("描述工具 — MCP 暴露 REST 描述载荷", () => {
     let descriptionId: string | undefined;
 
     try {
-      const created = await context.client.call<{
+      type Result = {
         success?: boolean;
         id?: string;
         updated?: boolean;
-        description?: { content?: string; id?: string | null };
+        description?: {
+          content?: string;
+          id?: string | null;
+          renderedHtml?: string;
+        };
         target?: { targetId?: number; type?: string };
-      }>("upsert_description", {
-        targetType: "teacher",
-        teacherId: teacher.id,
-        content: ` ${marker} `,
-        mode: "full",
-      });
+      };
+      const results: Array<{
+        mode: "default" | "summary" | "full";
+        result: Result;
+      }> = [];
+      for (const mode of ["default", "summary", "full"] as const) {
+        results.push({
+          mode,
+          result: await context.client.call<Result>("upsert_description", {
+            targetType: "teacher",
+            teacherId: teacher.id,
+            content: ` ${marker} `,
+            mode,
+          }),
+        });
+      }
+      const created = results[0]?.result ?? {};
       descriptionId = created.id;
 
       expect(created.success).toBe(true);
@@ -88,6 +120,12 @@ describe("描述工具 — MCP 暴露 REST 描述载荷", () => {
       });
       expect(created.description?.id).toBe(descriptionId);
       expect(created.description?.content).toBe(marker);
+      for (const { mode, result } of results) {
+        expect(result.id).toBe(descriptionId);
+        expect(Object.hasOwn(result.description ?? {}, "renderedHtml")).toBe(
+          mode === "full",
+        );
+      }
 
       const auditLog = descriptionId
         ? await fixtures.findDescriptionEditAuditLog(descriptionId)
@@ -97,17 +135,7 @@ describe("描述工具 — MCP 暴露 REST 描述载荷", () => {
         targetType: "teacher",
       });
 
-      const idempotent = await context.client.call<{
-        success?: boolean;
-        id?: string;
-        updated?: boolean;
-        description?: { content?: string };
-      }>("upsert_description", {
-        targetType: "teacher",
-        teacherId: teacher.id,
-        content: marker,
-        mode: "full",
-      });
+      const idempotent = results[2]?.result ?? {};
 
       expect(idempotent.success).toBe(true);
       expect(idempotent.id).toBe(descriptionId);

--- a/tests/unit/comment-panel-interactions.test.ts
+++ b/tests/unit/comment-panel-interactions.test.ts
@@ -7,6 +7,7 @@ function comment(overrides: Partial<CommentNode> = {}): CommentNode {
   return {
     id: "comment-1",
     body: "body",
+    renderedBody: "<p>body</p>",
     visibility: "public",
     status: "active",
     author: null,

--- a/tests/unit/comment-panel-upload-pending.test.ts
+++ b/tests/unit/comment-panel-upload-pending.test.ts
@@ -83,6 +83,7 @@ function comment(overrides: Partial<CommentNode> = {}): CommentNode {
     author: null,
     authorHidden: false,
     body: "existing body",
+    renderedBody: "<p>existing body</p>",
     canDelete: false,
     canEdit: true,
     canModerate: false,

--- a/tests/unit/comment-serialization-permissions.test.ts
+++ b/tests/unit/comment-serialization-permissions.test.ts
@@ -56,6 +56,20 @@ function viewer(overrides: Partial<ViewerInfo> = {}): ViewerInfo {
 }
 
 describe("评论序列化权限", () => {
+  it("在服务端序列化 sanitized Markdown HTML", () => {
+    const { roots } = buildCommentNodes(
+      [
+        comment({
+          body: 'section#123 <script>alert("xss")</script>',
+        }),
+      ],
+      viewer(),
+    );
+
+    expect(roots[0]?.renderedBody).toContain('href="/sections/123"');
+    expect(roots[0]?.renderedBody).not.toContain("<script>");
+  });
+
   it("保留普通作者的回复和编辑权限", () => {
     const { roots } = buildCommentNodes([comment()], viewer());
 

--- a/tests/unit/compact-payload.test.ts
+++ b/tests/unit/compact-payload.test.ts
@@ -40,6 +40,37 @@ describe("compactMcpPayload MCP 载荷压缩", () => {
       ).not.toHaveProperty("extra");
     });
 
+    it("递归省略 Markdown 派生 HTML 字段", () => {
+      const input = {
+        description: {
+          content: "Source Markdown",
+          renderedHtml: "<p>Source Markdown</p>",
+        },
+        comments: [
+          {
+            body: "Comment Markdown",
+            renderedBody: "<p>Comment Markdown</p>",
+            replies: [
+              {
+                body: "Reply Markdown",
+                renderedBody: "<p>Reply Markdown</p>",
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(compactMcpPayload(input)).toEqual({
+        description: { content: "Source Markdown" },
+        comments: [
+          {
+            body: "Comment Markdown",
+            replies: [{ body: "Reply Markdown" }],
+          },
+        ],
+      });
+    });
+
     it("压缩顶层已知记录数组", () => {
       const input = [
         {

--- a/tests/unit/markdown-renderer.test.ts
+++ b/tests/unit/markdown-renderer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { serializeDescriptionRecord } from "@/features/descriptions/server/description-payload";
 import {
   type CampusReferenceKind,
   campusReferenceMarkdownPlugins,
@@ -38,5 +39,16 @@ describe("markdown 渲染器", () => {
     });
 
     expect(html).toContain('href="/catalog/teacher/456"');
+  });
+
+  it("在服务端描述 payload 中保留 sanitized HTML 和 campus 链接", () => {
+    const description = serializeDescriptionRecord({
+      id: "description-1",
+      content: 'teacher#456 <script>alert("xss")</script>',
+    });
+
+    expect(description.content).toContain("<script>");
+    expect(description.renderedHtml).toContain('href="/teachers/456"');
+    expect(description.renderedHtml).not.toContain("<script>");
   });
 });

--- a/tests/unit/mcp-tool-descriptors.test.ts
+++ b/tests/unit/mcp-tool-descriptors.test.ts
@@ -8,7 +8,10 @@ import {
   installMcpToolDescriptorDefaults,
   installMcpToolListCompatibility,
 } from "@/lib/mcp/tool-descriptors";
-import { getMcpToolOutputSchema } from "@/lib/mcp/tool-output-schemas";
+import {
+  getMarkdownMcpToolOutputSchemaForMode,
+  getMcpToolOutputSchema,
+} from "@/lib/mcp/tool-output-schemas";
 import { jsonToolResult } from "@/lib/mcp/tools/_helpers";
 import { restReadScope, restWriteScope } from "@/lib/oauth/constants";
 
@@ -549,6 +552,95 @@ describe("MCP tool descriptors", () => {
     } finally {
       await client.close();
       await mcpServer.close();
+    }
+  });
+
+  it("keeps compact and full Markdown output schemas mutually strict", () => {
+    const fullComment = {
+      id: "comment-1",
+      body: "Source Markdown",
+      renderedBody: "<p>Source Markdown</p>",
+      visibility: "public",
+      status: "active",
+      author: null,
+      authorHidden: false,
+      isAnonymous: false,
+      isAuthor: true,
+      createdAt: "2026-07-19T00:00:00.000Z",
+      updatedAt: "2026-07-19T00:00:00.000Z",
+      parentId: null,
+      rootId: null,
+      replies: [],
+      attachments: [],
+      reactions: [],
+      canReact: true,
+      canReply: true,
+      canEdit: true,
+      canDelete: true,
+      canModerate: false,
+    };
+    const { renderedBody: _renderedBody, ...compactComment } = fullComment;
+    const fullDescription = {
+      id: "description-1",
+      content: "Source Markdown",
+      renderedHtml: "<p>Source Markdown</p>",
+      updatedAt: "2026-07-19T00:00:00.000Z",
+      lastEditedAt: "2026-07-19T00:00:00.000Z",
+      lastEditedBy: null,
+    };
+    const { renderedHtml: _renderedHtml, ...compactDescription } =
+      fullDescription;
+    const cases = [
+      {
+        name: "list_comments",
+        compact: { success: true, found: true, data: [compactComment] },
+        full: { success: true, found: true, data: [fullComment] },
+      },
+      {
+        name: "get_comment_thread",
+        compact: { success: true, found: true, thread: [compactComment] },
+        full: { success: true, found: true, thread: [fullComment] },
+      },
+      {
+        name: "get_description",
+        compact: {
+          success: true,
+          found: true,
+          description: compactDescription,
+        },
+        full: { success: true, found: true, description: fullDescription },
+      },
+      {
+        name: "upsert_description",
+        compact: {
+          success: true,
+          id: "description-1",
+          updated: true,
+          description: compactDescription,
+        },
+        full: {
+          success: true,
+          id: "description-1",
+          updated: true,
+          description: fullDescription,
+        },
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const compactSchema = getMarkdownMcpToolOutputSchemaForMode(
+        testCase.name,
+        "default",
+      );
+      const fullSchema = getMarkdownMcpToolOutputSchemaForMode(
+        testCase.name,
+        "full",
+      );
+
+      expect(compactSchema.safeParse(testCase.compact).success).toBe(true);
+      expect(compactSchema.safeParse(testCase.full).success).toBe(false);
+      expect(fullSchema.safeParse(testCase.full).success).toBe(true);
+      expect(fullSchema.safeParse(testCase.compact).success).toBe(false);
     }
   });
 

--- a/tests/unit/mcp-tool-helpers.test.ts
+++ b/tests/unit/mcp-tool-helpers.test.ts
@@ -106,6 +106,29 @@ describe("jsonToolResult canonical structured output", () => {
     });
   });
 
+  it("omits derived Markdown HTML in compact mode and keeps it in full mode", () => {
+    const payload = {
+      description: {
+        content: "Source Markdown",
+        renderedHtml: "<p>Source Markdown</p>",
+      },
+      thread: [
+        {
+          body: "Comment Markdown",
+          renderedBody: "<p>Comment Markdown</p>",
+        },
+      ],
+    };
+
+    const compact = parseToolText(jsonToolResult(payload));
+    const full = parseToolText(jsonToolResult(payload, { mode: "full" }));
+
+    expect(compact.description).toEqual({ content: "Source Markdown" });
+    expect(compact.thread).toEqual([{ body: "Comment Markdown" }]);
+    expect(full.description).toEqual(payload.description);
+    expect(full.thread).toEqual(payload.thread);
+  });
+
   it("wraps non-object payloads in object-shaped structuredContent", () => {
     const rawResult = jsonToolResult([{ id: 1 }, { id: 2 }], {
       mode: "full",


### PR DESCRIPTION
## Goal

Closes #513.

Keep public read pages fully rendered for no-JavaScript users and crawlers while removing the Markdown/remark/rehype pipeline from their hydration bundles.

## What changed

- Added a display-only `RenderedMarkdown` component for already sanitized server HTML.
- Server-rendered description, comment, homework, privacy, and terms Markdown with the existing sanitizer, campus-reference directives, GFM, and math pipeline.
- Kept the full parser lazy for actual authoring/preview flows:
  - `MarkdownEditor` imports it only after Preview is opened.
  - homework update payloads without server HTML use a lazy preview fallback.
- Added `renderedHtml` / `renderedBody` to REST response schemas and generated OpenAPI.
- Preserved AI-query efficiency:
  - MCP `full` mode retains the shared Markdown + rendered HTML response shape.
  - MCP compact/default/summary recursively omit `renderedHtml` and `renderedBody`, avoiding duplicate AI-context tokens.
  - MCP output schemas use strict compact/full branches so SDK output validation accepts each mode without weakening full-mode rendered-field requirements.
- Updated comment/description contracts and SSR/no-JS/editor/MCP regression coverage.

## Evidence

Production-manifest static-import closure estimate (sum of local gzip sizes, excluding dynamic imports):

| Route node | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Course detail | 449,112 B | 249,592 B | 199,520 B (44.4%) |
| Privacy | 238,492 B | 37,415 B | 201,077 B (84.3%) |
| Section detail | 507,232 B | 308,315 B | 198,917 B (39.2%) |
| Teacher detail | 449,889 B | 250,348 B | 199,541 B (44.4%) |
| Terms | 238,492 B | 37,415 B | 201,077 B (84.3%) |

The final static closures for those route nodes contain no `processSync`, `remarkGfm`, or `rehypeKatex`. The parser remains in a lazy chunk for preview/edit interactions.

Validation:

- `bunx biome check` (one pre-existing unused-variable warning outside this patch in `src/static-loader/import.ts`)
- `bunx svelte-check --tsconfig ./tsconfig.json`
- all three TypeScript project checks
- `bunx vitest run`: 195 files, 1,164 tests passed
- integration suite: 31 files, 180 tests passed
- focused MCP/compact/schema tests after final review fix: 3 files, 52 tests passed
- real InMemoryTransport coverage for `list_comments`, `get_comment_thread`, `get_description`, and `upsert_description` in default/summary/full modes: 2 files, 20 tests passed
- focused Playwright coverage for course/teacher/section comments, editor preview, homework save, and no-JS course/privacy rendering passed
- broader Playwright run reached 477 passing tests without an assertion failure before being intentionally stopped after 4.3 minutes; the remaining 206 tests were not run
- `bun run build`
- `bunx wrangler deploy --dry-run`
- `bun run openapi:check`

## Risks and tradeoffs

- Sanitized HTML is generated only through the existing rendering pipeline; clients do not render arbitrary source HTML.
- Server rendering shifts parser work from hydration to request/data serialization and adds HTML bytes to full REST/MCP payloads. MCP compact modes remove the duplicate HTML; a future cache/persistence follow-up can reduce repeated server parsing for high-traffic comment trees.
- API response shapes gain additive rendered fields; there are no auth, database-schema, or write-path changes.
