### PR TITLE
feat(observability): measure SSR page performance

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -8,7 +8,10 @@ import {
   recordApiRequestStart,
   setApiRequestObservabilityContext,
 } from "@/lib/log/api-observability";
-import { logAppEvent } from "@/lib/log/app-logger";
+import {
+  appendPageServerTiming,
+  recordPageRequestFinish,
+} from "@/lib/metrics/page-observability";
 import {
   OAUTH_DEVICE_AUTHORIZATION_ENDPOINT_PATH,
   OAUTH_TOKEN_ENDPOINT_PATH,
@@ -128,37 +131,12 @@ function contentLength(response: Response) {
   return Number(value);
 }
 
-function routeId(event: Parameters<Handle>[0]["event"]) {
-  return event.route.id ?? event.url.pathname;
-}
-
 function oauthAuthorizeFormActionSources(url: URL) {
   if (url.pathname !== "/oauth/authorize") return [];
   const source = formActionSourceFromOAuthRedirectUri(
     url.searchParams.get("redirect_uri"),
   );
   return source ? [source] : [];
-}
-
-function recordPageRequestFinish(input: {
-  durationMs: number;
-  event: Parameters<Handle>[0]["event"];
-  requestId: string;
-  response: Response;
-}) {
-  if (isApiRequest(input.event.url.pathname)) return;
-  if (!isHtmlResponse(input.response)) return;
-
-  logAppEvent("info", "page.request.finish", {
-    durationMs: input.durationMs,
-    event: "page.request.finish",
-    method: input.event.request.method,
-    requestId: input.requestId,
-    responseBytes: contentLength(input.response),
-    route: routeId(input.event),
-    source: "sveltekit",
-    status: input.response.status,
-  });
 }
 
 const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
@@ -185,11 +163,13 @@ const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
   );
   const nonce = createScriptNonce();
 
+  const authStartMs = Date.now();
   const session = hasAuthSignal
     ? await import("@/lib/auth/core").then(({ getSessionFromHeaders }) =>
         getSessionFromHeaders(event.request.headers),
       )
     : null;
+  const authDurationMs = Date.now() - authStartMs;
   event.locals.authUser = session?.user ?? null;
   if (
     shouldRedirectIncompleteProfileToWelcome({
@@ -203,6 +183,7 @@ const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
     throw redirect(303, `/welcome?callbackUrl=${encodeURIComponent(returnTo)}`);
   }
 
+  const appStartMs = Date.now();
   const response = await resolve(event, {
     transformPageChunk: ({ html }) =>
       addScriptNonce(
@@ -210,13 +191,25 @@ const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
         nonce,
       ),
   });
+  const appDurationMs = Date.now() - appStartMs;
+  const totalDurationMs = Date.now() - startMs;
   const shouldSetCsp = isHtmlResponse(response);
-  recordPageRequestFinish({
-    durationMs: Date.now() - startMs,
-    event,
-    requestId,
-    response,
-  });
+  if (!isApiRequest(event.url.pathname) && shouldSetCsp) {
+    recordPageRequestFinish({
+      authMode: session?.user.id ? "authenticated" : "anonymous",
+      locale,
+      method: event.request.method,
+      requestId,
+      responseBytes: contentLength(response),
+      routeId: event.route.id,
+      status: response.status,
+      timings: {
+        appDurationMs,
+        authDurationMs,
+        totalDurationMs,
+      },
+    });
+  }
 
   const mutableResponse = responseWithSecurityHeaders(response);
   if (apiObservability) {
@@ -225,6 +218,11 @@ const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
     mutableResponse.headers.set("x-request-id", requestId);
   }
   if (shouldSetCsp) {
+    appendPageServerTiming(mutableResponse.headers, {
+      appDurationMs,
+      authDurationMs,
+      totalDurationMs,
+    });
     if (!mutableResponse.headers.has("Cache-Control")) {
       mutableResponse.headers.set("Cache-Control", "no-store");
     }

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -10,6 +10,18 @@ type ApiRequestAnalyticsInput = {
   status: number;
 };
 
+type PageRequestAnalyticsInput = {
+  appDurationMs: number;
+  authDurationMs: number;
+  authMode: "anonymous" | "authenticated";
+  durationMs: number;
+  locale: string;
+  method: string;
+  responseBytes?: number;
+  route: string;
+  status: number;
+};
+
 type McpTransportAnalyticsInput = {
   durationMs: number;
   method: string;
@@ -134,6 +146,30 @@ export function writeApiRequestAnalytics(input: ApiRequestAnalyticsInput) {
       boundedValue(input.authMode),
     ],
     doubles: [input.durationMs, input.status],
+  });
+}
+
+export function writePageRequestAnalytics(input: PageRequestAnalyticsInput) {
+  const hasResponseBytes = input.responseBytes !== undefined;
+  writeAnalyticsDataPoint({
+    indexes: [`page:${boundedValue(input.route)}`],
+    blobs: [
+      "page_request",
+      boundedValue(input.route),
+      boundedValue(input.method),
+      String(input.status),
+      statusClass(input.status),
+      boundedValue(input.locale),
+      input.authMode,
+      hasResponseBytes ? "response_bytes_known" : "response_bytes_unknown",
+    ],
+    doubles: [
+      input.durationMs,
+      input.status,
+      input.responseBytes ?? 0,
+      input.authDurationMs,
+      input.appDurationMs,
+    ],
   });
 }
 

--- a/src/lib/metrics/page-observability.ts
+++ b/src/lib/metrics/page-observability.ts
@@ -1,0 +1,70 @@
+import { logAppEvent } from "@/lib/log/app-logger";
+import { writePageRequestAnalytics } from "@/lib/metrics/analytics-engine";
+
+export type PageAuthMode = "anonymous" | "authenticated";
+
+export type PageServerTimings = {
+  appDurationMs: number;
+  authDurationMs: number;
+  totalDurationMs: number;
+};
+
+function safeDuration(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, value);
+}
+
+function timingMetric(name: string, durationMs: number) {
+  return `${name};dur=${Math.round(safeDuration(durationMs))}`;
+}
+
+export function appendPageServerTiming(
+  headers: Headers,
+  timings: PageServerTimings,
+) {
+  const value = [
+    timingMetric("auth", timings.authDurationMs),
+    timingMetric("app", timings.appDurationMs),
+    timingMetric("total", timings.totalDurationMs),
+  ].join(", ");
+
+  headers.append("Server-Timing", value);
+}
+
+export function recordPageRequestFinish(input: {
+  authMode: PageAuthMode;
+  locale: string;
+  method: string;
+  requestId: string;
+  responseBytes?: number;
+  routeId: string | null;
+  status: number;
+  timings: PageServerTimings;
+}) {
+  const route = input.routeId ?? "unmatched";
+
+  logAppEvent("info", "page.request.finish", {
+    authMode: input.authMode,
+    durationMs: input.timings.totalDurationMs,
+    event: "page.request.finish",
+    locale: input.locale,
+    method: input.method,
+    requestId: input.requestId,
+    responseBytes: input.responseBytes,
+    route,
+    source: "sveltekit",
+    status: input.status,
+  });
+
+  writePageRequestAnalytics({
+    appDurationMs: input.timings.appDurationMs,
+    authDurationMs: input.timings.authDurationMs,
+    authMode: input.authMode,
+    durationMs: input.timings.totalDurationMs,
+    locale: input.locale,
+    method: input.method,
+    responseBytes: input.responseBytes,
+    route,
+    status: input.status,
+  });
+}

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -1,6 +1,7 @@
 const ANALYTICS_SCRIPT_SOURCES = [
   "https://www.googletagmanager.com",
   "https://www.google-analytics.com",
+  "https://static.cloudflareinsights.com/beacon.min.js",
 ];
 
 const ANALYTICS_CONNECT_SOURCES = [

--- a/tests/unit/csp.test.ts
+++ b/tests/unit/csp.test.ts
@@ -26,6 +26,9 @@ describe("CSP 辅助函数", () => {
     expect(scriptDirective).not.toContain("'unsafe-inline'");
     expect(scriptDirective).not.toContain("'unsafe-eval'");
     expect(scriptDirective).not.toContain("unpkg.com");
+    expect(scriptDirective).toContain(
+      "https://static.cloudflareinsights.com/beacon.min.js",
+    );
     expect(policy).toContain("object-src 'none'");
   });
 

--- a/tests/unit/page-observability.test.ts
+++ b/tests/unit/page-observability.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
+import {
+  appendPageServerTiming,
+  recordPageRequestFinish,
+} from "@/lib/metrics/page-observability";
+
+describe("页面性能可观测性", () => {
+  afterEach(() => {
+    setCloudflareRuntimeEnv(undefined);
+    vi.restoreAllMocks();
+  });
+
+  it("保留已有 Server-Timing 并追加已测量的通用阶段", () => {
+    const headers = new Headers({ "Server-Timing": "cache;dur=2" });
+
+    appendPageServerTiming(headers, {
+      appDurationMs: 42.25,
+      authDurationMs: 3,
+      totalDurationMs: 47.75,
+    });
+
+    expect(headers.get("Server-Timing")).toBe(
+      "cache;dur=2, auth;dur=3, app;dur=42, total;dur=48",
+    );
+  });
+
+  it("写入不包含 URL、查询参数或用户标识的页面数据点", () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    const writeDataPoint = vi.fn();
+    setCloudflareRuntimeEnv({ ANALYTICS: { writeDataPoint } });
+
+    recordPageRequestFinish({
+      authMode: "authenticated",
+      locale: "zh-cn",
+      method: "GET",
+      requestId: "request-id-only-in-logs",
+      responseBytes: 12345,
+      routeId: "/courses/[jwId]",
+      status: 200,
+      timings: {
+        appDurationMs: 80,
+        authDurationMs: 12,
+        totalDurationMs: 95,
+      },
+    });
+
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      indexes: ["page:/courses/[jwId]"],
+      blobs: [
+        "page_request",
+        "/courses/[jwId]",
+        "GET",
+        "200",
+        "2xx",
+        "zh-cn",
+        "authenticated",
+        "response_bytes_known",
+      ],
+      doubles: [95, 200, 12345, 12, 80],
+    });
+    expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain(
+      "request-id-only-in-logs",
+    );
+  });
+
+  it("对未匹配路由和未知响应大小使用低基数标记", () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    const writeDataPoint = vi.fn();
+    setCloudflareRuntimeEnv({ ANALYTICS: { writeDataPoint } });
+
+    recordPageRequestFinish({
+      authMode: "anonymous",
+      locale: "en-us",
+      method: "GET",
+      requestId: "request-2",
+      routeId: null,
+      status: 404,
+      timings: {
+        appDurationMs: 5,
+        authDurationMs: 0,
+        totalDurationMs: 6,
+      },
+    });
+
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      indexes: ["page:unmatched"],
+      blobs: [
+        "page_request",
+        "unmatched",
+        "GET",
+        "404",
+        "4xx",
+        "en-us",
+        "anonymous",
+        "response_bytes_unknown",
+      ],
+      doubles: [6, 404, 0, 0, 5],
+    });
+  });
+
+  it("Analytics Engine 失败不影响页面响应路径", () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    setCloudflareRuntimeEnv({
+      ANALYTICS: {
+        writeDataPoint: vi.fn(() => {
+          throw new Error("analytics unavailable");
+        }),
+      },
+    });
+
+    expect(() =>
+      recordPageRequestFinish({
+        authMode: "anonymous",
+        locale: "zh-cn",
+        method: "GET",
+        requestId: "request-3",
+        routeId: "/",
+        status: 200,
+        timings: {
+          appDurationMs: 20,
+          authDurationMs: 0,
+          totalDurationMs: 21,
+        },
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Goal

Add privacy-safe, queryable SSR page performance telemetry and the response headers needed to correlate server work with browser performance, while preparing the CSP for Cloudflare Web Analytics automatic injection.

Fixes #520.

## Changed Surfaces

- Records one `page_request` Analytics Engine data point for each HTML page response using only the SvelteKit route template, status, locale, anonymous/authenticated mode, measured durations, and response size when `Content-Length` is already available.
- Adds `Server-Timing` entries for the measured `auth`, `app`, and `total` phases and preserves any existing entries.
- Adds the exact Cloudflare beacon URL to `script-src`; the existing `connect-src 'self'` permits automatic `/cdn-cgi/rum` submission.
- Extends the existing structured page completion log with auth mode and locale.
- Does not enable Web Analytics or change any Cloudflare production setting.

## Evidence

- `bun run app:prepare`
- `bunx biome check` — passes with one pre-existing warning in `src/static-loader/import.ts`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` — 199 files, 1190 tests passed
- `bun run build`
- `bunx wrangler deploy --dry-run --outdir /tmp/life-ustc-page-observability-dry-run`
- Local `GET /privacy` returned 200 with the expected `Server-Timing`, exact Cloudflare beacon CSP source, and `connect-src 'self'`.

Integration and Playwright suites were not run because this change does not alter persistence, auth decisions, or rendered UI behavior; focused unit coverage and an HTTP response probe exercise the changed boundary.

## Docs / Contracts

No contract or public API shape changed. The durable operational rationale and acceptance criteria live in #520.

## Risk Areas

- Analytics writes use the existing fail-open writer, so binding failures cannot affect responses.
- Analytics contains no request ID, URL, query string, user ID, cookie, or session identifier. Unmatched routes collapse to `unmatched`.
- Response bodies are not cloned or buffered; unknown sizes are explicitly marked.
- Server timing stage names are intentionally generic and expose durations only.
- Web Analytics still requires an explicit Cloudflare dashboard enablement after merge.

## Cleanup

The branch contains only the six intended source/test changes. Generated clients, build output, dry-run output, and manual probe files are not tracked.
