### PR TITLE
fix(calendar): persist personal feed exports

### DIFF
--- a/docs/contracts/ical.json
+++ b/docs/contracts/ical.json
@@ -10,7 +10,7 @@
     "copyable-links": "iCal links should be presented as copyable links rather than requiring users to manually construct them.",
     "no-second-model": "iCal is an export / subscription capability and should not carry a second business model.",
     "rfc5545-dtstamp-utc": "Every VEVENT in section, multi-section, and personal feeds serializes DTSTAMP as a UTC DATE-TIME with a Z suffix while retaining Asia/Shanghai TZID values for event start and end times.",
-    "personal-feed-cache": "Personal feed responses may be served from a short-lived private server-side cache, include ETag, return 304 Not Modified for matching If-None-Match, and write cache hit/miss Cloudflare Analytics Engine datapoints without user IDs or feed tokens.",
+    "personal-feed-cache": "Personal feed responses may be served from a private Workers KV-backed server-side cache with a five-minute fresh window and a bounded stale fallback during refresh failures, include ETag, return 304 Not Modified for matching If-None-Match, and write cache lifecycle Cloudflare Analytics Engine datapoints without user IDs or feed tokens. Feed-token authorization is checked against the current user record before any cached export is returned.",
     "static-json-resilient": "Calendar location and building image enhancements only read static JSON published at https://static.life-ustc.tiankaima.dev; when loading fails or data is corrupted, diagnostic information should be logged and a valid iCal should still be returned."
   },
   "capabilities": {

--- a/src/features/calendar/server/calendar-export-cache.ts
+++ b/src/features/calendar/server/calendar-export-cache.ts
@@ -1,10 +1,16 @@
+import { getCloudflareCalendarExportsNamespace } from "@/lib/adapters/cloudflare-runtime";
 import { sha256Base64Url } from "@/lib/crypto/web-crypto";
 import { writeCalendarFeedCacheAnalytics } from "@/lib/metrics/analytics-engine";
 
-const USER_CALENDAR_EXPORT_CACHE_TTL_MS = 60_000;
+const USER_CALENDAR_EXPORT_CACHE_VERSION = 1;
+export const USER_CALENDAR_EXPORT_FRESH_TTL_MS = 5 * 60_000;
+export const USER_CALENDAR_EXPORT_STALE_TTL_MS = 24 * 60 * 60_000;
+const USER_CALENDAR_EXPORT_KV_CACHE_TTL_SECONDS = 30;
+const USER_CALENDAR_EXPORT_KV_EXPIRATION_TTL_SECONDS =
+  USER_CALENDAR_EXPORT_STALE_TTL_MS / 1_000;
 const MAX_USER_CALENDAR_EXPORT_CACHE_ENTRIES = 100;
 
-export type UserCalendarExportCacheStatus = "hit" | "miss";
+export type UserCalendarExportCacheStatus = "fresh" | "miss" | "stale";
 
 type UserCalendarExport = {
   cacheControl: string;
@@ -16,16 +22,44 @@ export type UserCalendarExportWithEtag = UserCalendarExport & {
   etag: string;
 };
 
-type CacheEntry = {
-  calendar: UserCalendarExportWithEtag;
-  expiresAtMs: number;
+type StoredUserCalendarExport = UserCalendarExportWithEtag & {
+  generatedAtMs: number;
+  version: typeof USER_CALENDAR_EXPORT_CACHE_VERSION;
 };
 
-const userCalendarExportCache = new Map<string, CacheEntry>();
+type UserCalendarExportCacheOptions = {
+  defer?: (promise: Promise<unknown>) => void;
+};
+
+const userCalendarExportCache = new Map<string, StoredUserCalendarExport>();
+const userCalendarExportRefreshes = new Map<
+  string,
+  Promise<UserCalendarExportWithEtag | null>
+>();
+
+function cacheKey(userId: string) {
+  return `user-calendar:v${USER_CALENDAR_EXPORT_CACHE_VERSION}:${userId}`;
+}
+
+function isStoredUserCalendarExport(
+  value: unknown,
+): value is StoredUserCalendarExport {
+  if (!value || typeof value !== "object") return false;
+  const entry = value as Partial<StoredUserCalendarExport>;
+  return (
+    entry.version === USER_CALENDAR_EXPORT_CACHE_VERSION &&
+    typeof entry.generatedAtMs === "number" &&
+    Number.isFinite(entry.generatedAtMs) &&
+    typeof entry.cacheControl === "string" &&
+    typeof entry.etag === "string" &&
+    typeof entry.filename === "string" &&
+    typeof entry.text === "string"
+  );
+}
 
 function pruneExpiredEntries(nowMs: number) {
   for (const [key, entry] of userCalendarExportCache) {
-    if (entry.expiresAtMs <= nowMs) {
+    if (nowMs - entry.generatedAtMs > USER_CALENDAR_EXPORT_STALE_TTL_MS) {
       userCalendarExportCache.delete(key);
     }
   }
@@ -41,12 +75,18 @@ function pruneOldestEntries() {
   }
 }
 
-function recordCalendarFeedCacheStatus(status: UserCalendarExportCacheStatus) {
+function recordCalendarFeedCacheStatus(
+  status:
+    | UserCalendarExportCacheStatus
+    | "refresh_error"
+    | "refresh_success"
+    | "store_error",
+) {
   writeCalendarFeedCacheAnalytics({
     feed: "user",
     status,
     storeSize: userCalendarExportCache.size,
-    ttlMs: USER_CALENDAR_EXPORT_CACHE_TTL_MS,
+    ttlMs: USER_CALENDAR_EXPORT_FRESH_TTL_MS,
   });
 }
 
@@ -64,52 +104,161 @@ export function requestMatchesEtag(request: Request, etag: string) {
   });
 }
 
+async function readStoredCalendar(userId: string) {
+  const memoryEntry = userCalendarExportCache.get(userId);
+  if (memoryEntry) return memoryEntry;
+
+  const namespace = getCloudflareCalendarExportsNamespace();
+  if (!namespace) return null;
+
+  try {
+    const entry = await namespace.get<StoredUserCalendarExport>(
+      cacheKey(userId),
+      {
+        cacheTtl: USER_CALENDAR_EXPORT_KV_CACHE_TTL_SECONDS,
+        type: "json",
+      },
+    );
+    if (!isStoredUserCalendarExport(entry)) return null;
+    userCalendarExportCache.set(userId, entry);
+    pruneOldestEntries();
+    return entry;
+  } catch {
+    recordCalendarFeedCacheStatus("store_error");
+    return null;
+  }
+}
+
+async function persistStoredCalendar(
+  userId: string,
+  entry: StoredUserCalendarExport,
+) {
+  const namespace = getCloudflareCalendarExportsNamespace();
+  if (!namespace) return;
+
+  try {
+    await namespace.put(cacheKey(userId), JSON.stringify(entry), {
+      expirationTtl: USER_CALENDAR_EXPORT_KV_EXPIRATION_TTL_SECONDS,
+    });
+  } catch {
+    recordCalendarFeedCacheStatus("store_error");
+  }
+}
+
+function refreshUserCalendarExport(
+  userId: string,
+  buildExport: () => Promise<UserCalendarExport | null>,
+  defer?: (promise: Promise<unknown>) => void,
+) {
+  const pending = userCalendarExportRefreshes.get(userId);
+  if (pending) return pending;
+
+  const refresh = (async () => {
+    const calendar = await buildExport();
+    if (!calendar) return null;
+
+    const stored: StoredUserCalendarExport = {
+      ...calendar,
+      etag: await createCalendarEtag(calendar.text),
+      generatedAtMs: Date.now(),
+      version: USER_CALENDAR_EXPORT_CACHE_VERSION,
+    };
+    userCalendarExportCache.set(userId, stored);
+    pruneOldestEntries();
+    const persistence = persistStoredCalendar(userId, stored);
+    if (defer) {
+      defer(persistence);
+    } else {
+      await persistence;
+    }
+    recordCalendarFeedCacheStatus("refresh_success");
+    return stored;
+  })();
+
+  userCalendarExportRefreshes.set(userId, refresh);
+  void refresh.then(
+    () => userCalendarExportRefreshes.delete(userId),
+    () => userCalendarExportRefreshes.delete(userId),
+  );
+  return refresh;
+}
+
+function backgroundRefresh(
+  refresh: Promise<UserCalendarExportWithEtag | null>,
+) {
+  return refresh.then(
+    () => undefined,
+    () => {
+      recordCalendarFeedCacheStatus("refresh_error");
+    },
+  );
+}
+
 export async function getCachedUserCalendarExport(
   userId: string,
   buildExport: () => Promise<UserCalendarExport | null>,
+  options: UserCalendarExportCacheOptions = {},
 ) {
   const nowMs = Date.now();
   pruneExpiredEntries(nowMs);
 
-  const cached = userCalendarExportCache.get(userId);
-  if (cached && cached.expiresAtMs > nowMs) {
-    recordCalendarFeedCacheStatus("hit");
-    return {
-      calendar: cached.calendar,
-      status: "hit" satisfies UserCalendarExportCacheStatus,
-    };
-  }
-
+  const cached = await readStoredCalendar(userId);
   if (cached) {
+    const ageMs = Math.max(0, nowMs - cached.generatedAtMs);
+    if (ageMs <= USER_CALENDAR_EXPORT_FRESH_TTL_MS) {
+      recordCalendarFeedCacheStatus("fresh");
+      return {
+        calendar: cached,
+        status: "fresh" satisfies UserCalendarExportCacheStatus,
+      };
+    }
+
+    if (ageMs <= USER_CALENDAR_EXPORT_STALE_TTL_MS) {
+      const refresh = refreshUserCalendarExport(userId, buildExport);
+      if (options.defer) {
+        options.defer(backgroundRefresh(refresh));
+        recordCalendarFeedCacheStatus("stale");
+        return {
+          calendar: cached,
+          status: "stale" satisfies UserCalendarExportCacheStatus,
+        };
+      }
+
+      try {
+        const refreshed = await refresh;
+        if (refreshed) {
+          return {
+            calendar: refreshed,
+            status: "miss" satisfies UserCalendarExportCacheStatus,
+          };
+        }
+      } catch {
+        recordCalendarFeedCacheStatus("refresh_error");
+      }
+
+      recordCalendarFeedCacheStatus("stale");
+      return {
+        calendar: cached,
+        status: "stale" satisfies UserCalendarExportCacheStatus,
+      };
+    }
+
     userCalendarExportCache.delete(userId);
   }
 
-  const calendar = await buildExport();
-  if (!calendar) {
-    recordCalendarFeedCacheStatus("miss");
-    return {
-      calendar: null,
-      status: "miss" satisfies UserCalendarExportCacheStatus,
-    };
-  }
-
-  const calendarWithEtag = {
-    ...calendar,
-    etag: await createCalendarEtag(calendar.text),
-  };
-  userCalendarExportCache.set(userId, {
-    calendar: calendarWithEtag,
-    expiresAtMs: nowMs + USER_CALENDAR_EXPORT_CACHE_TTL_MS,
-  });
-  pruneOldestEntries();
-
   recordCalendarFeedCacheStatus("miss");
+  const calendar = await refreshUserCalendarExport(
+    userId,
+    buildExport,
+    options.defer,
+  );
   return {
-    calendar: calendarWithEtag,
+    calendar,
     status: "miss" satisfies UserCalendarExportCacheStatus,
   };
 }
 
 export function resetUserCalendarExportCacheForTest() {
   userCalendarExportCache.clear();
+  userCalendarExportRefreshes.clear();
 }

--- a/src/features/calendar/server/calendar-export-data.ts
+++ b/src/features/calendar/server/calendar-export-data.ts
@@ -75,6 +75,16 @@ export async function getSectionsForCalendar(sectionIds: number[]) {
   });
 }
 
+export async function getUserCalendarAccessRecord(userId: string) {
+  return prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      calendarFeedToken: true,
+    },
+  });
+}
+
 export async function getUserCalendarRecord(userId: string) {
   return prisma.user.findUnique({
     where: { id: userId },

--- a/src/lib/adapters/cloudflare-runtime.ts
+++ b/src/lib/adapters/cloudflare-runtime.ts
@@ -40,8 +40,25 @@ export type CloudflareRateLimiter = {
   limit(options: { key: string }): Promise<{ success: boolean }>;
 };
 
+type CloudflareExecutionContext = {
+  waitUntil(promise: Promise<unknown>): void;
+};
+
+export type CloudflareKVNamespace = {
+  get<T = unknown>(
+    key: string,
+    options: { cacheTtl?: number; type: "json" },
+  ): Promise<T | null>;
+  put(
+    key: string,
+    value: string,
+    options?: { expirationTtl?: number },
+  ): Promise<void>;
+};
+
 type CloudflareRuntimeEnv = Record<string, unknown> & {
   ANALYTICS?: CloudflareAnalyticsEngineDataset;
+  CALENDAR_EXPORTS?: CloudflareKVNamespace;
   HYPERDRIVE?: {
     connectionString?: unknown;
   };
@@ -132,6 +149,25 @@ export function getCloudflareR2UploadsBucket() {
 
 export function getCloudflareAnalyticsEngineDataset() {
   return getCurrentCloudflareRuntimeEnv()?.ANALYTICS;
+}
+
+export function getCloudflareCalendarExportsNamespace() {
+  return getCurrentCloudflareRuntimeEnv()?.CALENDAR_EXPORTS;
+}
+
+export function getCloudflareTaskScheduler(platform: unknown) {
+  if (!platform || typeof platform !== "object") return undefined;
+  const value = platform as { context?: unknown; ctx?: unknown };
+  const context = value.ctx ?? value.context;
+  if (!context || typeof context !== "object" || !("waitUntil" in context)) {
+    return undefined;
+  }
+  const executionContext = context as Partial<CloudflareExecutionContext>;
+  if (typeof executionContext.waitUntil !== "function") return undefined;
+
+  return (promise: Promise<unknown>) => {
+    executionContext.waitUntil?.(promise);
+  };
 }
 
 export function getCloudflareUserMutationRateLimiter(tier: "batch" | "write") {

--- a/src/lib/api/routes/calendar-route-actions.ts
+++ b/src/lib/api/routes/calendar-route-actions.ts
@@ -5,6 +5,7 @@ import {
 import {
   getSectionForCalendar,
   getSectionsForCalendar,
+  getUserCalendarRecord,
 } from "@/features/calendar/server/calendar-export-data";
 import { buildUserCalendarExport } from "@/features/calendar/server/calendar-export-service";
 import {
@@ -50,12 +51,18 @@ export async function generateSectionCalendarAction(sectionJwId: number) {
 }
 
 export async function generateUserCalendarAction(
-  user: Parameters<typeof buildUserCalendarExport>[0],
   userId: string,
   request: Request,
+  defer?: (promise: Promise<unknown>) => void,
 ) {
-  const { calendar } = await getCachedUserCalendarExport(userId, () =>
-    buildUserCalendarExport(user, userId),
+  const { calendar } = await getCachedUserCalendarExport(
+    userId,
+    async () => {
+      const user = await getUserCalendarRecord(userId);
+      if (!user) return null;
+      return buildUserCalendarExport(user, userId);
+    },
+    { defer },
   );
   if (!calendar) {
     return notFound("No calendar items found");

--- a/src/lib/api/routes/calendar-route-user-access.ts
+++ b/src/lib/api/routes/calendar-route-user-access.ts
@@ -1,4 +1,4 @@
-import { getUserCalendarRecord } from "@/features/calendar/server/calendar-export-data";
+import { getUserCalendarAccessRecord } from "@/features/calendar/server/calendar-export-data";
 import { forbidden, notFound, unauthorized } from "@/lib/api/helpers";
 import { resolveApiUserId } from "@/lib/auth/api-auth";
 import { parseUserCalendarIdentifier } from "./calendar-route-utils";
@@ -15,7 +15,7 @@ export async function resolveUserCalendarAccess({
     tokenFromPath?.trim() ||
     new URL(request.url).searchParams.get("token")?.trim();
 
-  const user = await getUserCalendarRecord(userId);
+  const user = await getUserCalendarAccessRecord(userId);
 
   if (token) {
     if (!user || user.calendarFeedToken !== token) {
@@ -46,5 +46,5 @@ export async function resolveUserCalendarAccess({
     return { ok: false as const, response: notFound("User not found") };
   }
 
-  return { ok: true as const, user, userId };
+  return { ok: true as const, userId };
 }

--- a/src/lib/api/routes/calendars.ts
+++ b/src/lib/api/routes/calendars.ts
@@ -40,6 +40,7 @@ export async function getSectionCalendarRoute(params: { jwId: string }) {
 export async function getUserCalendarRoute(
   request: Request,
   params: { userId: string },
+  options: { defer?: (promise: Promise<unknown>) => void } = {},
 ) {
   try {
     const rawUserId = parseUserCalendarRawUserId(params);
@@ -52,9 +53,9 @@ export async function getUserCalendarRoute(
     }
 
     return await generateUserCalendarAction(
-      access.user,
       access.userId,
       request,
+      options.defer,
     );
   } catch (error) {
     return handleRouteError("Failed to generate user calendar", error);

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -61,7 +61,13 @@ type CacheEventAnalyticsInput = {
 
 type CalendarFeedCacheAnalyticsInput = {
   feed: "user";
-  status: "hit" | "miss";
+  status:
+    | "fresh"
+    | "miss"
+    | "refresh_error"
+    | "refresh_success"
+    | "stale"
+    | "store_error";
   storeSize: number;
   ttlMs: number;
 };

--- a/src/routes/api/users/[userId]/calendar.ics/+server.ts
+++ b/src/routes/api/users/[userId]/calendar.ics/+server.ts
@@ -1,4 +1,5 @@
 import type { RequestHandler } from "@sveltejs/kit";
+import { getCloudflareTaskScheduler } from "@/lib/adapters/cloudflare-runtime";
 import { getUserCalendarRoute } from "@/lib/api/routes/calendars";
 import { observedApiRoute } from "@/lib/log/api-observability";
 
@@ -11,7 +12,11 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  * @response 403:openApiErrorSchema
  * @response 404:openApiErrorSchema
  */
-export const GET: RequestHandler = ({ request, params }) =>
+export const GET: RequestHandler = ({ request, params, platform }) =>
   observedApiRoute(() =>
-    getUserCalendarRoute(request, { userId: params.userId }),
+    getUserCalendarRoute(
+      request,
+      { userId: params.userId },
+      { defer: getCloudflareTaskScheduler(platform) },
+    ),
   )(request);

--- a/tests/unit/calendar-export-cache.test.ts
+++ b/tests/unit/calendar-export-cache.test.ts
@@ -3,6 +3,7 @@ import {
   getCachedUserCalendarExport,
   requestMatchesEtag,
   resetUserCalendarExportCacheForTest,
+  USER_CALENDAR_EXPORT_FRESH_TTL_MS,
 } from "@/features/calendar/server/calendar-export-cache";
 import { setCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
 
@@ -12,6 +13,19 @@ const calendarExport = {
   text: "BEGIN:VCALENDAR\nEND:VCALENDAR",
 };
 
+function kvNamespace() {
+  const values = new Map<string, string>();
+  return {
+    get: vi.fn(async (key: string) => {
+      const value = values.get(key);
+      return value ? JSON.parse(value) : null;
+    }),
+    put: vi.fn(async (key: string, value: string) => {
+      values.set(key, value);
+    }),
+  };
+}
+
 describe("用户 iCal 导出缓存", () => {
   afterEach(() => {
     resetUserCalendarExportCacheForTest();
@@ -20,37 +34,53 @@ describe("用户 iCal 导出缓存", () => {
     vi.restoreAllMocks();
   });
 
-  it("在 TTL 内复用已生成的日历导出", async () => {
+  it("跨 isolate 从 KV 复用 fresh 导出", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-07T00:00:00.000Z"));
+    const namespace = kvNamespace();
     const writeDataPoint = vi.fn();
-    setCloudflareRuntimeEnv({ ANALYTICS: { writeDataPoint } });
+    setCloudflareRuntimeEnv({
+      ANALYTICS: { writeDataPoint },
+      CALENDAR_EXPORTS: namespace,
+    });
     const buildExport = vi.fn().mockResolvedValue(calendarExport);
 
     const first = await getCachedUserCalendarExport("user-1", buildExport);
+    resetUserCalendarExportCacheForTest();
     const second = await getCachedUserCalendarExport("user-1", buildExport);
 
     expect(first.status).toBe("miss");
-    expect(second.status).toBe("hit");
+    expect(second.status).toBe("fresh");
     expect(buildExport).toHaveBeenCalledTimes(1);
+    expect(namespace.put).toHaveBeenCalledWith(
+      "user-calendar:v1:user-1",
+      expect.any(String),
+      { expirationTtl: 86_400 },
+    );
+    expect(namespace.get).toHaveBeenLastCalledWith("user-calendar:v1:user-1", {
+      cacheTtl: 30,
+      type: "json",
+    });
     expect(second.calendar?.etag).toMatch(/^"sha256-[A-Za-z0-9_-]+"$/);
 
     expect(writeDataPoint).toHaveBeenCalledWith({
       indexes: ["cache:calendar:user"],
       blobs: ["calendar_feed_cache", "user", "miss"],
-      doubles: [60_000, 1],
+      doubles: [USER_CALENDAR_EXPORT_FRESH_TTL_MS, 0],
     });
     expect(writeDataPoint).toHaveBeenCalledWith({
       indexes: ["cache:calendar:user"],
-      blobs: ["calendar_feed_cache", "user", "hit"],
-      doubles: [60_000, 1],
+      blobs: ["calendar_feed_cache", "user", "fresh"],
+      doubles: [USER_CALENDAR_EXPORT_FRESH_TTL_MS, 1],
     });
     expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain("user-1");
   });
 
-  it("TTL 过期后重新生成导出", async () => {
+  it("stale 导出立即返回并通过 defer 后台刷新", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-07T00:00:00.000Z"));
+    const namespace = kvNamespace();
+    setCloudflareRuntimeEnv({ CALENDAR_EXPORTS: namespace });
     const buildExport = vi
       .fn()
       .mockResolvedValueOnce(calendarExport)
@@ -60,12 +90,101 @@ describe("用户 iCal 导出缓存", () => {
       });
 
     await getCachedUserCalendarExport("user-1", buildExport);
-    vi.setSystemTime(new Date("2026-06-07T00:01:01.000Z"));
-    const refreshed = await getCachedUserCalendarExport("user-1", buildExport);
+    vi.advanceTimersByTime(USER_CALENDAR_EXPORT_FRESH_TTL_MS + 1);
+    const tasks: Promise<unknown>[] = [];
+    const stale = await getCachedUserCalendarExport("user-1", buildExport, {
+      defer: (promise) => tasks.push(promise),
+    });
 
-    expect(refreshed.status).toBe("miss");
+    expect(stale.status).toBe("stale");
+    expect(stale.calendar?.text).toBe(calendarExport.text);
+    expect(tasks).toHaveLength(1);
+
+    await tasks[0];
+    const refreshed = await getCachedUserCalendarExport("user-1", buildExport);
+    expect(refreshed.status).toBe("fresh");
     expect(refreshed.calendar?.text).toContain("X-UPDATED:1");
     expect(buildExport).toHaveBeenCalledTimes(2);
+  });
+
+  it("cold miss 将 KV 写入移出响应关键路径", async () => {
+    let finishPut: (() => void) | undefined;
+    const namespace = {
+      get: vi.fn().mockResolvedValue(null),
+      put: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishPut = resolve;
+          }),
+      ),
+    };
+    setCloudflareRuntimeEnv({ CALENDAR_EXPORTS: namespace });
+    const tasks: Promise<unknown>[] = [];
+
+    const result = await getCachedUserCalendarExport(
+      "user-1",
+      vi.fn().mockResolvedValue(calendarExport),
+      { defer: (promise) => tasks.push(promise) },
+    );
+
+    expect(result.status).toBe("miss");
+    expect(namespace.put).toHaveBeenCalledOnce();
+    expect(tasks).toHaveLength(1);
+
+    finishPut?.();
+    await expect(tasks[0]).resolves.toBeUndefined();
+  });
+
+  it("合并同一 isolate 内的并发 miss", async () => {
+    const namespace = kvNamespace();
+    setCloudflareRuntimeEnv({ CALENDAR_EXPORTS: namespace });
+    let resolveBuild: ((value: typeof calendarExport) => void) | undefined;
+    const buildExport = vi.fn(
+      () =>
+        new Promise<typeof calendarExport>((resolve) => {
+          resolveBuild = resolve;
+        }),
+    );
+
+    const first = getCachedUserCalendarExport("user-1", buildExport);
+    const second = getCachedUserCalendarExport("user-1", buildExport);
+    await vi.waitFor(() => expect(buildExport).toHaveBeenCalledTimes(1));
+    resolveBuild?.(calendarExport);
+
+    const results = await Promise.all([first, second]);
+    expect(results.map((result) => result.status)).toEqual(["miss", "miss"]);
+    expect(namespace.put).toHaveBeenCalledTimes(1);
+  });
+
+  it("后台刷新失败时继续返回 stale 导出", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-07T00:00:00.000Z"));
+    const buildExport = vi
+      .fn()
+      .mockResolvedValueOnce(calendarExport)
+      .mockRejectedValueOnce(new Error("database unavailable"));
+
+    await getCachedUserCalendarExport("user-1", buildExport);
+    vi.advanceTimersByTime(USER_CALENDAR_EXPORT_FRESH_TTL_MS + 1);
+    const tasks: Promise<unknown>[] = [];
+    const stale = await getCachedUserCalendarExport("user-1", buildExport, {
+      defer: (promise) => tasks.push(promise),
+    });
+
+    await expect(tasks[0]).resolves.toBeUndefined();
+    expect(stale.status).toBe("stale");
+    expect(stale.calendar?.text).toBe(calendarExport.text);
+  });
+
+  it("KV 不可用时仍使用 isolate 内存缓存", async () => {
+    const buildExport = vi.fn().mockResolvedValue(calendarExport);
+
+    const first = await getCachedUserCalendarExport("user-1", buildExport);
+    const second = await getCachedUserCalendarExport("user-1", buildExport);
+
+    expect(first.status).toBe("miss");
+    expect(second.status).toBe("fresh");
+    expect(buildExport).toHaveBeenCalledTimes(1);
   });
 
   it("不缓存空日历结果", async () => {
@@ -75,17 +194,6 @@ describe("用户 iCal 导出缓存", () => {
     await getCachedUserCalendarExport("user-1", buildExport);
 
     expect(buildExport).toHaveBeenCalledTimes(2);
-  });
-
-  it("限制缓存条目数量", async () => {
-    const buildExport = vi.fn().mockResolvedValue(calendarExport);
-
-    for (let index = 0; index < 101; index += 1) {
-      await getCachedUserCalendarExport(`user-${index}`, buildExport);
-    }
-    await getCachedUserCalendarExport("user-0", buildExport);
-
-    expect(buildExport).toHaveBeenCalledTimes(102);
   });
 
   it("匹配强 ETag、弱 ETag 和多值 If-None-Match", () => {

--- a/tests/unit/calendar-route-actions.test.ts
+++ b/tests/unit/calendar-route-actions.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { buildUserCalendarExportMock, getCachedExportMock, getUserRecordMock } =
+  vi.hoisted(() => ({
+    buildUserCalendarExportMock: vi.fn(),
+    getCachedExportMock: vi.fn(),
+    getUserRecordMock: vi.fn(),
+  }));
+
+type BuiltCalendarExport = {
+  cacheControl: string;
+  filename: string;
+  text: string;
+};
+
+vi.mock("@/features/calendar/server/calendar-export-cache", () => ({
+  getCachedUserCalendarExport: getCachedExportMock,
+  requestMatchesEtag: vi.fn(() => false),
+}));
+
+vi.mock("@/features/calendar/server/calendar-export-data", () => ({
+  getSectionForCalendar: vi.fn(),
+  getSectionsForCalendar: vi.fn(),
+  getUserCalendarRecord: getUserRecordMock,
+}));
+
+vi.mock("@/features/calendar/server/calendar-export-service", () => ({
+  buildUserCalendarExport: buildUserCalendarExportMock,
+}));
+
+vi.mock("@/features/calendar/server/ical", () => ({
+  createMultiSectionCalendar: vi.fn(),
+  createSectionCalendar: vi.fn(),
+}));
+
+describe("personal calendar route cache ordering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not load calendar relations when the rendered export is cached", async () => {
+    getCachedExportMock.mockResolvedValue({
+      calendar: {
+        cacheControl: "private, max-age=300",
+        etag: '"sha256-cached"',
+        filename: "life-ustc-subscriptions.ics",
+        text: "BEGIN:VCALENDAR\nEND:VCALENDAR",
+      },
+      status: "fresh",
+    });
+    const { generateUserCalendarAction } = await import(
+      "@/lib/api/routes/calendar-route-actions"
+    );
+
+    const response = await generateUserCalendarAction(
+      "user-1",
+      new Request("https://example.test"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(getUserRecordMock).not.toHaveBeenCalled();
+    expect(buildUserCalendarExportMock).not.toHaveBeenCalled();
+  });
+
+  it("loads heavy calendar data only through the cache miss builder", async () => {
+    const user = { id: "user-1", subscribedSections: [], todos: [] };
+    getUserRecordMock.mockResolvedValue(user);
+    buildUserCalendarExportMock.mockResolvedValue({
+      cacheControl: "private, max-age=300",
+      filename: "life-ustc-subscriptions.ics",
+      text: "BEGIN:VCALENDAR\nEND:VCALENDAR",
+    });
+    getCachedExportMock.mockImplementation(
+      async (_userId: string, build: () => Promise<unknown>) => {
+        const calendar = (await build()) as BuiltCalendarExport;
+        return {
+          calendar: {
+            ...calendar,
+            etag: '"sha256-built"',
+          },
+          status: "miss",
+        };
+      },
+    );
+    const { generateUserCalendarAction } = await import(
+      "@/lib/api/routes/calendar-route-actions"
+    );
+
+    await generateUserCalendarAction(
+      "user-1",
+      new Request("https://example.test"),
+    );
+
+    expect(getUserRecordMock).toHaveBeenCalledOnce();
+    expect(buildUserCalendarExportMock).toHaveBeenCalledWith(user, "user-1");
+  });
+});

--- a/tests/unit/calendar-route-user-access.test.ts
+++ b/tests/unit/calendar-route-user-access.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getAccessRecordMock, resolveApiUserIdMock } = vi.hoisted(() => ({
+  getAccessRecordMock: vi.fn(),
+  resolveApiUserIdMock: vi.fn(),
+}));
+
+vi.mock("@/features/calendar/server/calendar-export-data", () => ({
+  getUserCalendarAccessRecord: getAccessRecordMock,
+}));
+
+vi.mock("@/lib/auth/api-auth", () => ({
+  resolveApiUserId: resolveApiUserIdMock,
+}));
+
+describe("personal calendar access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("validates the current feed token before returning a cache identity", async () => {
+    getAccessRecordMock.mockResolvedValue({
+      id: "user-1",
+      calendarFeedToken: "current-token",
+    });
+    const { resolveUserCalendarAccess } = await import(
+      "@/lib/api/routes/calendar-route-user-access"
+    );
+
+    const access = await resolveUserCalendarAccess({
+      rawUserId: "user-1",
+      request: new Request(
+        "https://example.test/api/users/user-1/calendar.ics?token=current-token",
+      ),
+    });
+
+    expect(access).toEqual({ ok: true, userId: "user-1" });
+    expect(resolveApiUserIdMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a revoked token before any rendered cache can be read", async () => {
+    getAccessRecordMock.mockResolvedValue({
+      id: "user-1",
+      calendarFeedToken: "replacement-token",
+    });
+    const { resolveUserCalendarAccess } = await import(
+      "@/lib/api/routes/calendar-route-user-access"
+    );
+
+    const access = await resolveUserCalendarAccess({
+      rawUserId: "user-1",
+      request: new Request(
+        "https://example.test/api/users/user-1/calendar.ics?token=revoked-token",
+      ),
+    });
+
+    expect(access.ok).toBe(false);
+    if (!access.ok) expect(access.response.status).toBe(403);
+    expect(resolveApiUserIdMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/section-lifecycle-queries.test.ts
+++ b/tests/unit/section-lifecycle-queries.test.ts
@@ -82,6 +82,22 @@ describe("retired Section query contracts", () => {
     );
   });
 
+  it("uses a minimal projection for personal calendar access checks", async () => {
+    const { getUserCalendarAccessRecord } = await import(
+      "@/features/calendar/server/calendar-export-data"
+    );
+
+    await getUserCalendarAccessRecord("user-1");
+
+    expect(userFindUniqueMock).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      select: {
+        id: true,
+        calendarFeedToken: true,
+      },
+    });
+  });
+
   it("keeps retired rows in the user's owned subscription history", async () => {
     const { getUserCalendarSubscription } = await import(
       "@/features/subscriptions/server/subscription-calendar-read-model"

--- a/wrangler.e2e.jsonc
+++ b/wrangler.e2e.jsonc
@@ -39,6 +39,12 @@
       "localConnectionString": "postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev"
     }
   ],
+  "kv_namespaces": [
+    {
+      "binding": "CALENDAR_EXPORTS",
+      "id": "c7411aac14fa45a6bb6f8b8f6b8e1a1d"
+    }
+  ],
   "ratelimits": [
     {
       "name": "USER_WRITE_RATE_LIMITER",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -58,6 +58,12 @@
       "dataset": "life_ustc_runtime"
     }
   ],
+  "kv_namespaces": [
+    {
+      "binding": "CALENDAR_EXPORTS",
+      "id": "c7411aac14fa45a6bb6f8b8f6b8e1a1d"
+    }
+  ],
   "ratelimits": [
     {
       "name": "USER_WRITE_RATE_LIMITER",


### PR DESCRIPTION
## Goal

Prevent personal iCalendar feed generation from repeatedly consuming the Worker CPU budget while preserving token revocation, ETag behavior, and bounded freshness. Closes #518.

## Changed Surfaces

- Validate the current feed token or session through a minimal user lookup before reading cached content.
- Move the expensive subscriptions/todos/homework query and iCalendar render behind cache misses.
- Add a 5-minute fresh Workers KV cache with a 24-hour stale-on-refresh-failure bound, isolate-local L1 cache, and in-flight request coalescing.
- Schedule stale refreshes and cold-miss KV persistence with `ExecutionContext.waitUntil` so storage writes do not extend response latency.
- Add cache outcome analytics without user IDs or feed tokens.
- Bind the dedicated `CALENDAR_EXPORTS` namespace (`c7411aac14fa45a6bb6f8b8f6b8e1a1d`) in production and local E2E configuration.
- The public section-calendar endpoints and external response shape are unchanged.

## Evidence

- `DATABASE_URL=dummy bun run app:prepare`
- `bunx biome check` (passes; one pre-existing unused-variable warning in `src/static-loader/import.ts`)
- `bunx svelte-check --tsconfig ./tsconfig.json` (0 errors/warnings)
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- test and operational TypeScript checks
- `bunx vitest run` (200 files, 1194 tests passed)
- isolated PostgreSQL integration suite (31 files, 180 tests passed)
- isolated focused Playwright iCalendar suite (9 tests passed)
- `DATABASE_URL=dummy bun run build`
- `bunx wrangler deploy --dry-run` (confirms `CALENDAR_EXPORTS` binding; no production deploy)
- `git diff --check`

## Docs / Contracts

Updated `docs/contracts/ical.json` to document private Workers KV storage, five-minute freshness, bounded stale fallback, and authorization before cache access.

## Risk Areas

- Authorization remains ahead of cache lookup, so token revocation cannot read an old cached export.
- KV is eventually consistent; ordinary freshness is bounded to five minutes, and stale content is served for at most 24 hours only when refresh fails.
- A first cold render still pays generation cost under the existing 1,000 ms CPU limit; production telemetry should confirm the observed hit ratio and cold-path headroom before changing that account-wide safety limit.
- Cache keys use internal user IDs, never public feed tokens; analytics contain only outcome labels.
- No Prisma migration, REST/MCP response-shape change, or production deployment is included.

## Cleanup

No scratch artifacts, generated Worker type files, unrelated rewrites, or manual generated-file edits remain.