### PR TITLE
fix(seo): declare SSR response language

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -218,6 +218,7 @@ const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
     mutableResponse.headers.set("x-request-id", requestId);
   }
   if (shouldSetCsp) {
+    mutableResponse.headers.set("Content-Language", locale);
     appendPageServerTiming(mutableResponse.headers, {
       appDurationMs,
       authDurationMs,

--- a/tests/e2e/src/app/courses/social-metadata.test.ts
+++ b/tests/e2e/src/app/courses/social-metadata.test.ts
@@ -27,6 +27,7 @@ const metadataSelectors = {
 
 type MetadataKey = keyof typeof metadataSelectors;
 type RawSocialMetadata = {
+  contentLanguage: string | undefined;
   htmlLang: string | null;
   origin: string;
   values: Record<MetadataKey, string[]>;
@@ -76,6 +77,7 @@ async function readRawSocialMetadata(
 
   return {
     ...parsed,
+    contentLanguage: response.headers()["content-language"],
     origin: new URL(response.url()).origin,
     values: parsed.values as Record<MetadataKey, string[]>,
   };
@@ -101,6 +103,7 @@ function expectCompleteSocialMetadata(
   const alternateLocale = expected.locale === "zh-cn" ? "en_US" : "zh_CN";
 
   expect(metadata.htmlLang).toBe(expected.locale);
+  expect(metadata.contentLanguage).toBe(expected.locale);
   expect(metadata.values.canonical[0]).toBe(canonicalUrl);
   expect(metadata.values.description[0]).toBe(expected.description);
   expect(metadata.values.ogTitle[0]).toBe(expected.title);


### PR DESCRIPTION
## Goal

Declare the negotiated locale on localized SSR HTML responses so HTTP clients and non-rendering crawlers can identify the representation language. Closes #525.

## Changed Surfaces

- `src/hooks.server.ts`: add `Content-Language` to HTML responses using the same negotiated locale that renders `<html lang>`.
- `tests/e2e/src/app/courses/social-metadata.test.ts`: require raw SSR `Content-Language`, `<html lang>`, canonical, and localized metadata to agree.
- API/non-HTML responses, route identity, canonical URLs, JSON-LD, and cache behavior are unchanged.

## Evidence

- `bun run app:prepare`
- `bunx biome check` (exit 0; one unrelated pre-existing warning in `src/static-loader/import.ts` on full-tree run)
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` — 201 files / 1,204 tests passed
- `bun run build`
- Focused Playwright/Chromium social-metadata spec — 6/6 passed against the built Worker and a dedicated seeded Postgres database.
- Browser plugin was unavailable. Production Playwright fallback checked course/list/section/teacher routes, UI language switching, no-JS detail rendering, and console health: no hydration warnings/errors; `lang`, title, canonical, OG locale, and JSON-LD stayed consistent.
- Port 3000 was occupied by another parallel worktree, so focused E2E used an uncommitted `/tmp` config on 3001 with the same Wrangler E2E build/config.

## Docs / Contracts

No docs or contract update: this aligns HTTP metadata with existing locale behavior without changing user-visible workflows or public API shapes.

## Risk Areas

Low. The new header is applied only when the response is HTML, beside the existing HTML security/cache headers. Locale-specific URLs and `hreflang` remain out of scope because both locales currently share a cookie/header-negotiated URL; that decision is coupled to #507.

## Cleanup

No scratch artifacts, screenshots, reports, local database, generated output, or unrelated rewrites are committed. Discovery endpoint edge caching is tracked separately in #526.