### PR TITLE
perf(dashboard): split anonymous home from signed workspace

### DIFF
--- a/docs/contracts/overview.json
+++ b/docs/contracts/overview.json
@@ -2,12 +2,12 @@
   "name": "Overview",
   "access": {
     "anon": "On the home page, can only see the public bus and frequent links views; cannot enter the personal overview.",
-    "user": "The home page serves as the personal workspace.",
-    "admin": "The home page personal workspace behavior is the same as regular users.",
-    "agent": "Can read overview results with the same semantics as the home page; REST and MCP should return consistent overview information."
+    "user": "Accessing the home page redirects to the personal workspace at /dashboard.",
+    "admin": "Accessing the home page redirects to the personal workspace at /dashboard, with the same dashboard behavior as regular users.",
+    "agent": "Can read overview results with the same semantics as the authenticated dashboard; REST and MCP should return consistent overview information."
   },
   "rules": {
-    "decision-page": "The home page is not a directory page but a decision page for 'what to do next'.",
+    "decision-page": "The anonymous home page is a public bus and frequent-links decision page; the authenticated /dashboard overview is the personal decision page for 'what to do next'.",
     "now-next-first": "The authenticated overview begins with the current or next actionable schedule, homework, exam, or todo in a rolling seven-day window. Today's urgent work follows it, while frequent links remain secondary and appear after planning content.",
     "current-semester-priority": "The above-the-fold area prioritizes personal learning tasks within the current semester, not historical semester content or complete directory information.",
     "homework-todo-layered": "Homework and todos are layered as 'due today / due soon / all incomplete'; homework with no due date does not participate in upcoming due date sorting.",
@@ -20,7 +20,7 @@
   },
   "capabilities": {
     "authenticated-overview": {
-      "title": "Authenticated Homepage Overview",
+      "title": "Authenticated Dashboard Overview",
       "auth": "user",
       "links": {
         "models": ["User", "Section", "Homework", "Todo", "Exam"]

--- a/src/features/dashboard/components/AnonymousDashboardView.svelte
+++ b/src/features/dashboard/components/AnonymousDashboardView.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-import type { DashboardBusCopy } from "@/features/dashboard/lib/bus-tab-types";
 import type {
-  AnonymousDashboardData,
+  DashboardBusCopy,
+  DashboardBusData,
+} from "@/features/dashboard/lib/bus-tab-types";
+import type {
   AnonymousLinkGroup,
   DashboardDashboardCopy,
   DashboardHomepageCopy,
@@ -10,10 +12,15 @@ import type {
 import AnonymousLinksTab from "./AnonymousLinksTab.svelte";
 import BusTab from "./BusTab.svelte";
 
-export let anonymousData: AnonymousDashboardData;
+export let anonymousData: {
+  bus?: DashboardBusData | null;
+  tab: string;
+};
 export let anonymousLinkGroups: AnonymousLinkGroup[];
 export let busCopy: DashboardBusCopy;
-export let dashboardCopy: DashboardDashboardCopy;
+export let dashboardCopy: Pick<DashboardDashboardCopy, "linkHub"> & {
+  nav: Pick<DashboardDashboardCopy["nav"], "bus" | "links">;
+};
 export let homepageCopy: DashboardHomepageCopy;
 export let linkIconLabel: (icon: string) => string;
 export let linkSearchInput: HTMLInputElement | null;

--- a/src/features/dashboard/components/AnonymousHomePageController.svelte
+++ b/src/features/dashboard/components/AnonymousHomePageController.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+import { onMount } from "svelte";
+import type {
+  DashboardBusCopy,
+  DashboardBusData,
+} from "@/features/dashboard/lib/bus-tab-types";
+import type {
+  DashboardDashboardCopy,
+  DashboardHomepageCopy,
+  LinkView,
+} from "@/features/dashboard/lib/dashboard-controller-helpers";
+import { dashboardLinkViewChange } from "@/features/dashboard/lib/dashboard-controller-view-actions";
+import { linkIconLabel } from "@/features/dashboard/lib/dashboard-link-icon";
+import {
+  DASHBOARD_VIEW_STORAGE_KEY,
+  dashboardViewsFromPreference,
+} from "@/features/dashboard/lib/view-preferences";
+import { groupDashboardLinks } from "@/features/dashboard-links/lib/dashboard-link-search";
+import type { DashboardLinkSummary } from "@/features/dashboard-links/server/dashboard-link-data";
+import { replaceState } from "$app/navigation";
+import AnonymousDashboardView from "./AnonymousDashboardView.svelte";
+
+type AnonymousHomePageData = {
+  bus?: DashboardBusData | null;
+  copy: {
+    bus: DashboardBusCopy;
+    dashboard: Pick<DashboardDashboardCopy, "linkHub"> & {
+      nav: Pick<DashboardDashboardCopy["nav"], "bus" | "links">;
+    };
+    homepage: DashboardHomepageCopy;
+    metadata: { home: string };
+  };
+  publicLinks: DashboardLinkSummary[];
+  signedIn: false;
+  tab: string;
+};
+
+export let data: AnonymousHomePageData;
+
+let linkSearchInput: HTMLInputElement | null = null;
+let linkSearchQuery = "";
+let linkView: LinkView = "grid";
+
+$: dashboardCopy = data.copy.dashboard;
+$: anonymousLinkGroups = groupDashboardLinks(
+  data.publicLinks,
+  linkSearchQuery,
+  dashboardCopy.linkHub.groups,
+);
+
+function setLinkView(mode: LinkView) {
+  const next = dashboardLinkViewChange(mode);
+  linkView = next.state.linkView;
+  replaceState(next.href, {});
+}
+
+onMount(() => {
+  const url = new URL(window.location.href);
+  linkView = dashboardViewsFromPreference(
+    url,
+    localStorage.getItem(DASHBOARD_VIEW_STORAGE_KEY),
+  ).linkView;
+
+  function handleShortcut(event: KeyboardEvent) {
+    if (
+      (event.metaKey || event.ctrlKey) &&
+      event.key.toLowerCase() === "k" &&
+      linkSearchInput
+    ) {
+      event.preventDefault();
+      linkSearchInput.focus();
+    }
+  }
+
+  window.addEventListener("keydown", handleShortcut);
+  return () => window.removeEventListener("keydown", handleShortcut);
+});
+</script>
+
+<svelte:head>
+  <title>{data.copy.metadata.home} - Life@USTC</title>
+</svelte:head>
+
+<AnonymousDashboardView
+  busCopy={data.copy.bus}
+  {dashboardCopy}
+  homepageCopy={data.copy.homepage}
+  anonymousData={data}
+  {anonymousLinkGroups}
+  {linkIconLabel}
+  {linkView}
+  {setLinkView}
+  bind:linkSearchInput
+  bind:linkSearchQuery
+/>

--- a/src/features/dashboard/components/AnonymousLinksTab.svelte
+++ b/src/features/dashboard/components/AnonymousLinksTab.svelte
@@ -9,7 +9,7 @@ import * as Empty from "$lib/components/ui/empty/index.js";
 import AnonymousLinksGroup from "./AnonymousLinksGroup.svelte";
 import AnonymousLinksToolbar from "./AnonymousLinksToolbar.svelte";
 
-export let dashboardCopy: DashboardDashboardCopy;
+export let dashboardCopy: Pick<DashboardDashboardCopy, "linkHub">;
 export let linkIconLabel: (icon: string) => string;
 export let setLinkView: (view: LinkView) => void;
 

--- a/src/features/dashboard/components/AnonymousLinksToolbar.svelte
+++ b/src/features/dashboard/components/AnonymousLinksToolbar.svelte
@@ -11,7 +11,7 @@ import * as InputGroup from "$lib/components/ui/input-group/index.js";
 import * as Kbd from "$lib/components/ui/kbd/index.js";
 import * as ToggleGroup from "$lib/components/ui/toggle-group/index.js";
 
-export let dashboardCopy: DashboardDashboardCopy;
+export let dashboardCopy: Pick<DashboardDashboardCopy, "linkHub">;
 export let linkSearchInput: HTMLInputElement | null;
 export let linkSearchQuery: string;
 export let linkView: LinkView;

--- a/src/features/dashboard/components/DashboardPageController.svelte
+++ b/src/features/dashboard/components/DashboardPageController.svelte
@@ -28,8 +28,6 @@ import {
 import { createDashboardDisplayActions } from "@/features/dashboard/lib/dashboard-controller-display-actions";
 import { createDashboardFormSubmitActions } from "@/features/dashboard/lib/dashboard-controller-form-actions";
 import {
-  type AnonymousDashboardData,
-  type AnonymousLinkGroup,
   buildCalendarWeekdayLabels,
   type DashboardActionData,
   type DashboardLinkItem,
@@ -44,7 +42,7 @@ import { createDashboardLinkStateActions } from "@/features/dashboard/lib/dashbo
 import { mountDashboardController } from "@/features/dashboard/lib/dashboard-controller-mount";
 import { createDashboardSubscriptionActions } from "@/features/dashboard/lib/dashboard-controller-subscription-actions";
 import { createDashboardTodoActions } from "@/features/dashboard/lib/dashboard-controller-todo-actions";
-import { linkIconLabel } from "@/features/dashboard/lib/dashboard-link-ui";
+import { linkIconLabel } from "@/features/dashboard/lib/dashboard-link-icon";
 import { dashboardTabHref } from "@/features/dashboard/lib/dashboard-nav";
 import {
   examReferenceNow,
@@ -61,7 +59,6 @@ import { todoPriorityOptions as buildTodoPriorityOptions } from "@/features/dash
 import { goto, invalidateAll, replaceState } from "$app/navigation";
 import { page } from "$app/stores";
 import * as Alert from "$lib/components/ui/alert/index.js";
-import AnonymousDashboardView from "./AnonymousDashboardView.svelte";
 import DashboardStatusAlerts from "./DashboardStatusAlerts.svelte";
 import type { DashboardCalendarTabProps } from "./dashboard-calendar-component-types";
 import SignedDashboardOverviewBranch from "./SignedDashboardOverviewBranch.svelte";
@@ -77,8 +74,6 @@ export let data: PageData;
 export let form: ActionData | undefined = undefined;
 
 let {
-  anonymousData,
-  anonymousLinkGroups,
   bulkImportError,
   bulkImportMessage,
   bulkImportSemesterId,
@@ -153,7 +148,6 @@ $: actionError = form?.error ?? "";
 $: commonCopy = copy.common;
 $: dashboardCopy = copy.dashboard;
 $: busCopy = copy.bus;
-$: homepageCopy = copy.homepage;
 $: homeworksCopy = copy.homeworks;
 $: homeworkCopy = copy.myHomeworks;
 $: sectionCopy = copy.sectionDetail;
@@ -474,7 +468,6 @@ $: derivedState = buildDashboardControllerDerivedState({
   currentTodoItems: todoSourceItems,
   todoFilter,
 });
-$: anonymousData = derivedState.anonymousData;
 $: homeworkItems = derivedState.homeworkItems;
 $: signedData = applyLocalTodoItemsToSignedData(
   applyLocalHomeworkItemsToSignedData(derivedState.signedData, homeworkItems),
@@ -488,7 +481,6 @@ $: filteredExamRows = derivedState.filteredExamRows;
 $: dashboardLinkItems = derivedState.dashboardLinkItems;
 $: overviewLinkItems = derivedState.overviewLinkItems;
 $: signedLinkGroups = derivedState.signedLinkGroups;
-$: anonymousLinkGroups = derivedState.anonymousLinkGroups;
 $: calendarData = derivedState.calendarData;
 $: syncCalendarStateFromUrl($page.url, calendarData);
 $: selectedImportSectionIdSet = new Set(selectedImportSectionIds);
@@ -712,18 +704,5 @@ onMount(() => {
     <Alert.Root>
       <Alert.Description>{commonCopy.userNotFound}</Alert.Description>
     </Alert.Root>
-  {:else if anonymousData}
-    <AnonymousDashboardView
-      {busCopy}
-      {dashboardCopy}
-      {homepageCopy}
-      anonymousData={anonymousData}
-      anonymousLinkGroups={anonymousLinkGroups}
-      {linkIconLabel}
-      {linkView}
-      {setLinkView}
-      bind:linkSearchInput
-      bind:linkSearchQuery
-    />
   {/if}
 </div>

--- a/src/features/dashboard/lib/dashboard-controller-default-state.ts
+++ b/src/features/dashboard/lib/dashboard-controller-default-state.ts
@@ -1,7 +1,5 @@
 import type { CalendarView } from "@/features/dashboard/lib/calendar";
 import type {
-  AnonymousDashboardData,
-  AnonymousLinkGroup,
   CalendarData,
   DashboardLinkItem,
   ExamRow,
@@ -22,8 +20,6 @@ import type { ExamFilter } from "@/features/dashboard/lib/exams";
 
 export function createDashboardControllerDefaultState() {
   return {
-    anonymousData: null as AnonymousDashboardData | null,
-    anonymousLinkGroups: [] as AnonymousLinkGroup[],
     bulkImportError: "",
     bulkImportMessage: "",
     bulkImportSemesterId: "",

--- a/src/features/dashboard/lib/dashboard-controller-derived-state.ts
+++ b/src/features/dashboard/lib/dashboard-controller-derived-state.ts
@@ -6,7 +6,6 @@ import {
   type DashboardPageData,
   type ExamRow,
   type HomeworkItem,
-  isAnonymousDashboardData,
   isSignedDashboardData,
   type SignedDashboardData,
   type TodoFilter,
@@ -66,9 +65,6 @@ export function buildDashboardControllerDerivedState(input: {
   todoFilter: TodoFilter;
 }) {
   const signedData = isSignedDashboardData(input.data) ? input.data : null;
-  const anonymousData = isAnonymousDashboardData(input.data)
-    ? input.data
-    : null;
   const homeworkItems = signedData?.homeworks
     ? signedData.homeworks.homeworkSummaries
     : [];
@@ -87,14 +83,6 @@ export function buildDashboardControllerDerivedState(input: {
     : [];
 
   return {
-    anonymousData,
-    anonymousLinkGroups: anonymousData
-      ? groupDashboardLinks(
-          anonymousData.publicLinks,
-          input.linkSearchQuery,
-          input.dashboardLinkGroupLabels,
-        )
-      : [],
     calendarData: (signedData?.overview?.calendar ??
       null) as CalendarData | null,
     dashboardLinkItems,

--- a/src/features/dashboard/lib/dashboard-controller-helpers.ts
+++ b/src/features/dashboard/lib/dashboard-controller-helpers.ts
@@ -7,12 +7,8 @@ export {
   homeworkTimestampNow as homeworkStartsNow,
   initialHomeworkTimestampDraft as initialCreateHomeworkDraft,
 } from "@/features/homeworks/lib/homework-timestamp-defaults";
-export {
-  isAnonymousDashboardData,
-  isSignedDashboardData,
-} from "./dashboard-controller-type-guards";
+export { isSignedDashboardData } from "./dashboard-controller-type-guards";
 export type {
-  AnonymousDashboardData,
   AnonymousLinkGroup,
   CalendarData,
   DashboardActionData,

--- a/src/features/dashboard/lib/dashboard-controller-type-guards.ts
+++ b/src/features/dashboard/lib/dashboard-controller-type-guards.ts
@@ -1,5 +1,4 @@
 import type {
-  AnonymousDashboardData,
   DashboardPageData,
   SignedDashboardData,
 } from "./dashboard-controller-types";
@@ -8,10 +7,4 @@ export function isSignedDashboardData(
   data: DashboardPageData,
 ): data is SignedDashboardData {
   return Boolean(data.signedIn && !data.userMissing);
-}
-
-export function isAnonymousDashboardData(
-  data: DashboardPageData,
-): data is AnonymousDashboardData {
-  return !data.signedIn;
 }

--- a/src/features/dashboard/lib/dashboard-controller-types.ts
+++ b/src/features/dashboard/lib/dashboard-controller-types.ts
@@ -507,12 +507,6 @@ export type SignedDashboardData = DashboardPageData & {
   >;
 };
 
-export type AnonymousDashboardData = DashboardPageData & {
-  signedIn: false;
-  counts: NonNullable<DashboardPageData["counts"]>;
-  publicLinks: NonNullable<DashboardPageData["publicLinks"]>;
-};
-
 export type HomeworkItem = NonNullable<
   SignedDashboardData["homeworks"]
 >["homeworkSummaries"][number];

--- a/src/features/dashboard/lib/dashboard-link-icon.ts
+++ b/src/features/dashboard/lib/dashboard-link-icon.ts
@@ -1,0 +1,27 @@
+type DashboardLinkIcon =
+  | "book-open"
+  | "building"
+  | "clipboard-list"
+  | "graduation-cap"
+  | "mail"
+  | "monitor-play"
+  | "network"
+  | "school"
+  | "users";
+
+export function linkIconLabel(icon: unknown) {
+  const labels: Record<DashboardLinkIcon, string> = {
+    "book-open": "BK",
+    building: "BD",
+    "clipboard-list": "CL",
+    "graduation-cap": "GR",
+    mail: "ML",
+    "monitor-play": "MP",
+    network: "NW",
+    school: "SC",
+    users: "US",
+  };
+  return typeof icon === "string" && icon in labels
+    ? labels[icon as DashboardLinkIcon]
+    : "LK";
+}

--- a/src/features/dashboard/lib/dashboard-link-ui.ts
+++ b/src/features/dashboard/lib/dashboard-link-ui.ts
@@ -4,38 +4,9 @@ export {
   linkMatchesTokens,
   searchQueryToTokens,
 } from "@/features/dashboard-links/lib/dashboard-link-search";
+export { linkIconLabel } from "./dashboard-link-icon";
 export {
   applyDashboardLinkPinnedSlugs,
   currentDashboardLinkReturnTo,
   submitDashboardLinkPinRequest,
 } from "./dashboard-link-pin-client";
-
-type DashboardLinkLike = {
-  icon:
-    | "book-open"
-    | "building"
-    | "clipboard-list"
-    | "graduation-cap"
-    | "mail"
-    | "monitor-play"
-    | "network"
-    | "school"
-    | "users";
-};
-
-export function linkIconLabel(icon: unknown) {
-  const labels: Record<DashboardLinkLike["icon"], string> = {
-    "book-open": "BK",
-    building: "BD",
-    "clipboard-list": "CL",
-    "graduation-cap": "GR",
-    mail: "ML",
-    "monitor-play": "MP",
-    network: "NW",
-    school: "SC",
-    users: "US",
-  };
-  return typeof icon === "string" && icon in labels
-    ? labels[icon as DashboardLinkLike["icon"]]
-    : "LK";
-}

--- a/src/features/dashboard/lib/dashboard-nav.ts
+++ b/src/features/dashboard/lib/dashboard-nav.ts
@@ -12,6 +12,21 @@ export const signedTabIds = [
 export type SignedTabId = (typeof signedTabIds)[number];
 
 const signedTabIdSet = new Set<string>(signedTabIds);
+const homeDashboardQueryKeys = new Set([
+  "calendarMonth",
+  "calendarSemester",
+  "calendarView",
+  "calendarWeek",
+  "dashboardLinkPinError",
+  "examView",
+  "homeworkView",
+  "imported",
+  "linkView",
+  "overviewWeek",
+  "removed",
+  "snapshotAt",
+  "todoView",
+]);
 
 export function isSignedDashboardTab(
   value: string | null | undefined,
@@ -32,4 +47,21 @@ export function dashboardTabHref(
   const search = query.toString();
   const path = `/dashboard/${id}`;
   return `${path}${search ? `?${search}` : ""}`;
+}
+
+export function dashboardRedirectHrefFromHome(url: URL) {
+  const query = new URLSearchParams();
+  const tab = url.searchParams.get("tab");
+  if (isSignedDashboardTab(tab)) {
+    query.set("tab", tab);
+  }
+
+  for (const [key, value] of url.searchParams) {
+    if (homeDashboardQueryKeys.has(key)) {
+      query.append(key, value);
+    }
+  }
+
+  const search = query.toString();
+  return `/dashboard${search ? `?${search}` : ""}`;
 }

--- a/src/features/dashboard/server/anonymous-home-page-load.ts
+++ b/src/features/dashboard/server/anonymous-home-page-load.ts
@@ -1,0 +1,34 @@
+import { getAnonymousHomePageCopy } from "@/features/dashboard/server/dashboard-page-copy";
+import { loadAnonymousDashboardPageData } from "@/features/dashboard/server/dashboard-page-load-public";
+import type { DashboardPageLoadEvent } from "@/features/dashboard/server/dashboard-page-load-types";
+import { normalizeDashboardTab } from "@/features/dashboard/server/dashboard-page-server";
+import { getPublicDashboardLinksData } from "@/features/dashboard-links/server/dashboard-link-data";
+import { logAppEvent } from "@/lib/log/app-logger";
+
+export async function loadAnonymousHomePage({
+  locals,
+  url,
+}: DashboardPageLoadEvent) {
+  const startMs = Date.now();
+  const locale = locals.locale;
+  const tab = normalizeDashboardTab(url.searchParams.get("tab"), false);
+  const publicLinks = await getPublicDashboardLinksData(locale);
+  const data = await loadAnonymousDashboardPageData({
+    locale,
+    pageCopy: getAnonymousHomePageCopy(locale),
+    publicLinks: publicLinks.dashboardLinks,
+    tab,
+  });
+
+  logAppEvent("info", "dashboard.load.finish", {
+    durationMs: Date.now() - startMs,
+    event: "dashboard.load.finish",
+    requestId: locals.requestId,
+    signedIn: false,
+    source: "dashboard",
+    status: "ok",
+    tab,
+  });
+
+  return data;
+}

--- a/src/features/dashboard/server/dashboard-page-copy.ts
+++ b/src/features/dashboard/server/dashboard-page-copy.ts
@@ -25,3 +25,23 @@ export function getDashboardPageCopy(locale: AppLocale) {
     todos: copy.todos,
   };
 }
+
+export function getAnonymousHomePageCopy(locale: AppLocale) {
+  const copy = getDashboardPageCopy(locale);
+  return {
+    bus: copy.bus,
+    dashboard: {
+      linkHub: copy.dashboard.linkHub,
+      nav: {
+        bus: copy.dashboard.nav.bus,
+        links: copy.dashboard.nav.links,
+      },
+    },
+    homepage: {
+      publicDashboard: copy.homepage.publicDashboard,
+    },
+    metadata: {
+      home: copy.metadata.home,
+    },
+  };
+}

--- a/src/features/dashboard/server/dashboard-page-load-public.ts
+++ b/src/features/dashboard/server/dashboard-page-load-public.ts
@@ -1,16 +1,11 @@
-import type {
-  DashboardPageCopy,
-  DashboardPublicCounts,
-} from "@/features/dashboard/server/dashboard-page-load-types";
+import type { AnonymousHomePageCopy } from "@/features/dashboard/server/dashboard-page-load-types";
 import { getBusTabData } from "@/features/dashboard/server/dashboard-tab-data";
 import type { DashboardLinkSummary } from "@/features/dashboard-links/server/dashboard-link-data";
 import type { AppLocale } from "@/i18n/config";
 
 export async function loadAnonymousDashboardPageData(input: {
-  counts: DashboardPublicCounts;
   locale: AppLocale;
-  overviewLinks: DashboardLinkSummary[];
-  pageCopy: DashboardPageCopy;
+  pageCopy: AnonymousHomePageCopy;
   publicLinks: DashboardLinkSummary[];
   tab: string;
 }) {
@@ -20,11 +15,9 @@ export async function loadAnonymousDashboardPageData(input: {
   return {
     copy: input.pageCopy,
     locale: input.locale,
-    signedIn: false,
+    signedIn: false as const,
     tab: input.tab,
-    counts: input.counts,
     publicLinks: input.publicLinks,
-    overviewLinks: input.overviewLinks,
     bus: bus?.data ?? null,
   };
 }

--- a/src/features/dashboard/server/dashboard-page-load-types.ts
+++ b/src/features/dashboard/server/dashboard-page-load-types.ts
@@ -1,19 +1,15 @@
 import type { DashboardLinkSummary } from "@/features/dashboard-links/server/dashboard-link-data";
 import type { AppLocale } from "@/i18n/config";
-import type { AppSession } from "@/lib/auth/session";
-import type { getDashboardPageCopy } from "./dashboard-page-copy";
+import type {
+  getAnonymousHomePageCopy,
+  getDashboardPageCopy,
+} from "./dashboard-page-copy";
 
 export type DashboardPageCopy = ReturnType<typeof getDashboardPageCopy>;
-
-export type DashboardPublicCounts = {
-  courses: number;
-  sections: number;
-  semesters: number;
-};
+export type AnonymousHomePageCopy = ReturnType<typeof getAnonymousHomePageCopy>;
 
 export type DashboardPageLoadEvent = {
   locals: {
-    authUser?: AppSession["user"] | null;
     locale: AppLocale;
     requestId?: string;
   };

--- a/src/features/dashboard/server/dashboard-page-load.ts
+++ b/src/features/dashboard/server/dashboard-page-load.ts
@@ -1,22 +1,18 @@
 import { isSignedDashboardTab } from "@/features/dashboard/lib/dashboard-nav";
 import { getDashboardPageCopy } from "@/features/dashboard/server/dashboard-page-copy";
-import { loadAnonymousDashboardPageData } from "@/features/dashboard/server/dashboard-page-load-public";
 import { loadSignedDashboardPageData } from "@/features/dashboard/server/dashboard-page-load-signed";
 import type { DashboardPageLoadEvent } from "@/features/dashboard/server/dashboard-page-load-types";
-import { loadDashboardPublicSummary } from "@/features/dashboard/server/dashboard-page-public-summary";
+import { loadDashboardPublicSummaryWithFallback } from "@/features/dashboard/server/dashboard-page-public-summary";
 import {
-  getDashboardUserId,
   normalizeDashboardTab,
   parsePositiveCalendarSemester,
   parseSnapshotReferenceTime,
 } from "@/features/dashboard/server/dashboard-page-server";
-import { getPrisma } from "@/lib/db/prisma";
 import { logAppEvent } from "@/lib/log/app-logger";
 
 function recordDashboardLoadFinish(input: {
   durationMs: number;
   requestId: string | undefined;
-  signedIn: boolean;
   status: "ok" | "user-missing";
   subscribedSectionCount?: number;
   tab: string;
@@ -25,7 +21,7 @@ function recordDashboardLoadFinish(input: {
     durationMs: input.durationMs,
     event: "dashboard.load.finish",
     requestId: input.requestId,
-    signedIn: input.signedIn,
+    signedIn: true,
     source: "dashboard",
     status: input.status,
     subscribedSectionCount: input.subscribedSectionCount,
@@ -33,64 +29,27 @@ function recordDashboardLoadFinish(input: {
   });
 }
 
-export async function loadDashboardPage({
+export async function loadSignedDashboardPage({
   locals,
-  request,
   url,
-}: DashboardPageLoadEvent) {
+  userId,
+}: DashboardPageLoadEvent & { userId: string }) {
   const startMs = Date.now();
   const locale = locals.locale;
   const pageCopy = getDashboardPageCopy(locale);
-  const userId = locals.authUser?.id ?? (await getDashboardUserId(request));
   const calendarSemesterId =
     url.searchParams.get("tab") === "calendar"
       ? parsePositiveCalendarSemester(url.searchParams.get("calendarSemester"))
       : undefined;
-  const tab = normalizeDashboardTab(
-    url.searchParams.get("tab"),
-    Boolean(userId),
-  );
+  const tab = normalizeDashboardTab(url.searchParams.get("tab"), true);
   const referenceNow = parseSnapshotReferenceTime(
     url.searchParams.get("snapshotAt"),
   );
 
-  const publicSummaryPromise = (async () => {
-    let publicSummary: Awaited<ReturnType<typeof loadDashboardPublicSummary>>;
-    try {
-      publicSummary = await loadDashboardPublicSummary(
-        getPrisma(locale),
-        referenceNow ?? null,
-        locale,
-      );
-    } catch {
-      publicSummary = await loadDashboardPublicSummary(
-        null,
-        referenceNow ?? null,
-        locale,
-      );
-    }
-    return publicSummary;
-  })();
-
-  if (!userId) {
-    const publicSummary = await publicSummaryPromise;
-    const data = await loadAnonymousDashboardPageData({
-      counts: publicSummary.counts,
-      locale,
-      overviewLinks: publicSummary.links.overviewLinks,
-      pageCopy,
-      publicLinks: publicSummary.links.dashboardLinks,
-      tab,
-    });
-    recordDashboardLoadFinish({
-      durationMs: Date.now() - startMs,
-      requestId: locals.requestId,
-      signedIn: false,
-      status: "ok",
-      tab,
-    });
-    return data;
-  }
+  const publicSummaryPromise = loadDashboardPublicSummaryWithFallback(
+    locale,
+    referenceNow ?? null,
+  );
 
   const signedTab = isSignedDashboardTab(tab) ? tab : "overview";
   const [publicSummary, signedData] = await Promise.all([
@@ -109,7 +68,6 @@ export async function loadDashboardPage({
   recordDashboardLoadFinish({
     durationMs: Date.now() - startMs,
     requestId: locals.requestId,
-    signedIn: true,
     status: "userMissing" in signedData ? "user-missing" : "ok",
     subscribedSectionCount:
       "subscribedSectionCount" in signedData

--- a/src/features/dashboard/server/dashboard-page-public-summary.ts
+++ b/src/features/dashboard/server/dashboard-page-public-summary.ts
@@ -1,6 +1,6 @@
 import { selectCurrentSemesterFromList } from "@/features/catalog/lib/current-semester";
 import { type AppLocale, DEFAULT_LOCALE } from "@/i18n/config";
-import type { getPrisma } from "@/lib/db/prisma";
+import { getPrisma } from "@/lib/db/prisma";
 
 export async function loadDashboardPublicSummary(
   prisma: ReturnType<typeof getPrisma> | null,
@@ -49,4 +49,19 @@ export async function loadDashboardPublicSummary(
         ?.nameCn ?? null,
     links,
   };
+}
+
+export async function loadDashboardPublicSummaryWithFallback(
+  locale: AppLocale,
+  referenceNow: Date | null,
+) {
+  try {
+    return await loadDashboardPublicSummary(
+      getPrisma(locale),
+      referenceNow,
+      locale,
+    );
+  } catch {
+    return loadDashboardPublicSummary(null, referenceNow, locale);
+  }
 }

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,6 +1,16 @@
-import { dashboardPageActions } from "@/features/dashboard/server/dashboard-page-actions";
-import { loadDashboardPage } from "@/features/dashboard/server/dashboard-page-load";
-import type { Actions, PageServerLoad } from "./$types";
+import { redirect } from "@sveltejs/kit";
+import { dashboardRedirectHrefFromHome } from "@/features/dashboard/lib/dashboard-nav";
+import { loadAnonymousHomePage } from "@/features/dashboard/server/anonymous-home-page-load";
+import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = loadDashboardPage;
-export const actions: Actions = dashboardPageActions;
+export const load: PageServerLoad = async (event) => {
+  if (event.locals.authUser?.id) {
+    throw redirect(303, dashboardRedirectHrefFromHome(event.url));
+  }
+
+  return loadAnonymousHomePage({
+    locals: event.locals,
+    request: event.request,
+    url: event.url,
+  });
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-import DashboardPageController from "@/features/dashboard/components/DashboardPageController.svelte";
-import type { ActionData, PageData } from "./$types";
+import AnonymousHomePageController from "@/features/dashboard/components/AnonymousHomePageController.svelte";
+import type { PageData } from "./$types";
 
 export let data: PageData;
-export let form: ActionData | undefined = undefined;
 </script>
 
-<DashboardPageController {data} {form} />
+<AnonymousHomePageController {data} />

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -1,6 +1,6 @@
 import { redirect } from "@sveltejs/kit";
 import { dashboardPageActions } from "@/features/dashboard/server/dashboard-page-actions";
-import { loadDashboardPage } from "@/features/dashboard/server/dashboard-page-load";
+import { loadSignedDashboardPage } from "@/features/dashboard/server/dashboard-page-load";
 import { buildSignInPageUrl } from "@/lib/auth/auth-routing";
 import type { Actions, PageServerLoad } from "./$types";
 
@@ -12,10 +12,11 @@ export const load: PageServerLoad = async (event) => {
     );
   }
 
-  return loadDashboardPage({
+  return loadSignedDashboardPage({
     locals: event.locals,
     request: event.request,
     url: event.url,
+    userId: event.locals.authUser.id,
   });
 };
 

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-import DashboardPage from "../+page.svelte";
+import DashboardPageController from "@/features/dashboard/components/DashboardPageController.svelte";
 import type { ActionData, PageData } from "./$types";
 
 export let data: PageData;
 export let form: ActionData | undefined = undefined;
 </script>
 
-<DashboardPage {data} {form} />
+<DashboardPageController {data} {form} />

--- a/src/routes/dashboard/[tab]/+page.server.ts
+++ b/src/routes/dashboard/[tab]/+page.server.ts
@@ -1,7 +1,7 @@
 import { error, redirect } from "@sveltejs/kit";
 import { isSignedDashboardTab } from "@/features/dashboard/lib/dashboard-nav";
 import { dashboardPageActions } from "@/features/dashboard/server/dashboard-page-actions";
-import { loadDashboardPage } from "@/features/dashboard/server/dashboard-page-load";
+import { loadSignedDashboardPage } from "@/features/dashboard/server/dashboard-page-load";
 import { buildSignInPageUrl } from "@/lib/auth/auth-routing";
 import type { Actions, PageServerLoad } from "./$types";
 
@@ -19,10 +19,11 @@ export const load: PageServerLoad = async (event) => {
   const url = new URL(event.url);
   url.searchParams.set("tab", event.params.tab);
 
-  return loadDashboardPage({
+  return loadSignedDashboardPage({
     locals: event.locals,
     request: event.request,
     url,
+    userId: event.locals.authUser.id,
   });
 };
 

--- a/src/routes/dashboard/subscriptions/+page.server.ts
+++ b/src/routes/dashboard/subscriptions/+page.server.ts
@@ -1,6 +1,6 @@
 import { redirect } from "@sveltejs/kit";
 import { dashboardPageActions } from "@/features/dashboard/server/dashboard-page-actions";
-import { loadDashboardPage } from "@/features/dashboard/server/dashboard-page-load";
+import { loadSignedDashboardPage } from "@/features/dashboard/server/dashboard-page-load";
 import { buildSignInPageUrl } from "@/lib/auth/auth-routing";
 import type { Actions, PageServerLoad } from "./$types";
 
@@ -15,10 +15,11 @@ export const load: PageServerLoad = async (event) => {
   const url = new URL(event.url);
   url.searchParams.set("tab", "subscriptions");
 
-  return loadDashboardPage({
+  return loadSignedDashboardPage({
     locals: event.locals,
     request: event.request,
     url,
+    userId: event.locals.authUser.id,
   });
 };
 

--- a/tests/e2e/src/app/dashboard/comments/test.ts
+++ b/tests/e2e/src/app/dashboard/comments/test.ts
@@ -11,8 +11,9 @@
  * - Authenticated view: falls back to overview tab content
  *
  * ## Edge Cases
- * - `?tab=comments` is not a recognized tab value — the app silently falls
- *   back to the default tab without redirecting. The URL retains `?tab=comments`.
+ * - `?tab=comments` is not a recognized tab value. The public home silently
+ *   falls back to its default tab and retains the query, while authenticated
+ *   requests redirect to the signed `/dashboard` overview.
  */
 import { expect, test } from "@playwright/test";
 import { signInAsDebugUser } from "../../../../utils/auth";
@@ -63,7 +64,7 @@ test.describe("仪表盘无效标签（comments）", () => {
   });
 
   test("登录后 ?tab=comments 回退到总览", async ({ page }, testInfo) => {
-    await signInAsDebugUser(page, "/?tab=comments");
+    await signInAsDebugUser(page, "/?tab=comments", "/dashboard");
 
     await expect(page.locator("#main-content")).toBeVisible();
     await expect(page.locator("#app-user-menu")).toBeVisible();

--- a/tests/e2e/src/app/dashboard/test.ts
+++ b/tests/e2e/src/app/dashboard/test.ts
@@ -63,7 +63,7 @@ test.describe("仪表盘", () => {
       screenshotLabel: "dashboard",
     });
 
-    await expect(page).toHaveURL(/\/(?:\?.*)?$/);
+    await expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/);
     await expect(
       page.getByRole("heading", {
         level: 1,

--- a/tests/e2e/src/app/signin/test.ts
+++ b/tests/e2e/src/app/signin/test.ts
@@ -94,7 +94,7 @@ test("/signin 调试用户按钮可登录", async ({ page }, testInfo) => {
   await captureStepScreenshot(page, testInfo, "signin/initial");
 
   await signInAsDebugUser(page, "/", "/", { ui: true });
-  await expect(page).toHaveURL(/\/(?:\?.*)?$/);
+  await expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/);
   await expect(page.locator("#main-content")).toBeVisible();
   await expect(page.locator("#app-logo")).toBeVisible();
   await expect(page.locator("#app-user-menu")).toBeVisible();

--- a/tests/e2e/src/app/test.ts
+++ b/tests/e2e/src/app/test.ts
@@ -20,6 +20,22 @@ test("/", async ({ page }, testInfo) => {
   await assertPageContract(page, { routePath: "/", testInfo });
 });
 
+test("/ 登录用户重定向至 dashboard 并仅保留支持的查询状态", async ({
+  page,
+}) => {
+  await signInAsDebugUser(page, "/dashboard");
+
+  const response = await page.request.get(
+    "/?tab=calendar&calendarView=week&calendarSemester=42&utm_source=ignored",
+    { maxRedirects: 0 },
+  );
+
+  expect(response.status()).toBe(303);
+  expect(response.headers().location).toBe(
+    "/dashboard?tab=calendar&calendarView=week&calendarSemester=42",
+  );
+});
+
 test("/ 首页快速入口可见", async ({ page }, testInfo) => {
   await gotoAndWaitForReady(page, "/", { testInfo, screenshotLabel: "home" });
 

--- a/tests/e2e/src/app/welcome/test.ts
+++ b/tests/e2e/src/app/welcome/test.ts
@@ -197,7 +197,7 @@ test("/welcome 未完善资料的用户可完成资料并返回首页", async ({
 
     await page.getByRole("button", { name: /继续|Continue/i }).click();
 
-    await expect(page).toHaveURL(/\/(?:\?.*)?$/, {
+    await expect(page).toHaveURL(/\/dashboard(?:\?.*)?$/, {
       timeout: 15_000,
     });
     await expect(page.locator("#main-content")).toBeVisible();

--- a/tests/e2e/utils/auth.ts
+++ b/tests/e2e/utils/auth.ts
@@ -14,6 +14,10 @@ type AuthStorageState = Awaited<
 
 const authStorageStateCache = new Map<AuthRole, AuthStorageState>();
 
+function authenticatedLandingPath(path: string) {
+  return path === "/" ? "/dashboard" : path;
+}
+
 function escapeForRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -184,11 +188,12 @@ export async function signInAsDebugUser(
   expectedPath = callbackPath,
   options: { ui?: boolean } = {},
 ) {
-  if (!options.ui && (await applyCachedSession(page, "debug", expectedPath))) {
+  const landingPath = authenticatedLandingPath(expectedPath);
+  if (!options.ui && (await applyCachedSession(page, "debug", landingPath))) {
     return;
   }
 
-  await signInWithDevButton(page, "debug", callbackPath, expectedPath);
+  await signInWithDevButton(page, "debug", callbackPath, landingPath);
 }
 
 export async function signInAsDevAdmin(
@@ -197,9 +202,10 @@ export async function signInAsDevAdmin(
   expectedPath = callbackPath,
   options: { ui?: boolean } = {},
 ) {
-  if (!options.ui && (await applyCachedSession(page, "admin", expectedPath))) {
+  const landingPath = authenticatedLandingPath(expectedPath);
+  if (!options.ui && (await applyCachedSession(page, "admin", landingPath))) {
     return;
   }
 
-  await signInWithDevButton(page, "admin", callbackPath, expectedPath);
+  await signInWithDevButton(page, "admin", callbackPath, landingPath);
 }

--- a/tests/unit/dashboard-nav.test.ts
+++ b/tests/unit/dashboard-nav.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { dashboardRedirectHrefFromHome } from "@/features/dashboard/lib/dashboard-nav";
+
+describe("dashboardRedirectHrefFromHome", () => {
+  it("preserves supported dashboard state and drops unrelated query values", () => {
+    const url = new URL(
+      "https://example.test/?tab=calendar&calendarView=week&calendarSemester=42&utm_source=ignored",
+    );
+
+    expect(dashboardRedirectHrefFromHome(url)).toBe(
+      "/dashboard?tab=calendar&calendarView=week&calendarSemester=42",
+    );
+  });
+
+  it("drops unsupported tab values while preserving supported view state", () => {
+    const url = new URL(
+      "https://example.test/?tab=unknown&homeworkView=completed&removed=3",
+    );
+
+    expect(dashboardRedirectHrefFromHome(url)).toBe(
+      "/dashboard?homeworkView=completed&removed=3",
+    );
+  });
+});

--- a/tests/unit/dashboard-route-boundary.test.ts
+++ b/tests/unit/dashboard-route-boundary.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { loadAnonymousHomePageMock, loadSignedDashboardPageMock } = vi.hoisted(
+  () => ({
+    loadAnonymousHomePageMock: vi.fn(),
+    loadSignedDashboardPageMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/features/dashboard/server/anonymous-home-page-load", () => ({
+  loadAnonymousHomePage: loadAnonymousHomePageMock,
+}));
+
+vi.mock("@/features/dashboard/server/dashboard-page-load", () => ({
+  loadSignedDashboardPage: loadSignedDashboardPageMock,
+}));
+
+vi.mock("@/features/dashboard/server/dashboard-page-actions", () => ({
+  dashboardPageActions: {},
+}));
+
+function routeEvent(url: string, userId?: string) {
+  return {
+    locals: {
+      authUser: userId ? { id: userId } : null,
+      locale: "en-us",
+    },
+    request: new Request(url),
+    url: new URL(url),
+  };
+}
+
+describe("anonymous home and signed dashboard route boundary", () => {
+  afterEach(() => {
+    loadAnonymousHomePageMock.mockReset();
+    loadSignedDashboardPageMock.mockReset();
+  });
+
+  it("loads only the public home data for anonymous visitors", async () => {
+    loadAnonymousHomePageMock.mockResolvedValue({
+      marker: "anonymous",
+      signedIn: false,
+    });
+    const homeRoute = await import("@/routes/+page.server");
+    const event = routeEvent("https://example.test/?tab=bus");
+
+    await expect(homeRoute.load(event as never)).resolves.toMatchObject({
+      marker: "anonymous",
+      signedIn: false,
+    });
+    expect(loadAnonymousHomePageMock).toHaveBeenCalledWith({
+      locals: event.locals,
+      request: event.request,
+      url: event.url,
+    });
+    expect(loadSignedDashboardPageMock).not.toHaveBeenCalled();
+    expect("actions" in homeRoute).toBe(false);
+  });
+
+  it("redirects signed visitors to the dashboard with supported state only", async () => {
+    const homeRoute = await import("@/routes/+page.server");
+
+    await expect(
+      homeRoute.load(
+        routeEvent(
+          "https://example.test/?tab=calendar&calendarView=week&calendarSemester=42&utm_source=ignored",
+          "user-1",
+        ) as never,
+      ),
+    ).rejects.toMatchObject({
+      location: "/dashboard?tab=calendar&calendarView=week&calendarSemester=42",
+      status: 303,
+    });
+    expect(loadAnonymousHomePageMock).not.toHaveBeenCalled();
+    expect(loadSignedDashboardPageMock).not.toHaveBeenCalled();
+  });
+
+  it("requires authentication before loading signed dashboard data", async () => {
+    const dashboardRoute = await import("@/routes/dashboard/+page.server");
+
+    await expect(
+      dashboardRoute.load(
+        routeEvent("https://example.test/dashboard?tab=overview") as never,
+      ),
+    ).rejects.toMatchObject({
+      location: "/signin?callbackUrl=%2Fdashboard%3Ftab%3Doverview",
+      status: 303,
+    });
+    expect(loadSignedDashboardPageMock).not.toHaveBeenCalled();
+  });
+
+  it("loads the signed dashboard with an explicit user id", async () => {
+    loadSignedDashboardPageMock.mockResolvedValue({
+      marker: "signed",
+      signedIn: true,
+    });
+    const dashboardRoute = await import("@/routes/dashboard/+page.server");
+    const event = routeEvent(
+      "https://example.test/dashboard?tab=overview",
+      "user-1",
+    );
+
+    await expect(dashboardRoute.load(event as never)).resolves.toMatchObject({
+      marker: "signed",
+      signedIn: true,
+    });
+    expect(loadSignedDashboardPageMock).toHaveBeenCalledWith({
+      locals: event.locals,
+      request: event.request,
+      url: event.url,
+      userId: "user-1",
+    });
+  });
+});


### PR DESCRIPTION
## Goal

Split the anonymous public homepage from the authenticated workspace so public SSR/hydration stays small and signed users land on /dashboard.

Fixes #523.

## Changed Surfaces

- GET / is anonymous-only; authenticated requests receive a 303 to /dashboard while supported dashboard query state is preserved and unrelated query parameters are dropped.
- /dashboard and its tab routes own signed dashboard loading and form actions.
- Anonymous SSR now loads only public links plus bus data for the active public tab; it no longer runs the four public-count/semester Prisma queries.
- The root client graph uses a dedicated anonymous controller and no longer imports signed dashboard, homework, comments, Markdown, or date-picker code.
- E2E auth helpers now treat /dashboard as the authenticated landing page.

## Evidence

- bun run app:prepare
- bunx biome check (passes with one pre-existing src/static-loader/import.ts unused-parameter warning)
- bunx svelte-check --tsconfig ./tsconfig.json
- bunx tsc --noEmit -p tsconfig.typecheck.json
- bunx tsc --noEmit -p tsconfig.typecheck.tests.json
- bunx tsc --noEmit -p tsconfig.typecheck.operational.json
- bunx vitest run: 203 files, 1210 tests passed
- bunx vitest run --config vitest.integration.config.ts: 31 files, 180 tests passed against an isolated Postgres database
- bun run build
- Focused Playwright: tests/e2e/src/app/test.ts, bus/test.ts, signin/test.ts: 37 passed with step screenshots inspected; anonymous SSR bus, signed SSR bus, redirect, language, theme, mobile shell, and interactions covered.
- A full Playwright attempt was skipped after setup because another parallel worktree owned the fixed 127.0.0.1:3000 test port; focused affected journeys passed.
- Root page static client closure before: 77 manifest entries / 79 files / 1,891,543 raw bytes / 538,694 gzip bytes.
- After: 37 entries / 37 files / 357,379 raw bytes / 120,437 gzip bytes (81.1% raw and 77.6% gzip reduction). No _page signed dashboard, DateTimePicker, MarkdownPreview, CommentsPanel, or HomeworkStyleGuide imports remain.

## Docs / Contracts

Updated docs/contracts/overview.json to distinguish the anonymous home decision page from the authenticated /dashboard workspace.

## Risk Areas

- Intentional behavior change: signed GET / now redirects to /dashboard.
- Root page actions are intentionally removed; signed mutations continue on /dashboard routes.
- No cache headers or HTML cache behavior changed; personalized dashboard HTML remains uncached.
- No Prisma schema, migrations, public REST, GraphQL, or MCP response shapes changed.

## Cleanup

Rebased on origin/main at 0ae845ce before commit. No generated files, screenshots, traces, temporary reports, or unrelated rewrites are included.