### PR TITLE
perf(seo): cache crawler discovery documents

### DIFF
--- a/src/features/catalog/server/sitemap-cache.ts
+++ b/src/features/catalog/server/sitemap-cache.ts
@@ -57,16 +57,6 @@ export async function getCachedSitemap(
   }
 }
 
-export function requestMatchesSitemapEtag(request: Request, etag: string) {
-  const ifNoneMatch = request.headers.get("If-None-Match");
-  if (!ifNoneMatch) return false;
-
-  return ifNoneMatch.split(",").some((token) => {
-    const normalized = token.trim().replace(/^W\//, "");
-    return normalized === "*" || normalized === etag;
-  });
-}
-
 export function resetSitemapCacheForTest() {
   cachedSitemap = undefined;
   sitemapGeneration = undefined;

--- a/src/lib/seo/crawler-discovery-response.ts
+++ b/src/lib/seo/crawler-discovery-response.ts
@@ -1,0 +1,46 @@
+import { sha256Base64Url } from "@/lib/crypto/web-crypto";
+import { CONTENT_SIGNAL } from "@/lib/seo/content-signal";
+
+export const CRAWLER_DISCOVERY_BROWSER_CACHE_CONTROL =
+  "public, max-age=0, must-revalidate";
+export const CRAWLER_DISCOVERY_CDN_CACHE_CONTROL =
+  "public, max-age=3600, stale-while-revalidate=21600";
+
+type CrawlerDiscoveryResponseOptions = {
+  body: string;
+  contentType: string;
+  etag?: string;
+  request: Request;
+};
+
+function requestMatchesEtag(request: Request, etag: string) {
+  const ifNoneMatch = request.headers.get("If-None-Match");
+  if (!ifNoneMatch) return false;
+
+  return ifNoneMatch.split(",").some((token) => {
+    const normalized = token.trim().replace(/^W\//, "");
+    return normalized === "*" || normalized === etag;
+  });
+}
+
+export async function createCrawlerDiscoveryResponse({
+  body,
+  contentType,
+  etag,
+  request,
+}: CrawlerDiscoveryResponseOptions) {
+  const responseEtag = etag ?? `"sha256-${await sha256Base64Url(body)}"`;
+  const headers = {
+    "Cache-Control": CRAWLER_DISCOVERY_BROWSER_CACHE_CONTROL,
+    "Cloudflare-CDN-Cache-Control": CRAWLER_DISCOVERY_CDN_CACHE_CONTROL,
+    "Content-Signal": CONTENT_SIGNAL,
+    "Content-Type": contentType,
+    ETag: responseEtag,
+  };
+
+  if (requestMatchesEtag(request, responseEtag)) {
+    return new Response(null, { headers, status: 304 });
+  }
+
+  return new Response(body, { headers });
+}

--- a/src/routes/llms.txt/+server.ts
+++ b/src/routes/llms.txt/+server.ts
@@ -1,8 +1,8 @@
-import { CONTENT_SIGNAL } from "@/lib/seo/content-signal";
+import { createCrawlerDiscoveryResponse } from "@/lib/seo/crawler-discovery-response";
 import { getCanonicalOrigin } from "@/lib/site-url";
 import type { RequestHandler } from "./$types";
 
-export const GET: RequestHandler = () => {
+export const GET: RequestHandler = async ({ request }) => {
   const origin = getCanonicalOrigin();
   const body = `# Life@USTC
 
@@ -25,10 +25,9 @@ export const GET: RequestHandler = () => {
 - [Sitemap](${origin}/sitemap.xml)
 `;
 
-  return new Response(body, {
-    headers: {
-      "Content-Signal": CONTENT_SIGNAL,
-      "Content-Type": "text/plain; charset=utf-8",
-    },
+  return createCrawlerDiscoveryResponse({
+    body,
+    contentType: "text/plain; charset=utf-8",
+    request,
   });
 };

--- a/src/routes/robots.txt/+server.ts
+++ b/src/routes/robots.txt/+server.ts
@@ -1,12 +1,12 @@
-import { CONTENT_SIGNAL } from "@/lib/seo/content-signal";
+import { createCrawlerDiscoveryResponse } from "@/lib/seo/crawler-discovery-response";
 import { getCanonicalOrigin } from "@/lib/site-url";
 import type { RequestHandler } from "./$types";
 
-export const GET: RequestHandler = () => {
+export const GET: RequestHandler = async ({ request }) => {
   const origin = getCanonicalOrigin();
 
-  return new Response(
-    [
+  return createCrawlerDiscoveryResponse({
+    body: [
       "User-agent: *",
       "Allow: /",
       "Allow: /api/docs$",
@@ -26,11 +26,7 @@ export const GET: RequestHandler = () => {
       `Sitemap: ${origin}/sitemap.xml`,
       "",
     ].join("\n"),
-    {
-      headers: {
-        "Content-Signal": CONTENT_SIGNAL,
-        "Content-Type": "text/plain; charset=utf-8",
-      },
-    },
-  );
+    contentType: "text/plain; charset=utf-8",
+    request,
+  });
 };

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,19 +1,8 @@
-import {
-  getCachedSitemap,
-  requestMatchesSitemapEtag,
-} from "@/features/catalog/server/sitemap-cache";
+import { getCachedSitemap } from "@/features/catalog/server/sitemap-cache";
 import { prisma } from "@/lib/db/prisma";
-import { CONTENT_SIGNAL } from "@/lib/seo/content-signal";
+import { createCrawlerDiscoveryResponse } from "@/lib/seo/crawler-discovery-response";
 import { getCanonicalOrigin } from "@/lib/site-url";
 import type { RequestHandler } from "./$types";
-
-const RESPONSE_HEADERS = {
-  "Cache-Control": "public, max-age=0, must-revalidate",
-  "Cloudflare-CDN-Cache-Control":
-    "public, max-age=3600, stale-while-revalidate=21600",
-  "Content-Signal": CONTENT_SIGNAL,
-  "Content-Type": "application/xml; charset=utf-8",
-};
 
 const STATIC_ROUTES = [
   "/",
@@ -51,19 +40,11 @@ async function loadSitemapUrls() {
 
 export const GET: RequestHandler = async ({ request }) => {
   const sitemap = await getCachedSitemap(loadSitemapUrls);
-  const headers = {
-    ...RESPONSE_HEADERS,
-    ETag: sitemap.etag,
-  };
 
-  if (requestMatchesSitemapEtag(request, sitemap.etag)) {
-    return new Response(null, {
-      headers,
-      status: 304,
-    });
-  }
-
-  return new Response(sitemap.body, {
-    headers,
+  return createCrawlerDiscoveryResponse({
+    body: sitemap.body,
+    contentType: "application/xml; charset=utf-8",
+    etag: sitemap.etag,
+    request,
   });
 };

--- a/tests/unit/seo-discovery-routes.test.ts
+++ b/tests/unit/seo-discovery-routes.test.ts
@@ -21,6 +21,20 @@ vi.mock("@/lib/db/prisma", () => ({
 const ORIGIN = "https://life.example";
 const CONTENT_SIGNAL = "search=yes, ai-input=yes, ai-train=no";
 
+type DiscoveryHandler = (event: never) => Response | Promise<Response>;
+
+function getDiscoveryDocument(
+  handler: DiscoveryHandler,
+  path: string,
+  headers?: HeadersInit,
+) {
+  return Promise.resolve(
+    handler({
+      request: new Request(`${ORIGIN}/${path}`, { headers }),
+    } as never),
+  );
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
@@ -37,7 +51,7 @@ describe("crawler discovery routes", () => {
   it("generates a precise robots policy with an absolute sitemap", async () => {
     vi.stubEnv("APP_CANONICAL_ORIGIN", ORIGIN);
 
-    const response = await getRobotsTxt({} as never);
+    const response = await getDiscoveryDocument(getRobotsTxt, "robots.txt");
     const body = await response.text();
 
     expect(response.headers.get("Content-Signal")).toBe(CONTENT_SIGNAL);
@@ -53,7 +67,7 @@ describe("crawler discovery routes", () => {
   it("lists only stable public discovery and protocol links", async () => {
     vi.stubEnv("APP_CANONICAL_ORIGIN", ORIGIN);
 
-    const response = await getLlmsTxt({} as never);
+    const response = await getDiscoveryDocument(getLlmsTxt, "llms.txt");
     const body = await response.text();
 
     expect(response.headers.get("Content-Signal")).toBe(CONTENT_SIGNAL);
@@ -67,6 +81,33 @@ describe("crawler discovery routes", () => {
     expect(body).toContain(`${ORIGIN}/api/mcp`);
     expect(body).toContain(`${ORIGIN}/sitemap.xml`);
     expect(body).not.toMatch(/\/(?:admin|settings|signin|welcome)(?:[/)\s]|$)/);
+  });
+
+  it.each([
+    ["robots.txt", getRobotsTxt],
+    ["llms.txt", getLlmsTxt],
+  ])("edge-caches %s while requiring browser revalidation", async (path, get) => {
+    vi.stubEnv("APP_CANONICAL_ORIGIN", ORIGIN);
+
+    const first = await getDiscoveryDocument(get, path);
+    const etag = first.headers.get("ETag");
+
+    expect(first.headers.get("Cache-Control")).toBe(
+      "public, max-age=0, must-revalidate",
+    );
+    expect(first.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
+      "public, max-age=3600, stale-while-revalidate=21600",
+    );
+    expect(first.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+    expect(etag).toMatch(/^"sha256-[A-Za-z0-9_-]+"$/);
+
+    const conditional = await getDiscoveryDocument(get, path, {
+      "If-None-Match": `"other", W/${etag}`,
+    });
+
+    expect(conditional.status).toBe(304);
+    expect(await conditional.text()).toBe("");
+    expect(conditional.headers.get("ETag")).toBe(etag);
   });
 
   it("adds the content-use policy to the sitemap", async () => {


### PR DESCRIPTION
## Goal

Let Cloudflare serve deploy-stable crawler discovery documents without executing the Worker on every request, while preventing long-lived browser staleness. Closes #526.

## Changed Surfaces

- Add a shared crawler discovery response helper with explicit content types, browser revalidation, a one-hour Cloudflare edge TTL, six-hour stale-while-revalidate, deterministic SHA-256 ETags, and weak/strong conditional request support.
- Apply the helper to `/robots.txt`, `/llms.txt`, and `/sitemap.xml`.
- Preserve every crawler directive, discovery link, canonical origin, `Content-Signal`, sitemap query, and sitemap runtime cache behavior.
- Do not enable Worker-wide or HTML caching and do not change localized HTML or #507 behavior.

## Evidence

Production baseline before the change:

- `/robots.txt` and `/llms.txt`: two sequential requests returned no `Cache-Control`, ETag, or `CF-Cache-Status`.
- `/sitemap.xml`: repeated requests returned `CF-Cache-Status: HIT` with increasing `Age`, confirming the existing edge-only policy works on the canonical domain.

Verification:

- Focused discovery/sitemap unit tests: 2 files, 12 tests passed.
- Full Vitest suite: 201 files, 1206 tests passed.
- `bunx biome check` (passes with one pre-existing unused `build` warning in `src/static-loader/import.ts`).
- `bunx svelte-check --tsconfig ./tsconfig.json` (0 errors/warnings).
- All application, test, and operational TypeScript checks passed.
- `DATABASE_URL=dummy bun run build` passed.
- `bunx wrangler deploy --dry-run --outdir /tmp/life-ustc-crawler-wrangler-dry-run` passed; no production deploy.
- Local Wrangler requests returned the expected 200 headers and 304 responses for weak `If-None-Match` validators.

Cloudflare branch-preview HIT evidence will be added after the preview build completes.

## Docs / Contracts

No product/API/MCP contract changed. The HTTP cache contract is covered directly by route tests and this issue/PR; no broad documentation rewrite is needed.

## Risk Areas

- Browsers receive `Cache-Control: public, max-age=0, must-revalidate`, so they do not retain discovery policy for a year.
- Cloudflare receives the higher-precedence `Cloudflare-CDN-Cache-Control: public, max-age=3600, stale-while-revalidate=21600`; this header is stripped before delivery to browsers.
- ETags are derived from the exact response body, including the configured canonical origin.
- The edge may serve an outdated discovery document during the bounded six-hour SWR window after its one-hour fresh TTL; these deploy-stable documents are intentionally suitable for that tradeoff.
- No database, auth, HTML cache, Cloudflare account setting, or production deployment changed.

## Cleanup

No scratch reports, generated Worker types, unrelated rewrites, or manual generated-file edits remain.