### PR TITLE
fix(a11y): expose sidebar expanded state

### DIFF
--- a/src/lib/components/ui/sidebar/sidebar-trigger.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-trigger.svelte
@@ -24,6 +24,7 @@
 	variant="ghost"
 	size="icon-sm"
 	class={cn("cn-sidebar-trigger", className)}
+	aria-expanded={sidebar.isMobile ? sidebar.openMobile : sidebar.state === "expanded"}
 	type="button"
 	onclick={(e) => {
 		onclick?.(e);

--- a/tests/e2e/src/app/test.ts
+++ b/tests/e2e/src/app/test.ts
@@ -101,7 +101,7 @@ test("/ 主题切换可写入 localStorage 并跟随系统主题", async ({
     const menuItem = page.getByRole("menuitemradio", { name });
 
     await expect(async () => {
-      if (!(await menuItem.isVisible().catch(() => false))) {
+      if ((await themeButton.getAttribute("aria-expanded")) !== "true") {
         await themeButton.click();
       }
       await expect(menuItem).toBeVisible({ timeout: 1_000 });
@@ -214,7 +214,12 @@ test("/ shell 菜单可一键切换", async ({ page }) => {
     page.getByRole("menuitem", { name: /设置|Settings/i }),
   ).toBeVisible();
 
-  await page.getByRole("button", { name: /^菜单$|^Menu$/i }).click();
+  const sidebarTrigger = page.getByRole("button", {
+    name: /^菜单$|^Menu$/i,
+  });
+  await expect(sidebarTrigger).toHaveAttribute("aria-expanded", "false");
+  await sidebarTrigger.click();
+  await expect(sidebarTrigger).toHaveAttribute("aria-expanded", "true");
 
   const sidebar = page.getByRole("dialog", { name: /Sidebar/i });
   await expect(sidebar).toBeVisible();


### PR DESCRIPTION
## Goal

Expose the responsive navigation drawer's open/closed state to assistive
technology. Closes #532.

## Changed Surfaces

- Shared `Sidebar.Trigger` now derives `aria-expanded` from the real mobile or
  desktop sidebar state.
- Shell E2E coverage verifies the mobile transition from `false` to `true`.
- The existing theme E2E helper now uses the trigger's real `aria-expanded`
  state instead of treating a stale, closing menu item as open.

## Evidence

- `bunx biome check src/lib/components/ui/sidebar/sidebar-trigger.svelte tests/e2e/src/app/test.ts`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` — 207 files, 1223 tests passed
- `bun run build`
- `bunx playwright test tests/e2e/src/app/test.ts --grep 'shell 菜单可一键切换'`
- `bunx playwright test tests/e2e/src/app/test.ts --grep '主题切换可写入|shell 菜单可一键切换'`
- Local Chromium at `390x844`: trigger reports `aria-expanded="true"` while
  the navigation dialog is visible; no console errors.
- Initial CI shard 4 exposed a pre-existing dropdown-animation race: trace
  showed the menu content at `data-state="closed"` while its item still
  returned visible. The helper now reads the trigger's authoritative open
  state; both affected flows pass locally.

## Docs / Contracts

No docs or contract update: this corrects accessibility state metadata without
changing navigation behavior, routes, copy, permissions, or data shape.

## Risk Areas

Low. The existing toggle handler and sidebar state source are unchanged. The
attribute is derived from the same state that controls the rendered drawer.

## Cleanup

Temporary audit scripts, screenshots, traces, and reports remain outside the
repository. The diff contains only the primitive and its focused E2E assertion.
