### PR TITLE
perf(ssr): reuse hook auth in detail loaders

### DIFF
--- a/src/features/catalog/server/catalog-detail-page-server.ts
+++ b/src/features/catalog/server/catalog-detail-page-server.ts
@@ -7,6 +7,7 @@ import {
 } from "@/features/catalog/lib/catalog-structured-data";
 import { getCoursePage } from "@/features/catalog/server/course-page-data";
 import { getTeacherPage } from "@/features/catalog/server/teacher-page-data";
+import { getViewerContext } from "@/lib/auth/viewer-context";
 import {
   buildSocialMetadata,
   formatSocialMetadataMessage,
@@ -16,7 +17,6 @@ import {
   getCourseDetailCopy,
   getTeacherDetailCopy,
 } from "./catalog-detail-copy";
-import { currentCatalogViewer } from "./catalog-detail-viewer";
 
 export type CourseDetailRouteSection =
   | "overview"
@@ -48,7 +48,6 @@ function resolveCatalogDetailRouteSection(
 export async function loadCourseDetailPage({
   locals,
   params,
-  request,
   url,
 }: {
   locals: App.Locals;
@@ -63,7 +62,7 @@ export async function loadCourseDetailPage({
   if (!Number.isInteger(jwId)) error(404, copy.notFound.description);
   const [course, viewer] = await Promise.all([
     getCoursePage(jwId, locals.locale),
-    currentCatalogViewer(request),
+    getViewerContext({ userId: locals.authUser?.id ?? null }),
   ]);
   if (!course) error(404, copy.notFound.description);
   if (course.jwId !== jwId) {
@@ -116,7 +115,6 @@ export async function loadCourseDetailPage({
 export async function loadTeacherDetailPage({
   locals,
   params,
-  request,
   url,
 }: {
   locals: App.Locals;
@@ -131,7 +129,7 @@ export async function loadTeacherDetailPage({
   if (!Number.isInteger(id)) error(404, copy.notFound.description);
   const [teacher, viewer] = await Promise.all([
     getTeacherPage(id, locals.locale),
-    currentCatalogViewer(request),
+    getViewerContext({ userId: locals.authUser?.id ?? null }),
   ]);
   if (!teacher) error(404, copy.notFound.description);
   const displayName = catalogPrimaryName(teacher);

--- a/src/features/catalog/server/catalog-detail-viewer.ts
+++ b/src/features/catalog/server/catalog-detail-viewer.ts
@@ -1,8 +1,0 @@
-import { getSessionFromHeaders } from "@/lib/auth/core";
-import { getViewerContext } from "@/lib/auth/viewer-context";
-
-export async function currentCatalogViewer(request: Request) {
-  const userId =
-    (await getSessionFromHeaders(request.headers))?.user?.id ?? null;
-  return getViewerContext({ userId });
-}

--- a/src/features/section-detail/server/section-detail-page-server.ts
+++ b/src/features/section-detail/server/section-detail-page-server.ts
@@ -17,7 +17,6 @@ import { getSectionDetailDescriptionAndComments } from "./section-detail-comment
 import { getSectionHomeworkData } from "./section-detail-homework-data";
 import { getSectionDetailPageCopy } from "./section-detail-page-copy";
 import { parseSectionJwId } from "./section-detail-params";
-import { getSectionDetailUserId } from "./section-detail-session";
 
 export {
   subscribeSectionAction,
@@ -54,7 +53,6 @@ function resolveSectionDetailRouteSection(
 export async function loadSectionDetailPage({
   locals,
   params,
-  request,
   url,
 }: {
   locals: App.Locals;
@@ -66,10 +64,8 @@ export async function loadSectionDetailPage({
   if (!detailSection) error(404, "Section not found");
   const jwId = parseSectionJwId(params.jwId);
   if (jwId === null) error(404, "Section not found");
-  const [section, userId] = await Promise.all([
-    getSectionPage(jwId, locals.locale),
-    getSectionDetailUserId(request),
-  ]);
+  const userId = locals.authUser?.id ?? null;
+  const section = await getSectionPage(jwId, locals.locale);
   if (!section) error(404, "Section not found");
   const copy = getSectionDetailPageCopy(locals.locale);
   const courseName = primaryName(section.course) || section.code;

--- a/src/features/section-detail/server/section-detail-session.ts
+++ b/src/features/section-detail/server/section-detail-session.ts
@@ -1,4 +1,0 @@
-export async function getSectionDetailUserId(request: Request) {
-  const { getSessionFromHeaders } = await import("@/lib/auth/core");
-  return (await getSessionFromHeaders(request.headers))?.user?.id ?? null;
-}

--- a/src/features/section-detail/server/section-detail-subscription-actions.ts
+++ b/src/features/section-detail/server/section-detail-subscription-actions.ts
@@ -2,21 +2,19 @@ import { fail, redirect } from "@sveltejs/kit";
 import type { AppLocale } from "@/i18n/config";
 import { getSectionDetailPageCopy } from "./section-detail-page-copy";
 import { parseSectionJwId } from "./section-detail-params";
-import { getSectionDetailUserId } from "./section-detail-session";
 
 async function updateSectionSubscription({
   action,
   locals,
   params,
-  request,
 }: {
   action: "subscribe" | "unsubscribe";
-  locals: { locale: AppLocale };
+  locals: { authUser: App.Locals["authUser"]; locale: AppLocale };
   params: { jwId: string };
   request: Request;
 }) {
   const copy = getSectionDetailPageCopy(locals.locale).sectionDetail;
-  const userId = await getSectionDetailUserId(request);
+  const userId = locals.authUser?.id ?? null;
   if (!userId) return fail(401, { error: copy.loginRequired });
   const jwId = parseSectionJwId(params.jwId);
   if (jwId === null) return fail(400, { error: copy.operationFailed });
@@ -32,7 +30,7 @@ async function updateSectionSubscription({
 }
 
 export function subscribeSectionAction(input: {
-  locals: { locale: AppLocale };
+  locals: { authUser: App.Locals["authUser"]; locale: AppLocale };
   params: { jwId: string };
   request: Request;
 }) {
@@ -40,7 +38,7 @@ export function subscribeSectionAction(input: {
 }
 
 export function unsubscribeSectionAction(input: {
-  locals: { locale: AppLocale };
+  locals: { authUser: App.Locals["authUser"]; locale: AppLocale };
   params: { jwId: string };
   request: Request;
 }) {

--- a/tests/unit/detail-page-loader-critical-path.test.ts
+++ b/tests/unit/detail-page-loader-critical-path.test.ts
@@ -3,27 +3,34 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
-  currentCatalogViewerMock,
   getCommentsPayloadMock,
   getCoursePageMock,
   getDescriptionPayloadMock,
-  getSectionDetailUserIdMock,
+  getSessionFromHeadersMock,
   getSectionHomeworkDataMock,
   getSectionPageMock,
   getTeacherPageMock,
   getUserSectionSubscriptionStateMock,
   getViewerContextMock,
 } = vi.hoisted(() => ({
-  currentCatalogViewerMock: vi.fn(),
   getCommentsPayloadMock: vi.fn(),
   getCoursePageMock: vi.fn(),
   getDescriptionPayloadMock: vi.fn(),
-  getSectionDetailUserIdMock: vi.fn(),
+  getSessionFromHeadersMock: vi.fn(),
   getSectionHomeworkDataMock: vi.fn(),
   getSectionPageMock: vi.fn(),
   getTeacherPageMock: vi.fn(),
   getUserSectionSubscriptionStateMock: vi.fn(),
   getViewerContextMock: vi.fn(),
+}));
+
+vi.mock("@/app-env", () => ({
+  getOptionalTrimmedEnv: () => undefined,
+  loadEnv: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/core", () => ({
+  getSessionFromHeaders: getSessionFromHeadersMock,
 }));
 
 vi.mock("@/features/catalog/server/course-page-data", () => ({
@@ -32,10 +39,6 @@ vi.mock("@/features/catalog/server/course-page-data", () => ({
 
 vi.mock("@/features/catalog/server/teacher-page-data", () => ({
   getTeacherPage: getTeacherPageMock,
-}));
-
-vi.mock("@/features/catalog/server/catalog-detail-viewer", () => ({
-  currentCatalogViewer: currentCatalogViewerMock,
 }));
 
 vi.mock("@/features/comments/server/comments-server", () => ({
@@ -48,10 +51,6 @@ vi.mock("@/features/descriptions/server/descriptions-server", () => ({
 
 vi.mock("@/features/section-detail/server/section-page-data", () => ({
   getSectionPage: getSectionPageMock,
-}));
-
-vi.mock("@/features/section-detail/server/section-detail-session", () => ({
-  getSectionDetailUserId: getSectionDetailUserIdMock,
 }));
 
 vi.mock(
@@ -119,9 +118,19 @@ const section = {
   teachers: [{ id: teacher.id, namePrimary: teacher.namePrimary }],
 };
 
-function locals(): App.Locals {
+const signedInUser = {
+  email: "user@example.test",
+  id: "user-1",
+  image: null,
+  isAdmin: false,
+  name: "User",
+  profilePictures: [],
+  username: "user",
+};
+
+function locals(authUser: App.Locals["authUser"] = null): App.Locals {
   return {
-    authUser: null,
+    authUser,
     locale: "en-us",
     requestId: "detail-loader-test",
   };
@@ -133,7 +142,6 @@ function request(path: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  currentCatalogViewerMock.mockResolvedValue(anonymousViewer);
   getCommentsPayloadMock.mockResolvedValue({
     comments: [],
     hiddenCount: 0,
@@ -141,7 +149,7 @@ beforeEach(() => {
   });
   getCoursePageMock.mockResolvedValue(course);
   getDescriptionPayloadMock.mockResolvedValue(descriptionData);
-  getSectionDetailUserIdMock.mockResolvedValue(null);
+  getSessionFromHeadersMock.mockResolvedValue(null);
   getSectionHomeworkDataMock.mockResolvedValue({
     auditLogs: [],
     homeworks: [],
@@ -176,7 +184,7 @@ describe("catalog detail loader critical path", () => {
     });
 
     await vi.waitFor(() => {
-      expect(currentCatalogViewerMock).toHaveBeenCalledOnce();
+      expect(getViewerContextMock).toHaveBeenCalledOnce();
     });
     expect(getDescriptionPayloadMock).not.toHaveBeenCalled();
 
@@ -227,8 +235,72 @@ describe("catalog detail loader critical path", () => {
   });
 });
 
+describe("detail request session resolution", () => {
+  async function resolveCourseThroughHook(headers?: HeadersInit) {
+    const request = new Request(`https://example.test/courses/${course.jwId}`, {
+      headers,
+    });
+    const event = {
+      cookies: { get: vi.fn(() => undefined) },
+      locals: locals(),
+      platform: undefined,
+      request,
+      route: { id: "/courses/[jwId]" },
+      url: new URL(request.url),
+    };
+    const { handle } = await import("@/hooks.server");
+    const { loadCourseDetailPage } = await import(
+      "@/features/catalog/server/catalog-detail-page-server"
+    );
+
+    return handle({
+      event,
+      resolve: async (resolvedEvent: { locals: App.Locals }) => {
+        await loadCourseDetailPage({
+          locals: resolvedEvent.locals,
+          params: { jwId: String(course.jwId) },
+          request,
+          url: new URL(request.url),
+        });
+        return new Response('<html lang="zh-CN"><script></script></html>', {
+          headers: { "Content-Type": "text/html; charset=utf-8" },
+        });
+      },
+    } as unknown as Parameters<typeof handle>[0]);
+  }
+
+  it.each([
+    ["cookie", { cookie: "better-auth.session_token=session-token" }],
+    ["bearer", { authorization: "Bearer access-token" }],
+  ])("parses a signed-in %s session once in the hook and reuses locals in the detail loader", async (_authKind, headers) => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    getSessionFromHeadersMock.mockResolvedValue({
+      session: { id: "session-1" },
+      user: signedInUser,
+    });
+
+    const response = await resolveCourseThroughHook(headers);
+
+    expect(response.status).toBe(200);
+    expect(getSessionFromHeadersMock).toHaveBeenCalledOnce();
+    expect(getViewerContextMock).toHaveBeenCalledWith({
+      userId: signedInUser.id,
+    });
+  });
+
+  it("does not initialize Better Auth for an anonymous detail request", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const response = await resolveCourseThroughHook();
+
+    expect(response.status).toBe(200);
+    expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
+    expect(getViewerContextMock).toHaveBeenCalledWith({ userId: null });
+  });
+});
+
 describe("section detail loader critical path", () => {
-  it("starts section and session work together and skips comments and homework on overview", async () => {
+  it("loads the section while reusing hook auth and skips comments and homework on overview", async () => {
     let resolveSection: ((value: typeof section) => void) | undefined;
     getSectionPageMock.mockReturnValue(
       new Promise<typeof section>((resolve) => {
@@ -247,7 +319,7 @@ describe("section detail loader critical path", () => {
     });
 
     await vi.waitFor(() => {
-      expect(getSectionDetailUserIdMock).toHaveBeenCalledOnce();
+      expect(getSectionPageMock).toHaveBeenCalledOnce();
     });
     expect(getDescriptionPayloadMock).not.toHaveBeenCalled();
 
@@ -298,7 +370,6 @@ describe("section detail loader critical path", () => {
   });
 
   it("retains subscription state on signed-in sections because the fixed header consumes it", async () => {
-    getSectionDetailUserIdMock.mockResolvedValue("user-1");
     getUserSectionSubscriptionStateMock.mockResolvedValue({
       subscribedSections: [section.id],
       subscriptionIcsUrl: "/api/users/user-1/calendar.ics",
@@ -308,7 +379,7 @@ describe("section detail loader critical path", () => {
     );
 
     const result = await loadSectionDetailPage({
-      locals: locals(),
+      locals: locals(signedInUser),
       params: { jwId: String(section.jwId), section: "teachers" },
       request: request(`/sections/${section.jwId}/teachers`),
       url: new URL(`https://example.test/sections/${section.jwId}/teachers`),

--- a/tests/unit/section-detail-subscription-actions.test.ts
+++ b/tests/unit/section-detail-subscription-actions.test.ts
@@ -1,12 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getSessionFromHeadersMock = vi.fn();
 const subscribeUserToSectionByJwIdMock = vi.fn();
 const unsubscribeUserFromSectionByJwIdMock = vi.fn();
-
-vi.mock("@/lib/auth/core", () => ({
-  getSessionFromHeaders: getSessionFromHeadersMock,
-}));
 
 vi.mock("@/features/subscriptions/server/subscriptions", () => ({
   subscribeUserToSectionByJwId: subscribeUserToSectionByJwIdMock,
@@ -15,7 +10,18 @@ vi.mock("@/features/subscriptions/server/subscriptions", () => ({
 
 function actionInput(jwId = "99999999") {
   return {
-    locals: { locale: "en-us" as const },
+    locals: {
+      authUser: {
+        email: "user@example.test",
+        id: "user-1",
+        image: null,
+        isAdmin: false,
+        name: "User",
+        profilePictures: [],
+        username: "user",
+      },
+      locale: "en-us" as const,
+    },
     params: { jwId },
     request: new Request("http://localhost/sections/99999999"),
   };
@@ -24,7 +30,6 @@ function actionInput(jwId = "99999999") {
 describe("课程详情订阅动作", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    getSessionFromHeadersMock.mockResolvedValue({ user: { id: "user-1" } });
   });
 
   it("订阅目标不存在时返回 404", async () => {
@@ -55,5 +60,20 @@ describe("课程详情订阅动作", () => {
       "user-1",
       99999999,
     );
+  });
+
+  it("使用 hook 已解析的匿名 locals 拒绝订阅", async () => {
+    const { subscribeSectionAction } = await import(
+      "@/features/section-detail/server/section-detail-subscription-actions"
+    );
+    const input = {
+      ...actionInput(),
+      locals: { authUser: null, locale: "en-us" as const },
+    };
+
+    const result = await subscribeSectionAction(input);
+
+    expect(result).toMatchObject({ status: 401 });
+    expect(subscribeUserToSectionByJwIdMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Goal

Remove redundant Better Auth session resolution from the anonymous course, teacher, and section detail SSR hot paths tracked by #530. The global SvelteKit hook remains the single authentication boundary; detail loaders and section subscription actions consume the already-verified `locals.authUser`.

## Changed Surfaces

- Course/teacher detail loaders derive viewer context from `locals.authUser` instead of calling `getSessionFromHeaders` again.
- Section detail loaders and subscription actions reuse `locals.authUser` and remove the obsolete session wrapper.
- Tests exercise anonymous, session-cookie, and Bearer requests through the hook plus detail loader.
- HTML remains `Cache-Control: no-store`; no shared HTML cache key or authentication boundary changed.

## Evidence

- Production 24h baseline from Analytics Engine: `/sections/[jwId]` 554 requests, 557.2 ms average, 2684 ms max; `/sections/[jwId]/[section]` 564 requests, 701.7 ms average, 2637 ms max. All observed detail traffic in this window was anonymous.
- `bunx biome check` (passes with one pre-existing warning in `src/static-loader/import.ts`)
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` — 207 files / 1227 tests passed
- `bun run build`
- `bunx wrangler deploy --dry-run`
- Browser E2E skipped: no rendered markup, client code, navigation, or styling changed.

## Docs / Contracts

No docs/contracts change. Authentication, authorization, response shape, cache headers, routes, and user-visible behavior are unchanged.

## Risk Areas

Authentication is intentionally scoped to the existing hook contract. Cookie and Bearer requests resolve exactly once in the hook; anonymous requests do not initialize Better Auth. Suspended-user/viewer checks still run through `getViewerContext`, and incomplete-profile redirects still happen in the hook before route loading.

## Cleanup

No scratch artifacts, generated-file edits, database changes, or unrelated rewrites are included.