### PR TITLE
fix(ui): tolerate unavailable browser storage

### DIFF
--- a/src/features/dashboard/components/AnonymousHomePageController.svelte
+++ b/src/features/dashboard/components/AnonymousHomePageController.svelte
@@ -17,6 +17,7 @@ import {
 } from "@/features/dashboard/lib/view-preferences";
 import { groupDashboardLinks } from "@/features/dashboard-links/lib/dashboard-link-search";
 import type { DashboardLinkSummary } from "@/features/dashboard-links/server/dashboard-link-data";
+import { getLocalStorageItem } from "@/lib/browser/local-storage";
 import { replaceState } from "$app/navigation";
 import AnonymousDashboardView from "./AnonymousDashboardView.svelte";
 
@@ -58,7 +59,7 @@ onMount(() => {
   const url = new URL(window.location.href);
   linkView = dashboardViewsFromPreference(
     url,
-    localStorage.getItem(DASHBOARD_VIEW_STORAGE_KEY),
+    getLocalStorageItem(DASHBOARD_VIEW_STORAGE_KEY),
   ).linkView;
 
   function handleShortcut(event: KeyboardEvent) {

--- a/src/features/dashboard/components/BusTab.svelte
+++ b/src/features/dashboard/components/BusTab.svelte
@@ -13,6 +13,11 @@ import type {
   DashboardBusData,
 } from "@/features/dashboard/lib/bus-tab-types";
 import { apiClient } from "@/lib/api/client";
+import {
+  getLocalStorageItem,
+  removeLocalStorageItem,
+  setLocalStorageItem,
+} from "@/lib/browser/local-storage";
 import { Button } from "$lib/components/ui/button/index.js";
 import * as Collapsible from "$lib/components/ui/collapsible/index.js";
 import * as Empty from "$lib/components/ui/empty/index.js";
@@ -63,7 +68,7 @@ function restoreRecentRoute() {
 
   try {
     const stored = JSON.parse(
-      window.localStorage.getItem(RECENT_BUS_ROUTE_KEY) ?? "null",
+      getLocalStorageItem(RECENT_BUS_ROUTE_KEY) ?? "null",
     ) as {
       endCampusId?: unknown;
       startCampusId?: unknown;
@@ -89,7 +94,7 @@ function restoreRecentRoute() {
     state.actions.selectBusStart(stored.startCampusId);
     state.actions.selectBusEnd(stored.endCampusId);
   } catch {
-    window.localStorage.removeItem(RECENT_BUS_ROUTE_KEY);
+    removeLocalStorageItem(RECENT_BUS_ROUTE_KEY);
   }
 }
 
@@ -102,7 +107,7 @@ function saveRecentRoute() {
     return;
   }
 
-  window.localStorage.setItem(
+  setLocalStorageItem(
     RECENT_BUS_ROUTE_KEY,
     JSON.stringify({
       endCampusId: state.values.busEndCampusId,

--- a/src/features/dashboard/lib/dashboard-controller-mount.ts
+++ b/src/features/dashboard/lib/dashboard-controller-mount.ts
@@ -1,3 +1,4 @@
+import { getLocalStorageItem } from "@/lib/browser/local-storage";
 import type { DashboardViewState } from "./dashboard-controller-helpers";
 import { currentDashboardLinkReturnTo } from "./dashboard-link-ui";
 import { formatMessage } from "./overview";
@@ -61,7 +62,7 @@ export function mountDashboardController(input: {
   input.applyViewState(
     dashboardViewsFromPreference(
       url,
-      localStorage.getItem(DASHBOARD_VIEW_STORAGE_KEY),
+      getLocalStorageItem(DASHBOARD_VIEW_STORAGE_KEY),
     ),
   );
 

--- a/src/features/dashboard/lib/view-preferences.ts
+++ b/src/features/dashboard/lib/view-preferences.ts
@@ -1,3 +1,5 @@
+import { setLocalStorageItem } from "@/lib/browser/local-storage";
+
 export type DashboardCardView = "cards" | "list";
 export type DashboardLinkView = "grid" | "list";
 
@@ -49,7 +51,7 @@ export function dashboardViewsFromPreference(
 }
 
 export function persistDashboardViewMode(mode: DashboardCardView) {
-  localStorage.setItem(DASHBOARD_VIEW_STORAGE_KEY, mode);
+  setLocalStorageItem(DASHBOARD_VIEW_STORAGE_KEY, mode);
 }
 
 export function dashboardViewHref(

--- a/src/features/section-detail/lib/section-detail-controller-navigation.ts
+++ b/src/features/section-detail/lib/section-detail-controller-navigation.ts
@@ -1,9 +1,14 @@
+import {
+  getLocalStorageItem,
+  setLocalStorageItem,
+} from "@/lib/browser/local-storage";
+
 export type SectionHomeworkView = "cards" | "list";
 
 const homeworkViewStorageKey = "life-ustc-dashboard-homework-view-mode";
 
 export function persistSectionHomeworkView(nextView: SectionHomeworkView) {
-  localStorage.setItem(homeworkViewStorageKey, nextView);
+  setLocalStorageItem(homeworkViewStorageKey, nextView);
   const url = new URL(window.location.href);
   if (nextView === "list") {
     url.searchParams.set("homeworkView", "list");
@@ -16,7 +21,7 @@ export function persistSectionHomeworkView(nextView: SectionHomeworkView) {
 export function initialSectionHomeworkViewFromBrowser(
   fallback: SectionHomeworkView,
 ): SectionHomeworkView {
-  const stored = localStorage.getItem(homeworkViewStorageKey);
+  const stored = getLocalStorageItem(homeworkViewStorageKey);
   if (stored === "cards" || stored === "list") {
     return stored;
   }
@@ -24,7 +29,7 @@ export function initialSectionHomeworkViewFromBrowser(
     "homeworkView",
   );
   if (viewParam === "list") {
-    localStorage.setItem(homeworkViewStorageKey, "list");
+    setLocalStorageItem(homeworkViewStorageKey, "list");
     return "list";
   }
   return fallback;

--- a/src/lib/browser/local-storage.ts
+++ b/src/lib/browser/local-storage.ts
@@ -1,0 +1,19 @@
+export function getLocalStorageItem(key: string) {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function setLocalStorageItem(key: string, value: string) {
+  try {
+    localStorage.setItem(key, value);
+  } catch {}
+}
+
+export function removeLocalStorageItem(key: string) {
+  try {
+    localStorage.removeItem(key);
+  } catch {}
+}

--- a/src/lib/components/shell/app-shell-actions.ts
+++ b/src/lib/components/shell/app-shell-actions.ts
@@ -1,11 +1,15 @@
 import {
+  getLocalStorageItem,
+  setLocalStorageItem,
+} from "@/lib/browser/local-storage";
+import {
   applyShellTheme,
   nextShellThemeMode,
   type ThemeMode,
-} from "$lib/components/shell/layout-shell";
+} from "@/lib/components/shell/layout-shell";
 
 export function loadStoredThemeMode(fallback: ThemeMode): ThemeMode {
-  const storedTheme = localStorage.getItem("life-ustc-theme");
+  const storedTheme = getLocalStorageItem("life-ustc-theme");
   return storedTheme === "light" ||
     storedTheme === "dark" ||
     storedTheme === "system"
@@ -15,13 +19,13 @@ export function loadStoredThemeMode(fallback: ThemeMode): ThemeMode {
 
 export function cycleStoredThemeMode(themeMode: ThemeMode) {
   const nextThemeMode = nextShellThemeMode(themeMode);
-  localStorage.setItem("life-ustc-theme", nextThemeMode);
+  setLocalStorageItem("life-ustc-theme", nextThemeMode);
   applyShellTheme(nextThemeMode);
   return nextThemeMode;
 }
 
 export function setStoredThemeMode(themeMode: ThemeMode) {
-  localStorage.setItem("life-ustc-theme", themeMode);
+  setLocalStorageItem("life-ustc-theme", themeMode);
   applyShellTheme(themeMode);
   return themeMode;
 }

--- a/tests/e2e/src/app/test.ts
+++ b/tests/e2e/src/app/test.ts
@@ -165,6 +165,36 @@ test("/ 存储的深色主题在 hydration 前应用且通过 CSP", async ({
   await context.close();
 });
 
+test("/ 浏览器存储不可用时仍完成 hydration 并允许切换主题", async ({
+  browser,
+}, testInfo) => {
+  const context = await browser.newContext({
+    baseURL: String(testInfo.project.use.baseURL),
+    colorScheme: "light",
+  });
+  await context.addInitScript(() => {
+    Storage.prototype.getItem = () => {
+      throw new DOMException("Storage disabled", "SecurityError");
+    };
+    Storage.prototype.setItem = () => {
+      throw new DOMException("Storage disabled", "SecurityError");
+    };
+  });
+  const page = await context.newPage();
+  const pageErrors: string[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+
+  await gotoAndWaitForReady(page, "/");
+  await page
+    .getByRole("button", { name: /^(主题选择|Theme selector)$/i })
+    .click();
+  await page.getByRole("menuitemradio", { name: /^(深色|Dark)$/i }).click();
+
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  expect(pageErrors).toEqual([]);
+  await context.close();
+});
+
 test("/ 禁用 JavaScript 时系统深色主题仍有 CSS fallback", async ({
   browser,
 }, testInfo) => {

--- a/tests/unit/app-shell-actions.test.ts
+++ b/tests/unit/app-shell-actions.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  loadStoredThemeMode,
+  setStoredThemeMode,
+} from "@/lib/components/shell/app-shell-actions";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("application shell theme storage", () => {
+  it("uses the fallback when stored theme access is unavailable", () => {
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new DOMException("Storage disabled", "SecurityError");
+      },
+    });
+
+    expect(loadStoredThemeMode("system")).toBe("system");
+  });
+
+  it("applies the selected theme when persistence is unavailable", () => {
+    vi.stubGlobal("localStorage", {
+      setItem: () => {
+        throw new DOMException("Storage disabled", "SecurityError");
+      },
+    });
+    vi.stubGlobal("window", {
+      matchMedia: () => ({ matches: false }),
+    });
+    const dataset: Record<string, string> = {};
+    vi.stubGlobal("document", {
+      documentElement: { dataset },
+    });
+
+    expect(setStoredThemeMode("dark")).toBe("dark");
+    expect(dataset.theme).toBe("dark");
+  });
+});

--- a/tests/unit/browser-local-storage.test.ts
+++ b/tests/unit/browser-local-storage.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getLocalStorageItem,
+  removeLocalStorageItem,
+  setLocalStorageItem,
+} from "@/lib/browser/local-storage";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("browser local storage", () => {
+  it("returns null when reads are unavailable", () => {
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new DOMException("Storage disabled", "SecurityError");
+      },
+    });
+
+    expect(getLocalStorageItem("preference")).toBeNull();
+  });
+
+  it("ignores unavailable writes and removals", () => {
+    vi.stubGlobal("localStorage", {
+      removeItem: () => {
+        throw new DOMException("Storage disabled", "SecurityError");
+      },
+      setItem: () => {
+        throw new DOMException("Storage disabled", "SecurityError");
+      },
+    });
+
+    expect(() => setLocalStorageItem("preference", "list")).not.toThrow();
+    expect(() => removeLocalStorageItem("preference")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Goal

Keep SSR-rendered pages interactive when browser privacy or sandbox policy makes `localStorage` throw. Fixes #531.

## Changed Surfaces

- Add one browser-only safe local-storage adapter for reads, writes, and removals.
- Route theme, anonymous/signed dashboard view, section homework view, and public bus route preferences through the adapter.
- Preserve in-session theme application even when persistence is unavailable.
- Add unit coverage and an anonymous-home Playwright regression that exercises storage failures during hydration and theme selection.

## Evidence

- Production Playwright before the fix: `/` and `/courses` rendered SSR content, but both emitted `pageerror: Storage disabled` and never set `data-life-ustc-hydrated`.
- `bunx biome check`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` — 209 files / 1227 tests passed.
- `bun run build`
- Focused Playwright: normal persisted theme, pre-hydration dark theme/CSP, unavailable storage, and no-JS system dark fallback — 4 passed.
- Inspected the final desktop screenshot: anonymous homepage remained rendered in dark mode with the selected theme and no page errors.

## Docs / Contracts

No docs or contract change: routes, persistence keys, visible workflow, API shape, locale behavior, and cache policy are unchanged. This only makes existing client preferences best-effort when browser storage is unavailable.

## Risk Areas

- No auth, database schema, API, SSR cache, CSP, or locale negotiation changes.
- Failed preference persistence intentionally falls back to current/default state; successful storage behavior is unchanged.
- Shared HTML remains `no-store`; this PR does not change the authenticated/locale cache boundary tracked in #507.

## Cleanup

No screenshots, Playwright reports, temporary probes, generated-file edits, or unrelated rewrites are included.
