### PR TITLE
perf(api): split browser and Cloudflare cache policy

### DIFF
--- a/src/lib/api/routes/academic-metadata-routes.ts
+++ b/src/lib/api/routes/academic-metadata-routes.ts
@@ -10,7 +10,7 @@ import {
   parseRouteQuery,
 } from "@/lib/api/helpers";
 import { semestersQuerySchema } from "@/lib/api/schemas/request-schemas";
-import { PUBLIC_CATALOG_CACHE_CONTROL } from "@/lib/public-cache-control";
+import { PUBLIC_CATALOG_HEADERS } from "@/lib/public-cache-control";
 import { cachedPublicRuntimeData } from "@/lib/public-runtime-cache";
 
 const METADATA_API_CACHE_TTL_MS = 60_000;
@@ -25,7 +25,7 @@ export async function getMetadataRoute() {
     );
 
     return jsonResponse(metadata, {
-      headers: { "Cache-Control": PUBLIC_CATALOG_CACHE_CONTROL },
+      headers: PUBLIC_CATALOG_HEADERS,
     });
   } catch (error) {
     return handleRouteError("Failed to fetch metadata", error);
@@ -53,7 +53,7 @@ export async function getSemestersRoute(request: Request) {
     );
 
     return jsonResponse(result, {
-      headers: { "Cache-Control": PUBLIC_CATALOG_CACHE_CONTROL },
+      headers: PUBLIC_CATALOG_HEADERS,
     });
   } catch (error) {
     return handleRouteError("Failed to fetch semesters", error);

--- a/src/lib/public-cache-control.ts
+++ b/src/lib/public-cache-control.ts
@@ -1,5 +1,4 @@
-export const PUBLIC_CATALOG_CACHE_CONTROL =
-  "public, max-age=0, must-revalidate";
+export const PUBLIC_CATALOG_CACHE_CONTROL = "public, max-age=0";
 
 export const PUBLIC_CATALOG_CDN_CACHE_CONTROL =
   "public, max-age=60, stale-while-revalidate=300";

--- a/src/lib/public-cache-control.ts
+++ b/src/lib/public-cache-control.ts
@@ -1,8 +1,16 @@
 export const PUBLIC_CATALOG_CACHE_CONTROL =
-  "public, max-age=0, s-maxage=60, stale-while-revalidate=300";
+  "public, max-age=0, must-revalidate";
+
+export const PUBLIC_CATALOG_CDN_CACHE_CONTROL =
+  "public, max-age=60, stale-while-revalidate=300";
+
+export const PUBLIC_CATALOG_HEADERS = {
+  "Cache-Control": PUBLIC_CATALOG_CACHE_CONTROL,
+  "Cloudflare-CDN-Cache-Control": PUBLIC_CATALOG_CDN_CACHE_CONTROL,
+} as const;
 
 export const PUBLIC_LOCALE_CATALOG_HEADERS = {
-  "Cache-Control": PUBLIC_CATALOG_CACHE_CONTROL,
+  ...PUBLIC_CATALOG_HEADERS,
   Vary: "Accept-Language, Cookie",
 } as const;
 

--- a/src/lib/public-cache-control.ts
+++ b/src/lib/public-cache-control.ts
@@ -1,4 +1,5 @@
-export const PUBLIC_CATALOG_CACHE_CONTROL = "public, max-age=0";
+export const PUBLIC_CATALOG_CACHE_CONTROL =
+  "public, max-age=0, stale-while-revalidate=300";
 
 export const PUBLIC_CATALOG_CDN_CACHE_CONTROL =
   "public, max-age=60, stale-while-revalidate=300";

--- a/tests/e2e/src/app/api/courses/test.ts
+++ b/tests/e2e/src/app/api/courses/test.ts
@@ -63,9 +63,7 @@ test.describe("GET /api/courses 接口", () => {
       },
     });
     expect(explicit.status()).toBe(200);
-    expect(explicit.headers()["cache-control"]).toBe(
-      "public, max-age=0, must-revalidate",
-    );
+    expect(explicit.headers()["cache-control"]).toBe("public, max-age=0");
     expect(explicit.headers()["cloudflare-cdn-cache-control"]).toBe(
       "public, max-age=60, stale-while-revalidate=300",
     );

--- a/tests/e2e/src/app/api/courses/test.ts
+++ b/tests/e2e/src/app/api/courses/test.ts
@@ -64,7 +64,10 @@ test.describe("GET /api/courses 接口", () => {
     });
     expect(explicit.status()).toBe(200);
     expect(explicit.headers()["cache-control"]).toBe(
-      "public, max-age=0, s-maxage=60, stale-while-revalidate=300",
+      "public, max-age=0, must-revalidate",
+    );
+    expect(explicit.headers()["cloudflare-cdn-cache-control"]).toBe(
+      "public, max-age=60, stale-while-revalidate=300",
     );
 
     const fallback = await request.get("/api/courses?pageSize=1", {

--- a/tests/e2e/src/app/api/courses/test.ts
+++ b/tests/e2e/src/app/api/courses/test.ts
@@ -63,7 +63,9 @@ test.describe("GET /api/courses 接口", () => {
       },
     });
     expect(explicit.status()).toBe(200);
-    expect(explicit.headers()["cache-control"]).toBe("public, max-age=0");
+    expect(explicit.headers()["cache-control"]).toBe(
+      "public, max-age=0, stale-while-revalidate=300",
+    );
     expect(explicit.headers()["cloudflare-cdn-cache-control"]).toBe(
       "public, max-age=60, stale-while-revalidate=300",
     );

--- a/tests/unit/academic-list-cache.test.ts
+++ b/tests/unit/academic-list-cache.test.ts
@@ -55,9 +55,7 @@ describe("academic 列表路由缓存", () => {
       ),
     );
 
-    expect(first.headers.get("Cache-Control")).toBe(
-      "public, max-age=0, must-revalidate",
-    );
+    expect(first.headers.get("Cache-Control")).toBe("public, max-age=0");
     expect(first.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
       "public, max-age=60, stale-while-revalidate=300",
     );
@@ -82,9 +80,7 @@ describe("academic 列表路由缓存", () => {
       ),
     );
 
-    expect(first.headers.get("Cache-Control")).toBe(
-      "public, max-age=0, must-revalidate",
-    );
+    expect(first.headers.get("Cache-Control")).toBe("public, max-age=0");
     expect(first.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
       "public, max-age=60, stale-while-revalidate=300",
     );

--- a/tests/unit/academic-list-cache.test.ts
+++ b/tests/unit/academic-list-cache.test.ts
@@ -55,7 +55,9 @@ describe("academic 列表路由缓存", () => {
       ),
     );
 
-    expect(first.headers.get("Cache-Control")).toBe("public, max-age=0");
+    expect(first.headers.get("Cache-Control")).toBe(
+      "public, max-age=0, stale-while-revalidate=300",
+    );
     expect(first.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
       "public, max-age=60, stale-while-revalidate=300",
     );
@@ -80,7 +82,9 @@ describe("academic 列表路由缓存", () => {
       ),
     );
 
-    expect(first.headers.get("Cache-Control")).toBe("public, max-age=0");
+    expect(first.headers.get("Cache-Control")).toBe(
+      "public, max-age=0, stale-while-revalidate=300",
+    );
     expect(first.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
       "public, max-age=60, stale-while-revalidate=300",
     );

--- a/tests/unit/academic-list-cache.test.ts
+++ b/tests/unit/academic-list-cache.test.ts
@@ -56,7 +56,10 @@ describe("academic 列表路由缓存", () => {
     );
 
     expect(first.headers.get("Cache-Control")).toBe(
-      "public, max-age=0, s-maxage=60, stale-while-revalidate=300",
+      "public, max-age=0, must-revalidate",
+    );
+    expect(first.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
+      "public, max-age=60, stale-while-revalidate=300",
     );
     expect(first.headers.get("Vary")).toBe("Accept-Language, Cookie");
     expect(second.status).toBe(200);
@@ -80,7 +83,10 @@ describe("academic 列表路由缓存", () => {
     );
 
     expect(first.headers.get("Cache-Control")).toBe(
-      "public, max-age=0, s-maxage=60, stale-while-revalidate=300",
+      "public, max-age=0, must-revalidate",
+    );
+    expect(first.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
+      "public, max-age=60, stale-while-revalidate=300",
     );
     expect(first.headers.get("Vary")).toBe("Accept-Language, Cookie");
     expect(second.status).toBe(200);

--- a/tests/unit/academic-route-locale.test.ts
+++ b/tests/unit/academic-route-locale.test.ts
@@ -348,7 +348,9 @@ describe("academic REST 语言适配器", () => {
     ];
 
     for (const response of responses) {
-      expect(response.headers.get("Cache-Control")).toBe("public, max-age=0");
+      expect(response.headers.get("Cache-Control")).toBe(
+        "public, max-age=0, stale-while-revalidate=300",
+      );
       expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
         "public, max-age=60, stale-while-revalidate=300",
       );

--- a/tests/unit/academic-route-locale.test.ts
+++ b/tests/unit/academic-route-locale.test.ts
@@ -348,9 +348,7 @@ describe("academic REST 语言适配器", () => {
     ];
 
     for (const response of responses) {
-      expect(response.headers.get("Cache-Control")).toBe(
-        "public, max-age=0, must-revalidate",
-      );
+      expect(response.headers.get("Cache-Control")).toBe("public, max-age=0");
       expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
         "public, max-age=60, stale-while-revalidate=300",
       );

--- a/tests/unit/academic-route-locale.test.ts
+++ b/tests/unit/academic-route-locale.test.ts
@@ -349,9 +349,11 @@ describe("academic REST 语言适配器", () => {
 
     for (const response of responses) {
       expect(response.headers.get("Cache-Control")).toBe(
-        "public, max-age=0, s-maxage=60, stale-while-revalidate=300",
+        "public, max-age=0, must-revalidate",
       );
-      expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+      expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
+        "public, max-age=60, stale-while-revalidate=300",
+      );
     }
 
     expect(findCourseDetailByJwIdMock).toHaveBeenCalledWith(123, "zh-cn");


### PR DESCRIPTION
## Summary

- split browser and Cloudflare edge cache directives for public catalog APIs
- remove `s-maxage`, which implicitly forbids stale serving on Cloudflare
- preserve private `no-store` for header/cookie-negotiated and invalid locale responses
- apply the same policy to public academic metadata APIs

## Response policy

```http
Cache-Control: public, max-age=0, stale-while-revalidate=300
Cloudflare-CDN-Cache-Control: public, max-age=60, stale-while-revalidate=300
```

`max-age=0` keeps browser responses immediately stale. The Cloudflare-specific header carries the separate 60-second edge freshness window without `s-maxage`, `must-revalidate`, or `proxy-revalidate`.

Refs #539. Selective Workers Caching is tracked in #541 and the anonymous SSR gateway in #507.

## Independent value and boundary

This keeps the existing 60-second edge freshness window while removing a contradictory directive and separating browser policy from Cloudflare policy. It is a low-risk prerequisite, not a claim that the current deployment now performs asynchronous SWR.

Preview findings:

- Explicit locale: initial Worker response followed by `CF-Cache-Status: HIT` with the same `x-request-id`.
- Negotiated locale: `Cache-Control: private, no-store` and `Cloudflare-CDN-Cache-Control: no-store`.
- After TTL expiry, the current app preview still performs blocking outer-CDN refresh rather than returning `UPDATING`.
- The `tiankaima.dev` Zone has `Always Online: on`; Cloudflare documents that Zone CDN SWR is ignored while it is enabled. This PR does not change the Zone.
- A temporary isolated Worker using the exact split headers plus `cache.enabled=true` produced `MISS` → stale `UPDATING` → fresh `HIT`, confirming the header combination for #541. The temporary Worker was deleted after the probe.

Enabling Workers Caching on the default SvelteKit entrypoint is unsafe: it would heuristically cache 200 responses without explicit headers and add cache lookups to private routes. #541 instead requires a cache-disabled default gateway and a named cached catalog entrypoint.

## Verification

- `bunx vitest run` — 207 files, 1221 tests passed
- `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors, 0 warnings
- three TypeScript project checks passed
- `bunx biome check .` — passed with one pre-existing warning in `src/static-loader/import.ts`
- `bun run build`
- Wrangler deployment dry-run passed

