### PR TITLE
feat(auth): add passkey server support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ WEBHOOK_SECRET="replace-with-random-secret"
 AUTH_SECRET="replace-with-random-secret"
 # Required in production. Local dev falls back to http://localhost:3000.
 # APP_PUBLIC_ORIGIN="https://life-ustc.example.com"
+# Optional canonical WebAuthn RP origin when preview and public origins differ.
+# Passkey preview origins must be configured explicitly; wildcard hosts are not accepted.
+# APP_CANONICAL_ORIGIN="https://life-ustc.example.com"
 
 # OAuth / OIDC providers
 # AUTH_GITHUB_ID=""

--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,8 @@ AUTH_SECRET="replace-with-random-secret"
 # Required in production. Local dev falls back to http://localhost:3000.
 # APP_PUBLIC_ORIGIN="https://life-ustc.example.com"
 # Optional canonical WebAuthn RP origin when preview and public origins differ.
-# Passkey preview origins must be configured explicitly; wildcard hosts are not accepted.
+# Passkey preview origins must be explicit and use this RP host or a subdomain;
+# wildcard or unrelated hosts are not accepted.
 # APP_CANONICAL_ORIGIN="https://life-ustc.example.com"
 
 # OAuth / OIDC providers

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "life-ustc-server",
       "dependencies": {
         "@better-auth/oauth-provider": "^1.6.11",
+        "@better-auth/passkey": "1.6.14",
         "@escape.tech/graphql-armor": "3.2.0",
         "@graphql-yoga/plugin-disable-introspection": "2.22.2",
         "@internationalized/date": "^3.12.2",
@@ -109,6 +110,8 @@
     "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.14", "", { "peerDependencies": { "@better-auth/core": "^1.6.14", "@better-auth/utils": "0.4.1", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-meaZx712k9c0Cl6urwYZRNa3mAy3/leaYiSNt+hVaCOEPlgTDxzmYMNACvTTYXgh4eCpDVf5G7ZMEYBtejKQdw=="],
 
     "@better-auth/oauth-provider": ["@better-auth/oauth-provider@1.6.14", "", { "dependencies": { "jose": "^6.1.3", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.14", "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.1.21", "better-auth": "^1.6.14", "better-call": "1.3.5" } }, "sha512-JL5UNKayERwRbYyZL7DsjOMtMjPWiOVnzUwztIuDNuYK5JZC2Pfm/16MdkEtic8+8YCv9qGK7dph/TTU5fdlKA=="],
+
+    "@better-auth/passkey": ["@better-auth/passkey@1.6.14", "", { "dependencies": { "@simplewebauthn/browser": "^13.2.2", "@simplewebauthn/server": "^13.2.3", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.14", "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.1.21", "better-auth": "^1.6.14", "better-call": "1.3.5", "nanostores": "^1.0.1" } }, "sha512-V6g5Uu3rrRhbQMbEv+Q70PfjeOkTLwU7a+p9zV6rz11JKVWObtdXSFg0cUCaQbMbpgOXirn3+SI6i4NcWpc/Sg=="],
 
     "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.14", "", { "peerDependencies": { "@better-auth/core": "^1.6.14", "@better-auth/utils": "0.4.1", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-9b9wSqhCthMmOYo0QdX+N/cOv+fNck/JE5CZQuuWwEJl5QeoYhCZesXjts5VfLAPMIf6vKw3QNBrn0SVMXXi2Q=="],
 
@@ -334,6 +337,8 @@
 
     "@headlessui/vue": ["@headlessui/vue@1.7.23", "", { "dependencies": { "@tanstack/vue-virtual": "^3.0.0-beta.60" }, "peerDependencies": { "vue": "^3.2.0" } }, "sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg=="],
 
+    "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
@@ -401,6 +406,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@kurkle/color": ["@kurkle/color@0.3.4", "", {}, "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="],
+
+    "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
 
     "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
 
@@ -493,6 +500,32 @@
     "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g=="],
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
+
+    "@peculiar/asn1-android": ["@peculiar/asn1-android@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-skLbS+IOGv1lUgDqtChr8xvtvEr3HMse/JGBaL2r1J1o/n7a8wqOrovMtlRq/UXLhxvmLaONP67hwtshgzwfzA=="],
+
+    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA=="],
+
+    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg=="],
+
+    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ=="],
+
+    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.8.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.8.0", "@peculiar/asn1-pkcs8": "^2.8.0", "@peculiar/asn1-rsa": "^2.8.0", "@peculiar/asn1-schema": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg=="],
+
+    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA=="],
+
+    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.8.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.8.0", "@peculiar/asn1-pfx": "^2.8.0", "@peculiar/asn1-pkcs8": "^2.8.0", "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ=="],
+
+    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg=="],
+
+    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.8.0", "", { "dependencies": { "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q=="],
+
+    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg=="],
+
+    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA=="],
+
+    "@peculiar/utils": ["@peculiar/utils@2.0.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ=="],
+
+    "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
 
     "@phosphor-icons/core": ["@phosphor-icons/core@2.1.1", "", {}, "sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ=="],
 
@@ -655,6 +688,10 @@
     "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@1.0.2", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0" } }, "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw=="],
 
     "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
+
+    "@simplewebauthn/browser": ["@simplewebauthn/browser@13.3.0", "", {}, "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ=="],
+
+    "@simplewebauthn/server": ["@simplewebauthn/server@13.3.2", "", { "dependencies": { "@hexagon/base64": "^1.1.27", "@levischuck/tiny-cbor": "^0.2.2", "@peculiar/asn1-android": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/x509": "^1.14.3" } }, "sha512-KEDhfcGP1PAKRVSDjA3npTQFqS2b/srm+ipoNBNHdkzrHAlaRQUTE+a5f4ywsx6thxAw1NU2rYcLEY1949RGbQ=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
@@ -837,6 +874,8 @@
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
     "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
+
+    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -1690,6 +1729,10 @@
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
     "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
@@ -1715,6 +1758,8 @@
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "regexparam": ["regexparam@3.0.0", "", {}, "sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q=="],
 
@@ -1947,6 +1992,8 @@
     "ts-morph": ["ts-morph@28.0.0", "", { "dependencies": { "@ts-morph/common": "~0.29.0", "code-block-writer": "^13.0.3" } }, "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
@@ -2579,6 +2626,8 @@
     "tempy/is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
 
     "tempy/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
+
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/docs/contracts/user.json
+++ b/docs/contracts/user.json
@@ -8,6 +8,8 @@
   },
   "rules": {
     "sign-in-providers": "Sign-in supports USTC, GitHub, and Google OAuth; custom username/password login is not considered due to security and maintenance cost.",
+    "passkey-server-boundary": "Better Auth passkey registration requires an existing fresh session. Its RP ID comes from the configured canonical origin, verification accepts only explicitly configured canonical/public/local origins, and the legacy Authenticator table is not reused. The sign-in and credential-management UI ships separately.",
+    "debug-password-boundary": "Email/password authentication is enabled only for local development or the explicit non-production E2E debug mode; production does not expose debug password authentication.",
     "oauth-callback-integrity": "On a canonical same-origin deployment, OAuth login callbacks must complete state validation and session creation directly, without losing state due to proxy wrapping or container-internal host differences.",
     "welcome-flow-required": "New users who have not set a name or username on first login must complete the welcome flow before proceeding.",
     "welcome-completion-resume": "If the welcome flow was reached from an app-relative callbackUrl, successful completion returns to that page; otherwise completion returns home.",

--- a/docs/contracts/user.json
+++ b/docs/contracts/user.json
@@ -8,7 +8,7 @@
   },
   "rules": {
     "sign-in-providers": "Sign-in supports USTC, GitHub, and Google OAuth; custom username/password login is not considered due to security and maintenance cost.",
-    "passkey-server-boundary": "Better Auth passkey registration requires an existing fresh session. Its RP ID comes from the configured canonical origin, verification accepts only explicitly configured canonical/public/local origins, and the legacy Authenticator table is not reused. The sign-in and credential-management UI ships separately.",
+    "passkey-server-boundary": "Better Auth passkey registration requires an existing fresh session. Its RP ID comes from the configured canonical origin; verification accepts only explicitly configured canonical/public origins whose host is the RP ID or its subdomain. Localhost and 127.0.0.1 are separate RPs and are not mixed. The legacy Authenticator table is not reused, and the sign-in and credential-management UI ships separately.",
     "debug-password-boundary": "Email/password authentication is enabled only for local development or the explicit non-production E2E debug mode; production does not expose debug password authentication.",
     "oauth-callback-integrity": "On a canonical same-origin deployment, OAuth login callbacks must complete state validation and session creation directly, without losing state due to proxy wrapping or container-internal host differences.",
     "welcome-flow-required": "New users who have not set a name or username on first login must complete the welcome flow before proceeding.",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@better-auth/oauth-provider": "^1.6.11",
+    "@better-auth/passkey": "1.6.14",
     "@escape.tech/graphql-armor": "3.2.0",
     "@graphql-yoga/plugin-disable-introspection": "2.22.2",
     "@internationalized/date": "^3.12.2",

--- a/prisma/migrations/20260720113000_add_better_auth_passkey/migration.sql
+++ b/prisma/migrations/20260720113000_add_better_auth_passkey/migration.sql
@@ -1,0 +1,25 @@
+-- Better Auth's passkey plugin uses a different schema from the legacy
+-- Auth.js Authenticator table, which remains untouched for a later audit.
+CREATE TABLE "Passkey" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+    "publicKey" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "credentialID" TEXT NOT NULL,
+    "counter" INTEGER NOT NULL,
+    "deviceType" TEXT NOT NULL,
+    "backedUp" BOOLEAN NOT NULL,
+    "transports" TEXT,
+    "createdAt" TIMESTAMP(3),
+    "aaguid" TEXT,
+
+    CONSTRAINT "Passkey_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "Passkey_userId_idx" ON "Passkey"("userId");
+CREATE INDEX "Passkey_credentialID_idx" ON "Passkey"("credentialID");
+
+ALTER TABLE "Passkey"
+ADD CONSTRAINT "Passkey_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "User"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -808,7 +808,8 @@ model User {
 
   accounts      Account[]
   sessions      Session[]
-  // Optional for WebAuthn support
+  passkeys      Passkey[]
+  // Legacy Auth.js WebAuthn records; Better Auth passkeys use Passkey.
   Authenticator Authenticator[]
 
   verifiedEmails VerifiedEmail[]
@@ -1102,7 +1103,26 @@ model VerificationToken {
   @@index([expires])
 }
 
-// Optional for WebAuthn support
+model Passkey {
+  id           String    @id @default(cuid())
+  name         String?
+  publicKey    String
+  userId       String
+  credentialID String
+  counter      Int
+  deviceType   String
+  backedUp     Boolean
+  transports   String?
+  createdAt    DateTime?
+  aaguid       String?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([credentialID])
+}
+
+// Legacy Auth.js WebAuthn records. Do not reuse for Better Auth passkeys.
 model Authenticator {
   credentialID         String  @unique
   userId               String

--- a/src/lib/auth/auth-origins.ts
+++ b/src/lib/auth/auth-origins.ts
@@ -1,4 +1,4 @@
-import { getPublicOrigin } from "@/lib/site-url";
+import { getCanonicalOrigin, getPublicOrigin } from "@/lib/site-url";
 
 function getLocalOriginAlternates(origin: string) {
   const url = new URL(origin);
@@ -55,6 +55,26 @@ export function getAuthAllowedHosts(): string[] {
   return uniqueOrigins(
     getAuthTrustedOrigins().map((origin) => new URL(origin).host),
   );
+}
+
+export function getPasskeyAllowedOrigins(): string[] {
+  const canonicalOrigin = getCanonicalOrigin();
+  const publicOrigin = getPublicOrigin();
+  const usesLocalOrigin = [canonicalOrigin, publicOrigin].some((origin) => {
+    const hostname = new URL(origin).hostname;
+    return hostname === "localhost" || hostname === "127.0.0.1";
+  });
+
+  return uniqueOrigins([
+    canonicalOrigin,
+    publicOrigin,
+    ...(usesLocalOrigin
+      ? getAuthTrustedOrigins().filter((origin) => {
+          const hostname = new URL(origin).hostname;
+          return hostname === "localhost" || hostname === "127.0.0.1";
+        })
+      : []),
+  ]);
 }
 
 function matchesTrustedOrigin(origin: string, trustedOrigin: string) {

--- a/src/lib/auth/auth-origins.ts
+++ b/src/lib/auth/auth-origins.ts
@@ -58,23 +58,7 @@ export function getAuthAllowedHosts(): string[] {
 }
 
 export function getPasskeyAllowedOrigins(): string[] {
-  const canonicalOrigin = getCanonicalOrigin();
-  const publicOrigin = getPublicOrigin();
-  const usesLocalOrigin = [canonicalOrigin, publicOrigin].some((origin) => {
-    const hostname = new URL(origin).hostname;
-    return hostname === "localhost" || hostname === "127.0.0.1";
-  });
-
-  return uniqueOrigins([
-    canonicalOrigin,
-    publicOrigin,
-    ...(usesLocalOrigin
-      ? getAuthTrustedOrigins().filter((origin) => {
-          const hostname = new URL(origin).hostname;
-          return hostname === "localhost" || hostname === "127.0.0.1";
-        })
-      : []),
-  ]);
+  return uniqueOrigins([getCanonicalOrigin(), getPublicOrigin()]);
 }
 
 function matchesTrustedOrigin(origin: string, trustedOrigin: string) {

--- a/src/lib/auth/better-auth-options.ts
+++ b/src/lib/auth/better-auth-options.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/auth/auth-origins";
 import { betterAuthApiErrorHandler } from "@/lib/auth/better-auth-api-errors";
 import { getBetterAuthOptionEnv } from "@/lib/auth/better-auth-option-env";
+import { betterAuthPasskeyRateLimitRules } from "@/lib/auth/better-auth-passkey-plugin";
 import { buildBetterAuthPlugins } from "@/lib/auth/better-auth-plugins";
 import { createBetterAuthPrismaAdapter } from "@/lib/auth/better-auth-prisma-adapter";
 import {
@@ -39,16 +40,22 @@ export function buildBetterAuthOptions() {
     // Disable Better Auth's built-in rate limiting in debug/E2E mode so that
     // rapid sequential requests (e.g. /api/auth/get-session during tests)
     // don't get throttled with 429 responses.
-    ...(debugAuthAllowed ? { rateLimit: { enabled: false } } : {}),
+    rateLimit: debugAuthAllowed
+      ? { enabled: false }
+      : { enabled: true, customRules: betterAuthPasskeyRateLimitRules },
     advanced: {
       // Reverse proxies should still forward the original scheme/host correctly
       // for request-aware Better Auth behavior, but deployment origin comes from config.
       trustedProxyHeaders: true,
+      // Better Auth otherwise skips origin checks automatically under NODE_ENV=test.
+      // Keep passkey and other cookie-backed auth routes on the production boundary.
+      disableCSRFCheck: false,
+      disableOriginCheck: false,
     },
     trustedOrigins: getAuthTrustedOrigins(),
     socialProviders: buildBetterAuthSocialProviders(authEnv),
     emailAndPassword: {
-      enabled: true,
+      enabled: debugAuthAllowed,
       disableSignUp: true,
       autoSignIn: false,
     },

--- a/src/lib/auth/better-auth-passkey-plugin.ts
+++ b/src/lib/auth/better-auth-passkey-plugin.ts
@@ -46,13 +46,30 @@ function validatePasskeyOrigin(origin: string) {
   return url.origin;
 }
 
+function validateOriginForRpId(origin: string, rpID: string) {
+  const normalizedOrigin = validatePasskeyOrigin(origin);
+  const hostname = new URL(normalizedOrigin).hostname;
+  const matchesRpId =
+    hostname === rpID ||
+    (!LOCAL_PASSKEY_HOSTS.has(rpID) && hostname.endsWith(`.${rpID}`));
+  if (!matchesRpId) {
+    throw new Error(
+      `Passkey origin ${normalizedOrigin} is not compatible with RP ID ${rpID}`,
+    );
+  }
+  return normalizedOrigin;
+}
+
 export function buildBetterAuthPasskeyPlugin() {
   requireConfiguredProductionOrigin();
   const canonicalOrigin = validatePasskeyOrigin(getCanonicalOrigin());
-  const allowedOrigins = getPasskeyAllowedOrigins().map(validatePasskeyOrigin);
+  const rpID = new URL(canonicalOrigin).hostname;
+  const allowedOrigins = getPasskeyAllowedOrigins().map((origin) =>
+    validateOriginForRpId(origin, rpID),
+  );
 
   return passkey({
-    rpID: new URL(canonicalOrigin).hostname,
+    rpID,
     rpName: PASSKEY_RP_NAME,
     origin: allowedOrigins,
     registration: {

--- a/src/lib/auth/better-auth-passkey-plugin.ts
+++ b/src/lib/auth/better-auth-passkey-plugin.ts
@@ -1,0 +1,62 @@
+import { passkey } from "@better-auth/passkey";
+import { getOptionalTrimmedEnv, isAppProductionBuildPhase } from "@/app-env";
+import { getPasskeyAllowedOrigins } from "@/lib/auth/auth-origins";
+import { getCanonicalOrigin } from "@/lib/site-url";
+
+const PASSKEY_RP_NAME = "Life@USTC";
+const LOCAL_PASSKEY_HOSTS = new Set(["localhost", "127.0.0.1"]);
+
+export const betterAuthPasskeyRateLimitRules = {
+  "/passkey/generate-authenticate-options": {
+    window: 60,
+    max: 20,
+  },
+  "/passkey/verify-authentication": {
+    window: 60,
+    max: 10,
+  },
+} as const;
+
+function requireConfiguredProductionOrigin() {
+  if (
+    getOptionalTrimmedEnv("NODE_ENV") !== "production" ||
+    isAppProductionBuildPhase()
+  ) {
+    return;
+  }
+
+  if (
+    !getOptionalTrimmedEnv("APP_CANONICAL_ORIGIN") &&
+    !getOptionalTrimmedEnv("APP_PUBLIC_ORIGIN")
+  ) {
+    throw new Error(
+      "APP_CANONICAL_ORIGIN or APP_PUBLIC_ORIGIN is required for passkeys in production",
+    );
+  }
+}
+
+function validatePasskeyOrigin(origin: string) {
+  const url = new URL(origin);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Passkey origins must use http or https");
+  }
+  if (url.protocol !== "https:" && !LOCAL_PASSKEY_HOSTS.has(url.hostname)) {
+    throw new Error("Non-local passkey origins must use https");
+  }
+  return url.origin;
+}
+
+export function buildBetterAuthPasskeyPlugin() {
+  requireConfiguredProductionOrigin();
+  const canonicalOrigin = validatePasskeyOrigin(getCanonicalOrigin());
+  const allowedOrigins = getPasskeyAllowedOrigins().map(validatePasskeyOrigin);
+
+  return passkey({
+    rpID: new URL(canonicalOrigin).hostname,
+    rpName: PASSKEY_RP_NAME,
+    origin: allowedOrigins,
+    registration: {
+      requireSession: true,
+    },
+  });
+}

--- a/src/lib/auth/better-auth-plugins.ts
+++ b/src/lib/auth/better-auth-plugins.ts
@@ -1,6 +1,7 @@
 import { genericOAuth, jwt, oAuthProxy } from "better-auth/plugins";
 import type { getAuthEnv } from "@/app-env";
 import { buildOAuthProviderPlugin } from "@/lib/auth/better-auth-oauth-provider-plugin";
+import { buildBetterAuthPasskeyPlugin } from "@/lib/auth/better-auth-passkey-plugin";
 import { mapOidcProfileToUser } from "@/lib/auth/oauth-profile";
 import { webhookLoginPlugin } from "@/lib/auth/webhook-login-plugin";
 import { getCanonicalOAuthIssuer } from "@/lib/mcp/urls";
@@ -33,6 +34,7 @@ export function buildBetterAuthPlugins(input: {
       ...(input.oauthProxySecret ? { secret: input.oauthProxySecret } : {}),
     }),
     webhookLoginPlugin(),
+    buildBetterAuthPasskeyPlugin(),
     buildOAuthProviderPlugin({
       authPublicOrigin: input.authPublicOrigin,
     }),

--- a/tests/integration/passkey-auth.test.ts
+++ b/tests/integration/passkey-auth.test.ts
@@ -1,0 +1,322 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { prisma } from "@/lib/db/prisma";
+
+const authOrigin = "http://localhost:3000";
+const createdUserIds: string[] = [];
+const verificationCleanupStartedAt = new Date(Date.now() - 1_000);
+const encoder = new TextEncoder();
+
+async function authRequest(path: string, init?: RequestInit) {
+  const { betterAuthInstance } = await import("@/lib/auth/core");
+  return betterAuthInstance.handler(
+    new Request(`${authOrigin}/api/auth${path}`, init),
+  );
+}
+
+function base64(bytes: Uint8Array) {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+async function createSessionCookie(userId: string) {
+  const token = crypto.randomUUID();
+  await prisma.session.create({
+    data: {
+      expires: new Date(Date.now() + 60 * 60 * 1000),
+      sessionToken: token,
+      userId,
+    },
+  });
+  const { getBetterAuthInstance } = await import("@/lib/auth/core");
+  const context = await getBetterAuthInstance().$context;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(context.secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(token),
+  );
+  const value = encodeURIComponent(
+    `${token}.${base64(new Uint8Array(signature))}`,
+  );
+  return `${context.authCookies.sessionToken.name}=${value}`;
+}
+
+async function repeatRequest(count: number, request: () => Promise<Response>) {
+  const responses: Response[] = [];
+  for (let index = 0; index < count; index += 1) {
+    responses.push(await request());
+  }
+  return responses;
+}
+
+describe.sequential("Better Auth passkey integration", () => {
+  afterAll(async () => {
+    await prisma.verificationToken.deleteMany({
+      where: { createdAt: { gte: verificationCleanupStartedAt } },
+    });
+    if (createdUserIds.length > 0) {
+      await prisma.user.deleteMany({
+        where: { id: { in: createdUserIds } },
+      });
+    }
+    await prisma.$disconnect();
+  });
+
+  it("keeps the Better Auth Passkey and legacy Authenticator models separate", async () => {
+    const marker = crypto.randomUUID();
+    const user = await prisma.user.create({
+      data: {
+        email: `passkey-integration-${marker}@example.test`,
+        name: "Passkey Integration",
+      },
+      select: { id: true },
+    });
+    createdUserIds.push(user.id);
+
+    const passkeyId = `passkey-${marker}`;
+    const passkeyCredentialId = `better-auth-credential-${marker}`;
+    const legacyCredentialId = `legacy-credential-${marker}`;
+    await prisma.passkey.create({
+      data: {
+        id: passkeyId,
+        name: "Integration passkey",
+        publicKey: "base64-public-key",
+        userId: user.id,
+        credentialID: passkeyCredentialId,
+        counter: 1,
+        deviceType: "singleDevice",
+        backedUp: false,
+        transports: "internal",
+        createdAt: new Date(),
+        aaguid: "00000000-0000-0000-0000-000000000000",
+      },
+    });
+    await prisma.authenticator.create({
+      data: {
+        credentialID: legacyCredentialId,
+        userId: user.id,
+        providerAccountId: `legacy-provider-${marker}`,
+        credentialPublicKey: "legacy-public-key",
+        counter: 2,
+        credentialDeviceType: "singleDevice",
+        credentialBackedUp: false,
+        transports: "usb",
+      },
+    });
+
+    const storedUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id },
+      include: {
+        passkeys: true,
+        Authenticator: true,
+      },
+    });
+    expect(storedUser.passkeys).toHaveLength(1);
+    expect(storedUser.passkeys[0]).toMatchObject({
+      id: passkeyId,
+      credentialID: passkeyCredentialId,
+      publicKey: "base64-public-key",
+    });
+    expect(storedUser.Authenticator).toHaveLength(1);
+    expect(storedUser.Authenticator[0].credentialID).toBe(legacyCredentialId);
+
+    await prisma.user.delete({ where: { id: user.id } });
+    createdUserIds.splice(createdUserIds.indexOf(user.id), 1);
+    expect(await prisma.passkey.count({ where: { id: passkeyId } })).toBe(0);
+    expect(
+      await prisma.authenticator.count({
+        where: { credentialID: legacyCredentialId },
+      }),
+    ).toBe(0);
+  });
+
+  it("matches the official Better Auth Passkey columns, indexes, and owner FK", async () => {
+    const columns = await prisma.$queryRaw<
+      Array<{
+        columnName: string;
+        dataType: string;
+        nullable: "YES" | "NO";
+      }>
+    >`
+      SELECT
+        column_name AS "columnName",
+        data_type AS "dataType",
+        is_nullable AS "nullable"
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'Passkey'
+      ORDER BY ordinal_position
+    `;
+    expect(columns).toEqual([
+      { columnName: "id", dataType: "text", nullable: "NO" },
+      { columnName: "name", dataType: "text", nullable: "YES" },
+      { columnName: "publicKey", dataType: "text", nullable: "NO" },
+      { columnName: "userId", dataType: "text", nullable: "NO" },
+      { columnName: "credentialID", dataType: "text", nullable: "NO" },
+      { columnName: "counter", dataType: "integer", nullable: "NO" },
+      { columnName: "deviceType", dataType: "text", nullable: "NO" },
+      { columnName: "backedUp", dataType: "boolean", nullable: "NO" },
+      { columnName: "transports", dataType: "text", nullable: "YES" },
+      {
+        columnName: "createdAt",
+        dataType: "timestamp without time zone",
+        nullable: "YES",
+      },
+      { columnName: "aaguid", dataType: "text", nullable: "YES" },
+    ]);
+
+    const indexes = await prisma.$queryRaw<Array<{ indexName: string }>>`
+      SELECT indexname AS "indexName"
+      FROM pg_indexes
+      WHERE schemaname = 'public' AND tablename = 'Passkey'
+      ORDER BY indexname
+    `;
+    expect(indexes.map(({ indexName }) => indexName)).toEqual([
+      "Passkey_credentialID_idx",
+      "Passkey_pkey",
+      "Passkey_userId_idx",
+    ]);
+
+    const foreignKeys = await prisma.$queryRaw<
+      Array<{ deleteAction: string; name: string; targetTable: string }>
+    >`
+      SELECT
+        constraint_name AS "name",
+        delete_rule AS "deleteAction",
+        unique_constraint_name AS "targetTable"
+      FROM information_schema.referential_constraints
+      WHERE constraint_schema = 'public'
+        AND constraint_name = 'Passkey_userId_fkey'
+    `;
+    expect(foreignKeys).toEqual([
+      {
+        name: "Passkey_userId_fkey",
+        deleteAction: "CASCADE",
+        targetTable: "User_pkey",
+      },
+    ]);
+  });
+
+  it("allows an anonymous authentication challenge but requires a session for registration", async () => {
+    const challengeResponse = await authRequest(
+      "/passkey/generate-authenticate-options",
+      {
+        headers: { origin: authOrigin },
+      },
+    );
+    const challenge = (await challengeResponse.json()) as {
+      challenge?: unknown;
+      rpId?: unknown;
+    };
+
+    expect(challengeResponse.status).toBe(200);
+    expect(challenge.challenge).toEqual(expect.any(String));
+    expect(challenge.rpId).toBe("localhost");
+    expect(challengeResponse.headers.get("set-cookie")).toContain(
+      "better-auth-passkey",
+    );
+
+    const registrationResponse = await authRequest(
+      "/passkey/generate-register-options",
+      {
+        headers: { origin: authOrigin },
+      },
+    );
+    expect(registrationResponse.status).toBe(401);
+  });
+
+  it("allows registration options only with an existing trusted session", async () => {
+    const marker = crypto.randomUUID();
+    const user = await prisma.user.create({
+      data: {
+        email: `passkey-session-${marker}@example.test`,
+        name: "Passkey Session",
+      },
+      select: { id: true },
+    });
+    createdUserIds.push(user.id);
+    const cookie = await createSessionCookie(user.id);
+
+    const response = await authRequest(
+      "/passkey/generate-register-options?name=Primary",
+      {
+        headers: {
+          cookie,
+          origin: authOrigin,
+        },
+      },
+    );
+    const payload = (await response.json()) as {
+      challenge?: unknown;
+      rp?: { id?: unknown; name?: unknown };
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.challenge).toEqual(expect.any(String));
+    expect(payload.rp).toEqual({
+      id: "localhost",
+      name: "Life@USTC",
+    });
+  });
+
+  it("rejects cookie-backed verification from missing or untrusted origins", async () => {
+    const request = (origin?: string) =>
+      authRequest("/passkey/verify-authentication", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          cookie: "better-auth-passkey=test-challenge",
+          ...(origin ? { origin } : {}),
+        },
+        body: JSON.stringify({ response: {} }),
+      });
+
+    expect((await request()).status).toBe(403);
+    expect((await request("https://evil.example")).status).toBe(403);
+    expect((await request(authOrigin)).status).toBe(400);
+  });
+
+  it("rate-limits only the anonymous passkey challenge and verification paths", async () => {
+    const requestChallenge = () =>
+      authRequest("/passkey/generate-authenticate-options", {
+        headers: {
+          origin: authOrigin,
+          "x-forwarded-for": "198.51.100.27",
+        },
+      });
+    const requestVerification = () =>
+      authRequest("/passkey/verify-authentication", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: authOrigin,
+          "x-forwarded-for": "198.51.100.28",
+        },
+        body: JSON.stringify({ response: {} }),
+      });
+
+    const challengeResponses = await repeatRequest(20, requestChallenge);
+    expect(challengeResponses.every(({ status }) => status === 200)).toBe(true);
+    expect((await requestChallenge()).status).toBe(429);
+    expect(
+      (
+        await authRequest("/passkey/list-user-passkeys", {
+          headers: {
+            origin: authOrigin,
+            "x-forwarded-for": "198.51.100.27",
+          },
+        })
+      ).status,
+    ).toBe(401);
+
+    const verificationResponses = await repeatRequest(10, requestVerification);
+    expect(verificationResponses.every(({ status }) => status === 400)).toBe(
+      true,
+    );
+    expect((await requestVerification()).status).toBe(429);
+  });
+});

--- a/tests/integration/passkey-auth.test.ts
+++ b/tests/integration/passkey-auth.test.ts
@@ -17,13 +17,14 @@ function base64(bytes: Uint8Array) {
   return btoa(String.fromCharCode(...bytes));
 }
 
-async function createSessionCookie(userId: string) {
+async function createSessionCookie(userId: string, createdAt?: Date) {
   const token = crypto.randomUUID();
   await prisma.session.create({
     data: {
       expires: new Date(Date.now() + 60 * 60 * 1000),
       sessionToken: token,
       userId,
+      ...(createdAt ? { createdAt } : {}),
     },
   });
   const { getBetterAuthInstance } = await import("@/lib/auth/core");
@@ -261,6 +262,21 @@ describe.sequential("Better Auth passkey integration", () => {
       id: "localhost",
       name: "Life@USTC",
     });
+
+    const staleCookie = await createSessionCookie(
+      user.id,
+      new Date(Date.now() - 25 * 60 * 60 * 1000),
+    );
+    const staleResponse = await authRequest(
+      "/passkey/generate-register-options?name=Stale",
+      {
+        headers: {
+          cookie: staleCookie,
+          origin: authOrigin,
+        },
+      },
+    );
+    expect(staleResponse.status).toBe(403);
   });
 
   it("rejects cookie-backed verification from missing or untrusted origins", async () => {

--- a/tests/unit/auth-origins.test.ts
+++ b/tests/unit/auth-origins.test.ts
@@ -62,15 +62,10 @@ describe("认证来源辅助函数", () => {
     ]);
   });
 
-  it("passkey 本地来源包含固定回环别名", () => {
+  it("passkey 本地来源不混用不同 WebAuthn RP host 的回环别名", () => {
     vi.stubEnv("APP_PUBLIC_ORIGIN", "http://127.0.0.1:3010");
 
-    expect(getPasskeyAllowedOrigins()).toEqual([
-      "http://127.0.0.1:3010",
-      "http://localhost:3010",
-      "http://localhost:3000",
-      "http://127.0.0.1:3000",
-    ]);
+    expect(getPasskeyAllowedOrigins()).toEqual(["http://127.0.0.1:3010"]);
   });
 });
 

--- a/tests/unit/auth-origins.test.ts
+++ b/tests/unit/auth-origins.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getAuthAllowedHosts,
   getAuthTrustedOrigins,
+  getPasskeyAllowedOrigins,
   isTrustedAuthOrigin,
 } from "@/lib/auth/auth-origins";
 
@@ -46,6 +47,27 @@ describe("认证来源辅助函数", () => {
     expect(getAuthTrustedOrigins()).toEqual([
       "http://localhost:3010",
       "http://127.0.0.1:3010",
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+    ]);
+  });
+
+  it("passkey 仅接受显式 canonical/public preview 来源", () => {
+    vi.stubEnv("APP_CANONICAL_ORIGIN", "https://life.example.com");
+    vi.stubEnv("APP_PUBLIC_ORIGIN", "https://preview.life.example.com");
+
+    expect(getPasskeyAllowedOrigins()).toEqual([
+      "https://life.example.com",
+      "https://preview.life.example.com",
+    ]);
+  });
+
+  it("passkey 本地来源包含固定回环别名", () => {
+    vi.stubEnv("APP_PUBLIC_ORIGIN", "http://127.0.0.1:3010");
+
+    expect(getPasskeyAllowedOrigins()).toEqual([
+      "http://127.0.0.1:3010",
+      "http://localhost:3010",
       "http://localhost:3000",
       "http://127.0.0.1:3000",
     ]);

--- a/tests/unit/better-auth-options.test.ts
+++ b/tests/unit/better-auth-options.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { allowDebugAuthMock, buildPluginsMock } = vi.hoisted(() => ({
+  allowDebugAuthMock: vi.fn(),
+  buildPluginsMock: vi.fn(() => [{ id: "plugins" }]),
+}));
+
+vi.mock("@/lib/auth/auth-config", () => ({
+  allowDebugAuth: allowDebugAuthMock,
+  getBetterAuthSecret: () => "test-secret",
+}));
+
+vi.mock("@/lib/auth/auth-origins", () => ({
+  getAuthAllowedHosts: () => ["life.example.com"],
+  getAuthTrustedOrigins: () => ["https://life.example.com"],
+}));
+
+vi.mock("@/lib/auth/better-auth-api-errors", () => ({
+  betterAuthApiErrorHandler: {},
+}));
+
+vi.mock("@/lib/auth/better-auth-option-env", () => ({
+  getBetterAuthOptionEnv: () => ({
+    authEnv: {},
+    authPublicOrigin: "https://life.example.com",
+    authPublicProtocol: "https",
+    oauthProxySecret: undefined,
+    oidcDiscoveryUrl:
+      "https://oidc.example.com/.well-known/openid-configuration",
+    oidcIssuer: "https://oidc.example.com",
+  }),
+}));
+
+vi.mock("@/lib/auth/better-auth-plugins", () => ({
+  buildBetterAuthPlugins: buildPluginsMock,
+}));
+
+vi.mock("@/lib/auth/better-auth-prisma-adapter", () => ({
+  createBetterAuthPrismaAdapter: () => ({ id: "adapter" }),
+}));
+
+vi.mock("@/lib/auth/better-auth-social-providers", () => ({
+  buildBetterAuthSocialProviders: () => ({}),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {},
+}));
+
+describe("Better Auth options", () => {
+  beforeEach(() => {
+    allowDebugAuthMock.mockReset();
+    buildPluginsMock.mockClear();
+  });
+
+  it("keeps password auth disabled and passkey abuse limits enabled in production", async () => {
+    allowDebugAuthMock.mockReturnValue(false);
+    const { buildBetterAuthOptions } = await import(
+      "@/lib/auth/better-auth-options"
+    );
+
+    const options = buildBetterAuthOptions();
+
+    expect(options.emailAndPassword.enabled).toBe(false);
+    expect(options.rateLimit).toEqual({
+      enabled: true,
+      customRules: {
+        "/passkey/generate-authenticate-options": {
+          window: 60,
+          max: 20,
+        },
+        "/passkey/verify-authentication": {
+          window: 60,
+          max: 10,
+        },
+      },
+    });
+    expect(options.trustedOrigins).toEqual(["https://life.example.com"]);
+    expect(options.advanced).toMatchObject({
+      disableCSRFCheck: false,
+      disableOriginCheck: false,
+    });
+  });
+
+  it("enables password auth only with debug auth and disables its request limiter", async () => {
+    allowDebugAuthMock.mockReturnValue(true);
+    const { buildBetterAuthOptions } = await import(
+      "@/lib/auth/better-auth-options"
+    );
+
+    const options = buildBetterAuthOptions();
+
+    expect(options.emailAndPassword.enabled).toBe(true);
+    expect(options.rateLimit).toEqual({ enabled: false });
+  });
+});

--- a/tests/unit/better-auth-passkey-plugin.test.ts
+++ b/tests/unit/better-auth-passkey-plugin.test.ts
@@ -35,7 +35,7 @@ describe("Better Auth passkey plugin", () => {
     });
   });
 
-  it("uses only pinned local origins when no development origin is set", async () => {
+  it("uses only the localhost RP origin when no development origin is set", async () => {
     vi.stubEnv("NODE_ENV", "development");
     vi.stubEnv("APP_CANONICAL_ORIGIN", "");
     vi.stubEnv("APP_PUBLIC_ORIGIN", "");
@@ -49,9 +49,21 @@ describe("Better Auth passkey plugin", () => {
     expect(passkeyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         rpID: "localhost",
-        origin: ["http://localhost:3000", "http://127.0.0.1:3000"],
+        origin: ["http://localhost:3000"],
       }),
     );
+  });
+
+  it("accepts an explicit origin on a subdomain of the canonical RP", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("APP_CANONICAL_ORIGIN", "https://life.example.com");
+    vi.stubEnv("APP_PUBLIC_ORIGIN", "https://preview.life.example.com");
+
+    const { buildBetterAuthPasskeyPlugin } = await import(
+      "@/lib/auth/better-auth-passkey-plugin"
+    );
+
+    expect(() => buildBetterAuthPasskeyPlugin()).not.toThrow();
   });
 
   it("fails closed when production has no configured origin", async () => {
@@ -83,6 +95,40 @@ describe("Better Auth passkey plugin", () => {
     );
 
     expect(() => buildBetterAuthPasskeyPlugin()).toThrow();
+    expect(passkeyMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "https://branch.workers.dev",
+    "https://evil-life.example.com",
+    "http://127.0.0.1:3000",
+  ])("rejects origin %s when it cannot use the canonical RP ID", async (publicOrigin) => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("APP_CANONICAL_ORIGIN", "https://life.example.com");
+    vi.stubEnv("APP_PUBLIC_ORIGIN", publicOrigin);
+
+    const { buildBetterAuthPasskeyPlugin } = await import(
+      "@/lib/auth/better-auth-passkey-plugin"
+    );
+
+    expect(() => buildBetterAuthPasskeyPlugin()).toThrow(
+      /is not compatible with RP ID life\.example\.com/,
+    );
+    expect(passkeyMock).not.toHaveBeenCalled();
+  });
+
+  it("does not mix localhost and 127.0.0.1 under one local RP ID", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("APP_CANONICAL_ORIGIN", "http://localhost:3000");
+    vi.stubEnv("APP_PUBLIC_ORIGIN", "http://127.0.0.1:3000");
+
+    const { buildBetterAuthPasskeyPlugin } = await import(
+      "@/lib/auth/better-auth-passkey-plugin"
+    );
+
+    expect(() => buildBetterAuthPasskeyPlugin()).toThrow(
+      /is not compatible with RP ID localhost/,
+    );
     expect(passkeyMock).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/better-auth-passkey-plugin.test.ts
+++ b/tests/unit/better-auth-passkey-plugin.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { passkeyMock } = vi.hoisted(() => ({
+  passkeyMock: vi.fn((options) => ({ id: "passkey", options })),
+}));
+
+vi.mock("@better-auth/passkey", () => ({
+  passkey: passkeyMock,
+}));
+
+describe("Better Auth passkey plugin", () => {
+  afterEach(() => {
+    passkeyMock.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  it("uses the configured canonical RP and explicit preview origin", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("APP_CANONICAL_ORIGIN", "https://life.example.com");
+    vi.stubEnv("APP_PUBLIC_ORIGIN", "https://preview.life.example.com");
+
+    const { buildBetterAuthPasskeyPlugin } = await import(
+      "@/lib/auth/better-auth-passkey-plugin"
+    );
+
+    buildBetterAuthPasskeyPlugin();
+
+    expect(passkeyMock).toHaveBeenCalledWith({
+      rpID: "life.example.com",
+      rpName: "Life@USTC",
+      origin: ["https://life.example.com", "https://preview.life.example.com"],
+      registration: {
+        requireSession: true,
+      },
+    });
+  });
+
+  it("uses only pinned local origins when no development origin is set", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("APP_CANONICAL_ORIGIN", "");
+    vi.stubEnv("APP_PUBLIC_ORIGIN", "");
+
+    const { buildBetterAuthPasskeyPlugin } = await import(
+      "@/lib/auth/better-auth-passkey-plugin"
+    );
+
+    buildBetterAuthPasskeyPlugin();
+
+    expect(passkeyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rpID: "localhost",
+        origin: ["http://localhost:3000", "http://127.0.0.1:3000"],
+      }),
+    );
+  });
+
+  it("fails closed when production has no configured origin", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("APP_PHASE", "");
+    vi.stubEnv("APP_CANONICAL_ORIGIN", "");
+    vi.stubEnv("APP_PUBLIC_ORIGIN", "");
+
+    const { buildBetterAuthPasskeyPlugin } = await import(
+      "@/lib/auth/better-auth-passkey-plugin"
+    );
+
+    expect(() => buildBetterAuthPasskeyPlugin()).toThrow(
+      "APP_CANONICAL_ORIGIN or APP_PUBLIC_ORIGIN is required for passkeys in production",
+    );
+    expect(passkeyMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["ftp://life.example.com", "https://life.example.com"],
+    ["http://life.example.com", "http://life.example.com"],
+  ])("rejects an unsafe canonical origin %s", async (canonicalOrigin, publicOrigin) => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("APP_CANONICAL_ORIGIN", canonicalOrigin);
+    vi.stubEnv("APP_PUBLIC_ORIGIN", publicOrigin);
+
+    const { buildBetterAuthPasskeyPlugin } = await import(
+      "@/lib/auth/better-auth-passkey-plugin"
+    );
+
+    expect(() => buildBetterAuthPasskeyPlugin()).toThrow();
+    expect(passkeyMock).not.toHaveBeenCalled();
+  });
+
+  it("limits only the anonymous authentication endpoints", async () => {
+    const { betterAuthPasskeyRateLimitRules } = await import(
+      "@/lib/auth/better-auth-passkey-plugin"
+    );
+
+    expect(betterAuthPasskeyRateLimitRules).toEqual({
+      "/passkey/generate-authenticate-options": {
+        window: 60,
+        max: 20,
+      },
+      "/passkey/verify-authentication": {
+        window: 60,
+        max: 10,
+      },
+    });
+    expect(Object.keys(betterAuthPasskeyRateLimitRules)).not.toContain(
+      "/passkey/list-user-passkeys",
+    );
+    expect(Object.keys(betterAuthPasskeyRateLimitRules)).not.toContain(
+      "/passkey/delete-passkey",
+    );
+  });
+});


### PR DESCRIPTION
## Goal

Add the server and schema foundation for Better Auth passkeys while keeping credential registration behind an existing fresh session. Part of #547.

## Changed Surfaces

- Pins `@better-auth/passkey` 1.6.14 to the installed Better Auth 1.6.14 family and registers the server plugin.
- Derives the WebAuthn RP ID from the configured canonical origin and accepts only explicit canonical/public origins whose hosts equal the RP ID or are its subdomains; loopback RP hosts must match exactly.
- Adds anonymous authentication challenge/verification rate limits without applying them to signed-in passkey management endpoints.
- Disables production email/password debug auth and keeps Better Auth CSRF/origin checks enabled in test and production paths.
- Adds the independent Better Auth `Passkey` Prisma model and manual migration while preserving the legacy Auth.js `Authenticator` model.
- Adds unit/integration coverage for origin validation, fresh-session registration, schema/index/FK drift, endpoint limits, and legacy-model coexistence.
- No passkey UI/client plugin in this PR; that follows separately.

## Evidence

- `bun install --frozen-lockfile`
- `bun run app:prepare`
- `bunx biome check` (passes; one pre-existing unrelated warning in `src/static-loader/import.ts`)
- `bunx svelte-check --tsconfig ./tsconfig.json` (0 errors, 0 warnings)
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` (209 files, 1231 tests passed)
- `bunx vitest run --config vitest.integration.config.ts` (32 files, 187 tests passed)
- Focused Passkey integration rerun (6/6 passed, including stale-session rejection)
- Focused Playwright auth/sign-in E2E (10/10 passed)
- Clean PostgreSQL replay of all 45 migrations plus seed
- `prisma migrate diff --exit-code --from-config-datasource --to-schema=prisma/schema.prisma` (`No difference detected`)
- `bun run build`
- Wrangler deployment dry-run

## Docs / Contracts

Updated `docs/contracts/user.json` with the passkey server boundary and production debug-password boundary. `.env.example` documents the optional canonical RP origin and explicit preview-origin requirement.

REST/MCP parity is N/A: this PR adds Better Auth credential endpoints rather than an application-domain REST or MCP operation.

## Risk Areas

- Auth/WebAuthn: registration uses Better Auth 1.6.14 `freshSessionMiddleware`; anonymous authentication remains available but rate-limited.
- Deployment: production fails closed when no static canonical/public origin exists, rejects non-HTTP(S), and requires HTTPS outside loopback. Preview hosts must be listed explicitly and be RP-compatible; unrelated hosts, wildcards, and request `Host` inference are not used.
- Prisma: `Passkey` is intentionally separate from legacy `Authenticator`; clean migration replay and schema drift checks passed.
- Residual: a real browser authenticator ceremony is deferred to the UI/client follow-up. This PR verifies server-generated registration/authentication boundaries but does not claim virtual-authenticator end-to-end coverage.

## Cleanup

No scratch files, Playwright artifacts, generated-file edits, or unrelated rewrites remain. The branch was merged with the latest `origin/main` before opening this PR; history was not rebased or force-pushed.
