### PR TITLE
feat(graphql): add homework CRUD mutations

### DIFF
--- a/docs/contracts/graphql.json
+++ b/docs/contracts/graphql.json
@@ -31,7 +31,7 @@
           "/api/graphql",
           "Public semester, course, section, teacher, and bus queries",
           "Authenticated Viewer reads with exact feature:read scopes",
-          "Authenticated todo, homework completion, section subscription, dashboard pin, bus preference, description, and comment mutations",
+          "Authenticated todo and homework CRUD, homework completion, section subscription, dashboard pin, bus preference, description, and comment mutations",
           "GET, POST, and OPTIONS",
           "GraphQL-audience bearer tokens require matching feature scopes; MCP exposes metadata resources only"
         ]

--- a/docs/contracts/homework.json
+++ b/docs/contracts/homework.json
@@ -4,7 +4,7 @@
     "anon": "Can read homework information under public sections, but cannot create, update, or delete.",
     "user": "When signed in and not suspended, can create and update homework; delete permission is limited to the creator and admins; each user can only manage their own homework completion state.",
     "admin": "Can delete homework and participate in governance.",
-    "agent": "After authorization, can read, create, update, and delete permitted homework and set the current user's completion state; both REST and MCP currently provide this capability."
+    "agent": "After authorization, can read, create, update, and delete permitted homework and set the current user's completion state; REST, GraphQL, and MCP provide the supported business mutations."
   },
   "rules": {
     "attached-to-section": "Homework is attached to a section, not a personal user todo.",
@@ -125,6 +125,41 @@
             "method": "DELETE",
             "returns": "{ success: Boolean }",
             "auth": "user"
+          }
+        ]
+      },
+      "graphql": {
+        "mutations": [
+          {
+            "name": "createHomework",
+            "returns": "HomeworkMutationPayload!",
+            "required_scopes": ["homework:write"],
+            "rest_equivalent": "POST /api/homeworks",
+            "mcp_equivalent": "create_homework_on_section",
+            "notes": [
+              "Accepts the public sectionJwId, returns the localized Homework snapshot, and preserves the shared created HomeworkAuditLog transaction."
+            ]
+          },
+          {
+            "name": "updateHomework",
+            "returns": "HomeworkMutationPayload!",
+            "required_scopes": ["homework:write"],
+            "rest_equivalent": "PATCH /api/homeworks/[id]",
+            "mcp_equivalent": "update_homework_on_section",
+            "notes": [
+              "Nullable description and timestamp fields clear existing values; omitted fields remain unchanged.",
+              "Description changes preserve the shared DescriptionEdit and description_edit audit transaction."
+            ]
+          },
+          {
+            "name": "deleteHomework",
+            "returns": "HomeworkDeleteMutationPayload!",
+            "required_scopes": ["homework:write"],
+            "rest_equivalent": "DELETE /api/homeworks/[id]",
+            "mcp_equivalent": "delete_homework_on_section",
+            "notes": [
+              "Only the creator or an admin may delete; repeated deletion remains successful with alreadyDeleted=true and does not add another deletion audit row."
+            ]
           }
         ]
       },

--- a/docs/graphql/schema.graphql
+++ b/docs/graphql/schema.graphql
@@ -144,6 +144,17 @@ input CreateCommentInput {
   visibility: CommentVisibility = PUBLIC
 }
 
+input CreateHomeworkInput {
+  description: String
+  isMajor: Boolean! = false
+  publishedAt: DateTime
+  requiresTeam: Boolean! = false
+  sectionJwId: Int!
+  submissionDueAt: DateTime
+  submissionStartAt: DateTime
+  title: String!
+}
+
 input CreateTodoInput {
   content: String
   dueAt: DateTime
@@ -251,11 +262,22 @@ type HomeworkCompletionMutationPayload {
   homeworkId: ID!
 }
 
+type HomeworkDeleteMutationPayload {
+  alreadyDeleted: Boolean!
+  id: ID!
+  success: Boolean!
+}
+
 input HomeworkFilter {
   completed: Boolean
   dueAtFrom: DateTime
   dueAtTo: DateTime
   semesterId: Int
+}
+
+type HomeworkMutationPayload {
+  homework: Homework!
+  id: ID!
 }
 
 type HomeworkPage {
@@ -266,8 +288,10 @@ type HomeworkPage {
 type Mutation {
   addCommentReaction(commentId: ID!, type: CommentReactionType!): CommentReactionMutationPayload!
   createComment(input: CreateCommentInput!): CommentMutationPayload!
+  createHomework(input: CreateHomeworkInput!): HomeworkMutationPayload!
   createTodo(input: CreateTodoInput!): TodoMutationPayload!
   deleteComment(id: ID!): DeleteMutationPayload!
+  deleteHomework(id: ID!): HomeworkDeleteMutationPayload!
   deleteTodo(id: ID!): DeleteMutationPayload!
   removeCommentReaction(commentId: ID!, type: CommentReactionType!): CommentReactionMutationPayload!
   saveBusPreferences(input: BusPreferenceInput!): BusPreferenceMutationPayload!
@@ -276,6 +300,7 @@ type Mutation {
   subscribeSection(jwId: Int!): SectionSubscriptionMutationPayload!
   unsubscribeSection(jwId: Int!): SectionSubscriptionMutationPayload!
   updateComment(id: ID!, input: UpdateCommentInput!): CommentMutationPayload!
+  updateHomework(id: ID!, input: UpdateHomeworkInput!): HomeworkMutationPayload!
   updateTodo(id: ID!, input: UpdateTodoInput!): TodoMutationPayload!
   upsertDescription(input: UpsertDescriptionInput!): DescriptionMutationPayload!
 }
@@ -479,6 +504,16 @@ input UpdateCommentInput {
   body: String!
   isAnonymous: Boolean
   visibility: CommentVisibility
+}
+
+input UpdateHomeworkInput {
+  description: String
+  isMajor: Boolean
+  publishedAt: DateTime
+  requiresTeam: Boolean
+  submissionDueAt: DateTime
+  submissionStartAt: DateTime
+  title: String
 }
 
 input UpdateTodoInput {

--- a/src/lib/graphql/mutations.ts
+++ b/src/lib/graphql/mutations.ts
@@ -18,7 +18,22 @@ import {
   resolveDescriptionTargetReference,
 } from "@/features/descriptions/server/description-targets";
 import { upsertDescriptionContent } from "@/features/descriptions/server/description-upsert";
+import {
+  homeworkDescriptionInputSchema,
+  homeworkTitleSchema,
+} from "@/features/homeworks/lib/homework-schema";
 import { setHomeworkCompletion } from "@/features/homeworks/server/homework-completion";
+import { createHomeworkForSection } from "@/features/homeworks/server/homework-create";
+import { homeworkDateError } from "@/features/homeworks/server/homework-dates";
+import {
+  deleteHomework,
+  updateHomework,
+} from "@/features/homeworks/server/homework-mutations";
+import { requireHomeworkItemById } from "@/features/homeworks/server/homework-read-model";
+import {
+  buildHomeworkUpdateIntent,
+  hasHomeworkUpdateIntentChanges,
+} from "@/features/homeworks/server/homework-update-intent";
 import { setUserSectionSubscriptionByJwId } from "@/features/subscriptions/server/subscriptions";
 import type { TodoPriorityValue } from "@/features/todos/lib/todo-priority";
 import {
@@ -102,6 +117,27 @@ export const graphqlMutationTypeDefs = /* GraphQL */ `
     completed: Boolean
   }
 
+  input CreateHomeworkInput {
+    sectionJwId: Int!
+    title: String!
+    description: String
+    isMajor: Boolean! = false
+    requiresTeam: Boolean! = false
+    publishedAt: DateTime
+    submissionStartAt: DateTime
+    submissionDueAt: DateTime
+  }
+
+  input UpdateHomeworkInput {
+    title: String
+    description: String
+    isMajor: Boolean
+    requiresTeam: Boolean
+    publishedAt: DateTime
+    submissionStartAt: DateTime
+    submissionDueAt: DateTime
+  }
+
   input BusPreferenceInput {
     preferredOriginCampusId: Int
     preferredDestinationCampusId: Int
@@ -156,6 +192,17 @@ export const graphqlMutationTypeDefs = /* GraphQL */ `
     completedAt: DateTime
   }
 
+  type HomeworkMutationPayload {
+    id: ID!
+    homework: Homework!
+  }
+
+  type HomeworkDeleteMutationPayload {
+    id: ID!
+    success: Boolean!
+    alreadyDeleted: Boolean!
+  }
+
   type SectionSubscriptionMutationPayload {
     sectionJwId: Int!
     subscribed: Boolean!
@@ -194,6 +241,12 @@ export const graphqlMutationTypeDefs = /* GraphQL */ `
     createTodo(input: CreateTodoInput!): TodoMutationPayload!
     updateTodo(id: ID!, input: UpdateTodoInput!): TodoMutationPayload!
     deleteTodo(id: ID!): DeleteMutationPayload!
+    createHomework(input: CreateHomeworkInput!): HomeworkMutationPayload!
+    updateHomework(
+      id: ID!
+      input: UpdateHomeworkInput!
+    ): HomeworkMutationPayload!
+    deleteHomework(id: ID!): HomeworkDeleteMutationPayload!
     setHomeworkCompletion(
       homeworkId: ID!
       completed: Boolean!
@@ -239,6 +292,27 @@ type UpdateTodoInput = {
   content?: string | null;
   dueAt?: string | null;
   priority?: TodoPriorityValue | null;
+  title?: string | null;
+};
+
+type CreateHomeworkInput = {
+  description?: string | null;
+  isMajor: boolean;
+  publishedAt?: string | null;
+  requiresTeam: boolean;
+  sectionJwId: number;
+  submissionDueAt?: string | null;
+  submissionStartAt?: string | null;
+  title: string;
+};
+
+type UpdateHomeworkInput = {
+  description?: string | null;
+  isMajor?: boolean | null;
+  publishedAt?: string | null;
+  requiresTeam?: boolean | null;
+  submissionDueAt?: string | null;
+  submissionStartAt?: string | null;
   title?: string | null;
 };
 
@@ -329,6 +403,44 @@ function handleDescriptionFailure(result: { error: string }): never {
   return forbiddenMutation();
 }
 
+function handleHomeworkFailure(
+  result: { error: string },
+  missingTarget: "Homework" | "Section",
+): never {
+  if (result.error === "not_found") {
+    mutationNotFound(`${missingTarget} not found.`);
+  }
+  if (result.error === "mismatch") {
+    badMutationInput("Invalid section.");
+  }
+  if (result.error === "no_changes") {
+    badMutationInput("No homework changes were provided.");
+  }
+  if (result.error === "deleted") {
+    forbiddenMutation("Homework is deleted.");
+  }
+  if (result.error === "suspended") {
+    forbiddenMutation("Homework writes are suspended.");
+  }
+  return forbiddenMutation();
+}
+
+function normalizeHomeworkTitle(value: string) {
+  const result = homeworkTitleSchema.safeParse(value);
+  if (!result.success) {
+    badMutationInput("title must contain 1-200 characters.");
+  }
+  return result.data;
+}
+
+function normalizeHomeworkDescription(value: string | null | undefined) {
+  const result = homeworkDescriptionInputSchema.safeParse(value);
+  if (!result.success) {
+    badMutationInput("description must not exceed 4000 characters.");
+  }
+  return result.data;
+}
+
 async function setSectionSubscription(
   context: GraphqlContext,
   jwId: number,
@@ -406,6 +518,127 @@ export const graphqlMutationResolvers = {
       const result = await deleteOwnedTodo(id, principal.userId);
       if (!result.ok) handleTodoFailure(result);
       return { id, success: true };
+    },
+    async createHomework(
+      _parent: unknown,
+      args: { input: CreateHomeworkInput },
+      context: GraphqlContext,
+    ) {
+      const principal = await requireGraphqlMutation(context, "homework");
+      const input = args.input;
+      const publishedAt = dateTimeInput(input.publishedAt) ?? null;
+      const submissionStartAt = dateTimeInput(input.submissionStartAt) ?? null;
+      const submissionDueAt = dateTimeInput(input.submissionDueAt) ?? null;
+      const dateError = homeworkDateError({
+        publishedAt,
+        submissionDueAt,
+        submissionStartAt,
+      });
+      if (dateError) badMutationInput(dateError);
+
+      const result = await createHomeworkForSection(principal.userId, {
+        description: normalizeHomeworkDescription(input.description),
+        isMajor: input.isMajor,
+        publishedAt,
+        requiresTeam: input.requiresTeam,
+        sectionJwId: requireGraphqlId(input.sectionJwId, "sectionJwId"),
+        submissionDueAt,
+        submissionStartAt,
+        title: normalizeHomeworkTitle(input.title),
+      });
+      if (!result.ok) handleHomeworkFailure(result, "Section");
+
+      const id = result.homework.id;
+      const homework = await requireHomeworkItemById({
+        homeworkId: id,
+        locale: context.locale,
+        userId: principal.userId,
+      });
+      return { id, homework };
+    },
+    async updateHomework(
+      _parent: unknown,
+      args: { id: string; input: UpdateHomeworkInput },
+      context: GraphqlContext,
+    ) {
+      const principal = await requireGraphqlMutation(context, "homework");
+      const id = requireMutationId(args.id, "id");
+      const input = args.input;
+      rejectExplicitNullFields(input, ["title", "isMajor", "requiresTeam"]);
+
+      const hasDescription = Object.hasOwn(input, "description");
+      const hasPublishedAt = Object.hasOwn(input, "publishedAt");
+      const hasSubmissionStartAt = Object.hasOwn(input, "submissionStartAt");
+      const hasSubmissionDueAt = Object.hasOwn(input, "submissionDueAt");
+      const publishedAt = hasPublishedAt
+        ? dateTimeInput(input.publishedAt)
+        : undefined;
+      const submissionStartAt = hasSubmissionStartAt
+        ? dateTimeInput(input.submissionStartAt)
+        : undefined;
+      const submissionDueAt = hasSubmissionDueAt
+        ? dateTimeInput(input.submissionDueAt)
+        : undefined;
+      const dateError = homeworkDateError({
+        publishedAt,
+        publishedAtProvided: hasPublishedAt,
+        submissionDueAt,
+        submissionDueAtProvided: hasSubmissionDueAt,
+        submissionStartAt,
+        submissionStartAtProvided: hasSubmissionStartAt,
+      });
+      if (dateError) badMutationInput(dateError);
+
+      const update = buildHomeworkUpdateIntent({
+        dates: {
+          hasPublishedAt,
+          hasSubmissionDueAt,
+          hasSubmissionStartAt,
+          publishedAt,
+          submissionDueAt,
+          submissionStartAt,
+        },
+        description: hasDescription
+          ? normalizeHomeworkDescription(input.description)
+          : undefined,
+        hasDescription,
+        isMajor: input.isMajor,
+        requiresTeam: input.requiresTeam,
+        title:
+          input.title == null ? undefined : normalizeHomeworkTitle(input.title),
+        userId: principal.userId,
+      });
+      if (!hasHomeworkUpdateIntentChanges(update)) {
+        badMutationInput("No homework changes were provided.");
+      }
+
+      const result = await updateHomework({
+        homeworkId: id,
+        update,
+        userId: principal.userId,
+      });
+      if (!result.ok) handleHomeworkFailure(result, "Homework");
+
+      const homework = await requireHomeworkItemById({
+        homeworkId: id,
+        locale: context.locale,
+        userId: principal.userId,
+      });
+      return { id, homework };
+    },
+    async deleteHomework(
+      _parent: unknown,
+      args: { id: string },
+      context: GraphqlContext,
+    ) {
+      const principal = await requireGraphqlMutation(context, "homework");
+      const id = requireMutationId(args.id, "id");
+      const result = await deleteHomework({
+        homeworkId: id,
+        userId: principal.userId,
+      });
+      if (!result.ok) handleHomeworkFailure(result, "Homework");
+      return { id, success: true, alreadyDeleted: result.alreadyDeleted };
     },
     async setHomeworkCompletion(
       _parent: unknown,

--- a/tests/integration/graphql-homework-mutations.test.ts
+++ b/tests/integration/graphql-homework-mutations.test.ts
@@ -1,0 +1,451 @@
+import type { RequestEvent } from "@sveltejs/kit";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { signResourceBoundOAuthAccessToken } from "@/features/oauth/server/device-token-issuer.server";
+import { prisma } from "@/lib/db/prisma";
+import { createGraphqlRequestHandler } from "@/lib/graphql/server";
+import { getOAuthGraphqlResourceUrl } from "@/lib/oauth/resource-urls";
+import { restReadScope, restWriteScope } from "@/lib/oauth/scope-registry";
+import { DEV_SEED } from "../fixtures/dev-seed";
+
+const handler = createGraphqlRequestHandler(false);
+const marker = `[integration-test] graphql-homework-${Date.now()}`;
+const createdHomeworkIds: string[] = [];
+
+let creatorId = "";
+let collaboratorId = "";
+
+type GraphqlPayload = {
+  data?: Record<string, unknown> | null;
+  errors?: Array<{
+    message: string;
+    extensions?: Record<string, unknown>;
+  }>;
+};
+
+function requestEvent(body: unknown, token?: string): RequestEvent {
+  return {
+    request: new Request("https://life.example/api/graphql", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(body),
+    }),
+    locals: {
+      authUser: null,
+      locale: "en-us",
+      requestId: "graphql-homework-mutations-integration",
+    },
+  } as unknown as RequestEvent;
+}
+
+async function execute(body: unknown, token?: string) {
+  const response = await handler(requestEvent(body, token));
+  return {
+    response,
+    payload: (await response.json()) as GraphqlPayload,
+  };
+}
+
+async function signToken(userId: string, scopes: string[]) {
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const token = await signResourceBoundOAuthAccessToken({
+    clientId: "graphql-homework-mutations-integration",
+    expiresAt: issuedAt + 300,
+    issuedAt,
+    resources: [getOAuthGraphqlResourceUrl()],
+    scopes,
+    userId,
+  });
+  if (!token) throw new Error("Expected a signed GraphQL access token");
+  return token;
+}
+
+function expectErrorCode(payload: GraphqlPayload, code: string) {
+  expect(payload.data).toBeNull();
+  expect(payload.errors?.[0]?.extensions?.code).toBe(code);
+}
+
+beforeAll(async () => {
+  const [creator, collaborator] = await Promise.all([
+    prisma.user.create({
+      data: {
+        email: `${marker}-creator@example.test`,
+        name: "GraphQL Homework Creator",
+      },
+      select: { id: true },
+    }),
+    prisma.user.create({
+      data: {
+        email: `${marker}-collaborator@example.test`,
+        name: "GraphQL Homework Collaborator",
+      },
+      select: { id: true },
+    }),
+  ]);
+  creatorId = creator.id;
+  collaboratorId = collaborator.id;
+});
+
+afterAll(async () => {
+  await prisma.auditLog.deleteMany({
+    where: { userId: { in: [creatorId, collaboratorId] } },
+  });
+  await prisma.homeworkAuditLog.deleteMany({
+    where: {
+      OR: [
+        { actorId: { in: [creatorId, collaboratorId] } },
+        { homeworkId: { in: createdHomeworkIds } },
+      ],
+    },
+  });
+  await prisma.homework.deleteMany({
+    where: { id: { in: createdHomeworkIds } },
+  });
+  await prisma.userSuspension.deleteMany({
+    where: { userId: { in: [creatorId, collaboratorId] } },
+  });
+  await prisma.user.deleteMany({
+    where: { id: { in: [creatorId, collaboratorId] } },
+  });
+  await prisma.$disconnect();
+});
+
+describe("GraphQL homework CRUD mutations", () => {
+  it("requires the exact homework write scope before resolving a section", async () => {
+    const readToken = await signToken(creatorId, [restReadScope("homework")]);
+    const result = await execute(
+      {
+        query: /* GraphQL */ `
+          mutation CreateWithoutWriteScope($sectionJwId: Int!) {
+            createHomework(
+              input: {
+                sectionJwId: $sectionJwId
+                title: "${marker} missing scope"
+              }
+            ) {
+              id
+            }
+          }
+        `,
+        variables: { sectionJwId: DEV_SEED.section.jwId },
+      },
+      readToken,
+    );
+
+    expectErrorCode(result.payload, "FORBIDDEN");
+    expect(result.payload.errors?.[0]?.extensions?.requiredScopes).toEqual([
+      "homework:write",
+    ]);
+    await expect(
+      prisma.homework.count({
+        where: { title: `${marker} missing scope` },
+      }),
+    ).resolves.toBe(0);
+  });
+
+  it("validates the shared homework submission window before writing", async () => {
+    const token = await signToken(creatorId, [restWriteScope("homework")]);
+    const result = await execute(
+      {
+        query: /* GraphQL */ `
+          mutation InvalidHomeworkWindow(
+            $sectionJwId: Int!
+            $start: DateTime!
+            $due: DateTime!
+          ) {
+            createHomework(
+              input: {
+                sectionJwId: $sectionJwId
+                title: "${marker} invalid window"
+                submissionStartAt: $start
+                submissionDueAt: $due
+              }
+            ) {
+              id
+            }
+          }
+        `,
+        variables: {
+          sectionJwId: DEV_SEED.section.jwId,
+          start: "2026-08-02T08:00:00+08:00",
+          due: "2026-08-01T18:00:00+08:00",
+        },
+      },
+      token,
+    );
+
+    expectErrorCode(result.payload, "BAD_USER_INPUT");
+    expect(result.payload.errors?.[0]?.message).toBe(
+      "Submission start must be before due",
+    );
+    await expect(
+      prisma.homework.count({
+        where: { title: `${marker} invalid window` },
+      }),
+    ).resolves.toBe(0);
+  });
+
+  it("creates, collaboratively updates, and creator-deletes with shared audit semantics", async () => {
+    const [creatorToken, collaboratorToken] = await Promise.all([
+      signToken(creatorId, [restWriteScope("homework")]),
+      signToken(collaboratorId, [restWriteScope("homework")]),
+    ]);
+    const created = await execute(
+      {
+        query: /* GraphQL */ `
+          mutation CreateHomework(
+            $sectionJwId: Int!
+            $publishedAt: DateTime!
+            $start: DateTime!
+            $due: DateTime!
+          ) {
+            createHomework(
+              input: {
+                sectionJwId: $sectionJwId
+                title: "  ${marker} initial  "
+                description: "  Solve question 1  "
+                isMajor: true
+                requiresTeam: true
+                publishedAt: $publishedAt
+                submissionStartAt: $start
+                submissionDueAt: $due
+              }
+            ) {
+              id
+              homework {
+                id
+                title
+                isMajor
+                requiresTeam
+                publishedAt
+                submissionStartAt
+                submissionDueAt
+                completed
+                commentCount
+                section {
+                  jwId
+                }
+              }
+            }
+          }
+        `,
+        variables: {
+          sectionJwId: DEV_SEED.section.jwId,
+          publishedAt: "2026-07-20T08:00:00+08:00",
+          start: "2026-07-21T08:00:00+08:00",
+          due: "2026-07-22T18:00:00+08:00",
+        },
+      },
+      creatorToken,
+    );
+    expect(created.response.headers.get("cache-control")).toBe("no-store");
+    expect(created.payload.errors).toBeUndefined();
+    const createPayload = created.payload.data?.createHomework as
+      | {
+          id: string;
+          homework: Record<string, unknown>;
+        }
+      | undefined;
+    expect(createPayload?.id).toEqual(expect.any(String));
+    const homeworkId = createPayload?.id as string;
+    createdHomeworkIds.push(homeworkId);
+    expect(createPayload?.homework).toMatchObject({
+      id: homeworkId,
+      title: `${marker} initial`,
+      isMajor: true,
+      requiresTeam: true,
+      publishedAt: "2026-07-20T00:00:00.000Z",
+      submissionStartAt: "2026-07-21T00:00:00.000Z",
+      submissionDueAt: "2026-07-22T10:00:00.000Z",
+      completed: false,
+      commentCount: 0,
+      section: { jwId: DEV_SEED.section.jwId },
+    });
+
+    const createdRecord = await prisma.homework.findUniqueOrThrow({
+      where: { id: homeworkId },
+      select: {
+        createdById: true,
+        description: { select: { content: true } },
+        isMajor: true,
+        requiresTeam: true,
+        title: true,
+      },
+    });
+    expect(createdRecord).toEqual({
+      createdById: creatorId,
+      description: { content: "Solve question 1" },
+      isMajor: true,
+      requiresTeam: true,
+      title: `${marker} initial`,
+    });
+    await expect(
+      prisma.homeworkAuditLog.findMany({
+        where: { homeworkId },
+        select: { action: true, actorId: true, titleSnapshot: true },
+      }),
+    ).resolves.toEqual([
+      {
+        action: "created",
+        actorId: creatorId,
+        titleSnapshot: `${marker} initial`,
+      },
+    ]);
+
+    const updated = await execute(
+      {
+        query: /* GraphQL */ `
+          mutation UpdateHomework($id: ID!, $due: DateTime!) {
+            updateHomework(
+              id: $id
+              input: {
+                title: "  ${marker} updated  "
+                description: null
+                isMajor: false
+                requiresTeam: false
+                publishedAt: null
+                submissionStartAt: null
+                submissionDueAt: $due
+              }
+            ) {
+              id
+              homework {
+                id
+                title
+                isMajor
+                requiresTeam
+                publishedAt
+                submissionStartAt
+                submissionDueAt
+              }
+            }
+          }
+        `,
+        variables: {
+          id: homeworkId,
+          due: "2026-07-23T18:00:00+08:00",
+        },
+      },
+      collaboratorToken,
+    );
+    expect(updated.payload).toEqual({
+      data: {
+        updateHomework: {
+          id: homeworkId,
+          homework: {
+            id: homeworkId,
+            title: `${marker} updated`,
+            isMajor: false,
+            requiresTeam: false,
+            publishedAt: null,
+            submissionStartAt: null,
+            submissionDueAt: "2026-07-23T10:00:00.000Z",
+          },
+        },
+      },
+    });
+    const updatedRecord = await prisma.homework.findUniqueOrThrow({
+      where: { id: homeworkId },
+      select: {
+        description: { select: { content: true, id: true } },
+        updatedById: true,
+      },
+    });
+    expect(updatedRecord).toMatchObject({
+      description: { content: "" },
+      updatedById: collaboratorId,
+    });
+    await expect(
+      prisma.auditLog.findFirstOrThrow({
+        where: {
+          action: "description_edit",
+          targetId: updatedRecord.description?.id,
+          userId: collaboratorId,
+        },
+        select: { metadata: true },
+      }),
+    ).resolves.toMatchObject({
+      metadata: { targetType: "homework" },
+    });
+
+    const forbiddenDelete = await execute(
+      {
+        query:
+          "mutation DeleteOtherHomework($id: ID!) { deleteHomework(id: $id) { success } }",
+        variables: { id: homeworkId },
+      },
+      collaboratorToken,
+    );
+    expectErrorCode(forbiddenDelete.payload, "FORBIDDEN");
+
+    const deleted = await execute(
+      {
+        query: /* GraphQL */ `
+          mutation DeleteHomework($id: ID!) {
+            deleteHomework(id: $id) {
+              id
+              success
+              alreadyDeleted
+            }
+          }
+        `,
+        variables: { id: homeworkId },
+      },
+      creatorToken,
+    );
+    expect(deleted.payload).toEqual({
+      data: {
+        deleteHomework: {
+          id: homeworkId,
+          success: true,
+          alreadyDeleted: false,
+        },
+      },
+    });
+
+    const repeatedDelete = await execute(
+      {
+        query: /* GraphQL */ `
+          mutation DeleteHomeworkAgain($id: ID!) {
+            deleteHomework(id: $id) {
+              id
+              success
+              alreadyDeleted
+            }
+          }
+        `,
+        variables: { id: homeworkId },
+      },
+      creatorToken,
+    );
+    expect(repeatedDelete.payload).toEqual({
+      data: {
+        deleteHomework: {
+          id: homeworkId,
+          success: true,
+          alreadyDeleted: true,
+        },
+      },
+    });
+    await expect(
+      prisma.homeworkAuditLog.findMany({
+        where: { homeworkId },
+        orderBy: [{ createdAt: "asc" }, { action: "asc" }],
+        select: { action: true, actorId: true, titleSnapshot: true },
+      }),
+    ).resolves.toEqual([
+      {
+        action: "created",
+        actorId: creatorId,
+        titleSnapshot: `${marker} initial`,
+      },
+      {
+        action: "deleted",
+        actorId: creatorId,
+        titleSnapshot: `${marker} updated`,
+      },
+    ]);
+  });
+});

--- a/tests/unit/graphql-homework-mutations.test.ts
+++ b/tests/unit/graphql-homework-mutations.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GraphqlContext } from "@/lib/graphql/context";
+import { graphqlMutationResolvers } from "@/lib/graphql/mutations";
+
+const {
+  createHomeworkForSectionMock,
+  deleteHomeworkMock,
+  requireGraphqlMutationMock,
+  requireHomeworkItemByIdMock,
+  updateHomeworkMock,
+} = vi.hoisted(() => ({
+  createHomeworkForSectionMock: vi.fn(),
+  deleteHomeworkMock: vi.fn(),
+  requireGraphqlMutationMock: vi.fn(),
+  requireHomeworkItemByIdMock: vi.fn(),
+  updateHomeworkMock: vi.fn(),
+}));
+
+vi.mock("@/features/homeworks/server/homework-create", () => ({
+  createHomeworkForSection: createHomeworkForSectionMock,
+}));
+
+vi.mock("@/features/homeworks/server/homework-mutations", () => ({
+  deleteHomework: deleteHomeworkMock,
+  updateHomework: updateHomeworkMock,
+}));
+
+vi.mock("@/features/homeworks/server/homework-read-model", () => ({
+  requireHomeworkItemById: requireHomeworkItemByIdMock,
+}));
+
+vi.mock("@/lib/graphql/mutation-guard", () => ({
+  requireGraphqlMutation: requireGraphqlMutationMock,
+}));
+
+const context = {
+  locale: "en-us",
+  principal: { kind: "anonymous" },
+  request: new Request("https://life.example/api/graphql"),
+} as unknown as GraphqlContext;
+
+describe("GraphQL homework mutation resolvers", () => {
+  beforeEach(() => {
+    createHomeworkForSectionMock.mockReset();
+    deleteHomeworkMock.mockReset();
+    requireGraphqlMutationMock.mockReset();
+    requireHomeworkItemByIdMock.mockReset();
+    updateHomeworkMock.mockReset();
+    requireGraphqlMutationMock.mockResolvedValue({ userId: "user-1" });
+  });
+
+  it("creates through the shared service and returns the localized snapshot", async () => {
+    createHomeworkForSectionMock.mockResolvedValue({
+      ok: true,
+      homework: { id: "homework-1" },
+    });
+    const homework = { id: "homework-1", title: "第 1 次作业" };
+    requireHomeworkItemByIdMock.mockResolvedValue(homework);
+
+    const result = await graphqlMutationResolvers.Mutation.createHomework(
+      null,
+      {
+        input: {
+          description: "  第一题  ",
+          isMajor: true,
+          publishedAt: "2026-07-20T08:00:00+08:00",
+          requiresTeam: false,
+          sectionJwId: 1234,
+          submissionDueAt: "2026-07-22T18:00:00+08:00",
+          submissionStartAt: "2026-07-21T08:00:00+08:00",
+          title: "  第 1 次作业  ",
+        },
+      },
+      context,
+    );
+
+    expect(requireGraphqlMutationMock).toHaveBeenCalledWith(
+      context,
+      "homework",
+    );
+    expect(createHomeworkForSectionMock).toHaveBeenCalledWith("user-1", {
+      description: "第一题",
+      isMajor: true,
+      publishedAt: new Date("2026-07-20T00:00:00.000Z"),
+      requiresTeam: false,
+      sectionJwId: 1234,
+      submissionDueAt: new Date("2026-07-22T10:00:00.000Z"),
+      submissionStartAt: new Date("2026-07-21T00:00:00.000Z"),
+      title: "第 1 次作业",
+    });
+    expect(requireHomeworkItemByIdMock).toHaveBeenCalledWith({
+      homeworkId: "homework-1",
+      locale: "en-us",
+      userId: "user-1",
+    });
+    expect(result).toEqual({ id: "homework-1", homework });
+  });
+
+  it("updates through the shared intent and preserves nullable clear fields", async () => {
+    updateHomeworkMock.mockResolvedValue({ ok: true });
+    const homework = { id: "homework-1", title: "Updated" };
+    requireHomeworkItemByIdMock.mockResolvedValue(homework);
+
+    const result = await graphqlMutationResolvers.Mutation.updateHomework(
+      null,
+      {
+        id: " homework-1 ",
+        input: {
+          description: null,
+          isMajor: false,
+          publishedAt: null,
+          submissionDueAt: "2026-07-23T18:00:00+08:00",
+          title: "  Updated  ",
+        },
+      },
+      context,
+    );
+
+    expect(updateHomeworkMock).toHaveBeenCalledWith({
+      homeworkId: "homework-1",
+      update: {
+        description: null,
+        homeworkUpdates: {
+          isMajor: false,
+          publishedAt: null,
+          submissionDueAt: new Date("2026-07-23T10:00:00.000Z"),
+          title: "Updated",
+          updatedBy: { connect: { id: "user-1" } },
+        },
+      },
+      userId: "user-1",
+    });
+    expect(requireHomeworkItemByIdMock).toHaveBeenCalledWith({
+      homeworkId: "homework-1",
+      locale: "en-us",
+      userId: "user-1",
+    });
+    expect(result).toEqual({ id: "homework-1", homework });
+  });
+
+  it("preserves idempotent delete semantics from the shared service", async () => {
+    deleteHomeworkMock.mockResolvedValue({
+      ok: true,
+      alreadyDeleted: true,
+    });
+
+    await expect(
+      graphqlMutationResolvers.Mutation.deleteHomework(
+        null,
+        { id: " homework-1 " },
+        context,
+      ),
+    ).resolves.toEqual({
+      id: "homework-1",
+      success: true,
+      alreadyDeleted: true,
+    });
+    expect(deleteHomeworkMock).toHaveBeenCalledWith({
+      homeworkId: "homework-1",
+      userId: "user-1",
+    });
+  });
+
+  it.each([
+    {
+      error: "not_found",
+      expectedCode: "NOT_FOUND",
+      expectedMessage: "Section not found.",
+      mutation: "create",
+    },
+    {
+      error: "deleted",
+      expectedCode: "FORBIDDEN",
+      expectedMessage: "Homework is deleted.",
+      mutation: "update",
+    },
+    {
+      error: "suspended",
+      expectedCode: "FORBIDDEN",
+      expectedMessage: "Homework writes are suspended.",
+      mutation: "delete",
+    },
+  ])("maps $mutation service error $error to $expectedCode", async ({
+    error,
+    expectedCode,
+    expectedMessage,
+    mutation,
+  }) => {
+    let promise: Promise<unknown>;
+    if (mutation === "create") {
+      createHomeworkForSectionMock.mockResolvedValue({ ok: false, error });
+      promise = graphqlMutationResolvers.Mutation.createHomework(
+        null,
+        {
+          input: {
+            isMajor: false,
+            requiresTeam: false,
+            sectionJwId: 1234,
+            title: "Homework",
+          },
+        },
+        context,
+      );
+    } else if (mutation === "update") {
+      updateHomeworkMock.mockResolvedValue({ ok: false, error });
+      promise = graphqlMutationResolvers.Mutation.updateHomework(
+        null,
+        { id: "homework-1", input: { title: "Updated" } },
+        context,
+      );
+    } else {
+      deleteHomeworkMock.mockResolvedValue({ ok: false, error });
+      promise = graphqlMutationResolvers.Mutation.deleteHomework(
+        null,
+        { id: "homework-1" },
+        context,
+      );
+    }
+
+    await expect(promise).rejects.toMatchObject({
+      extensions: { code: expectedCode },
+      message: expectedMessage,
+    });
+  });
+});


### PR DESCRIPTION
## Goal

Close the Homework CRUD slice of #549 with explicit business-domain GraphQL mutations. This does not add generated Prisma CRUD, arbitrary MCP GraphQL execution, admin governance mutations, or new auth protocol surfaces.

## Changed Surfaces

- Added explicit `CreateHomeworkInput` / `UpdateHomeworkInput` and create, update, and delete payloads to the public SDL.
- Added `createHomework`, `updateHomework`, and `deleteHomework` resolvers behind the existing `homework:write` scope and shared per-user mutation rate limit.
- Reused the feature-owned create/update/delete services and localized homework read model; resolvers do not access Prisma or loop back over HTTP.
- Kept the public section selector to `sectionJwId`, preserved nullable description/timestamp clearing, collaborative updates, creator-or-admin deletion, and idempotent repeated deletion.
- Added resolver tests and a real PostgreSQL GraphQL lifecycle test covering scope, date validation, returned snapshots, permissions, and existing Homework/Description audit behavior.

## Evidence

- `bun run app:prepare`
- `bunx biome check` (passes; one pre-existing static-loader unused-parameter warning)
- `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors / 0 warnings
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` — 1231/1231 tests passed
- `bunx vitest run --config vitest.integration.config.ts` — 185/185 tests passed against an isolated PostgreSQL database
- `bun run build`
- `bunx playwright test tests/e2e/src/app/api/graphql/test.ts` — 1/1 Cloudflare Worker smoke test passed
- Inspected the GraphQL lifecycle output and persisted records for create/update/delete, duplicate deletion, ownership denial, and audit rows.

## Docs / Contracts

- Updated `docs/contracts/homework.json` and `docs/contracts/graphql.json`.
- Regenerated `docs/graphql/schema.graphql` through the schema snapshot test and reran snapshot/contract parity checks.
- REST and MCP shapes are intentionally unchanged; each GraphQL mutation maps to the existing equivalent service-backed surface.

## Risk Areas

- No Prisma schema or migration changes.
- No MCP tool or persisted-operation runner changes.
- Expected service failures map to stable `BAD_USER_INPUT`, `NOT_FOUND`, and `FORBIDDEN` GraphQL errors; unexpected errors retain the existing masking path.
- Audit behavior stays feature-owned: create/delete use existing HomeworkAuditLog transactions and description changes use existing DescriptionEdit/description_edit audit transactions.

## Cleanup

- Worktree is clean after the commit.
- Playwright reports and temporary probes were removed.
- No generated Prisma files, unrelated rewrites, or scratch artifacts are included.

Part of #549.