### PR TITLE
feat(web): add semantic public tool routes

### DIFF
--- a/docs/contracts/bus.json
+++ b/docs/contracts/bus.json
@@ -12,9 +12,10 @@
     "shanghai-time-interpretation": "When calculating 'how long until departure', whether a trip has departed, and route ordering, the dashboard client interprets HH:mm times in the timetable uniformly as Shanghai Time, not changing with the browser's timezone.",
     "core-filters-only": "The dashboard bus page provides only core filters for departure stop, arrival stop, direction reversal, and 'show already-departed trips'; departure and arrival stops use a directly clickable vertical stop column to avoid secondary dropdowns, maintaining clear departure/arrival hierarchy.",
     "visual-priority": "The dashboard visual structure should prioritize 'quick scanning of the next trip and route differences'; selected stop, direction, next departure time, and route grouping must be more prominent than decorative cards.",
-    "public-home-next-departure-first": "The anonymous home bus view leads with the next boardable departure and up to two following departures for the selected direction; it reuses a valid recent local route when no signed-in preference is available, while route controls and the complete grouped timetable remain accessible through progressive disclosure.",
+    "public-next-departure-first": "The public /bus page leads with the next boardable departure and up to two following departures for the selected direction; it reuses a valid recent local route when no signed-in preference is available, while route controls and the complete grouped timetable remain accessible through progressive disclosure.",
+    "semantic-public-route": "Anonymous /?tab=bus requests permanently redirect to /bus; signed-in compatibility requests redirect to /dashboard/bus.",
     "sort-by-next-boardable": "Routes are currently sorted by 'the next boardable time from the selected departure stop'; if a stop has no exact time in the original timetable, the average of adjacent known stop times in the same trip is used as an estimate.",
-    "merged-table-grouped-by-route": "The signed-in dashboard and the anonymous home's expanded timetable use a single merged large table to display all applicable routes, grouped into table sections by route; each section shows the visible trips for that route.",
+    "merged-table-grouped-by-route": "The signed-in dashboard and the public /bus expanded timetable use a single merged large table to display all applicable routes, grouped into table sections by route; each section shows the visible trips for that route.",
     "raw-data-returned": "/api/bus and query_bus_timetable return raw route/stop/trip data within the selected timetable version; the preferences field is null for anonymous callers and returns the authenticated caller's saved preferences; the server does not pre-apply recommendations, filtering, or sorting.",
     "version-topology-self-contained": "When versionKey selects a historical timetable version, routes, stops, campuses, and trips are derived from that same imported schedule version rather than the latest global route topology.",
     "current-version-only": "list_bus_routes only lists routes actually present in the current active timetable version; it does not expose historical route IDs outside the current version.",
@@ -29,7 +30,7 @@
       "title": "Bus Dashboard",
       "auth": "anon",
       "web": {
-        "pages": ["/dashboard/bus", "/?tab=bus"]
+        "pages": ["/bus", "/dashboard/bus"]
       },
       "rest": {
         "routes": [

--- a/docs/contracts/dashboard-link.json
+++ b/docs/contracts/dashboard-link.json
@@ -11,6 +11,7 @@
     "search-fuzzy": "Search supports Chinese, pinyin, and whitespace-tolerant matching.",
     "links-vs-buttons": "Links are for navigation; buttons are for actions.",
     "pin-limit": "Currently a maximum of 4 links can be pinned; exceeding this displaces the earliest pinned link.",
+    "semantic-public-route": "Anonymous /?tab=links requests permanently redirect to /links; signed-in compatibility requests redirect to /dashboard/links.",
     "pin-error-clear": "When pin/unpin writes fail, the endpoint returns a clear error; failures are not disguised as successes."
   },
   "capabilities": {
@@ -18,7 +19,7 @@
       "title": "Link Browse & Search",
       "auth": "anon",
       "web": {
-        "pages": ["/dashboard/links", "/?tab=links", "/dashboard"]
+        "pages": ["/links", "/dashboard/links"]
       },
       "rest": "unavailable",
       "mcp": {

--- a/docs/contracts/exam.json
+++ b/docs/contracts/exam.json
@@ -20,7 +20,7 @@
         "models": ["Exam"]
       },
       "web": {
-        "pages": ["/dashboard/exams", "/?tab=exams"]
+        "pages": ["/dashboard/exams"]
       },
       "rest": "unavailable",
       "graphql": {

--- a/docs/contracts/homework.json
+++ b/docs/contracts/homework.json
@@ -22,7 +22,7 @@
         "models": ["Homework"]
       },
       "web": {
-        "pages": ["/dashboard/homeworks", "/?tab=homeworks"]
+        "pages": ["/dashboard/homeworks"]
       },
       "rest": {
         "routes": [

--- a/docs/contracts/overview.json
+++ b/docs/contracts/overview.json
@@ -8,6 +8,7 @@
   },
   "rules": {
     "decision-page": "The anonymous home page is a public bus and frequent-links decision page; the authenticated /dashboard overview is the personal decision page for 'what to do next'.",
+    "semantic-route-compatibility": "Known legacy /?tab= inputs permanently redirect to semantic public or dashboard paths while preserving unrelated query parameters.",
     "now-next-first": "The authenticated overview begins with the current or next actionable schedule, homework, exam, or todo in a rolling seven-day window. Today's urgent work follows it, while frequent links remain secondary and appear after planning content.",
     "current-semester-priority": "The above-the-fold area prioritizes personal learning tasks within the current semester, not historical semester content or complete directory information.",
     "homework-todo-layered": "Homework and todos are layered as 'due today / due soon / all incomplete'; homework with no due date does not participate in upcoming due date sorting.",

--- a/docs/contracts/subscribed-sections.json
+++ b/docs/contracts/subscribed-sections.json
@@ -21,7 +21,7 @@
         "ui": ["List Table"]
       },
       "web": {
-        "pages": ["/dashboard/subscriptions", "/?tab=subscriptions"]
+        "pages": ["/dashboard/subscriptions"]
       },
       "rest": {
         "routes": [

--- a/docs/contracts/subscription.json
+++ b/docs/contracts/subscription.json
@@ -77,7 +77,7 @@
         "models": ["Section", "User"]
       },
       "web": {
-        "pages": ["/dashboard/subscriptions", "/?tab=subscriptions", "/welcome"]
+        "pages": ["/dashboard/subscriptions", "/welcome"]
       },
       "rest": {
         "routes": [

--- a/docs/contracts/todo.json
+++ b/docs/contracts/todo.json
@@ -20,7 +20,7 @@
         "models": ["Todo"]
       },
       "web": {
-        "pages": ["/dashboard/todos", "/?tab=todos"]
+        "pages": ["/dashboard/todos"]
       },
       "graphql": {
         "fields": [
@@ -110,7 +110,7 @@
         "models": ["Todo"]
       },
       "web": {
-        "pages": ["/dashboard/todos", "/?tab=todos"]
+        "pages": ["/dashboard/todos"]
       },
       "rest": {
         "routes": [

--- a/src/features/dashboard/lib/dashboard-nav.ts
+++ b/src/features/dashboard/lib/dashboard-nav.ts
@@ -28,6 +28,17 @@ const homeDashboardQueryKeys = new Set([
   "todoView",
 ]);
 
+function appendSearch(pathname: string, query: URLSearchParams) {
+  const search = query.toString();
+  return `${pathname}${search ? `?${search}` : ""}`;
+}
+
+function queryWithoutTab(url: URL) {
+  const query = new URLSearchParams(url.searchParams);
+  query.delete("tab");
+  return query;
+}
+
 export function isSignedDashboardTab(
   value: string | null | undefined,
 ): value is SignedTabId {
@@ -52,9 +63,6 @@ export function dashboardTabHref(
 export function dashboardRedirectHrefFromHome(url: URL) {
   const query = new URLSearchParams();
   const tab = url.searchParams.get("tab");
-  if (isSignedDashboardTab(tab)) {
-    query.set("tab", tab);
-  }
 
   for (const [key, value] of url.searchParams) {
     if (homeDashboardQueryKeys.has(key)) {
@@ -62,6 +70,25 @@ export function dashboardRedirectHrefFromHome(url: URL) {
     }
   }
 
-  const search = query.toString();
-  return `/dashboard${search ? `?${search}` : ""}`;
+  return appendSearch(
+    isSignedDashboardTab(tab) ? `/dashboard/${tab}` : "/dashboard",
+    query,
+  );
+}
+
+export function homeTabCompatibilityRedirectHref(url: URL, signedIn: boolean) {
+  const tab = url.searchParams.get("tab");
+  if (!isSignedDashboardTab(tab)) return null;
+
+  const pathname =
+    signedIn || (tab !== "bus" && tab !== "links")
+      ? `/dashboard/${tab}`
+      : `/${tab}`;
+  return appendSearch(pathname, queryWithoutTab(url));
+}
+
+export function dashboardTabCompatibilityRedirectHref(url: URL) {
+  const tab = url.searchParams.get("tab");
+  if (!isSignedDashboardTab(tab)) return null;
+  return appendSearch(`/dashboard/${tab}`, queryWithoutTab(url));
 }

--- a/src/features/dashboard/server/dashboard-page-copy.ts
+++ b/src/features/dashboard/server/dashboard-page-copy.ts
@@ -45,3 +45,43 @@ export function getAnonymousHomePageCopy(locale: AppLocale) {
     },
   };
 }
+
+export function getPublicBusPageCopy(locale: AppLocale) {
+  const copy = messages[locale];
+  return {
+    bus: copy.bus,
+    dashboard: {
+      nav: {
+        bus: copy.meDashboard.nav.bus,
+      },
+    },
+    homepage: {
+      publicDashboard: {
+        title: copy.homepage.publicDashboard.title,
+      },
+    },
+    metadata: {
+      home: copy.metadata.pages.home,
+    },
+  };
+}
+
+export function getPublicLinksPageCopy(locale: AppLocale) {
+  const copy = messages[locale];
+  return {
+    dashboard: {
+      linkHub: copy.meDashboard.linkHub,
+      nav: {
+        links: copy.meDashboard.nav.links,
+      },
+    },
+    homepage: {
+      publicDashboard: {
+        title: copy.homepage.publicDashboard.title,
+      },
+    },
+    metadata: {
+      home: copy.metadata.pages.home,
+    },
+  };
+}

--- a/src/features/dashboard/server/public-bus-page-load.ts
+++ b/src/features/dashboard/server/public-bus-page-load.ts
@@ -1,0 +1,13 @@
+import { getPublicBusPageCopy } from "@/features/dashboard/server/dashboard-page-copy";
+import type { DashboardPageLoadEvent } from "@/features/dashboard/server/dashboard-page-load-types";
+import { getBusTabData } from "@/features/dashboard/server/dashboard-tab-data";
+
+export async function loadPublicBusPage({ locals }: DashboardPageLoadEvent) {
+  const bus = await getBusTabData(null, locals.locale);
+
+  return {
+    bus: bus.data,
+    copy: getPublicBusPageCopy(locals.locale),
+    locale: locals.locale,
+  };
+}

--- a/src/features/dashboard/server/public-links-page-load.ts
+++ b/src/features/dashboard/server/public-links-page-load.ts
@@ -1,0 +1,13 @@
+import { getPublicLinksPageCopy } from "@/features/dashboard/server/dashboard-page-copy";
+import type { DashboardPageLoadEvent } from "@/features/dashboard/server/dashboard-page-load-types";
+import { getPublicDashboardLinksData } from "@/features/dashboard-links/server/dashboard-link-data";
+
+export async function loadPublicLinksPage({ locals }: DashboardPageLoadEvent) {
+  const publicLinks = await getPublicDashboardLinksData(locals.locale);
+
+  return {
+    copy: getPublicLinksPageCopy(locals.locale),
+    locale: locals.locale,
+    publicLinks: publicLinks.dashboardLinks,
+  };
+}

--- a/src/lib/components/shell/AppShell.svelte
+++ b/src/lib/components/shell/AppShell.svelte
@@ -159,8 +159,8 @@ function buildShellNavGroups(
         defaultOpen: true,
         label: copy.nav.groups.publicTools,
         links: [
-          { href: "/?tab=bus", icon: BusFrontIcon, label: copy.nav.bus },
-          { href: "/?tab=links", icon: LinkIcon, label: copy.nav.links },
+          { href: "/bus", icon: BusFrontIcon, label: copy.nav.bus },
+          { href: "/links", icon: LinkIcon, label: copy.nav.links },
         ],
       },
       {
@@ -410,22 +410,8 @@ function isActiveLink(link: ShellLink) {
   const target = new URL(link.href, $page.url.origin);
   const pathname = $page.url.pathname;
 
-  if (link.href === "/?tab=bus") {
-    return pathname === "/" && $page.url.searchParams.get("tab") !== "links";
-  }
-  if (link.href === "/?tab=links") {
-    return pathname === "/" && $page.url.searchParams.get("tab") === "links";
-  }
   if (target.pathname === "/dashboard/overview") {
-    if (pathname === "/dashboard" || pathname === "/dashboard/overview") {
-      return true;
-    }
-    // Signed-in fallback to overview on the home route (e.g. /?tab=comments)
-    if (pathname === "/" && data.user) {
-      const tab = $page.url.searchParams.get("tab");
-      return tab !== "bus" && tab !== "links";
-    }
-    return false;
+    return pathname === "/dashboard" || pathname === "/dashboard/overview";
   }
   if (target.pathname.startsWith("/dashboard/")) {
     return pathname === target.pathname;

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,9 +1,21 @@
 import { redirect } from "@sveltejs/kit";
-import { dashboardRedirectHrefFromHome } from "@/features/dashboard/lib/dashboard-nav";
+import {
+  dashboardRedirectHrefFromHome,
+  homeTabCompatibilityRedirectHref,
+} from "@/features/dashboard/lib/dashboard-nav";
 import { loadAnonymousHomePage } from "@/features/dashboard/server/anonymous-home-page-load";
 import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
+  const signedIn = Boolean(event.locals.authUser?.id);
+  const compatibilityHref = homeTabCompatibilityRedirectHref(
+    event.url,
+    signedIn,
+  );
+  if (compatibilityHref) {
+    throw redirect(308, compatibilityHref);
+  }
+
   if (event.locals.authUser?.id) {
     throw redirect(303, dashboardRedirectHrefFromHome(event.url));
   }

--- a/src/routes/bus/+page.server.ts
+++ b/src/routes/bus/+page.server.ts
@@ -1,0 +1,22 @@
+import { loadPublicBusPage } from "@/features/dashboard/server/public-bus-page-load";
+import type { PageServerLoad } from "./$types";
+
+export const load: PageServerLoad = async (event) => {
+  const [data, layoutData] = await Promise.all([
+    loadPublicBusPage({
+      locals: event.locals,
+      request: event.request,
+      url: event.url,
+    }),
+    event.parent(),
+  ]);
+
+  return {
+    ...data,
+    socialMetadata: {
+      ...layoutData.socialMetadata,
+      description: data.copy.dashboard.nav.bus.description,
+      title: `${data.copy.dashboard.nav.bus.title} - Life@USTC`,
+    },
+  };
+};

--- a/src/routes/bus/+page.svelte
+++ b/src/routes/bus/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+import BusTab from "@/features/dashboard/components/BusTab.svelte";
+import type { PageData } from "./$types";
+
+export let data: PageData;
+</script>
+
+<svelte:head>
+  <title>{data.copy.dashboard.nav.bus.title} - Life@USTC</title>
+</svelte:head>
+
+<div class="mx-auto grid w-full max-w-7xl gap-5">
+  <div class="grid gap-1">
+    <p class="font-medium text-muted-foreground text-sm">
+      {data.copy.homepage.publicDashboard.title}
+    </p>
+    <h1 class="font-semibold text-2xl tracking-normal sm:text-3xl">
+      {data.copy.dashboard.nav.bus.title}
+    </h1>
+    <p class="max-w-3xl text-muted-foreground text-sm">
+      {data.copy.dashboard.nav.bus.description}
+    </p>
+  </div>
+
+  <BusTab busCopy={data.copy.bus} bus={data.bus} compact />
+</div>

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -1,10 +1,16 @@
 import { redirect } from "@sveltejs/kit";
+import { dashboardTabCompatibilityRedirectHref } from "@/features/dashboard/lib/dashboard-nav";
 import { dashboardPageActions } from "@/features/dashboard/server/dashboard-page-actions";
 import { loadSignedDashboardPage } from "@/features/dashboard/server/dashboard-page-load";
 import { buildSignInPageUrl } from "@/lib/auth/auth-routing";
 import type { Actions, PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
+  const compatibilityHref = dashboardTabCompatibilityRedirectHref(event.url);
+  if (compatibilityHref) {
+    throw redirect(308, compatibilityHref);
+  }
+
   if (!event.locals.authUser?.id) {
     throw redirect(
       303,

--- a/src/routes/links/+page.server.ts
+++ b/src/routes/links/+page.server.ts
@@ -1,0 +1,22 @@
+import { loadPublicLinksPage } from "@/features/dashboard/server/public-links-page-load";
+import type { PageServerLoad } from "./$types";
+
+export const load: PageServerLoad = async (event) => {
+  const [data, layoutData] = await Promise.all([
+    loadPublicLinksPage({
+      locals: event.locals,
+      request: event.request,
+      url: event.url,
+    }),
+    event.parent(),
+  ]);
+
+  return {
+    ...data,
+    socialMetadata: {
+      ...layoutData.socialMetadata,
+      description: data.copy.dashboard.nav.links.description,
+      title: `${data.copy.dashboard.nav.links.title} - Life@USTC`,
+    },
+  };
+};

--- a/src/routes/links/+page.svelte
+++ b/src/routes/links/+page.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+import { onMount } from "svelte";
+import AnonymousLinksTab from "@/features/dashboard/components/AnonymousLinksTab.svelte";
+import type { LinkView } from "@/features/dashboard/lib/dashboard-controller-helpers";
+import { dashboardLinkViewChange } from "@/features/dashboard/lib/dashboard-controller-view-actions";
+import { linkIconLabel } from "@/features/dashboard/lib/dashboard-link-icon";
+import {
+  DASHBOARD_VIEW_STORAGE_KEY,
+  dashboardViewsFromPreference,
+} from "@/features/dashboard/lib/view-preferences";
+import { groupDashboardLinks } from "@/features/dashboard-links/lib/dashboard-link-search";
+import { getLocalStorageItem } from "@/lib/browser/local-storage";
+import { replaceState } from "$app/navigation";
+import type { PageData } from "./$types";
+
+export let data: PageData;
+
+let linkSearchInput: HTMLInputElement | null = null;
+let linkSearchQuery = "";
+let linkView: LinkView = "grid";
+
+$: dashboardCopy = data.copy.dashboard;
+$: anonymousLinkGroups = groupDashboardLinks(
+  data.publicLinks,
+  linkSearchQuery,
+  dashboardCopy.linkHub.groups,
+);
+
+function setLinkView(mode: LinkView) {
+  const next = dashboardLinkViewChange(mode);
+  linkView = next.state.linkView;
+  replaceState(next.href, {});
+}
+
+onMount(() => {
+  const url = new URL(window.location.href);
+  linkView = dashboardViewsFromPreference(
+    url,
+    getLocalStorageItem(DASHBOARD_VIEW_STORAGE_KEY),
+  ).linkView;
+
+  function handleShortcut(event: KeyboardEvent) {
+    if (
+      (event.metaKey || event.ctrlKey) &&
+      event.key.toLowerCase() === "k" &&
+      linkSearchInput
+    ) {
+      event.preventDefault();
+      linkSearchInput.focus();
+    }
+  }
+
+  window.addEventListener("keydown", handleShortcut);
+  return () => window.removeEventListener("keydown", handleShortcut);
+});
+</script>
+
+<svelte:head>
+  <title>{data.copy.dashboard.nav.links.title} - Life@USTC</title>
+</svelte:head>
+
+<div class="mx-auto grid w-full max-w-7xl gap-5">
+  <div class="grid gap-1">
+    <p class="font-medium text-muted-foreground text-sm">
+      {data.copy.homepage.publicDashboard.title}
+    </p>
+    <h1 class="font-semibold text-2xl tracking-normal sm:text-3xl">
+      {data.copy.dashboard.nav.links.title}
+    </h1>
+    <p class="max-w-3xl text-muted-foreground text-sm">
+      {data.copy.dashboard.nav.links.description}
+    </p>
+  </div>
+
+  <AnonymousLinksTab
+    {dashboardCopy}
+    {linkIconLabel}
+    {setLinkView}
+    {linkView}
+    {anonymousLinkGroups}
+    bind:linkSearchQuery
+    bind:linkSearchInput
+  />
+</div>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -9,6 +9,8 @@ const STATIC_ROUTES = [
   "/courses",
   "/sections",
   "/teachers",
+  "/bus",
+  "/links",
   "/bus-map",
   "/api/docs/tag/sections",
   "/privacy",

--- a/tests/e2e/mobile-screenshots/screenshots.spec.ts
+++ b/tests/e2e/mobile-screenshots/screenshots.spec.ts
@@ -47,12 +47,12 @@ test.describe("移动端截图", () => {
 
     for (const path of [
       "/dashboard",
-      "/dashboard?tab=homeworks",
-      "/dashboard?tab=todos",
-      "/dashboard?tab=calendar",
-      "/dashboard?tab=exams",
-      "/dashboard?tab=links",
-      "/dashboard?tab=subscriptions",
+      "/dashboard/homeworks",
+      "/dashboard/todos",
+      "/dashboard/calendar",
+      "/dashboard/exams",
+      "/dashboard/links",
+      "/dashboard/subscriptions",
       "/settings?tab=profile",
       "/settings?tab=accounts",
       "/settings?tab=content",

--- a/tests/e2e/src/app/api/dashboard-links/pin/test.ts
+++ b/tests/e2e/src/app/api/dashboard-links/pin/test.ts
@@ -52,7 +52,7 @@ test.describe("POST /api/dashboard-links/pin 接口", () => {
 
   test("非 JSON 模式未登录时重定向", async ({ request }) => {
     const response = await request.post(BASE, {
-      form: { slug: "jw", action: "pin", returnTo: "/?tab=links" },
+      form: { slug: "jw", action: "pin", returnTo: "/links" },
       maxRedirects: 0,
     });
     expect(response.status()).toBe(303);
@@ -126,7 +126,7 @@ test.describe("POST /api/dashboard-links/pin 接口", () => {
     await signInAsDebugUser(page, "/");
 
     const response = await page.request.post(BASE, {
-      form: { slug: "jw", action: "pin", returnTo: "/?tab=links" },
+      form: { slug: "jw", action: "pin", returnTo: "/links" },
       maxRedirects: 0,
     });
     expect(response.status()).toBe(303);

--- a/tests/e2e/src/app/bus/test.ts
+++ b/tests/e2e/src/app/bus/test.ts
@@ -2,7 +2,7 @@
  * E2E tests for the bus dashboard tab (/dashboard/bus)
  *
  * ## Behavior
- * - /bus page returns 404
+ * - /bus is the canonical public planner; /dashboard/bus keeps saved preferences
  * - Public users get a client-side planner: weekday/weekend, start stop, end stop,
  *   reverse, and departed-trip toggle
  * - Applicable routes are ordered by the next bus available from the selected start stop
@@ -124,25 +124,36 @@ test.describe("校车面板标签页", () => {
     await page.clock.setFixedTime(new Date("2026-07-17T03:00:00.000Z"));
   });
 
-  test("/bus 返回 404（重定向已移除）", async ({ page }) => {
-    const response = await page.goto("/bus");
-    expect(response?.status()).toBe(404);
-  });
-
-  test("旧版查询标签页仍渲染校车规划器", async ({ page }) => {
-    await gotoAndWaitForReady(page, "/?tab=bus", {
-      screenshotLabel: "bus-legacy",
+  test("/bus 是可索引的公共语义路径", async ({ page }, testInfo) => {
+    const response = await gotoAndWaitForReady(page, "/bus", {
+      testInfo,
+      screenshotLabel: "bus-public-route",
     });
 
+    expect(response?.status()).toBe(200);
+    await expect(page).toHaveURL(/\/bus$/);
     await expect(
-      page.getByRole("link", { name: /Transit map|线路图/ }),
-    ).toHaveAttribute("href", "/bus-map");
+      page.getByRole("heading", { level: 1, name: /校车|Shuttle Bus/i }),
+    ).toBeVisible();
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      /\/bus$/,
+    );
   });
 
-  test("公共校车标签页优先显示下一班并按需展开规划器", async ({
+  test("旧版查询标签永久重定向并保留其他状态", async ({ page }) => {
+    const response = await page.request.get("/?tab=bus&linkView=list", {
+      maxRedirects: 0,
+    });
+
+    expect(response.status()).toBe(308);
+    expect(response.headers().location).toBe("/bus?linkView=list");
+  });
+
+  test("公共校车页面优先显示下一班并按需展开规划器", async ({
     page,
   }, testInfo) => {
-    await gotoAndWaitForReady(page, "/?tab=bus", {
+    await gotoAndWaitForReady(page, "/bus", {
       testInfo,
       screenshotLabel: "bus",
     });
@@ -186,7 +197,7 @@ test.describe("校车面板标签页", () => {
     baseURL,
   }, testInfo) => {
     await setLocale(page, baseURL, "zh-cn");
-    await gotoAndWaitForReady(page, "/?tab=bus");
+    await gotoAndWaitForReady(page, "/bus");
     await expect(page.getByText("当前版本", { exact: true })).toHaveCount(0);
     await expect(
       page.getByText("Static Structured Bus Timetable", { exact: true }),
@@ -228,7 +239,7 @@ test.describe("校车面板标签页", () => {
   });
 
   test("匿名校车面板 SSR 渲染公共时刻表数据", async ({ page }) => {
-    const response = await page.request.get("/?tab=bus");
+    const response = await page.request.get("/bus");
     expect(response.status()).toBe(200);
     const html = await response.text();
 
@@ -241,11 +252,11 @@ test.describe("校车面板标签页", () => {
     );
   });
 
-  test("公共校车标签页在移动端保持下一班、路线更改和全表可用", async ({
+  test("公共校车页面在移动端保持下一班、路线更改和全表可用", async ({
     page,
   }, testInfo) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await gotoAndWaitForReady(page, "/?tab=bus", {
+    await gotoAndWaitForReady(page, "/bus", {
       testInfo,
       screenshotLabel: "bus-mobile",
     });
@@ -280,7 +291,7 @@ test.describe("校车面板标签页", () => {
   test("默认站点对按下一班可用校车排序显示所有适用线路", async ({
     page,
   }, testInfo) => {
-    await gotoAndWaitForReady(page, "/?tab=bus", {
+    await gotoAndWaitForReady(page, "/bus", {
       testInfo,
       screenshotLabel: "bus",
     });
@@ -299,7 +310,7 @@ test.describe("校车面板标签页", () => {
   });
 
   test("反向交换方向并重新计算适用线路", async ({ page }, testInfo) => {
-    await gotoAndWaitForReady(page, "/?tab=bus", {
+    await gotoAndWaitForReady(page, "/bus", {
       testInfo,
       screenshotLabel: "bus",
     });
@@ -337,7 +348,7 @@ test.describe("校车面板标签页", () => {
   });
 
   test("选择东区到南区缩小为直达线路", async ({ page }, testInfo) => {
-    await gotoAndWaitForReady(page, "/?tab=bus", {
+    await gotoAndWaitForReady(page, "/bus", {
       testInfo,
       screenshotLabel: "bus",
     });
@@ -354,7 +365,7 @@ test.describe("校车面板标签页", () => {
   });
 
   test("已发车切换保持时刻表可见且可切换", async ({ page }, testInfo) => {
-    await gotoAndWaitForReady(page, "/?tab=bus", {
+    await gotoAndWaitForReady(page, "/bus", {
       testInfo,
       screenshotLabel: "bus",
     });
@@ -375,7 +386,7 @@ test.describe("校车面板标签页", () => {
   });
 
   test("工作日/周末切换更新所选线路时刻表", async ({ page }, testInfo) => {
-    await gotoAndWaitForReady(page, "/?tab=bus", {
+    await gotoAndWaitForReady(page, "/bus", {
       testInfo,
       screenshotLabel: "bus",
     });
@@ -410,7 +421,7 @@ test.describe("校车面板标签页", () => {
   }) => {
     for (const width of [280, 320]) {
       await page.setViewportSize({ width, height: 900 });
-      await gotoAndWaitForReady(page, "/?tab=bus");
+      await gotoAndWaitForReady(page, "/bus");
       const summary = page.getByTestId("bus-compact-summary");
       await expect(summary).toBeVisible();
 

--- a/tests/e2e/src/app/dashboard/[tab]/test.ts
+++ b/tests/e2e/src/app/dashboard/[tab]/test.ts
@@ -134,7 +134,7 @@ for (const locale of ["zh-cn", "en-us"] as const) {
 
 test("查询参数别名永久跳转后使用规范化的工作台页面身份", async ({ page }) => {
   await setLocale(page, "zh-cn");
-  await signInAsDebugUser(page, "/dashboard?tab=todos");
+  await signInAsDebugUser(page, "/dashboard/todos");
   await gotoAndWaitForReady(page, "/dashboard?tab=todos");
 
   await expect(page).toHaveURL(/\/dashboard\/todos$/);

--- a/tests/e2e/src/app/dashboard/[tab]/test.ts
+++ b/tests/e2e/src/app/dashboard/[tab]/test.ts
@@ -132,10 +132,11 @@ for (const locale of ["zh-cn", "en-us"] as const) {
   });
 }
 
-test("查询参数别名使用规范化后的工作台页面身份", async ({ page }) => {
+test("查询参数别名永久跳转后使用规范化的工作台页面身份", async ({ page }) => {
   await setLocale(page, "zh-cn");
   await signInAsDebugUser(page, "/dashboard?tab=todos");
   await gotoAndWaitForReady(page, "/dashboard?tab=todos");
 
+  await expect(page).toHaveURL(/\/dashboard\/todos$/);
   await expectDashboardPageIdentity(page, "zh-cn", "待办");
 });

--- a/tests/e2e/src/app/dashboard/calendar/test.ts
+++ b/tests/e2e/src/app/dashboard/calendar/test.ts
@@ -17,7 +17,7 @@
  * - Copy calendar link button (iCal)
  *
  * ## Edge Cases
- * - Unauthenticated → public links view (calendar auth-only)
+ * - Unauthenticated legacy tab → protected semantic route, then sign-in
  * - Different layout per view mode
  */
 import { expect, test } from "@playwright/test";
@@ -28,28 +28,32 @@ import { captureStepScreenshot } from "../../../../utils/screenshot";
 import { ensureSeedSectionSubscription } from "../../../../utils/subscriptions";
 
 test.describe("仪表盘日历", () => {
-  test("未登录 ?tab=calendar 显示公共视图", async ({ page }, testInfo) => {
-    await gotoAndWaitForReady(page, "/?tab=calendar", {
-      testInfo,
-      screenshotLabel: "calendar",
-    });
+  test("未登录旧 calendar tab 重定向到语义路径", async ({ page }) => {
+    const response = await page.request.get(
+      "/?tab=calendar&calendarView=week",
+      {
+        maxRedirects: 0,
+      },
+    );
 
-    await expect(page).toHaveURL(/\/\?tab=calendar$/);
-    await expect(page.locator("#main-content")).toBeVisible();
+    expect(response.status()).toBe(308);
+    expect(response.headers().location).toBe(
+      "/dashboard/calendar?calendarView=week",
+    );
+  });
 
-    // Public view: links/bus tabs, sign-in CTA
-    await expect(
-      page.getByRole("link", { name: /^(网站|Websites)$/i }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("link", { name: /^(登录|Sign in)$/i }).first(),
-    ).toBeVisible();
-    // Calendar tab NOT in public nav
-    await expect(
-      page.getByRole("link", { name: /^(日历|Calendar)$/i }),
-    ).toHaveCount(0);
+  test("dashboard 查询 tab 也仅作为永久兼容入口", async ({ page }) => {
+    const response = await page.request.get(
+      "/dashboard?tab=calendar&calendarView=week",
+      {
+        maxRedirects: 0,
+      },
+    );
 
-    await captureStepScreenshot(page, testInfo, "calendar/unauthenticated");
+    expect(response.status()).toBe(308);
+    expect(response.headers().location).toBe(
+      "/dashboard/calendar?calendarView=week",
+    );
   });
 
   test("登录后显示日历，包含班级事件链接和星期标签", async ({

--- a/tests/e2e/src/app/dashboard/exams/test.ts
+++ b/tests/e2e/src/app/dashboard/exams/test.ts
@@ -15,7 +15,7 @@
  * - Completed vs incomplete: exam end time vs now
  *
  * ## Edge Cases
- * - Unauthenticated → public links view (no exams tab)
+ * - Unauthenticated legacy tab → protected semantic route, then sign-in
  * - Exams without a date appear after dated exams
  * - Empty state when no subscriptions or no exams
  */
@@ -27,30 +27,13 @@ import { captureStepScreenshot } from "../../../../utils/screenshot";
 import { ensureSeedSectionSubscription } from "../../../../utils/subscriptions";
 
 test.describe("仪表盘考试", () => {
-  test("未登录 ?tab=exams 显示公共视图（无考试标签）", async ({
-    page,
-  }, testInfo) => {
-    await gotoAndWaitForReady(page, "/?tab=exams", {
-      testInfo,
-      screenshotLabel: "exams",
+  test("未登录旧 exams tab 重定向到语义路径", async ({ page }) => {
+    const response = await page.request.get("/?tab=exams&examView=list", {
+      maxRedirects: 0,
     });
 
-    await expect(page).toHaveURL(/\/\?tab=exams$/);
-    await expect(page.locator("#main-content")).toBeVisible();
-
-    // Public view: sign-in CTA, no auth-only tabs
-    await expect(
-      page.getByRole("link", { name: /^(网站|Websites)$/i }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("link", { name: /^(登录|Sign in)$/i }).first(),
-    ).toBeVisible();
-    // Exams tab should NOT appear in public nav
-    await expect(
-      page.getByRole("link", { name: /^(考试|Exams)$/i }),
-    ).toHaveCount(0);
-
-    await captureStepScreenshot(page, testInfo, "exams/unauthenticated");
+    expect(response.status()).toBe(308);
+    expect(response.headers().location).toBe("/dashboard/exams?examView=list");
   });
 
   test("登录后显示考试筛选工具栏和卡片", async ({ page }, testInfo) => {

--- a/tests/e2e/src/app/dashboard/homeworks/test.ts
+++ b/tests/e2e/src/app/dashboard/homeworks/test.ts
@@ -17,7 +17,7 @@
  * - Create homework button → modal form
  *
  * ## Edge Cases
- * - Unauthenticated → public links view (homeworks tab auth-only)
+ * - Unauthenticated legacy tab → protected semantic route, then sign-in
  * - Completion toggle calls PUT /api/homeworks/{id}/completion
  * - Empty state when filter yields no results
  */
@@ -32,28 +32,29 @@ import { ensureSeedSectionSubscription } from "../../../../utils/subscriptions";
 test.describe("仪表盘作业", () => {
   test.describe.configure({ mode: "serial" });
 
-  test("未登录 ?tab=homeworks 回退到公共视图", async ({ page }, testInfo) => {
-    await gotoAndWaitForReady(page, "/?tab=homeworks", {
-      testInfo,
-      screenshotLabel: "homeworks",
+  test("未登录旧 homework tab 重定向到语义路径", async ({ page }) => {
+    const response = await page.request.get(
+      "/?tab=homeworks&homeworkView=list",
+      {
+        maxRedirects: 0,
+      },
+    );
+
+    expect(response.status()).toBe(308);
+    expect(response.headers().location).toBe(
+      "/dashboard/homeworks?homeworkView=list",
+    );
+  });
+
+  test("未登录语义路径要求登录", async ({ page }) => {
+    const response = await page.request.get("/dashboard/homeworks", {
+      maxRedirects: 0,
     });
 
-    await expect(page).toHaveURL(/\/\?tab=homeworks$/);
-    await expect(page.locator("#main-content")).toBeVisible();
-
-    // Public view: sign-in CTA visible, no auth-only tabs
-    await expect(
-      page.getByRole("link", { name: /^(登录|Sign in)$/i }).first(),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("link", { name: /^(网站|Websites)$/i }),
-    ).toBeVisible();
-    // Homeworks tab NOT in public nav
-    await expect(
-      page.getByRole("link", { name: /^(作业|Homework)$/i }),
-    ).toHaveCount(0);
-
-    await captureStepScreenshot(page, testInfo, "homeworks/unauthenticated");
+    expect(response.status()).toBe(303);
+    expect(response.headers().location).toBe(
+      "/signin?callbackUrl=%2Fdashboard%2Fhomeworks",
+    );
   });
 
   test("登录后显示种子作业及所有必填字段", async ({ page }, testInfo) => {

--- a/tests/e2e/src/app/dashboard/links/test.ts
+++ b/tests/e2e/src/app/dashboard/links/test.ts
@@ -44,12 +44,16 @@ async function setLocale(page: Page, locale: "en-us" | "zh-cn") {
 }
 
 test.describe("仪表盘网站链接", () => {
-  test("公共 ?tab=links 显示搜索和链接，无置顶控件", async ({
-    page,
-  }, testInfo) => {
+  test("公共 /links 显示搜索和链接，无置顶控件", async ({ page }, testInfo) => {
     await setLocale(page, "zh-cn");
-    await gotoAndWaitForReady(page, "/?tab=links");
+    const response = await gotoAndWaitForReady(page, "/links");
 
+    expect(response?.status()).toBe(200);
+    await expect(page).toHaveURL(/\/links$/);
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      /\/links$/,
+    );
     const searchInput = page.getByRole("searchbox", {
       name: /搜索网站名称或描述|Search by name or description/i,
     });
@@ -66,10 +70,22 @@ test.describe("仪表盘网站链接", () => {
     await captureStepScreenshot(page, testInfo, "public-dashboard-links-tab");
   });
 
-  test("公共英文链接标签在搜索中使用本地化标题", async ({ page }, testInfo) => {
+  test("旧版 links 查询标签永久重定向到语义路径", async ({ page }) => {
+    const response = await page.request.get(
+      "/?tab=links&linkView=list&utm_source=bookmark",
+      { maxRedirects: 0 },
+    );
+
+    expect(response.status()).toBe(308);
+    expect(response.headers().location).toBe(
+      "/links?linkView=list&utm_source=bookmark",
+    );
+  });
+
+  test("公共英文链接页面在搜索中使用本地化标题", async ({ page }, testInfo) => {
     await setLocale(page, "en-us");
 
-    await gotoAndWaitForReady(page, "/?tab=links");
+    await gotoAndWaitForReady(page, "/links");
 
     const searchInput = page.getByRole("searchbox", {
       name: /Search by name or description/i,

--- a/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
+++ b/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
@@ -67,25 +67,15 @@ test.describe("仪表盘关注班级", () => {
     await expect(page).toHaveURL(/\/dashboard\/subscriptions(?:\?.*)?$/);
   });
 
-  test("未登录 ?tab=subscriptions 回退到公共视图", async ({
-    page,
-  }, testInfo) => {
-    await gotoAndWaitForReady(page, "/?tab=subscriptions");
+  test("未登录旧 subscriptions tab 重定向到语义路径", async ({ page }) => {
+    const response = await page.request.get(
+      "/?tab=subscriptions&semester=2026-spring",
+      { maxRedirects: 0 },
+    );
 
-    await expect(page).toHaveURL(/\/\?tab=subscriptions$/);
-    await expect(page.locator("#main-content")).toBeVisible();
-
-    await expect(
-      page.getByRole("link", { name: /^(网站|Websites)$/i }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("link", { name: /^(登录|Sign in)$/i }).first(),
-    ).toBeVisible();
-
-    await captureStepScreenshot(
-      page,
-      testInfo,
-      "dashboard-subscriptions-unauthorized",
+    expect(response.status()).toBe(308);
+    expect(response.headers().location).toBe(
+      "/dashboard/subscriptions?semester=2026-spring",
     );
   });
 

--- a/tests/e2e/src/app/dashboard/test.ts
+++ b/tests/e2e/src/app/dashboard/test.ts
@@ -14,7 +14,7 @@
  * - User menu visible when authenticated; sign-in CTA when not
  *
  * ## Edge Cases
- * - `?tab=homeworks` for unauthenticated users falls back to public bus tab
+ * - Recognized legacy `?tab=` values permanently redirect to semantic routes
  * - Invalid `?tab=` values default to "overview" (auth) or "bus" (public)
  */
 import { expect, test } from "@playwright/test";
@@ -30,29 +30,18 @@ import { captureStepScreenshot } from "../../../utils/screenshot";
 import { ensureSeedSectionSubscription } from "../../../utils/subscriptions";
 
 test.describe("仪表盘", () => {
-  test("未登录 ?tab=homeworks 显示公共校车视图", async ({ page }, testInfo) => {
-    await gotoAndWaitForReady(page, "/?tab=homeworks", {
-      testInfo,
-      screenshotLabel: "dashboard",
-    });
+  test("未登录旧 homework tab 永久重定向到受保护语义路径", async ({ page }) => {
+    const response = await page.request.get(
+      "/?tab=homeworks&homeworkView=list",
+      {
+        maxRedirects: 0,
+      },
+    );
 
-    await expect(page).toHaveURL(/\/\?tab=homeworks$/);
-    await expect(page.locator("#app-logo")).toBeVisible();
-
-    // Public view shows bus + links entries and sign-in CTA
-    await expect(
-      page.getByRole("link", { name: /^(校车|Shuttle Bus)$/i }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("link", { name: /^(登录|Sign in)$/i }).first(),
-    ).toBeVisible();
-
-    // Auth-only dashboard entries should not be present
-    await expect(
-      page.getByRole("link", { name: /^(总览|Overview)$/i }),
-    ).toHaveCount(0);
-
-    await captureStepScreenshot(page, testInfo, "home-public-with-tab");
+    expect(response.status()).toBe(308);
+    expect(response.headers().location).toBe(
+      "/dashboard/homeworks?homeworkView=list",
+    );
   });
 
   test("登录后首页显示总览、所有标签和种子数据", async ({ page }, testInfo) => {

--- a/tests/e2e/src/app/dashboard/todos/test.ts
+++ b/tests/e2e/src/app/dashboard/todos/test.ts
@@ -15,34 +15,23 @@
  * - Todo cards display priority badges (high/medium/low)
  *
  * ## Edge Cases
- * - Unauthenticated users see the public dashboard view (todos tab is auth-only)
+ * - Unauthenticated legacy tab → protected semantic route, then sign-in
  * - Optimistic updates via useOptimistic for toggle/delete/add
  * - Empty state shown when filter yields no matching todos
  */
 import { expect, test } from "@playwright/test";
 import { signInAsDebugUser } from "../../../../utils/auth";
 import { DEV_SEED } from "../../../../utils/dev-seed";
-import { gotoAndWaitForReady } from "../../../../utils/page-ready";
 import { captureStepScreenshot } from "../../../../utils/screenshot";
 
 test.describe("仪表盘待办", () => {
-  test("未登录 ?tab=todos 回退到公共视图", async ({ page }, testInfo) => {
-    await gotoAndWaitForReady(page, "/?tab=todos", {
-      testInfo,
-      screenshotLabel: "todos",
+  test("未登录旧 todos tab 重定向到语义路径", async ({ page }) => {
+    const response = await page.request.get("/?tab=todos&todoView=list", {
+      maxRedirects: 0,
     });
 
-    await expect(page).toHaveURL(/\/\?tab=todos$/);
-    await expect(page.locator("#main-content")).toBeVisible();
-
-    await expect(
-      page.getByRole("link", { name: /^(网站|Websites)$/i }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("link", { name: /^(登录|Sign in)$/i }).first(),
-    ).toBeVisible();
-
-    await captureStepScreenshot(page, testInfo, "dashboard-todos-unauthorized");
+    expect(response.status()).toBe(308);
+    expect(response.headers().location).toBe("/dashboard/todos?todoView=list");
   });
 
   test("登录后显示种子待办", async ({ page }, testInfo) => {

--- a/tests/e2e/src/app/test.ts
+++ b/tests/e2e/src/app/test.ts
@@ -20,9 +20,7 @@ test("/", async ({ page }, testInfo) => {
   await assertPageContract(page, { routePath: "/", testInfo });
 });
 
-test("/ 登录用户重定向至 dashboard 并仅保留支持的查询状态", async ({
-  page,
-}) => {
+test("/ 登录用户的旧 tab 永久重定向至语义 dashboard 路径", async ({ page }) => {
   await signInAsDebugUser(page, "/dashboard");
 
   const response = await page.request.get(
@@ -30,9 +28,9 @@ test("/ 登录用户重定向至 dashboard 并仅保留支持的查询状态", a
     { maxRedirects: 0 },
   );
 
-  expect(response.status()).toBe(303);
+  expect(response.status()).toBe(308);
   expect(response.headers().location).toBe(
-    "/dashboard?tab=calendar&calendarView=week&calendarSemester=42",
+    "/dashboard/calendar?calendarView=week&calendarSemester=42&utm_source=ignored",
   );
 });
 
@@ -41,7 +39,7 @@ test("/ 首页快速入口可见", async ({ page }, testInfo) => {
 
   await expect(page.locator("#app-logo")).toBeVisible();
   await expect(page.locator("#app-user-menu")).toHaveCount(0);
-  // Bus is the default public tab; both bus and links tabs are visible in nav
+  // Bus is the default public tab; both bus and links destinations are visible.
   await expect(
     page.getByRole("link", { name: /^(校车|Shuttle Bus)$/i }),
   ).toBeVisible();

--- a/tests/unit/dashboard-nav.test.ts
+++ b/tests/unit/dashboard-nav.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { dashboardRedirectHrefFromHome } from "@/features/dashboard/lib/dashboard-nav";
+import {
+  dashboardRedirectHrefFromHome,
+  dashboardTabCompatibilityRedirectHref,
+  homeTabCompatibilityRedirectHref,
+} from "@/features/dashboard/lib/dashboard-nav";
 
 describe("dashboardRedirectHrefFromHome", () => {
   it("preserves supported dashboard state and drops unrelated query values", () => {
@@ -8,7 +12,7 @@ describe("dashboardRedirectHrefFromHome", () => {
     );
 
     expect(dashboardRedirectHrefFromHome(url)).toBe(
-      "/dashboard?tab=calendar&calendarView=week&calendarSemester=42",
+      "/dashboard/calendar?calendarView=week&calendarSemester=42",
     );
   });
 
@@ -19,6 +23,52 @@ describe("dashboardRedirectHrefFromHome", () => {
 
     expect(dashboardRedirectHrefFromHome(url)).toBe(
       "/dashboard?homeworkView=completed&removed=3",
+    );
+  });
+});
+
+describe("homeTabCompatibilityRedirectHref", () => {
+  it("maps anonymous public tabs to semantic public routes", () => {
+    const url = new URL(
+      "https://example.test/?tab=links&linkView=list&utm_source=bookmark",
+    );
+
+    expect(homeTabCompatibilityRedirectHref(url, false)).toBe(
+      "/links?linkView=list&utm_source=bookmark",
+    );
+  });
+
+  it("maps signed-in public tabs to their workspace routes", () => {
+    const url = new URL("https://example.test/?tab=bus");
+
+    expect(homeTabCompatibilityRedirectHref(url, true)).toBe("/dashboard/bus");
+  });
+
+  it("maps authenticated-only tabs to their protected semantic routes", () => {
+    const url = new URL(
+      "https://example.test/?tab=homeworks&homeworkView=list",
+    );
+
+    expect(homeTabCompatibilityRedirectHref(url, false)).toBe(
+      "/dashboard/homeworks?homeworkView=list",
+    );
+  });
+
+  it("ignores unknown tab values", () => {
+    const url = new URL("https://example.test/?tab=unknown");
+
+    expect(homeTabCompatibilityRedirectHref(url, false)).toBeNull();
+  });
+});
+
+describe("dashboardTabCompatibilityRedirectHref", () => {
+  it("maps dashboard query tabs to semantic child routes", () => {
+    const url = new URL(
+      "https://example.test/dashboard?tab=calendar&calendarView=week",
+    );
+
+    expect(dashboardTabCompatibilityRedirectHref(url)).toBe(
+      "/dashboard/calendar?calendarView=week",
     );
   });
 });

--- a/tests/unit/dashboard-route-boundary.test.ts
+++ b/tests/unit/dashboard-route-boundary.test.ts
@@ -42,7 +42,7 @@ describe("anonymous home and signed dashboard route boundary", () => {
       signedIn: false,
     });
     const homeRoute = await import("@/routes/+page.server");
-    const event = routeEvent("https://example.test/?tab=bus");
+    const event = routeEvent("https://example.test/");
 
     await expect(homeRoute.load(event as never)).resolves.toMatchObject({
       marker: "anonymous",
@@ -57,21 +57,69 @@ describe("anonymous home and signed dashboard route boundary", () => {
     expect("actions" in homeRoute).toBe(false);
   });
 
-  it("redirects signed visitors to the dashboard with supported state only", async () => {
+  it("permanently redirects anonymous public tab bookmarks", async () => {
     const homeRoute = await import("@/routes/+page.server");
 
     await expect(
       homeRoute.load(
         routeEvent(
-          "https://example.test/?tab=calendar&calendarView=week&calendarSemester=42&utm_source=ignored",
+          "https://example.test/?tab=bus&utm_source=bookmark",
+        ) as never,
+      ),
+    ).rejects.toMatchObject({
+      location: "/bus?utm_source=bookmark",
+      status: 308,
+    });
+    expect(loadAnonymousHomePageMock).not.toHaveBeenCalled();
+    expect(loadSignedDashboardPageMock).not.toHaveBeenCalled();
+  });
+
+  it("permanently redirects signed legacy tabs to semantic workspace paths", async () => {
+    const homeRoute = await import("@/routes/+page.server");
+
+    await expect(
+      homeRoute.load(
+        routeEvent(
+          "https://example.test/?tab=calendar&calendarView=week&calendarSemester=42&utm_source=bookmark",
           "user-1",
         ) as never,
       ),
     ).rejects.toMatchObject({
-      location: "/dashboard?tab=calendar&calendarView=week&calendarSemester=42",
-      status: 303,
+      location:
+        "/dashboard/calendar?calendarView=week&calendarSemester=42&utm_source=bookmark",
+      status: 308,
     });
     expect(loadAnonymousHomePageMock).not.toHaveBeenCalled();
+    expect(loadSignedDashboardPageMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects a signed visitor without a legacy tab to the dashboard", async () => {
+    const homeRoute = await import("@/routes/+page.server");
+
+    await expect(
+      homeRoute.load(
+        routeEvent(
+          "https://example.test/?overviewWeek=next",
+          "user-1",
+        ) as never,
+      ),
+    ).rejects.toMatchObject({
+      location: "/dashboard?overviewWeek=next",
+      status: 303,
+    });
+  });
+
+  it("permanently redirects dashboard query tabs before auth handling", async () => {
+    const dashboardRoute = await import("@/routes/dashboard/+page.server");
+
+    await expect(
+      dashboardRoute.load(
+        routeEvent("https://example.test/dashboard?tab=overview") as never,
+      ),
+    ).rejects.toMatchObject({
+      location: "/dashboard/overview",
+      status: 308,
+    });
     expect(loadSignedDashboardPageMock).not.toHaveBeenCalled();
   });
 
@@ -80,10 +128,10 @@ describe("anonymous home and signed dashboard route boundary", () => {
 
     await expect(
       dashboardRoute.load(
-        routeEvent("https://example.test/dashboard?tab=overview") as never,
+        routeEvent("https://example.test/dashboard") as never,
       ),
     ).rejects.toMatchObject({
-      location: "/signin?callbackUrl=%2Fdashboard%3Ftab%3Doverview",
+      location: "/signin?callbackUrl=%2Fdashboard",
       status: 303,
     });
     expect(loadSignedDashboardPageMock).not.toHaveBeenCalled();
@@ -95,10 +143,7 @@ describe("anonymous home and signed dashboard route boundary", () => {
       signedIn: true,
     });
     const dashboardRoute = await import("@/routes/dashboard/+page.server");
-    const event = routeEvent(
-      "https://example.test/dashboard?tab=overview",
-      "user-1",
-    );
+    const event = routeEvent("https://example.test/dashboard", "user-1");
 
     await expect(dashboardRoute.load(event as never)).resolves.toMatchObject({
       marker: "signed",

--- a/tests/unit/public-page-load.test.ts
+++ b/tests/unit/public-page-load.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getBusTabDataMock, getPublicDashboardLinksDataMock } = vi.hoisted(
+  () => ({
+    getBusTabDataMock: vi.fn(),
+    getPublicDashboardLinksDataMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/features/dashboard/server/dashboard-tab-data", () => ({
+  getBusTabData: getBusTabDataMock,
+}));
+
+vi.mock("@/features/dashboard-links/server/dashboard-link-data", () => ({
+  getPublicDashboardLinksData: getPublicDashboardLinksDataMock,
+}));
+
+import { loadPublicBusPage } from "@/features/dashboard/server/public-bus-page-load";
+import { loadPublicLinksPage } from "@/features/dashboard/server/public-links-page-load";
+
+const url = new URL("https://example.test/");
+const event = {
+  locals: {
+    locale: "en-us" as const,
+    requestId: "request-1",
+  },
+  request: new Request(url),
+  url,
+};
+
+describe("public page loaders", () => {
+  beforeEach(() => {
+    getBusTabDataMock.mockReset();
+    getPublicDashboardLinksDataMock.mockReset();
+  });
+
+  it("loads only bus data for the public bus page", async () => {
+    getBusTabDataMock.mockResolvedValue({ data: { routes: [] } });
+
+    const result = await loadPublicBusPage(event);
+
+    expect(result.bus).toEqual({ routes: [] });
+    expect(getBusTabDataMock).toHaveBeenCalledWith(null, "en-us");
+    expect(getPublicDashboardLinksDataMock).not.toHaveBeenCalled();
+  });
+
+  it("loads only public links for the public links page", async () => {
+    getPublicDashboardLinksDataMock.mockResolvedValue({
+      dashboardLinks: [{ slug: "jw" }],
+    });
+
+    const result = await loadPublicLinksPage(event);
+
+    expect(result.publicLinks).toEqual([{ slug: "jw" }]);
+    expect(getPublicDashboardLinksDataMock).toHaveBeenCalledWith("en-us");
+    expect(getBusTabDataMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/public-semantic-route.test.ts
+++ b/tests/unit/public-semantic-route.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { loadPublicBusPageMock, loadPublicLinksPageMock } = vi.hoisted(() => ({
+  loadPublicBusPageMock: vi.fn(),
+  loadPublicLinksPageMock: vi.fn(),
+}));
+
+vi.mock("@/features/dashboard/server/public-bus-page-load", () => ({
+  loadPublicBusPage: loadPublicBusPageMock,
+}));
+
+vi.mock("@/features/dashboard/server/public-links-page-load", () => ({
+  loadPublicLinksPage: loadPublicLinksPageMock,
+}));
+
+function routeEvent(pathname: string) {
+  const url = new URL(pathname, "https://life.example");
+  return {
+    locals: { locale: "en-us" },
+    parent: vi.fn().mockResolvedValue({
+      socialMetadata: {
+        canonicalUrl: `https://life.example${pathname}`,
+        description: "Life@USTC",
+        title: "Life@USTC",
+      },
+    }),
+    request: new Request(url),
+    url,
+  };
+}
+
+describe("public semantic page routes", () => {
+  afterEach(() => {
+    loadPublicBusPageMock.mockReset();
+    loadPublicLinksPageMock.mockReset();
+  });
+
+  it("loads only the public bus page and exposes route-specific metadata", async () => {
+    loadPublicBusPageMock.mockResolvedValue({
+      bus: { routes: [] },
+      copy: {
+        dashboard: {
+          nav: {
+            bus: {
+              description: "Find the next shuttle",
+              title: "Shuttle Bus",
+            },
+          },
+        },
+      },
+    });
+    const route = await import("@/routes/bus/+page.server");
+    const event = routeEvent("/bus");
+
+    await expect(route.load(event as never)).resolves.toMatchObject({
+      bus: { routes: [] },
+      socialMetadata: {
+        canonicalUrl: "https://life.example/bus",
+        description: "Find the next shuttle",
+        title: "Shuttle Bus - Life@USTC",
+      },
+    });
+    expect(loadPublicBusPageMock).toHaveBeenCalledWith({
+      locals: event.locals,
+      request: event.request,
+      url: event.url,
+    });
+    expect(loadPublicLinksPageMock).not.toHaveBeenCalled();
+  });
+
+  it("loads only the public links page and exposes route-specific metadata", async () => {
+    loadPublicLinksPageMock.mockResolvedValue({
+      copy: {
+        dashboard: {
+          nav: {
+            links: {
+              description: "Search campus links",
+              title: "Websites",
+            },
+          },
+        },
+      },
+      publicLinks: [],
+    });
+    const route = await import("@/routes/links/+page.server");
+    const event = routeEvent("/links");
+
+    await expect(route.load(event as never)).resolves.toMatchObject({
+      publicLinks: [],
+      socialMetadata: {
+        canonicalUrl: "https://life.example/links",
+        description: "Search campus links",
+        title: "Websites - Life@USTC",
+      },
+    });
+    expect(loadPublicLinksPageMock).toHaveBeenCalledWith({
+      locals: event.locals,
+      request: event.request,
+      url: event.url,
+    });
+    expect(loadPublicBusPageMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/sitemap-route.test.ts
+++ b/tests/unit/sitemap-route.test.ts
@@ -56,6 +56,8 @@ describe("sitemap route", () => {
       "https://life.example/courses",
       "https://life.example/sections",
       "https://life.example/teachers",
+      "https://life.example/bus",
+      "https://life.example/links",
       "https://life.example/bus-map",
       "https://life.example/api/docs/tag/sections",
       "https://life.example/privacy",


### PR DESCRIPTION
## Goal

Replace query-selected public/dashboard tabs with stable semantic routes while keeping old bookmarks compatible.

Part of #544

## Changed Surfaces

- Add canonical public pages at `/bus` and `/links`, reusing the existing `BusTab` and `AnonymousLinksTab` implementations.
- Permanently redirect known legacy `/?tab=...` and `/dashboard?tab=...` requests to semantic paths, preserving unrelated query state.
- Point shell navigation and the sitemap at semantic public paths.
- Keep the anonymous `/` page and its existing data/loading behavior unchanged in this PR.

## Evidence

- `bunx biome check` (passes; one pre-existing unused-parameter warning in `src/static-loader/import.ts`)
- `bunx svelte-check --tsconfig ./tsconfig.json`
- all three TypeScript typecheck projects
- `bunx vitest run` — 209 files, 1237 tests passed
- integration suite — 32 files, 183 tests passed against an isolated PostgreSQL database
- `bun run build`
- focused Playwright route/UI regression — 97 tests passed
- inspected desktop/mobile `/bus` and `/links` rendering and browser console; no console issues or horizontal overflow

## Docs / Contracts

Updated bus, dashboard-link, overview, homework, todo, exam, and subscription contracts to make semantic pages canonical and document the compatibility redirect.

## Risk Areas

- Known legacy tab values now return HTTP 308 before auth handling. Unknown tab values retain their existing fallback behavior.
- Signed-in public-tab bookmarks continue to land on `/dashboard/bus` or `/dashboard/links`.
- No API, MCP, GraphQL, database, auth, or migration behavior changes.

## Cleanup

No generated files, screenshots, traces, scratch artifacts, or unrelated refactors are included. Production scope is 12 files.
