### PR TITLE
feat(graphql): add personal batch mutations

### DIFF
--- a/docs/contracts/graphql.json
+++ b/docs/contracts/graphql.json
@@ -8,6 +8,7 @@
   },
   "rules": {
     "scoped-mutations": "Every personal mutation requires authentication, the matching feature:write OAuth scope for bearer callers, and the shared per-user mutation rate-limit action key used by REST and MCP. Trusted session callers receive the equivalent first-party access.",
+    "batch-mutations": "Todo and homework batches preserve REST per-item partial-success results. Section subscription batches reuse the shared transaction-aware service. Every GraphQL batch uses the stricter feature:batch-write rate-limit budget, rejects duplicate targets before writing, and relies on GraphQL input coercion to reject unknown fields and non-null ambiguity.",
     "single-endpoint": "GraphQL HTTP requests use /api/graphql with GET, POST, and OPTIONS handlers.",
     "production-discovery": "GraphiQL and schema introspection are disabled in production.",
     "request-budgets": "Requests are limited to 64 KiB, one operation per HTTP request, five seconds, depth 8, 10 top-level fields, 15 aliases, 10 directives, 1000 tokens, and cost 5000; operation cost weights every paginated selection by its effective pageSize, including values supplied through variables.",
@@ -31,7 +32,7 @@
           "/api/graphql",
           "Public semester, course, section, teacher, and bus queries",
           "Authenticated Viewer reads with exact feature:read scopes",
-          "Authenticated todo and homework CRUD, homework completion, section subscription, dashboard pin, bus preference, description, and comment mutations",
+          "Authenticated todo and homework CRUD, todo/homework completion batches, section subscription batches, dashboard pin, bus preference, description, and comment mutations",
           "GET, POST, and OPTIONS",
           "GraphQL-audience bearer tokens require matching feature scopes; MCP exposes metadata resources only"
         ]

--- a/docs/contracts/homework.json
+++ b/docs/contracts/homework.json
@@ -273,6 +273,18 @@
             "required_scopes": ["homework:write"],
             "rest_equivalent": "PUT /api/homeworks/[id]/completion",
             "mcp_equivalent": "set_my_homework_completion"
+          },
+          {
+            "name": "setHomeworkCompletions",
+            "returns": "HomeworkCompletionBatchPayload!",
+            "auth": "user",
+            "required_scopes": ["homework:write"],
+            "rest_equivalent": "PUT /api/homeworks/completions",
+            "mcp_equivalent": "set_my_homework_completion",
+            "notes": [
+              "Accepts 1-100 unique homework IDs and preserves REST per-item partial-success semantics.",
+              "Missing or deleted homework IDs are reported on their result item without aborting valid updates."
+            ]
           }
         ]
       },

--- a/docs/contracts/subscription.json
+++ b/docs/contracts/subscription.json
@@ -79,6 +79,23 @@
       "web": {
         "pages": ["/dashboard/subscriptions", "/?tab=subscriptions", "/welcome"]
       },
+      "graphql": {
+        "mutations": [
+          {
+            "name": "updateSectionSubscriptions",
+            "returns": "SectionSubscriptionBatchPayload!",
+            "auth": "user",
+            "required_scopes": ["subscription:write"],
+            "rest_equivalent": "POST /api/calendar-subscriptions/batch",
+            "mcp_equivalent": "subscribe_my_sections_by_codes",
+            "notes": [
+              "Accepts at most 500 unique public section/course codes; internal section IDs are intentionally not exposed.",
+              "ADD and REMOVE require at least one code. SET requires semesterId and may use an empty code list to clear only that semester.",
+              "Unknown codes remain successful unmatchedCodes results, matching REST preview-and-apply semantics."
+            ]
+          }
+        ]
+      },
       "rest": {
         "routes": [
           {

--- a/docs/contracts/todo.json
+++ b/docs/contracts/todo.json
@@ -61,6 +61,29 @@
             "required_scopes": ["todo:write"],
             "rest_equivalent": "DELETE /api/todos/[id]",
             "mcp_equivalent": "delete_my_todo"
+          },
+          {
+            "name": "setTodoCompletions",
+            "returns": "TodoCompletionBatchPayload!",
+            "auth": "user",
+            "required_scopes": ["todo:write"],
+            "rest_equivalent": "PATCH /api/todos/batch",
+            "mcp_equivalent": "update_my_todo",
+            "notes": [
+              "Accepts 1-100 unique todo IDs and preserves REST per-item partial-success semantics.",
+              "Missing and non-owned todos are reported on their result item without aborting valid updates."
+            ]
+          },
+          {
+            "name": "deleteTodos",
+            "returns": "TodoDeleteBatchPayload!",
+            "auth": "user",
+            "required_scopes": ["todo:write"],
+            "rest_equivalent": "DELETE /api/todos/batch",
+            "mcp_equivalent": "delete_my_todo",
+            "notes": [
+              "Accepts 1-100 unique todo IDs and preserves REST per-item partial-success semantics."
+            ]
           }
         ]
       },

--- a/docs/graphql/mutation-capabilities.json
+++ b/docs/graphql/mutation-capabilities.json
@@ -1,0 +1,268 @@
+{
+  "schemaVersion": 1,
+  "scope": "Ordinary user and collaborative business writes. Authentication protocols, account security, admin governance, locale cookies, browser redirects, and raw R2 bytes require separate threat models or transports.",
+  "excludedFamilies": [
+    {
+      "id": "auth-and-account-security",
+      "reason": "OAuth consent, credentials, sessions, passkeys, and account lifecycle require the authorization-management threat model."
+    },
+    {
+      "id": "admin-governance",
+      "reason": "Admin mutations require an explicit governance and audit design before GraphQL exposure."
+    },
+    {
+      "id": "transport-only-writes",
+      "reason": "Locale cookies, redirects, OAuth protocol endpoints, MCP transport state, and raw R2 byte transfer are not GraphQL business commands."
+    }
+  ],
+  "capabilities": [
+    {
+      "id": "todo.create",
+      "rest": ["POST /api/todos"],
+      "graphql": { "status": "stable", "field": "createTodo" },
+      "mcp": { "status": "native", "tools": ["create_my_todo"] },
+      "semantics": "single"
+    },
+    {
+      "id": "todo.update",
+      "rest": ["PATCH /api/todos/[id]"],
+      "graphql": { "status": "stable", "field": "updateTodo" },
+      "mcp": { "status": "native", "tools": ["update_my_todo"] },
+      "semantics": "single"
+    },
+    {
+      "id": "todo.delete",
+      "rest": ["DELETE /api/todos/[id]"],
+      "graphql": { "status": "stable", "field": "deleteTodo" },
+      "mcp": { "status": "native", "tools": ["delete_my_todo"] },
+      "semantics": "single"
+    },
+    {
+      "id": "todo.set-completions-batch",
+      "rest": ["PATCH /api/todos/batch"],
+      "graphql": { "status": "stable", "field": "setTodoCompletions" },
+      "mcp": { "status": "single_item_only", "tools": ["update_my_todo"] },
+      "semantics": "per_item_partial"
+    },
+    {
+      "id": "todo.delete-batch",
+      "rest": ["DELETE /api/todos/batch"],
+      "graphql": { "status": "stable", "field": "deleteTodos" },
+      "mcp": { "status": "single_item_only", "tools": ["delete_my_todo"] },
+      "semantics": "per_item_partial"
+    },
+    {
+      "id": "homework.create",
+      "rest": ["POST /api/homeworks"],
+      "graphql": { "status": "stable", "field": "createHomework" },
+      "mcp": { "status": "native", "tools": ["create_homework_on_section"] },
+      "semantics": "single"
+    },
+    {
+      "id": "homework.update",
+      "rest": ["PATCH /api/homeworks/[id]"],
+      "graphql": { "status": "stable", "field": "updateHomework" },
+      "mcp": { "status": "native", "tools": ["update_homework_on_section"] },
+      "semantics": "single"
+    },
+    {
+      "id": "homework.delete",
+      "rest": ["DELETE /api/homeworks/[id]"],
+      "graphql": { "status": "stable", "field": "deleteHomework" },
+      "mcp": { "status": "native", "tools": ["delete_homework_on_section"] },
+      "semantics": "single_idempotent"
+    },
+    {
+      "id": "homework.set-completion",
+      "rest": ["PUT /api/homeworks/[id]/completion"],
+      "graphql": { "status": "stable", "field": "setHomeworkCompletion" },
+      "mcp": { "status": "native", "tools": ["set_my_homework_completion"] },
+      "semantics": "single"
+    },
+    {
+      "id": "homework.set-completions-batch",
+      "rest": ["PUT /api/homeworks/completions"],
+      "graphql": { "status": "stable", "field": "setHomeworkCompletions" },
+      "mcp": {
+        "status": "single_item_only",
+        "tools": ["set_my_homework_completion"]
+      },
+      "semantics": "per_item_partial"
+    },
+    {
+      "id": "subscription.subscribe-section",
+      "rest": [],
+      "graphql": { "status": "stable", "field": "subscribeSection" },
+      "mcp": { "status": "native", "tools": ["subscribe_section_by_jw_id"] },
+      "semantics": "single"
+    },
+    {
+      "id": "subscription.unsubscribe-section",
+      "rest": [],
+      "graphql": { "status": "stable", "field": "unsubscribeSection" },
+      "mcp": {
+        "status": "native",
+        "tools": ["unsubscribe_section_by_jw_id"]
+      },
+      "semantics": "single"
+    },
+    {
+      "id": "subscription.update-by-codes-batch",
+      "rest": [
+        "POST /api/calendar-subscriptions/batch",
+        "POST /api/calendar-subscriptions/import-codes"
+      ],
+      "graphql": {
+        "status": "stable",
+        "field": "updateSectionSubscriptions"
+      },
+      "mcp": {
+        "status": "partial",
+        "tools": ["subscribe_my_sections_by_codes"]
+      },
+      "semantics": "service_transaction_or_single_atomic_write"
+    },
+    {
+      "id": "dashboard.set-link-pin-state",
+      "rest": ["POST /api/dashboard-links/pin"],
+      "graphql": {
+        "status": "stable",
+        "field": "setDashboardLinkPinState"
+      },
+      "mcp": {
+        "status": "native",
+        "tools": ["set_dashboard_link_pin_state"]
+      },
+      "semantics": "single"
+    },
+    {
+      "id": "bus.save-preferences",
+      "rest": ["POST /api/bus/preferences"],
+      "graphql": { "status": "stable", "field": "saveBusPreferences" },
+      "mcp": { "status": "native", "tools": ["save_my_bus_preferences"] },
+      "semantics": "single"
+    },
+    {
+      "id": "description.upsert",
+      "rest": ["POST /api/descriptions"],
+      "graphql": { "status": "stable", "field": "upsertDescription" },
+      "mcp": { "status": "native", "tools": ["upsert_description"] },
+      "semantics": "single_audited"
+    },
+    {
+      "id": "comment.create",
+      "rest": ["POST /api/comments"],
+      "graphql": { "status": "stable", "field": "createComment" },
+      "mcp": { "status": "native", "tools": ["create_comment"] },
+      "semantics": "single_audited"
+    },
+    {
+      "id": "comment.update",
+      "rest": ["PATCH /api/comments/[id]"],
+      "graphql": { "status": "stable", "field": "updateComment" },
+      "mcp": { "status": "native", "tools": ["update_own_comment"] },
+      "semantics": "single_audited"
+    },
+    {
+      "id": "comment.delete",
+      "rest": ["DELETE /api/comments/[id]"],
+      "graphql": { "status": "stable", "field": "deleteComment" },
+      "mcp": { "status": "native", "tools": ["delete_own_comment"] },
+      "semantics": "single_audited"
+    },
+    {
+      "id": "comment.add-reaction",
+      "rest": ["POST /api/comments/[id]/reactions"],
+      "graphql": { "status": "stable", "field": "addCommentReaction" },
+      "mcp": { "status": "native", "tools": ["add_comment_reaction"] },
+      "semantics": "single_audited_idempotent"
+    },
+    {
+      "id": "comment.remove-reaction",
+      "rest": ["DELETE /api/comments/[id]/reactions"],
+      "graphql": { "status": "stable", "field": "removeCommentReaction" },
+      "mcp": { "status": "native", "tools": ["remove_comment_reaction"] },
+      "semantics": "single_audited_idempotent"
+    },
+    {
+      "id": "dashboard.set-link-pin-state-batch",
+      "rest": ["POST /api/dashboard-links/pin/batch"],
+      "graphql": { "status": "intentional_gap", "field": null },
+      "mcp": {
+        "status": "single_item_only",
+        "tools": ["set_dashboard_link_pin_state"]
+      },
+      "semantics": "ordered_non_atomic",
+      "notes": [
+        "The REST handler currently sequences single-item writes in the transport layer and returns only final state. Add a shared atomic or explicit per-item service before exposing GraphQL batch semantics."
+      ]
+    },
+    {
+      "id": "comment.delete-batch",
+      "rest": ["DELETE /api/comments/batch"],
+      "graphql": { "status": "intentional_gap", "field": null },
+      "mcp": {
+        "status": "single_item_only",
+        "tools": ["delete_own_comment"]
+      },
+      "semantics": "per_item_partial",
+      "notes": [
+        "A shared audited batch service is required before GraphQL exposure; the REST transport currently fans out the single audited mutation."
+      ]
+    },
+    {
+      "id": "upload.create-session",
+      "rest": ["POST /api/uploads"],
+      "graphql": { "status": "intentional_gap", "field": null },
+      "mcp": { "status": "unavailable", "tools": [] },
+      "semantics": "multi_step_storage_workflow",
+      "notes": [
+        "GraphQL may later initiate metadata workflow, but raw object transfer remains on the on-site R2 route."
+      ]
+    },
+    {
+      "id": "upload.complete",
+      "rest": ["POST /api/uploads/complete"],
+      "graphql": { "status": "intentional_gap", "field": null },
+      "mcp": { "status": "unavailable", "tools": [] },
+      "semantics": "multi_step_storage_workflow",
+      "notes": [
+        "Completion requires a dedicated GraphQL workflow contract and must not proxy object bytes."
+      ]
+    },
+    {
+      "id": "upload.rename",
+      "rest": ["PATCH /api/uploads/[id]"],
+      "graphql": { "status": "intentional_gap", "field": null },
+      "mcp": { "status": "native", "tools": ["rename_my_upload"] },
+      "semantics": "single_audited",
+      "notes": [
+        "Upload metadata mutations remain a focused follow-up after the storage workflow boundary is designed."
+      ]
+    },
+    {
+      "id": "upload.delete",
+      "rest": ["DELETE /api/uploads/[id]"],
+      "graphql": { "status": "intentional_gap", "field": null },
+      "mcp": { "status": "native", "tools": ["delete_my_upload"] },
+      "semantics": "storage_then_transactional_metadata_delete",
+      "notes": [
+        "The storage-delete-before-metadata invariant needs an explicit GraphQL failure contract."
+      ]
+    },
+    {
+      "id": "subscription.update-by-internal-ids",
+      "rest": [
+        "POST /api/calendar-subscriptions",
+        "PATCH /api/calendar-subscriptions",
+        "DELETE /api/calendar-subscriptions"
+      ],
+      "graphql": { "status": "intentional_gap", "field": null },
+      "mcp": { "status": "unavailable", "tools": [] },
+      "semantics": "compatibility_only",
+      "notes": [
+        "GraphQL uses public section JW IDs for single changes and public section/course codes for batches; database section IDs remain REST compatibility input only."
+      ]
+    }
+  ]
+}

--- a/docs/graphql/schema.graphql
+++ b/docs/graphql/schema.graphql
@@ -1,3 +1,14 @@
+type BatchMutationError {
+  code: BatchMutationErrorCode!
+  message: String!
+}
+
+enum BatchMutationErrorCode {
+  DELETED
+  FORBIDDEN
+  NOT_FOUND
+}
+
 type BusCampus {
   id: Int!
   latitude: Float!
@@ -256,6 +267,23 @@ type Homework {
   updatedAt: DateTime!
 }
 
+input HomeworkCompletionBatchItemInput {
+  completed: Boolean!
+  homeworkId: ID!
+}
+
+type HomeworkCompletionBatchPayload {
+  results: [HomeworkCompletionBatchResult!]!
+}
+
+type HomeworkCompletionBatchResult {
+  completed: Boolean!
+  completedAt: DateTime
+  error: BatchMutationError
+  homeworkId: ID!
+  success: Boolean!
+}
+
 type HomeworkCompletionMutationPayload {
   completed: Boolean!
   completedAt: DateTime
@@ -293,14 +321,18 @@ type Mutation {
   deleteComment(id: ID!): DeleteMutationPayload!
   deleteHomework(id: ID!): HomeworkDeleteMutationPayload!
   deleteTodo(id: ID!): DeleteMutationPayload!
+  deleteTodos(ids: [ID!]!): TodoDeleteBatchPayload!
   removeCommentReaction(commentId: ID!, type: CommentReactionType!): CommentReactionMutationPayload!
   saveBusPreferences(input: BusPreferenceInput!): BusPreferenceMutationPayload!
   setDashboardLinkPinState(pinned: Boolean!, slug: String!): DashboardLinkPinMutationPayload!
   setHomeworkCompletion(completed: Boolean!, homeworkId: ID!): HomeworkCompletionMutationPayload!
+  setHomeworkCompletions(items: [HomeworkCompletionBatchItemInput!]!): HomeworkCompletionBatchPayload!
+  setTodoCompletions(items: [TodoCompletionBatchItemInput!]!): TodoCompletionBatchPayload!
   subscribeSection(jwId: Int!): SectionSubscriptionMutationPayload!
   unsubscribeSection(jwId: Int!): SectionSubscriptionMutationPayload!
   updateComment(id: ID!, input: UpdateCommentInput!): CommentMutationPayload!
   updateHomework(id: ID!, input: UpdateHomeworkInput!): HomeworkMutationPayload!
+  updateSectionSubscriptions(input: UpdateSectionSubscriptionsInput!): SectionSubscriptionBatchPayload!
   updateTodo(id: ID!, input: UpdateTodoInput!): TodoMutationPayload!
   upsertDescription(input: UpsertDescriptionInput!): DescriptionMutationPayload!
 }
@@ -421,6 +453,23 @@ type SectionPage {
   pageInfo: PageInfo!
 }
 
+enum SectionSubscriptionBatchAction {
+  ADD
+  REMOVE
+  SET
+}
+
+type SectionSubscriptionBatchPayload {
+  action: SectionSubscriptionBatchAction!
+  addedCount: Int!
+  matchedCodes: [String!]!
+  removedCount: Int!
+  semesterId: Int
+  total: Int!
+  unchangedCount: Int!
+  unmatchedCodes: [String!]!
+}
+
 type SectionSubscriptionMutationPayload {
   sectionJwId: Int!
   subscribed: Boolean!
@@ -477,6 +526,33 @@ type Todo {
   updatedAt: DateTime!
 }
 
+input TodoCompletionBatchItemInput {
+  completed: Boolean!
+  todoId: ID!
+}
+
+type TodoCompletionBatchPayload {
+  results: [TodoCompletionBatchResult!]!
+}
+
+type TodoCompletionBatchResult {
+  completed: Boolean!
+  error: BatchMutationError
+  success: Boolean!
+  todo: Todo
+  todoId: ID!
+}
+
+type TodoDeleteBatchPayload {
+  results: [TodoDeleteBatchResult!]!
+}
+
+type TodoDeleteBatchResult {
+  error: BatchMutationError
+  id: ID!
+  success: Boolean!
+}
+
 input TodoFilter {
   completed: Boolean
   dueAfter: DateTime
@@ -514,6 +590,12 @@ input UpdateHomeworkInput {
   submissionDueAt: DateTime
   submissionStartAt: DateTime
   title: String
+}
+
+input UpdateSectionSubscriptionsInput {
+  action: SectionSubscriptionBatchAction!
+  codes: [String!]!
+  semesterId: Int
 }
 
 input UpdateTodoInput {

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ is the project map: start here, then follow the closest source of truth.
 - [docs/contracts/_product.json](contracts/_product.json) - product roles, workflow, and display conventions.
 - [docs/contracts/openapi.json](contracts/openapi.json) - OpenAPI contract surface.
 - [docs/contracts/graphql.json](contracts/graphql.json) - GraphQL contract surface.
+- [docs/graphql/mutation-capabilities.json](graphql/mutation-capabilities.json) - REST/GraphQL/MCP business-write parity matrix and intentional exclusions.
 - [docs/contracts/mcp.json](contracts/mcp.json) - MCP contract surface.
 - [docs/contracts/security.json](contracts/security.json) - security and permission expectations.
 - [docs/observability.md](observability.md) - production logs, metrics, alerts, and dashboard guidance.

--- a/src/lib/graphql/mutation-guard.ts
+++ b/src/lib/graphql/mutation-guard.ts
@@ -2,6 +2,7 @@ import type { RestFeature } from "@/lib/oauth/constants";
 import {
   checkUserMutationRateLimit,
   USER_MUTATION_RATE_LIMIT_PERIOD_SECONDS,
+  type UserMutationRateLimitTier,
 } from "@/lib/security/user-mutation-rate-limit";
 import { requireGraphqlScope } from "./auth";
 import type { GraphqlContext } from "./context";
@@ -10,14 +11,17 @@ import { GraphqlMutationError } from "./mutation-errors";
 export async function requireGraphqlMutation(
   context: Pick<GraphqlContext, "principal" | "request">,
   feature: RestFeature,
+  options: { rateLimitTier?: UserMutationRateLimitTier } = {},
 ) {
   const principal = requireGraphqlScope(context.principal, {
     feature,
     action: "write",
   });
+  const rateLimitTier = options.rateLimitTier ?? "write";
   const outcome = await checkUserMutationRateLimit({
-    action: `${feature}:write`,
+    action: `${feature}:${rateLimitTier === "batch" ? "batch-write" : "write"}`,
     host: new URL(context.request.url).host,
+    tier: rateLimitTier,
     userId: principal.userId,
   });
   if (outcome.allowed) return principal;

--- a/src/lib/graphql/mutation-input.ts
+++ b/src/lib/graphql/mutation-input.ts
@@ -88,6 +88,25 @@ export function rejectExplicitNullFields(
   }
 }
 
+export function requireMutationBatchSize(
+  values: readonly unknown[],
+  label: string,
+  max: number,
+) {
+  if (values.length < 1 || values.length > max) {
+    badMutationInput(`${label} must contain 1-${max} items.`);
+  }
+}
+
+export function rejectDuplicateMutationTargets(
+  values: readonly string[],
+  label: string,
+) {
+  if (new Set(values).size !== values.length) {
+    badMutationInput(`${label} must not contain duplicate targets.`);
+  }
+}
+
 export function dateTimeInput(value: string | null | undefined) {
   if (value == null) return value;
   return new Date(value);

--- a/src/lib/graphql/mutations.ts
+++ b/src/lib/graphql/mutations.ts
@@ -22,7 +22,10 @@ import {
   homeworkDescriptionInputSchema,
   homeworkTitleSchema,
 } from "@/features/homeworks/lib/homework-schema";
-import { setHomeworkCompletion } from "@/features/homeworks/server/homework-completion";
+import {
+  setHomeworkCompletion,
+  setHomeworkCompletions,
+} from "@/features/homeworks/server/homework-completion";
 import { createHomeworkForSection } from "@/features/homeworks/server/homework-create";
 import { homeworkDateError } from "@/features/homeworks/server/homework-dates";
 import {
@@ -34,7 +37,10 @@ import {
   buildHomeworkUpdateIntent,
   hasHomeworkUpdateIntentChanges,
 } from "@/features/homeworks/server/homework-update-intent";
-import { setUserSectionSubscriptionByJwId } from "@/features/subscriptions/server/subscriptions";
+import {
+  batchUpdateUserSectionSubscriptions,
+  setUserSectionSubscriptionByJwId,
+} from "@/features/subscriptions/server/subscriptions";
 import type { TodoPriorityValue } from "@/features/todos/lib/todo-priority";
 import {
   createTodo,
@@ -66,7 +72,9 @@ import {
   normalizeIdList,
   normalizeTodoContent,
   normalizeTodoTitle,
+  rejectDuplicateMutationTargets,
   rejectExplicitNullFields,
+  requireMutationBatchSize,
   requireMutationId,
 } from "./mutation-input";
 
@@ -102,6 +110,18 @@ export const graphqlMutationTypeDefs = /* GraphQL */ `
     HOMEWORK
   }
 
+  enum BatchMutationErrorCode {
+    NOT_FOUND
+    FORBIDDEN
+    DELETED
+  }
+
+  enum SectionSubscriptionBatchAction {
+    ADD
+    REMOVE
+    SET
+  }
+
   input CreateTodoInput {
     title: String!
     content: String
@@ -115,6 +135,22 @@ export const graphqlMutationTypeDefs = /* GraphQL */ `
     priority: TodoPriority
     dueAt: DateTime
     completed: Boolean
+  }
+
+  input TodoCompletionBatchItemInput {
+    todoId: ID!
+    completed: Boolean!
+  }
+
+  input HomeworkCompletionBatchItemInput {
+    homeworkId: ID!
+    completed: Boolean!
+  }
+
+  input UpdateSectionSubscriptionsInput {
+    action: SectionSubscriptionBatchAction!
+    codes: [String!]!
+    semesterId: Int
   }
 
   input CreateHomeworkInput {
@@ -181,6 +217,33 @@ export const graphqlMutationTypeDefs = /* GraphQL */ `
     id: ID!
   }
 
+  type BatchMutationError {
+    code: BatchMutationErrorCode!
+    message: String!
+  }
+
+  type TodoCompletionBatchResult {
+    success: Boolean!
+    todoId: ID!
+    completed: Boolean!
+    todo: Todo
+    error: BatchMutationError
+  }
+
+  type TodoCompletionBatchPayload {
+    results: [TodoCompletionBatchResult!]!
+  }
+
+  type TodoDeleteBatchResult {
+    success: Boolean!
+    id: ID!
+    error: BatchMutationError
+  }
+
+  type TodoDeleteBatchPayload {
+    results: [TodoDeleteBatchResult!]!
+  }
+
   type DeleteMutationPayload {
     id: ID!
     success: Boolean!
@@ -190,6 +253,18 @@ export const graphqlMutationTypeDefs = /* GraphQL */ `
     homeworkId: ID!
     completed: Boolean!
     completedAt: DateTime
+  }
+
+  type HomeworkCompletionBatchResult {
+    success: Boolean!
+    homeworkId: ID!
+    completed: Boolean!
+    completedAt: DateTime
+    error: BatchMutationError
+  }
+
+  type HomeworkCompletionBatchPayload {
+    results: [HomeworkCompletionBatchResult!]!
   }
 
   type HomeworkMutationPayload {
@@ -206,6 +281,17 @@ export const graphqlMutationTypeDefs = /* GraphQL */ `
   type SectionSubscriptionMutationPayload {
     sectionJwId: Int!
     subscribed: Boolean!
+  }
+
+  type SectionSubscriptionBatchPayload {
+    action: SectionSubscriptionBatchAction!
+    semesterId: Int
+    matchedCodes: [String!]!
+    unmatchedCodes: [String!]!
+    addedCount: Int!
+    removedCount: Int!
+    unchangedCount: Int!
+    total: Int!
   }
 
   type DashboardLinkPinMutationPayload {
@@ -241,6 +327,10 @@ export const graphqlMutationTypeDefs = /* GraphQL */ `
     createTodo(input: CreateTodoInput!): TodoMutationPayload!
     updateTodo(id: ID!, input: UpdateTodoInput!): TodoMutationPayload!
     deleteTodo(id: ID!): DeleteMutationPayload!
+    setTodoCompletions(
+      items: [TodoCompletionBatchItemInput!]!
+    ): TodoCompletionBatchPayload!
+    deleteTodos(ids: [ID!]!): TodoDeleteBatchPayload!
     createHomework(input: CreateHomeworkInput!): HomeworkMutationPayload!
     updateHomework(
       id: ID!
@@ -251,8 +341,14 @@ export const graphqlMutationTypeDefs = /* GraphQL */ `
       homeworkId: ID!
       completed: Boolean!
     ): HomeworkCompletionMutationPayload!
+    setHomeworkCompletions(
+      items: [HomeworkCompletionBatchItemInput!]!
+    ): HomeworkCompletionBatchPayload!
     subscribeSection(jwId: Int!): SectionSubscriptionMutationPayload!
     unsubscribeSection(jwId: Int!): SectionSubscriptionMutationPayload!
+    updateSectionSubscriptions(
+      input: UpdateSectionSubscriptionsInput!
+    ): SectionSubscriptionBatchPayload!
     setDashboardLinkPinState(
       slug: String!
       pinned: Boolean!
@@ -293,6 +389,24 @@ type UpdateTodoInput = {
   dueAt?: string | null;
   priority?: TodoPriorityValue | null;
   title?: string | null;
+};
+
+type TodoCompletionBatchItemInput = {
+  completed: boolean;
+  todoId: string;
+};
+
+type HomeworkCompletionBatchItemInput = {
+  completed: boolean;
+  homeworkId: string;
+};
+
+type SectionSubscriptionBatchAction = "add" | "remove" | "set";
+
+type UpdateSectionSubscriptionsInput = {
+  action: SectionSubscriptionBatchAction;
+  codes: string[];
+  semesterId?: number | null;
 };
 
 type CreateHomeworkInput = {
@@ -358,6 +472,18 @@ const descriptionTargetTypeResolver = {
   TEACHER: "teacher",
   HOMEWORK: "homework",
 } as const satisfies Record<string, DescriptionTargetType>;
+
+const batchMutationErrorCodeResolver = {
+  NOT_FOUND: "not_found",
+  FORBIDDEN: "forbidden",
+  DELETED: "deleted",
+} as const;
+
+const sectionSubscriptionBatchActionResolver = {
+  ADD: "add",
+  REMOVE: "remove",
+  SET: "set",
+} as const satisfies Record<string, SectionSubscriptionBatchAction>;
 
 function graphqlCommentAuditMetadata(request: Request) {
   return {
@@ -441,6 +567,35 @@ function normalizeHomeworkDescription(value: string | null | undefined) {
   return result.data;
 }
 
+function normalizeBatchIds(
+  values: readonly string[],
+  label: string,
+  max: number,
+) {
+  requireMutationBatchSize(values, label, max);
+  const ids = values.map((value) => requireMutationId(value, label));
+  rejectDuplicateMutationTargets(ids, label);
+  return ids;
+}
+
+function normalizeSubscriptionBatchCodes(values: readonly string[]) {
+  if (values.length > 500) {
+    badMutationInput("codes must contain at most 500 items.");
+  }
+  const codes = values.map((value) => {
+    const code = value.trim();
+    if (!code || code.length > 64) {
+      badMutationInput("codes must contain 1-64 character values.");
+    }
+    return code;
+  });
+  rejectDuplicateMutationTargets(
+    codes.map((code) => code.toUpperCase()),
+    "codes",
+  );
+  return codes;
+}
+
 async function setSectionSubscription(
   context: GraphqlContext,
   jwId: number,
@@ -457,10 +612,12 @@ async function setSectionSubscription(
 }
 
 export const graphqlMutationResolvers = {
+  BatchMutationErrorCode: batchMutationErrorCodeResolver,
   CommentVisibility: commentVisibilityResolver,
   CommentReactionType: commentReactionTypeResolver,
   CommentTargetType: commentTargetTypeResolver,
   DescriptionTargetType: descriptionTargetTypeResolver,
+  SectionSubscriptionBatchAction: sectionSubscriptionBatchActionResolver,
   Mutation: {
     async createTodo(
       _parent: unknown,
@@ -518,6 +675,72 @@ export const graphqlMutationResolvers = {
       const result = await deleteOwnedTodo(id, principal.userId);
       if (!result.ok) handleTodoFailure(result);
       return { id, success: true };
+    },
+    async setTodoCompletions(
+      _parent: unknown,
+      args: { items: TodoCompletionBatchItemInput[] },
+      context: GraphqlContext,
+    ) {
+      const principal = await requireGraphqlMutation(context, "todo", {
+        rateLimitTier: "batch",
+      });
+      const ids = normalizeBatchIds(
+        args.items.map((item) => item.todoId),
+        "todo IDs",
+        100,
+      );
+      const results = await Promise.all(
+        args.items.map(async (item, index) => {
+          const todoId = ids[index];
+          const result = await updateOwnedTodo({
+            id: todoId,
+            userId: principal.userId,
+            data: {
+              completed: item.completed,
+              dueAt: undefined,
+              hasDueAt: false,
+            },
+          });
+          if (!result.ok) {
+            return {
+              success: false as const,
+              todoId,
+              completed: item.completed,
+              error: { code: result.error, message: result.error },
+            };
+          }
+          return {
+            success: true as const,
+            todoId,
+            completed: item.completed,
+            todo: result.todo,
+          };
+        }),
+      );
+      return { results };
+    },
+    async deleteTodos(
+      _parent: unknown,
+      args: { ids: string[] },
+      context: GraphqlContext,
+    ) {
+      const principal = await requireGraphqlMutation(context, "todo", {
+        rateLimitTier: "batch",
+      });
+      const ids = normalizeBatchIds(args.ids, "todo IDs", 100);
+      const results = await Promise.all(
+        ids.map(async (id) => {
+          const result = await deleteOwnedTodo(id, principal.userId);
+          return result.ok
+            ? { success: true as const, id }
+            : {
+                success: false as const,
+                id,
+                error: { code: result.error, message: result.error },
+              };
+        }),
+      );
+      return { results };
     },
     async createHomework(
       _parent: unknown,
@@ -654,6 +877,27 @@ export const graphqlMutationResolvers = {
       if (!result.success) mutationNotFound("Homework not found.");
       return result;
     },
+    async setHomeworkCompletions(
+      _parent: unknown,
+      args: { items: HomeworkCompletionBatchItemInput[] },
+      context: GraphqlContext,
+    ) {
+      const principal = await requireGraphqlMutation(context, "homework", {
+        rateLimitTier: "batch",
+      });
+      const homeworkIds = normalizeBatchIds(
+        args.items.map((item) => item.homeworkId),
+        "homework IDs",
+        100,
+      );
+      return setHomeworkCompletions({
+        items: args.items.map((item, index) => ({
+          completed: item.completed,
+          homeworkId: homeworkIds[index],
+        })),
+        userId: principal.userId,
+      });
+    },
     subscribeSection(
       _parent: unknown,
       args: { jwId: number },
@@ -667,6 +911,47 @@ export const graphqlMutationResolvers = {
       context: GraphqlContext,
     ) {
       return setSectionSubscription(context, args.jwId, false);
+    },
+    async updateSectionSubscriptions(
+      _parent: unknown,
+      args: { input: UpdateSectionSubscriptionsInput },
+      context: GraphqlContext,
+    ) {
+      const principal = await requireGraphqlMutation(context, "subscription", {
+        rateLimitTier: "batch",
+      });
+      const input = args.input;
+      rejectExplicitNullFields(input, ["semesterId"]);
+      const codes = normalizeSubscriptionBatchCodes(input.codes);
+      if (input.action !== "set" && codes.length === 0) {
+        badMutationInput("codes must contain at least one item.");
+      }
+      const semesterId = validateOptionalGraphqlId(
+        input.semesterId,
+        "semesterId",
+      );
+      if (input.action === "set" && semesterId === undefined) {
+        badMutationInput("semesterId is required when action is SET.");
+      }
+
+      const result = await batchUpdateUserSectionSubscriptions({
+        action: input.action,
+        codes,
+        locale: context.locale,
+        semesterId,
+        userId: principal.userId,
+      });
+      if (!result) mutationNotFound("Semester not found.");
+      return {
+        action: result.action,
+        semesterId: result.semester?.id ?? null,
+        matchedCodes: result.matchedCodes,
+        unmatchedCodes: result.unmatchedCodes,
+        addedCount: result.addedCount,
+        removedCount: result.removedCount,
+        unchangedCount: result.unchangedCount,
+        total: result.total,
+      };
     },
     async setDashboardLinkPinState(
       _parent: unknown,

--- a/tests/integration/graphql-batch-mutations.test.ts
+++ b/tests/integration/graphql-batch-mutations.test.ts
@@ -1,0 +1,471 @@
+import type { RequestEvent } from "@sveltejs/kit";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { signResourceBoundOAuthAccessToken } from "@/features/oauth/server/device-token-issuer.server";
+import { prisma } from "@/lib/db/prisma";
+import { createGraphqlRequestHandler } from "@/lib/graphql/server";
+import { getOAuthGraphqlResourceUrl } from "@/lib/oauth/resource-urls";
+import { restReadScope, restWriteScope } from "@/lib/oauth/scope-registry";
+import { DEV_SEED } from "../fixtures/dev-seed";
+
+const handler = createGraphqlRequestHandler(false);
+const marker = `[integration-test] graphql-batches-${Date.now()}`;
+
+let userAId = "";
+let userBId = "";
+let ownedCompletionTodoId = "";
+let ownedDeleteTodoId = "";
+let otherTodoId = "";
+let activeHomeworkId = "";
+let deletedHomeworkId = "";
+let sectionId = 0;
+let semesterId = 0;
+
+type GraphqlPayload = {
+  data?: Record<string, unknown> | null;
+  errors?: Array<{
+    message: string;
+    extensions?: Record<string, unknown>;
+  }>;
+};
+
+function requestEvent(body: unknown, token?: string): RequestEvent {
+  return {
+    request: new Request("https://life.example/api/graphql", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(body),
+    }),
+    locals: {
+      authUser: null,
+      locale: "en-us",
+      requestId: "graphql-batches-integration",
+    },
+  } as unknown as RequestEvent;
+}
+
+async function execute(body: unknown, token?: string) {
+  const response = await handler(requestEvent(body, token));
+  return {
+    response,
+    payload: (await response.json()) as GraphqlPayload,
+  };
+}
+
+async function signToken(userId: string, scopes: string[]) {
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const token = await signResourceBoundOAuthAccessToken({
+    clientId: "graphql-batches-integration",
+    expiresAt: issuedAt + 300,
+    issuedAt,
+    resources: [getOAuthGraphqlResourceUrl()],
+    scopes,
+    userId,
+  });
+  if (!token) throw new Error("Expected a signed GraphQL access token");
+  return token;
+}
+
+function expectErrorCode(payload: GraphqlPayload, code: string) {
+  expect(payload.data).toBeNull();
+  expect(payload.errors?.[0]?.extensions?.code).toBe(code);
+}
+
+beforeAll(async () => {
+  const section = await prisma.section.findUniqueOrThrow({
+    where: { jwId: DEV_SEED.section.jwId },
+    select: { id: true, semesterId: true },
+  });
+  sectionId = section.id;
+  if (section.semesterId == null) {
+    throw new Error("GraphQL batch integration requires a semester section");
+  }
+  semesterId = section.semesterId;
+
+  const [userA, userB] = await Promise.all([
+    prisma.user.create({
+      data: {
+        email: `${marker}-a@example.test`,
+        name: "GraphQL Batch A",
+      },
+      select: { id: true },
+    }),
+    prisma.user.create({
+      data: {
+        email: `${marker}-b@example.test`,
+        name: "GraphQL Batch B",
+      },
+      select: { id: true },
+    }),
+  ]);
+  userAId = userA.id;
+  userBId = userB.id;
+
+  const [ownedCompletionTodo, ownedDeleteTodo, otherTodo, active, deleted] =
+    await Promise.all([
+      prisma.todo.create({
+        data: { userId: userAId, title: `${marker} completion` },
+        select: { id: true },
+      }),
+      prisma.todo.create({
+        data: { userId: userAId, title: `${marker} delete` },
+        select: { id: true },
+      }),
+      prisma.todo.create({
+        data: { userId: userBId, title: `${marker} other` },
+        select: { id: true },
+      }),
+      prisma.homework.create({
+        data: {
+          createdById: userAId,
+          sectionId,
+          title: `${marker} active homework`,
+        },
+        select: { id: true },
+      }),
+      prisma.homework.create({
+        data: {
+          createdById: userAId,
+          deletedAt: new Date("2026-07-20T00:00:00.000Z"),
+          sectionId,
+          title: `${marker} deleted homework`,
+        },
+        select: { id: true },
+      }),
+    ]);
+  ownedCompletionTodoId = ownedCompletionTodo.id;
+  ownedDeleteTodoId = ownedDeleteTodo.id;
+  otherTodoId = otherTodo.id;
+  activeHomeworkId = active.id;
+  deletedHomeworkId = deleted.id;
+});
+
+afterAll(async () => {
+  await prisma.homework.deleteMany({
+    where: { id: { in: [activeHomeworkId, deletedHomeworkId] } },
+  });
+  await prisma.todo.deleteMany({
+    where: { userId: { in: [userAId, userBId] } },
+  });
+  await prisma.user.deleteMany({
+    where: { id: { in: [userAId, userBId] } },
+  });
+  await prisma.$disconnect();
+});
+
+describe("GraphQL batch mutations", () => {
+  it("requires the exact write scope before any batch item changes", async () => {
+    const readToken = await signToken(userAId, [restReadScope("todo")]);
+    const result = await execute(
+      {
+        query: /* GraphQL */ `
+          mutation SetWithoutWrite($items: [TodoCompletionBatchItemInput!]!) {
+            setTodoCompletions(items: $items) {
+              results {
+                success
+              }
+            }
+          }
+        `,
+        variables: {
+          items: [{ todoId: ownedCompletionTodoId, completed: true }],
+        },
+      },
+      readToken,
+    );
+
+    expectErrorCode(result.payload, "FORBIDDEN");
+    expect(result.payload.errors?.[0]?.extensions?.requiredScopes).toEqual([
+      "todo:write",
+    ]);
+    await expect(
+      prisma.todo.findUniqueOrThrow({
+        where: { id: ownedCompletionTodoId },
+        select: { completed: true },
+      }),
+    ).resolves.toEqual({ completed: false });
+  });
+
+  it("returns todo completion and delete results per item", async () => {
+    const token = await signToken(userAId, [restWriteScope("todo")]);
+    const completion = await execute(
+      {
+        query: /* GraphQL */ `
+          mutation SetTodoBatch($items: [TodoCompletionBatchItemInput!]!) {
+            setTodoCompletions(items: $items) {
+              results {
+                success
+                todoId
+                completed
+                todo {
+                  id
+                  completed
+                }
+                error {
+                  code
+                  message
+                }
+              }
+            }
+          }
+        `,
+        variables: {
+          items: [
+            { todoId: ownedCompletionTodoId, completed: true },
+            { todoId: otherTodoId, completed: true },
+          ],
+        },
+      },
+      token,
+    );
+
+    expect(completion.payload.errors).toBeUndefined();
+    expect(completion.payload.data?.setTodoCompletions).toEqual({
+      results: [
+        {
+          success: true,
+          todoId: ownedCompletionTodoId,
+          completed: true,
+          todo: { id: ownedCompletionTodoId, completed: true },
+          error: null,
+        },
+        {
+          success: false,
+          todoId: otherTodoId,
+          completed: true,
+          todo: null,
+          error: { code: "FORBIDDEN", message: "forbidden" },
+        },
+      ],
+    });
+
+    const deletion = await execute(
+      {
+        query: /* GraphQL */ `
+          mutation DeleteTodoBatch($ids: [ID!]!) {
+            deleteTodos(ids: $ids) {
+              results {
+                success
+                id
+                error {
+                  code
+                }
+              }
+            }
+          }
+        `,
+        variables: {
+          ids: [ownedDeleteTodoId, `${marker}-missing`, otherTodoId],
+        },
+      },
+      token,
+    );
+    expect(deletion.payload.errors).toBeUndefined();
+    expect(deletion.payload.data?.deleteTodos).toEqual({
+      results: [
+        { success: true, id: ownedDeleteTodoId, error: null },
+        {
+          success: false,
+          id: `${marker}-missing`,
+          error: { code: "NOT_FOUND" },
+        },
+        {
+          success: false,
+          id: otherTodoId,
+          error: { code: "FORBIDDEN" },
+        },
+      ],
+    });
+  });
+
+  it("rejects duplicate, extra, and null inputs before writing", async () => {
+    const token = await signToken(userAId, [restWriteScope("todo")]);
+    await prisma.todo.update({
+      where: { id: ownedCompletionTodoId },
+      data: { completed: false },
+    });
+    const query = /* GraphQL */ `
+      mutation StrictTodoBatch($items: [TodoCompletionBatchItemInput!]!) {
+        setTodoCompletions(items: $items) {
+          results {
+            success
+          }
+        }
+      }
+    `;
+
+    const duplicate = await execute(
+      {
+        query,
+        variables: {
+          items: [
+            { todoId: ownedCompletionTodoId, completed: true },
+            { todoId: ` ${ownedCompletionTodoId} `, completed: false },
+          ],
+        },
+      },
+      token,
+    );
+    expectErrorCode(duplicate.payload, "BAD_USER_INPUT");
+
+    for (const items of [
+      [{ todoId: ownedCompletionTodoId, completed: true, extra: "reject" }],
+      [{ todoId: ownedCompletionTodoId, completed: null }],
+    ]) {
+      const invalid = await execute({ query, variables: { items } }, token);
+      expect(invalid.payload.errors?.length).toBeGreaterThan(0);
+      expect(invalid.payload.data).toBeUndefined();
+    }
+
+    await expect(
+      prisma.todo.findUniqueOrThrow({
+        where: { id: ownedCompletionTodoId },
+        select: { completed: true },
+      }),
+    ).resolves.toEqual({ completed: false });
+  });
+
+  it("preserves homework per-item not-found and deleted errors", async () => {
+    const token = await signToken(userAId, [restWriteScope("homework")]);
+    const result = await execute(
+      {
+        query: /* GraphQL */ `
+          mutation SetHomeworkBatch(
+            $items: [HomeworkCompletionBatchItemInput!]!
+          ) {
+            setHomeworkCompletions(items: $items) {
+              results {
+                success
+                homeworkId
+                completed
+                completedAt
+                error {
+                  code
+                }
+              }
+            }
+          }
+        `,
+        variables: {
+          items: [
+            { homeworkId: activeHomeworkId, completed: true },
+            { homeworkId: deletedHomeworkId, completed: true },
+            { homeworkId: `${marker}-missing`, completed: false },
+          ],
+        },
+      },
+      token,
+    );
+
+    expect(result.payload.errors).toBeUndefined();
+    expect(result.payload.data?.setHomeworkCompletions).toEqual({
+      results: [
+        {
+          success: true,
+          homeworkId: activeHomeworkId,
+          completed: true,
+          completedAt: expect.any(String),
+          error: null,
+        },
+        {
+          success: false,
+          homeworkId: deletedHomeworkId,
+          completed: true,
+          completedAt: null,
+          error: { code: "DELETED" },
+        },
+        {
+          success: false,
+          homeworkId: `${marker}-missing`,
+          completed: false,
+          completedAt: null,
+          error: { code: "NOT_FOUND" },
+        },
+      ],
+    });
+  });
+
+  it("applies and clears one semester through the shared subscription service", async () => {
+    const token = await signToken(userAId, [restWriteScope("subscription")]);
+    const mutation = /* GraphQL */ `
+      mutation UpdateSubscriptions($input: UpdateSectionSubscriptionsInput!) {
+        updateSectionSubscriptions(input: $input) {
+          action
+          semesterId
+          matchedCodes
+          unmatchedCodes
+          addedCount
+          removedCount
+          unchangedCount
+          total
+        }
+      }
+    `;
+    const added = await execute(
+      {
+        query: mutation,
+        variables: {
+          input: {
+            action: "ADD",
+            codes: [DEV_SEED.section.code, `${marker}-unknown`],
+            semesterId,
+          },
+        },
+      },
+      token,
+    );
+    expect(added.payload.errors).toBeUndefined();
+    expect(added.payload.data?.updateSectionSubscriptions).toMatchObject({
+      action: "ADD",
+      semesterId,
+      matchedCodes: [DEV_SEED.section.code],
+      unmatchedCodes: [`${marker}-unknown`],
+      addedCount: 1,
+      removedCount: 0,
+    });
+    await expect(
+      prisma.user.findUniqueOrThrow({
+        where: { id: userAId },
+        select: {
+          subscribedSections: {
+            where: { id: sectionId },
+            select: { id: true },
+          },
+        },
+      }),
+    ).resolves.toEqual({ subscribedSections: [{ id: sectionId }] });
+
+    const cleared = await execute(
+      {
+        query: mutation,
+        variables: {
+          input: { action: "SET", codes: [], semesterId },
+        },
+      },
+      token,
+    );
+    expect(cleared.payload.errors).toBeUndefined();
+    expect(cleared.payload.data?.updateSectionSubscriptions).toMatchObject({
+      action: "SET",
+      semesterId,
+      matchedCodes: [],
+      unmatchedCodes: [],
+      addedCount: 0,
+      removedCount: 1,
+      total: 0,
+    });
+    await expect(
+      prisma.user.findUniqueOrThrow({
+        where: { id: userAId },
+        select: {
+          subscribedSections: {
+            where: { semesterId },
+            select: { id: true },
+          },
+        },
+      }),
+    ).resolves.toEqual({ subscribedSections: [] });
+  });
+});

--- a/tests/unit/graphql-batch-mutations.test.ts
+++ b/tests/unit/graphql-batch-mutations.test.ts
@@ -1,0 +1,348 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GraphqlContext } from "@/lib/graphql/context";
+import { graphqlMutationResolvers } from "@/lib/graphql/mutations";
+
+const {
+  batchUpdateUserSectionSubscriptionsMock,
+  deleteOwnedTodoMock,
+  requireGraphqlMutationMock,
+  setHomeworkCompletionsMock,
+  updateOwnedTodoMock,
+} = vi.hoisted(() => ({
+  batchUpdateUserSectionSubscriptionsMock: vi.fn(),
+  deleteOwnedTodoMock: vi.fn(),
+  requireGraphqlMutationMock: vi.fn(),
+  setHomeworkCompletionsMock: vi.fn(),
+  updateOwnedTodoMock: vi.fn(),
+}));
+
+vi.mock("@/features/todos/server/todo-service", () => ({
+  createTodo: vi.fn(),
+  deleteOwnedTodo: deleteOwnedTodoMock,
+  updateOwnedTodo: updateOwnedTodoMock,
+}));
+
+vi.mock("@/features/homeworks/server/homework-completion", () => ({
+  setHomeworkCompletion: vi.fn(),
+  setHomeworkCompletions: setHomeworkCompletionsMock,
+}));
+
+vi.mock("@/features/subscriptions/server/subscriptions", () => ({
+  batchUpdateUserSectionSubscriptions: batchUpdateUserSectionSubscriptionsMock,
+  setUserSectionSubscriptionByJwId: vi.fn(),
+}));
+
+vi.mock("@/lib/graphql/mutation-guard", () => ({
+  requireGraphqlMutation: requireGraphqlMutationMock,
+}));
+
+const context = {
+  locale: "en-us",
+  principal: { kind: "anonymous" },
+  request: new Request("https://life.example/api/graphql"),
+} as unknown as GraphqlContext;
+
+describe("GraphQL batch mutation resolvers", () => {
+  beforeEach(() => {
+    batchUpdateUserSectionSubscriptionsMock.mockReset();
+    deleteOwnedTodoMock.mockReset();
+    requireGraphqlMutationMock.mockReset();
+    setHomeworkCompletionsMock.mockReset();
+    updateOwnedTodoMock.mockReset();
+    requireGraphqlMutationMock.mockResolvedValue({ userId: "user-1" });
+  });
+
+  it("preserves todo completion per-item partial success", async () => {
+    const todo = {
+      id: "todo-1",
+      title: "Todo",
+      content: null,
+      priority: "medium",
+      completed: true,
+      dueAt: null,
+      createdAt: new Date("2026-07-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-07-20T00:00:00.000Z"),
+    };
+    updateOwnedTodoMock
+      .mockResolvedValueOnce({ ok: true, todo })
+      .mockResolvedValueOnce({ ok: false, error: "forbidden" });
+
+    const result = await graphqlMutationResolvers.Mutation.setTodoCompletions(
+      null,
+      {
+        items: [
+          { todoId: " todo-1 ", completed: true },
+          { todoId: "todo-2", completed: false },
+        ],
+      },
+      context,
+    );
+
+    expect(requireGraphqlMutationMock).toHaveBeenCalledWith(context, "todo", {
+      rateLimitTier: "batch",
+    });
+    expect(updateOwnedTodoMock).toHaveBeenNthCalledWith(1, {
+      id: "todo-1",
+      userId: "user-1",
+      data: { completed: true, dueAt: undefined, hasDueAt: false },
+    });
+    expect(result).toEqual({
+      results: [
+        {
+          success: true,
+          todoId: "todo-1",
+          completed: true,
+          todo,
+        },
+        {
+          success: false,
+          todoId: "todo-2",
+          completed: false,
+          error: { code: "forbidden", message: "forbidden" },
+        },
+      ],
+    });
+  });
+
+  it.each([
+    {
+      call: () =>
+        graphqlMutationResolvers.Mutation.setTodoCompletions(
+          null,
+          {
+            items: [
+              { todoId: "todo-1", completed: true },
+              { todoId: " todo-1 ", completed: false },
+            ],
+          },
+          context,
+        ),
+      service: updateOwnedTodoMock,
+      message: "todo IDs must not contain duplicate targets.",
+    },
+    {
+      call: () =>
+        graphqlMutationResolvers.Mutation.deleteTodos(
+          null,
+          { ids: ["todo-1", " todo-1 "] },
+          context,
+        ),
+      service: deleteOwnedTodoMock,
+      message: "todo IDs must not contain duplicate targets.",
+    },
+    {
+      call: () =>
+        graphqlMutationResolvers.Mutation.setHomeworkCompletions(
+          null,
+          {
+            items: [
+              { homeworkId: "homework-1", completed: true },
+              { homeworkId: " homework-1 ", completed: false },
+            ],
+          },
+          context,
+        ),
+      service: setHomeworkCompletionsMock,
+      message: "homework IDs must not contain duplicate targets.",
+    },
+  ])("rejects duplicate targets before calling the service", async (testCase) => {
+    await expect(testCase.call()).rejects.toMatchObject({
+      extensions: { code: "BAD_USER_INPUT" },
+      message: testCase.message,
+    });
+    expect(testCase.service).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      call: () =>
+        graphqlMutationResolvers.Mutation.setTodoCompletions(
+          null,
+          { items: [] },
+          context,
+        ),
+      service: updateOwnedTodoMock,
+      message: "todo IDs must contain 1-100 items.",
+    },
+    {
+      call: () =>
+        graphqlMutationResolvers.Mutation.deleteTodos(
+          null,
+          { ids: Array.from({ length: 101 }, (_, index) => `todo-${index}`) },
+          context,
+        ),
+      service: deleteOwnedTodoMock,
+      message: "todo IDs must contain 1-100 items.",
+    },
+    {
+      call: () =>
+        graphqlMutationResolvers.Mutation.setHomeworkCompletions(
+          null,
+          { items: [] },
+          context,
+        ),
+      service: setHomeworkCompletionsMock,
+      message: "homework IDs must contain 1-100 items.",
+    },
+  ])("enforces the documented batch bounds", async (testCase) => {
+    await expect(testCase.call()).rejects.toMatchObject({
+      extensions: { code: "BAD_USER_INPUT" },
+      message: testCase.message,
+    });
+    expect(testCase.service).not.toHaveBeenCalled();
+  });
+
+  it("delegates one normalized homework batch to the shared service", async () => {
+    const payload = {
+      results: [
+        {
+          success: false,
+          homeworkId: "homework-missing",
+          completed: true,
+          error: { code: "not_found", message: "Homework not found" },
+        },
+      ],
+    };
+    setHomeworkCompletionsMock.mockResolvedValue(payload);
+
+    await expect(
+      graphqlMutationResolvers.Mutation.setHomeworkCompletions(
+        null,
+        {
+          items: [{ homeworkId: " homework-missing ", completed: true }],
+        },
+        context,
+      ),
+    ).resolves.toEqual(payload);
+    expect(requireGraphqlMutationMock).toHaveBeenCalledWith(
+      context,
+      "homework",
+      { rateLimitTier: "batch" },
+    );
+    expect(setHomeworkCompletionsMock).toHaveBeenCalledWith({
+      items: [{ homeworkId: "homework-missing", completed: true }],
+      userId: "user-1",
+    });
+  });
+
+  it("reuses subscription batch semantics and returns unmatched codes", async () => {
+    batchUpdateUserSectionSubscriptionsMock.mockResolvedValue({
+      action: "add",
+      semester: { id: 7 },
+      matchedCodes: ["MATH1001"],
+      unmatchedCodes: ["UNKNOWN"],
+      addedCount: 2,
+      removedCount: 0,
+      unchangedCount: 1,
+      total: 3,
+    });
+
+    const result =
+      await graphqlMutationResolvers.Mutation.updateSectionSubscriptions(
+        null,
+        {
+          input: {
+            action: "add",
+            codes: [" MATH1001 ", "UNKNOWN"],
+            semesterId: 7,
+          },
+        },
+        context,
+      );
+
+    expect(requireGraphqlMutationMock).toHaveBeenCalledWith(
+      context,
+      "subscription",
+      { rateLimitTier: "batch" },
+    );
+    expect(batchUpdateUserSectionSubscriptionsMock).toHaveBeenCalledWith({
+      action: "add",
+      codes: ["MATH1001", "UNKNOWN"],
+      locale: "en-us",
+      semesterId: 7,
+      userId: "user-1",
+    });
+    expect(result).toEqual({
+      action: "add",
+      semesterId: 7,
+      matchedCodes: ["MATH1001"],
+      unmatchedCodes: ["UNKNOWN"],
+      addedCount: 2,
+      removedCount: 0,
+      unchangedCount: 1,
+      total: 3,
+    });
+  });
+
+  it.each([
+    {
+      input: { action: "add" as const, codes: [] },
+      message: "codes must contain at least one item.",
+    },
+    {
+      input: { action: "set" as const, codes: ["MATH1001"] },
+      message: "semesterId is required when action is SET.",
+    },
+    {
+      input: {
+        action: "add" as const,
+        codes: ["math1001", " MATH1001 "],
+      },
+      message: "codes must not contain duplicate targets.",
+    },
+    {
+      input: {
+        action: "add" as const,
+        codes: ["MATH1001"],
+        semesterId: null,
+      },
+      message: "semesterId must not be null.",
+    },
+    {
+      input: {
+        action: "add" as const,
+        codes: Array.from({ length: 501 }, (_, index) => `CODE-${index}`),
+      },
+      message: "codes must contain at most 500 items.",
+    },
+  ])("rejects ambiguous subscription batches", async ({ input, message }) => {
+    await expect(
+      graphqlMutationResolvers.Mutation.updateSectionSubscriptions(
+        null,
+        { input },
+        context,
+      ),
+    ).rejects.toMatchObject({
+      extensions: { code: "BAD_USER_INPUT" },
+      message,
+    });
+    expect(batchUpdateUserSectionSubscriptionsMock).not.toHaveBeenCalled();
+  });
+
+  it("allows an empty SET target to clear one semester", async () => {
+    batchUpdateUserSectionSubscriptionsMock.mockResolvedValue({
+      action: "set",
+      semester: { id: 7 },
+      matchedCodes: [],
+      unmatchedCodes: [],
+      addedCount: 0,
+      removedCount: 2,
+      unchangedCount: 0,
+      total: 0,
+    });
+
+    await graphqlMutationResolvers.Mutation.updateSectionSubscriptions(
+      null,
+      { input: { action: "set", codes: [], semesterId: 7 } },
+      context,
+    );
+
+    expect(batchUpdateUserSectionSubscriptionsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "set",
+        codes: [],
+        semesterId: 7,
+      }),
+    );
+  });
+});

--- a/tests/unit/graphql-mutation-capabilities.test.ts
+++ b/tests/unit/graphql-mutation-capabilities.test.ts
@@ -1,0 +1,104 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { buildSchema } from "graphql";
+import { describe, expect, it } from "vitest";
+import { graphqlTypeDefs } from "@/lib/graphql/schema";
+import { getExplicitMcpToolScopeNames } from "@/lib/mcp/tool-scopes";
+
+type Capability = {
+  id: string;
+  graphql: {
+    field: string | null;
+    status: "intentional_gap" | "stable";
+  };
+  mcp: {
+    tools: string[];
+  };
+  notes?: string[];
+  rest: string[];
+};
+
+type CapabilityMatrix = {
+  capabilities: Capability[];
+  schemaVersion: number;
+};
+
+const matrixPath = fileURLToPath(
+  new URL("../../docs/graphql/mutation-capabilities.json", import.meta.url),
+);
+const openApiPath = fileURLToPath(
+  new URL("../../public/openapi.generated.json", import.meta.url),
+);
+
+async function readMatrix() {
+  return JSON.parse(await readFile(matrixPath, "utf8")) as CapabilityMatrix;
+}
+
+describe("GraphQL mutation capability matrix", () => {
+  it("maps every stable SDL mutation exactly once", async () => {
+    const matrix = await readMatrix();
+    const schema = buildSchema(graphqlTypeDefs);
+    const schemaFields = Object.keys(
+      schema.getMutationType()?.getFields() ?? {},
+    ).sort();
+    const stableFields = matrix.capabilities
+      .filter((capability) => capability.graphql.status === "stable")
+      .map((capability) => capability.graphql.field)
+      .sort();
+
+    expect(matrix.schemaVersion).toBe(1);
+    expect(stableFields).toEqual(schemaFields);
+  });
+
+  it("keeps IDs and stable fields unique and explains every gap", async () => {
+    const matrix = await readMatrix();
+    const ids = matrix.capabilities.map((capability) => capability.id);
+    const stableFields = matrix.capabilities
+      .filter((capability) => capability.graphql.status === "stable")
+      .map((capability) => capability.graphql.field);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(new Set(stableFields).size).toBe(stableFields.length);
+    for (const capability of matrix.capabilities) {
+      if (capability.graphql.status === "intentional_gap") {
+        expect(capability.graphql.field).toBeNull();
+        expect(capability.notes?.join(" ").trim()).toBeTruthy();
+      } else {
+        expect(capability.graphql.field).toEqual(expect.any(String));
+      }
+    }
+  });
+
+  it("references only checked-in REST operations and scoped MCP tools", async () => {
+    const [matrix, openApi] = await Promise.all([
+      readMatrix(),
+      readFile(openApiPath, "utf8").then(
+        (text) =>
+          JSON.parse(text) as {
+            paths: Record<string, Record<string, unknown>>;
+          },
+      ),
+    ]);
+    const mcpTools = new Set(getExplicitMcpToolScopeNames());
+
+    for (const capability of matrix.capabilities) {
+      for (const restOperation of capability.rest) {
+        const [method, rawPath, ...extra] = restOperation.split(" ");
+        const path = rawPath.replace(/\[([^\]]+)\]/g, "{$1}");
+        expect(extra, `${capability.id} has an invalid REST operation`).toEqual(
+          [],
+        );
+        expect(
+          openApi.paths[path]?.[method.toLowerCase()],
+          `${capability.id} references missing ${restOperation}`,
+        ).toBeTruthy();
+      }
+      for (const tool of capability.mcp.tools) {
+        expect(
+          mcpTools.has(tool),
+          `${capability.id} references missing MCP tool ${tool}`,
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/tests/unit/graphql-mutation-guard.test.ts
+++ b/tests/unit/graphql-mutation-guard.test.ts
@@ -42,6 +42,31 @@ describe("GraphQL mutation guard", () => {
     ]);
   });
 
+  it("uses the stricter shared batch budget without changing OAuth scope", async () => {
+    const limit = vi.fn().mockResolvedValue({ success: true });
+    setCloudflareRuntimeEnv({ USER_BATCH_WRITE_RATE_LIMITER: { limit } });
+
+    await expect(
+      requireGraphqlMutation(
+        context({
+          kind: "oauth",
+          userId: "user-1",
+          scopes: new Set(["todo:write"]),
+          resource: "https://life.example/api/graphql",
+        }),
+        "todo",
+        { rateLimitTier: "batch" },
+      ),
+    ).resolves.toMatchObject({ userId: "user-1" });
+
+    expect(JSON.parse(limit.mock.calls[0][0].key)).toEqual([
+      "user-mutation:v1",
+      "life.example",
+      "todo:batch-write",
+      "user-1",
+    ]);
+  });
+
   it.each([
     "todo",
     "description",


### PR DESCRIPTION
## Summary

- add bounded, scope-gated GraphQL batch mutations for Todo completion/delete, Homework completion, and section subscription code updates
- preserve the existing REST per-item partial-success semantics for Todo/Homework and reuse the shared transactional subscription service
- add a checked-in capability matrix for 21 stable ordinary business mutations and document intentional gaps instead of copying unsafe transport-only behavior
- give batch writes the shared batch mutation limiter tier and reject duplicate, empty, oversized, null, and malformed inputs before service execution

## Safety decisions

- every operation requires the exact `*:write` OAuth scope (or trusted same-origin session authority)
- batch bounds are 1–100 for Todo/Homework and at most 500 subscription codes
- Dashboard and comment transport fan-out remain explicit gaps until they have shared atomic or audited batch services
- auth/account security, admin governance, locale/redirect protocol writes, and raw R2 bytes remain outside GraphQL business mutation scope

## Verification

- 45 migrations replayed on an isolated PostgreSQL database and canonical seed loaded
- full static/type checks
- 211 unit files / 1248 tests
- 34 integration files / 191 tests
- focused GraphQL batch suite / 21 tests
- production build
- `git diff --check`

Part of #549