### PR TITLE
fix(ci): preserve queued E2E report publishers

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -25,6 +25,9 @@ Keep Bun versions aligned with:
 - Production deploy is owned by Cloudflare's Git integration; do not add repo-managed deploy jobs.
 - Docker is only for local infra, CI service containers, and the static loader image; do not add app-serving Docker jobs.
 - Keep workflow YAML as orchestration. Reusable check, test, and seed sequences live in `$life-ustc-dev-loop`.
+- E2E HTML report publication is non-required infrastructure: keep it
+  `continue-on-error`, and keep its global concurrency group on `queue: max` so
+  artifact-repository writes stay serial without replacing pending publishers.
 - Never commit secrets
 - `copilot-setup-steps.yml` must keep a direct job named exactly `copilot-setup-steps`; inline `runs-on`, `permissions`, `services`, `timeout-minutes`, and `steps` instead of delegating the job through a reusable workflow.
 - When changing Copilot setup, run it through `workflow_dispatch` or a PR check. If setup fails, Copilot can still start from the partially prepared environment, so setup logs are part of the verification evidence.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,9 +172,11 @@ jobs:
     name: Publish E2E HTML report
     needs: test-e2e
     if: always()
+    continue-on-error: true
     runs-on: ubuntu-latest
     concurrency:
       group: publish-e2e-html-report
+      queue: max
       cancel-in-progress: false
     permissions:
       contents: write

--- a/tests/unit/ci-e2e-report-workflow.test.ts
+++ b/tests/unit/ci-e2e-report-workflow.test.ts
@@ -1,0 +1,34 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+async function publishJobSource() {
+  const workflow = await readFile(
+    new URL("../../.github/workflows/ci.yml", import.meta.url),
+    "utf8",
+  );
+  const marker = "  publish-e2e-html-report:";
+  const jobStart = workflow.indexOf(marker);
+
+  expect(jobStart).toBeGreaterThan(-1);
+
+  const remainingWorkflow = workflow.slice(jobStart + marker.length);
+  const nextJobOffset = remainingWorkflow.search(/\n {2}[a-z0-9-]+:\n/);
+
+  return workflow.slice(
+    jobStart,
+    nextJobOffset === -1 ? undefined : jobStart + marker.length + nextJobOffset,
+  );
+}
+
+describe("E2E report publication workflow", () => {
+  it("serializes every pending publisher without making reports required", async () => {
+    const job = await publishJobSource();
+
+    expect(job).toContain("continue-on-error: true");
+    expect(job).toMatch(
+      /concurrency:\n\s+group: publish-e2e-html-report\n\s+queue: max\n\s+cancel-in-progress: false/,
+    );
+    expect(job).toMatch(/reports\/\$\{RUN_ID\}/);
+  });
+});


### PR DESCRIPTION
## Goal

Preserve every E2E HTML report publisher when several CI runs finish together. Closes #562.

GitHub Actions now supports `queue: max` for concurrency groups, so the existing global publisher group can stay a single-writer queue without replacing an older pending job: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency

## Changed Surfaces

- Keep `publish-e2e-html-report` globally serialized and opt it into the multi-entry pending queue.
- Mark report publication as non-required infrastructure with job-level `continue-on-error`; test, integration, build, and E2E jobs continue to determine CI correctness.
- Add a focused unit contract that locks the queue, cancellation, non-required, and per-run report-path behavior.
- Record the operational policy in `.github/workflows/AGENTS.md`.

## Evidence

- `bunx vitest run tests/unit/ci-e2e-report-workflow.test.ts` — 1/1 passed.
- `bunx vitest run` — 214 files, 1268 tests passed.
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json` — passed.
- `bunx biome check` — passed with one pre-existing warning in `src/static-loader/import.ts`.
- `bun run app:prepare` — passed with an explicit local `DATABASE_URL`.
- Current `actionlint` v1.7.12 predates the documented `queue` key and reports it as unknown; GitHub-hosted workflow parsing/CI is the authoritative validation for this newly released syntax.

## Docs / Contracts

No product/API contract changes. The scoped workflow agent guide documents that report publication is intentionally non-required and queued globally.

## Risk Areas

- `queue: max` retains up to 100 pending publishers; unlike the old default single-pending queue, ordinary parallel PR traffic is not superseded.
- Artifact pushes remain force-updates, but publishers cannot overlap because the global queue still admits only one running job. This deliberately avoids a larger concurrent Git retry implementation.
- Publication failures remain visible on the report job while no longer changing an otherwise test-successful workflow into a failed run.

## Cleanup

The worktree is clean, and the PR contains only the workflow, scoped policy, and regression test.