### PR TITLE
test(security): lock cross-site form boundary

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -62,7 +62,7 @@ function isFormContentType(request: Request) {
   return FORM_CONTENT_TYPES.some((type) => contentType?.includes(type));
 }
 
-function crossSiteFormResponse(event: Parameters<Handle>[0]["event"]) {
+export function crossSiteFormResponse(event: Parameters<Handle>[0]["event"]) {
   if (getOptionalTrimmedEnv("NODE_ENV") === "development") return null;
   if (!FORM_METHODS.has(event.request.method)) return null;
   if (!isFormContentType(event.request)) return null;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -74,7 +74,7 @@ export function crossSiteFormResponse(event: Parameters<Handle>[0]["event"]) {
   if (configuredTrustedFormOrigins().has(requestOrigin)) return null;
 
   const message = `Cross-site ${event.request.method} form submissions are forbidden`;
-  if (event.request.headers.get("accept") === "application/json") {
+  if (event.request.headers.get("accept")?.includes("application/json")) {
     return Response.json({ message }, { status: 403 });
   }
   return new Response(message, { status: 403 });

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -7,6 +7,9 @@ const config = {
   kit: {
     adapter: adapterCloudflare(),
     csrf: {
+      // OAuth token and device endpoints accept cross-origin form requests. The
+      // server hook below is the single CSRF gate so it can exempt only those
+      // endpoints while rejecting cross-site forms everywhere else.
       trustedOrigins: ["*"],
     },
     alias: {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -8,8 +8,8 @@ const config = {
     adapter: adapterCloudflare(),
     csrf: {
       // OAuth token and device endpoints accept cross-origin form requests. The
-      // application hook in src/hooks.server.ts is the single CSRF gate so it
-      // can exempt only those endpoints while rejecting cross-site forms elsewhere.
+      // production hook in src/hooks.server.ts is the single CSRF gate so it can
+      // exempt only those endpoints while rejecting cross-site forms elsewhere.
       trustedOrigins: ["*"],
     },
     alias: {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -8,8 +8,8 @@ const config = {
     adapter: adapterCloudflare(),
     csrf: {
       // OAuth token and device endpoints accept cross-origin form requests. The
-      // server hook below is the single CSRF gate so it can exempt only those
-      // endpoints while rejecting cross-site forms everywhere else.
+      // application hook in src/hooks.server.ts is the single CSRF gate so it
+      // can exempt only those endpoints while rejecting cross-site forms elsewhere.
       trustedOrigins: ["*"],
     },
     alias: {

--- a/tests/unit/hooks-cross-site-form.test.ts
+++ b/tests/unit/hooks-cross-site-form.test.ts
@@ -10,7 +10,7 @@ function event(
     request: new Request(url, {
       method: "POST",
       headers: {
-        accept: "application/json",
+        accept: "application/json, */*",
         "content-type": "application/x-www-form-urlencoded",
         origin,
       },

--- a/tests/unit/hooks-cross-site-form.test.ts
+++ b/tests/unit/hooks-cross-site-form.test.ts
@@ -28,7 +28,8 @@ describe("cross-site form protection", () => {
 
     const response = crossSiteFormResponse(event());
     expect(response).not.toBeNull();
-    if (!response) throw new Error("Expected the CSRF gate to reject the request");
+    if (!response)
+      throw new Error("Expected the CSRF gate to reject the request");
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({

--- a/tests/unit/hooks-cross-site-form.test.ts
+++ b/tests/unit/hooks-cross-site-form.test.ts
@@ -27,9 +27,11 @@ describe("cross-site form protection", () => {
     vi.stubEnv("NODE_ENV", "production");
 
     const response = crossSiteFormResponse(event());
+    expect(response).not.toBeNull();
+    if (!response) throw new Error("Expected the CSRF gate to reject the request");
 
-    expect(response?.status).toBe(403);
-    await expect(response?.json()).resolves.toEqual({
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
       message: "Cross-site POST form submissions are forbidden",
     });
   });

--- a/tests/unit/hooks-cross-site-form.test.ts
+++ b/tests/unit/hooks-cross-site-form.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { crossSiteFormResponse } from "@/hooks.server";
+
+function event(
+  pathname = "/settings/profile",
+  origin = "https://evil.example",
+) {
+  const url = new URL(`https://life.example${pathname}`);
+  return {
+    request: new Request(url, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/x-www-form-urlencoded",
+        origin,
+      },
+      body: new URLSearchParams({ name: "Mallory" }),
+    }),
+    url,
+  } as Parameters<typeof crossSiteFormResponse>[0];
+}
+
+describe("cross-site form protection", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("rejects an untrusted cross-origin form request in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    const response = crossSiteFormResponse(event());
+
+    expect(response?.status).toBe(403);
+    await expect(response?.json()).resolves.toEqual({
+      message: "Cross-site POST form submissions are forbidden",
+    });
+  });
+
+  it("allows same-origin and configured public origins", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("APP_PUBLIC_ORIGIN", "https://preview.example");
+
+    expect(
+      crossSiteFormResponse(event("/settings/profile", "https://life.example")),
+    ).toBeNull();
+    expect(
+      crossSiteFormResponse(
+        event("/settings/profile", "https://preview.example"),
+      ),
+    ).toBeNull();
+  });
+
+  it.each([
+    "/api/auth/oauth2/token",
+    "/api/auth/oauth2/device-authorization",
+  ])("allows OAuth form CORS at %s", (pathname) => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    expect(crossSiteFormResponse(event(pathname))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- document why SvelteKit's broad form-origin bypass is required for OAuth token/device CORS
- expose the server hook's selective CSRF gate for direct regression coverage
- verify hostile origins are rejected while same-origin, configured preview, and OAuth protocol endpoints remain allowed

## Verification
- `bunx vitest run tests/unit/hooks-cross-site-form.test.ts`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx biome check svelte.config.js src/hooks.server.ts tests/unit/hooks-cross-site-form.test.ts`

Closes #574