### PR TITLE
test(graphql): verify full field signatures

### DIFF
--- a/docs/contracts.schema.json
+++ b/docs/contracts.schema.json
@@ -584,6 +584,18 @@
         "auth": {
           "$ref": "#/$defs/authLevel"
         },
+        "arguments": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "pattern": "^(?:\\[[A-Z][A-Za-z0-9]*!?\\]|[A-Z][A-Za-z0-9]*)!?$",
+            "maxLength": 90
+          },
+          "propertyNames": {
+            "pattern": "^[a-z][A-Za-z0-9]*$",
+            "maxLength": 80
+          }
+        },
         "required_scopes": {
           "type": "array",
           "minItems": 1,

--- a/docs/contracts/bus.json
+++ b/docs/contracts/bus.json
@@ -58,6 +58,7 @@
         "queries": [
           {
             "name": "busRoutes",
+            "arguments": { "page": "PageInput" },
             "returns": "BusRoutePage!",
             "rest_equivalent": "GET /api/bus",
             "mcp_equivalent": "list_bus_routes",
@@ -67,6 +68,12 @@
           },
           {
             "name": "busTimetable",
+            "arguments": {
+              "routeId": "Int!",
+              "page": "PageInput",
+              "now": "DateTime",
+              "versionKey": "String"
+            },
             "returns": "BusRouteTimetable",
             "rest_equivalent": "GET /api/bus",
             "mcp_equivalent": "get_bus_route_timetable",
@@ -79,6 +86,7 @@
         "mutations": [
           {
             "name": "saveBusPreferences",
+            "arguments": { "input": "BusPreferenceInput!" },
             "returns": "BusPreferenceMutationPayload!",
             "auth": "user",
             "required_scopes": ["bus:write"],

--- a/docs/contracts/comment.json
+++ b/docs/contracts/comment.json
@@ -26,6 +26,7 @@
         "mutations": [
           {
             "name": "createComment",
+            "arguments": { "input": "CreateCommentInput!" },
             "returns": "CommentMutationPayload!",
             "auth": "user",
             "required_scopes": ["comment:write"],
@@ -34,6 +35,10 @@
           },
           {
             "name": "updateComment",
+            "arguments": {
+              "id": "ID!",
+              "input": "UpdateCommentInput!"
+            },
             "returns": "CommentMutationPayload!",
             "auth": "user",
             "required_scopes": ["comment:write"],
@@ -42,6 +47,7 @@
           },
           {
             "name": "deleteComment",
+            "arguments": { "id": "ID!" },
             "returns": "DeleteMutationPayload!",
             "auth": "user",
             "required_scopes": ["comment:write"],
@@ -50,6 +56,7 @@
           },
           {
             "name": "deleteComments",
+            "arguments": { "ids": "[ID!]!" },
             "returns": "CommentDeleteBatchPayload!",
             "auth": "user",
             "required_scopes": ["comment:write"],
@@ -63,6 +70,10 @@
           },
           {
             "name": "addCommentReaction",
+            "arguments": {
+              "commentId": "ID!",
+              "type": "CommentReactionType!"
+            },
             "returns": "CommentReactionMutationPayload!",
             "auth": "user",
             "required_scopes": ["comment:write"],
@@ -71,6 +82,10 @@
           },
           {
             "name": "removeCommentReaction",
+            "arguments": {
+              "commentId": "ID!",
+              "type": "CommentReactionType!"
+            },
             "returns": "CommentReactionMutationPayload!",
             "auth": "user",
             "required_scopes": ["comment:write"],

--- a/docs/contracts/course.json
+++ b/docs/contracts/course.json
@@ -45,6 +45,10 @@
         "queries": [
           {
             "name": "courses",
+            "arguments": {
+              "page": "PageInput",
+              "filter": "CourseFilter"
+            },
             "returns": "CoursePage!",
             "rest_equivalent": "GET /api/courses",
             "mcp_equivalent": "search_courses",
@@ -100,6 +104,7 @@
         "queries": [
           {
             "name": "course",
+            "arguments": { "jwId": "Int!" },
             "returns": "Course",
             "rest_equivalent": "GET /api/courses/[jwId]",
             "mcp_equivalent": "get_course_by_jw_id"

--- a/docs/contracts/dashboard-link.json
+++ b/docs/contracts/dashboard-link.json
@@ -56,6 +56,10 @@
         "mutations": [
           {
             "name": "setDashboardLinkPinState",
+            "arguments": {
+              "slug": "String!",
+              "pinned": "Boolean!"
+            },
             "returns": "DashboardLinkPinMutationPayload!",
             "auth": "user",
             "required_scopes": ["dashboard:write"],
@@ -64,6 +68,9 @@
           },
           {
             "name": "setDashboardLinkPinStates",
+            "arguments": {
+              "items": "[DashboardLinkPinBatchItemInput!]!"
+            },
             "returns": "DashboardLinkPinBatchMutationPayload!",
             "auth": "user",
             "required_scopes": ["dashboard:write"],

--- a/docs/contracts/description.json
+++ b/docs/contracts/description.json
@@ -21,6 +21,7 @@
         "mutations": [
           {
             "name": "upsertDescription",
+            "arguments": { "input": "UpsertDescriptionInput!" },
             "returns": "DescriptionMutationPayload!",
             "auth": "user",
             "required_scopes": ["description:write"],

--- a/docs/contracts/exam.json
+++ b/docs/contracts/exam.json
@@ -28,6 +28,10 @@
           {
             "parent": "Viewer",
             "name": "exams",
+            "arguments": {
+              "filter": "ExamFilter",
+              "page": "PageInput"
+            },
             "returns": "ExamPage!",
             "auth": "user",
             "required_scopes": ["exam:read"],

--- a/docs/contracts/homework.json
+++ b/docs/contracts/homework.json
@@ -41,6 +41,10 @@
           {
             "parent": "Viewer",
             "name": "homeworks",
+            "arguments": {
+              "filter": "HomeworkFilter",
+              "page": "PageInput"
+            },
             "returns": "HomeworkPage!",
             "auth": "user",
             "required_scopes": ["homework:read"],
@@ -132,6 +136,7 @@
         "mutations": [
           {
             "name": "createHomework",
+            "arguments": { "input": "CreateHomeworkInput!" },
             "returns": "HomeworkMutationPayload!",
             "required_scopes": ["homework:write"],
             "rest_equivalent": "POST /api/homeworks",
@@ -142,6 +147,10 @@
           },
           {
             "name": "updateHomework",
+            "arguments": {
+              "id": "ID!",
+              "input": "UpdateHomeworkInput!"
+            },
             "returns": "HomeworkMutationPayload!",
             "required_scopes": ["homework:write"],
             "rest_equivalent": "PATCH /api/homeworks/[id]",
@@ -153,6 +162,7 @@
           },
           {
             "name": "deleteHomework",
+            "arguments": { "id": "ID!" },
             "returns": "HomeworkDeleteMutationPayload!",
             "required_scopes": ["homework:write"],
             "rest_equivalent": "DELETE /api/homeworks/[id]",
@@ -268,6 +278,10 @@
         "mutations": [
           {
             "name": "setHomeworkCompletion",
+            "arguments": {
+              "homeworkId": "ID!",
+              "completed": "Boolean!"
+            },
             "returns": "HomeworkCompletionMutationPayload!",
             "auth": "user",
             "required_scopes": ["homework:write"],
@@ -276,6 +290,9 @@
           },
           {
             "name": "setHomeworkCompletions",
+            "arguments": {
+              "items": "[HomeworkCompletionBatchItemInput!]!"
+            },
             "returns": "HomeworkCompletionBatchPayload!",
             "auth": "user",
             "required_scopes": ["homework:write"],

--- a/docs/contracts/overview.json
+++ b/docs/contracts/overview.json
@@ -56,6 +56,7 @@
           {
             "parent": "Viewer",
             "name": "overview",
+            "arguments": { "atTime": "DateTime" },
             "returns": "ViewerOverview!",
             "auth": "user",
             "required_scopes": ["dashboard:read"],

--- a/docs/contracts/schedule.json
+++ b/docs/contracts/schedule.json
@@ -41,6 +41,10 @@
           {
             "parent": "Viewer",
             "name": "schedules",
+            "arguments": {
+              "filter": "ScheduleFilter",
+              "page": "PageInput"
+            },
             "returns": "SchedulePage!",
             "auth": "user",
             "required_scopes": ["schedule:read"],

--- a/docs/contracts/section.json
+++ b/docs/contracts/section.json
@@ -45,6 +45,10 @@
         "queries": [
           {
             "name": "sections",
+            "arguments": {
+              "page": "PageInput",
+              "filter": "SectionFilter"
+            },
             "returns": "SectionPage!",
             "rest_equivalent": "GET /api/sections",
             "mcp_equivalent": "search_sections",
@@ -110,6 +114,7 @@
         "queries": [
           {
             "name": "section",
+            "arguments": { "jwId": "Int!" },
             "returns": "Section",
             "rest_equivalent": "GET /api/sections/[jwId]",
             "mcp_equivalent": "get_section_by_jw_id"

--- a/docs/contracts/semester.json
+++ b/docs/contracts/semester.json
@@ -34,6 +34,7 @@
         "queries": [
           {
             "name": "semesters",
+            "arguments": { "page": "PageInput" },
             "returns": "SemesterPage!",
             "rest_equivalent": "GET /api/semesters",
             "mcp_equivalent": "list_semesters",

--- a/docs/contracts/subscribed-sections.json
+++ b/docs/contracts/subscribed-sections.json
@@ -39,6 +39,7 @@
           {
             "parent": "Viewer",
             "name": "subscribedSections",
+            "arguments": { "page": "PageInput" },
             "returns": "SectionPage!",
             "auth": "user",
             "required_scopes": ["subscription:read"],

--- a/docs/contracts/subscription.json
+++ b/docs/contracts/subscription.json
@@ -26,6 +26,7 @@
         "mutations": [
           {
             "name": "subscribeSection",
+            "arguments": { "jwId": "Int!" },
             "returns": "SectionSubscriptionMutationPayload!",
             "auth": "user",
             "required_scopes": ["subscription:write"],
@@ -33,6 +34,7 @@
           },
           {
             "name": "unsubscribeSection",
+            "arguments": { "jwId": "Int!" },
             "returns": "SectionSubscriptionMutationPayload!",
             "auth": "user",
             "required_scopes": ["subscription:write"],
@@ -83,6 +85,9 @@
         "mutations": [
           {
             "name": "updateSectionSubscriptions",
+            "arguments": {
+              "input": "UpdateSectionSubscriptionsInput!"
+            },
             "returns": "SectionSubscriptionBatchPayload!",
             "auth": "user",
             "required_scopes": ["subscription:write"],

--- a/docs/contracts/teacher.json
+++ b/docs/contracts/teacher.json
@@ -38,6 +38,10 @@
         "queries": [
           {
             "name": "teachers",
+            "arguments": {
+              "page": "PageInput",
+              "filter": "TeacherFilter"
+            },
             "returns": "TeacherPage!",
             "rest_equivalent": "GET /api/teachers",
             "mcp_equivalent": "search_teachers",
@@ -93,6 +97,7 @@
         "queries": [
           {
             "name": "teacher",
+            "arguments": { "id": "Int!" },
             "returns": "Teacher",
             "rest_equivalent": "GET /api/teachers/[id]",
             "mcp_equivalent": "get_teacher_by_id"

--- a/docs/contracts/todo.json
+++ b/docs/contracts/todo.json
@@ -27,6 +27,10 @@
           {
             "parent": "Viewer",
             "name": "todos",
+            "arguments": {
+              "filter": "TodoFilter",
+              "page": "PageInput"
+            },
             "returns": "TodoPage!",
             "auth": "user",
             "required_scopes": ["todo:read"],
@@ -40,6 +44,7 @@
         "mutations": [
           {
             "name": "createTodo",
+            "arguments": { "input": "CreateTodoInput!" },
             "returns": "TodoMutationPayload!",
             "auth": "user",
             "required_scopes": ["todo:write"],
@@ -48,6 +53,10 @@
           },
           {
             "name": "updateTodo",
+            "arguments": {
+              "id": "ID!",
+              "input": "UpdateTodoInput!"
+            },
             "returns": "TodoMutationPayload!",
             "auth": "user",
             "required_scopes": ["todo:write"],
@@ -56,6 +65,7 @@
           },
           {
             "name": "deleteTodo",
+            "arguments": { "id": "ID!" },
             "returns": "DeleteMutationPayload!",
             "auth": "user",
             "required_scopes": ["todo:write"],
@@ -64,6 +74,9 @@
           },
           {
             "name": "setTodoCompletions",
+            "arguments": {
+              "items": "[TodoCompletionBatchItemInput!]!"
+            },
             "returns": "TodoCompletionBatchPayload!",
             "auth": "user",
             "required_scopes": ["todo:write"],
@@ -76,6 +89,7 @@
           },
           {
             "name": "deleteTodos",
+            "arguments": { "ids": "[ID!]!" },
             "returns": "TodoDeleteBatchPayload!",
             "auth": "user",
             "required_scopes": ["todo:write"],

--- a/docs/contracts/upload.json
+++ b/docs/contracts/upload.json
@@ -71,6 +71,7 @@
         "mutations": [
           {
             "name": "createUploadSession",
+            "arguments": { "input": "CreateUploadSessionInput!" },
             "returns": "UploadSessionPayload!",
             "auth": "user",
             "required_scopes": ["upload:write"],
@@ -84,6 +85,7 @@
           },
           {
             "name": "completeUploadSession",
+            "arguments": { "input": "CompleteUploadSessionInput!" },
             "returns": "UploadCompletionPayload!",
             "auth": "user",
             "required_scopes": ["upload:write"],
@@ -177,6 +179,10 @@
         "mutations": [
           {
             "name": "renameUpload",
+            "arguments": {
+              "id": "ID!",
+              "filename": "String!"
+            },
             "returns": "UploadMutationPayload!",
             "auth": "user",
             "required_scopes": ["upload:write"],
@@ -186,6 +192,7 @@
           },
           {
             "name": "deleteUpload",
+            "arguments": { "id": "ID!" },
             "returns": "UploadDeleteMutationPayload!",
             "auth": "user",
             "required_scopes": ["upload:write"],

--- a/tests/unit/graphql-contract-parity.test.ts
+++ b/tests/unit/graphql-contract-parity.test.ts
@@ -1,6 +1,6 @@
 import { readdir, readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
-import { buildSchema, type GraphQLFieldMap } from "graphql";
+import { buildSchema, type GraphQLFieldMap, isObjectType } from "graphql";
 import { describe, expect, it } from "vitest";
 import { graphqlTypeDefs } from "@/lib/graphql/schema";
 
@@ -9,7 +9,9 @@ const contractsDirectory = fileURLToPath(
 );
 
 type GraphqlFieldContract = {
+  arguments?: Record<string, string>;
   name: string;
+  parent?: string;
   returns: string;
   status?: "stable" | "planned" | "unavailable";
 };
@@ -23,12 +25,13 @@ type ContractModule = {
         | {
             queries?: GraphqlFieldContract[];
             mutations?: GraphqlFieldContract[];
+            fields?: GraphqlFieldContract[];
           };
     }
   >;
 };
 
-async function collectContractFields(kind: "queries" | "mutations") {
+async function collectContractFields(kind: "queries" | "mutations" | "fields") {
   const filenames = (await readdir(contractsDirectory))
     .filter((filename) => filename.endsWith(".json"))
     .sort();
@@ -56,13 +59,35 @@ async function collectContractFields(kind: "queries" | "mutations") {
   return fields;
 }
 
-function contractFieldMap(fields: GraphqlFieldContract[]) {
-  const map = new Map<string, string>();
+type GraphqlFieldShape = {
+  arguments: Record<string, string>;
+  returns: string;
+};
+
+function sortedRecord(record: Record<string, string>) {
+  return Object.fromEntries(
+    Object.entries(record).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function contractFieldMap(
+  fields: GraphqlFieldContract[],
+  expectedParent: "Query" | "Mutation" | "Viewer",
+) {
+  const map = new Map<string, GraphqlFieldShape>();
   for (const field of fields) {
+    if (field.parent !== (expectedParent === "Viewer" ? "Viewer" : undefined)) {
+      throw new Error(
+        `GraphQL contract field ${field.name} must belong to ${expectedParent}`,
+      );
+    }
     if (map.has(field.name)) {
       throw new Error(`Duplicate GraphQL contract field: ${field.name}`);
     }
-    map.set(field.name, field.returns);
+    map.set(field.name, {
+      arguments: sortedRecord(field.arguments ?? {}),
+      returns: field.returns,
+    });
   }
   return Object.fromEntries(
     [...map].sort(([left], [right]) => left.localeCompare(right)),
@@ -72,24 +97,47 @@ function contractFieldMap(fields: GraphqlFieldContract[]) {
 function schemaFieldMap(fields: GraphQLFieldMap<unknown, unknown> | undefined) {
   return Object.fromEntries(
     Object.entries(fields ?? {})
-      .map(([name, field]) => [name, String(field.type)])
+      .map(
+        ([name, field]) =>
+          [
+            name,
+            {
+              arguments: sortedRecord(
+                Object.fromEntries(
+                  field.args.map((argument) => [
+                    argument.name,
+                    String(argument.type),
+                  ]),
+                ),
+              ),
+              returns: String(field.type),
+            },
+          ] as const,
+      )
       .sort(([left], [right]) => left.localeCompare(right)),
   );
 }
 
 describe("GraphQL contract and SDL parity", () => {
-  it("keeps every stable Query and Mutation name and return type aligned", async () => {
+  it("keeps stable root and Viewer field signatures aligned", async () => {
     const schema = buildSchema(graphqlTypeDefs);
-    const [queryContracts, mutationContracts] = await Promise.all([
-      collectContractFields("queries"),
-      collectContractFields("mutations"),
-    ]);
+    const [queryContracts, mutationContracts, viewerContracts] =
+      await Promise.all([
+        collectContractFields("queries"),
+        collectContractFields("mutations"),
+        collectContractFields("fields"),
+      ]);
+    const viewerType = schema.getType("Viewer");
 
-    expect(contractFieldMap(queryContracts)).toEqual(
+    expect(contractFieldMap(queryContracts, "Query")).toEqual(
       schemaFieldMap(schema.getQueryType()?.getFields()),
     );
-    expect(contractFieldMap(mutationContracts)).toEqual(
+    expect(contractFieldMap(mutationContracts, "Mutation")).toEqual(
       schemaFieldMap(schema.getMutationType()?.getFields()),
+    );
+    expect(isObjectType(viewerType)).toBe(true);
+    expect(contractFieldMap(viewerContracts, "Viewer")).toEqual(
+      schemaFieldMap(isObjectType(viewerType) ? viewerType.getFields() : {}),
     );
   });
 });

--- a/tests/unit/graphql-contract-parity.test.ts
+++ b/tests/unit/graphql-contract-parity.test.ts
@@ -76,9 +76,13 @@ function contractFieldMap(
 ) {
   const map = new Map<string, GraphqlFieldShape>();
   for (const field of fields) {
-    if (field.parent !== (expectedParent === "Viewer" ? "Viewer" : undefined)) {
+    const validParent =
+      expectedParent === "Viewer"
+        ? field.parent === "Viewer"
+        : field.parent === undefined || field.parent === expectedParent;
+    if (!validParent) {
       throw new Error(
-        `GraphQL contract field ${field.name} must belong to ${expectedParent}`,
+        `GraphQL contract field ${field.name} has parent ${field.parent ?? "(omitted)"}; expected ${expectedParent}`,
       );
     }
     if (map.has(field.name)) {


### PR DESCRIPTION
## Summary
- add structured GraphQL argument signatures to the domain contract schema and existing field declarations
- compare arguments and return types for every stable Query and Mutation field
- include the nested `Viewer` surface that the previous root-only gate ignored
- keep input members, enum values, and defaults in the canonical SDL compatibility gate instead of duplicating the whole schema into contract JSON

## Why
The previous parity check reduced root fields to `{ name: returnType }`. Argument rename/type/requiredness/list changes and every nested `Viewer` field could drift without failing the contract gate.

## Verification
- contract tests: 2/2
- GraphQL unit tests: 18 files / 162 tests
- full unit suite: 233 files / 1,432 tests
- Biome changed files clean
- Svelte check: 0 errors / 0 warnings
- all three TypeScript projects
- production build

Closes #575