### PR TITLE
fix(ui): cover visual matrix regressions

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,7 +43,23 @@ export default defineConfig({
     {
       name: "mobile-chrome",
       use: { ...devices["Pixel 7"] },
-      testMatch: ["mobile-screenshots/**/*.spec.ts"],
+      testMatch: [
+        "mobile-screenshots/**/*.spec.ts",
+        "visual-matrix/**/*.spec.ts",
+      ],
+    },
+    {
+      name: "visual-tablet",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { height: 1180, width: 820 },
+      },
+      testMatch: ["visual-matrix/**/*.spec.ts"],
+    },
+    {
+      name: "visual-desktop",
+      use: { ...devices["Desktop Chrome"] },
+      testMatch: ["visual-matrix/**/*.spec.ts"],
     },
   ],
 });

--- a/src/features/catalog/components/CatalogMobileFilters.svelte
+++ b/src/features/catalog/components/CatalogMobileFilters.svelte
@@ -46,7 +46,7 @@ export let searchValue: string;
     class={cn(
       "grid min-w-0 gap-2",
       inlineFilters
-        ? "grid-cols-[minmax(0,1fr)_auto]"
+        ? "grid-cols-1 min-[420px]:grid-cols-[minmax(0,1fr)_auto]"
         : "grid-cols-2 min-[420px]:grid-cols-[minmax(0,1fr)_auto_auto]",
       inlineFilters && "xl:min-w-0 xl:flex-1",
     )}

--- a/src/features/dashboard/components/OverviewTab.svelte
+++ b/src/features/dashboard/components/OverviewTab.svelte
@@ -105,6 +105,7 @@ function overviewCalendarWeekDays(
     overviewCalendar,
     overviewWeekStart,
     calendarTimelineItemsForDay,
+    locale,
   );
 }
 

--- a/src/features/dashboard/components/overview-tab-week-days.ts
+++ b/src/features/dashboard/components/overview-tab-week-days.ts
@@ -15,6 +15,7 @@ export function overviewCalendarWeekDays(
   overviewCalendar: DashboardCalendarData,
   overviewWeekStart: string,
   calendarTimelineItemsForDay: OverviewCalendarTimelineItemsForDay,
+  locale: string,
 ): OverviewWeekDay[] {
   return weekDaysFor(overviewWeekStart).map((dayKey) => {
     const events = calendarEventsForDay(overviewCalendar, dayKey);
@@ -22,7 +23,7 @@ export function overviewCalendarWeekDays(
     return {
       key: dayKey,
       label: overviewDayLabel(dayKey),
-      sublabel: formatCampusDate(dayKey, dayKey, undefined, {
+      sublabel: formatCampusDate(dayKey, dayKey, locale, {
         weekday: "short",
       }),
       isToday: dayKey === overviewCalendar.todayDate,

--- a/tests/e2e/src/app/dashboard/test.ts
+++ b/tests/e2e/src/app/dashboard/test.ts
@@ -211,4 +211,26 @@ test.describe("仪表盘", () => {
 
     await captureStepScreenshot(page, testInfo, "dashboard/mobile-priority");
   });
+
+  test("中文总览周视图使用本地化星期标签", async ({ page }, testInfo) => {
+    const localeResponse = await page.request.post("/api/locale", {
+      data: { locale: "zh-cn" },
+    });
+    expect(localeResponse.status()).toBe(200);
+    await signInAsDebugUser(page, "/dashboard/overview");
+    await ensureSeedSectionSubscription(page);
+    await gotoAndWaitForReady(page, "/dashboard/overview");
+
+    const weekCard = page
+      .getByRole("link", { name: "本周" })
+      .locator('xpath=ancestor::*[@data-slot="card"][1]');
+    await expect(weekCard).toBeVisible();
+    await expect(weekCard.getByText("周日", { exact: true })).toBeVisible();
+    await expect(weekCard.getByText("Sun", { exact: true })).toHaveCount(0);
+    await captureStepScreenshot(
+      page,
+      testInfo,
+      "dashboard/overview-week-zh-cn",
+    );
+  });
 });

--- a/tests/e2e/src/app/dashboard/test.ts
+++ b/tests/e2e/src/app/dashboard/test.ts
@@ -213,13 +213,14 @@ test.describe("仪表盘", () => {
   });
 
   test("中文总览周视图使用本地化星期标签", async ({ page }, testInfo) => {
+    await signInAsDebugUser(page, "/dashboard/overview");
     const localeResponse = await page.request.post("/api/locale", {
       data: { locale: "zh-cn" },
     });
     expect(localeResponse.status()).toBe(200);
-    await signInAsDebugUser(page, "/dashboard/overview");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/overview");
+    await expect(page.locator("html")).toHaveAttribute("lang", "zh-cn");
 
     const weekCard = page
       .getByRole("link", { name: "本周" })

--- a/tests/e2e/utils/catalog-inline-filters.ts
+++ b/tests/e2e/utils/catalog-inline-filters.ts
@@ -46,7 +46,14 @@ export async function expectCatalogInlineFilters(page: Page, labels: RegExp[]) {
   expect(searchButtonBox).not.toBeNull();
   expect(inputBox?.height ?? 0).toBeGreaterThanOrEqual(44);
   expect(searchButtonBox?.height ?? 0).toBeGreaterThanOrEqual(44);
-  expect(searchButtonBox?.y ?? 0).toBe(inputBox?.y ?? 0);
+  if (viewport.width < 420) {
+    expect(searchButtonBox?.y ?? 0).toBeGreaterThan(inputBox?.y ?? 0);
+    expect(
+      Math.abs((searchButtonBox?.width ?? 0) - (inputBox?.width ?? 0)),
+    ).toBeLessThan(1);
+  } else {
+    expect(searchButtonBox?.y ?? 0).toBe(inputBox?.y ?? 0);
+  }
 
   let firstControlBox = null as Awaited<
     ReturnType<typeof inlineFilters.boundingBox>

--- a/tests/e2e/visual-matrix/screenshots.spec.ts
+++ b/tests/e2e/visual-matrix/screenshots.spec.ts
@@ -13,8 +13,11 @@ test.describe("语言、主题和视口矩阵", () => {
   for (const locale of UI_MATRIX_LOCALES) {
     for (const theme of UI_MATRIX_THEMES) {
       test(`${locale} / ${theme}`, async ({ baseURL, page }, testInfo) => {
+        const prefersDark =
+          theme === "dark" ||
+          (theme === "system" && testInfo.project.name === "mobile-chrome");
         await page.emulateMedia({
-          colorScheme: theme === "light" ? "light" : "dark",
+          colorScheme: prefersDark ? "dark" : "light",
         });
         await page.context().addCookies([
           {
@@ -33,7 +36,7 @@ test.describe("语言、主题和视口矩阵", () => {
         await expect(page.locator("html")).toHaveAttribute("lang", locale);
         await expect(page.locator("html")).toHaveAttribute(
           "data-theme",
-          theme === "light" ? "light" : "dark",
+          prefersDark ? "dark" : "light",
         );
         await expect(
           page.getByRole("heading", {

--- a/tests/e2e/visual-matrix/screenshots.spec.ts
+++ b/tests/e2e/visual-matrix/screenshots.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { gotoAndWaitForReady } from "../utils/page-ready";
+import { absoluteTestUrl } from "../utils/request-url";
 import { captureStepScreenshot } from "../utils/screenshot";
 
 const UI_MATRIX_LOCALES = ["zh-cn", "en-us"] as const;
@@ -8,7 +9,7 @@ const UI_MATRIX_THEMES = ["light", "dark", "system"] as const;
 test.describe("语言、主题和视口矩阵", () => {
   for (const locale of UI_MATRIX_LOCALES) {
     for (const theme of UI_MATRIX_THEMES) {
-      test(`${locale} / ${theme}`, async ({ page }, testInfo) => {
+      test(`${locale} / ${theme}`, async ({ baseURL, page }, testInfo) => {
         await page.emulateMedia({
           colorScheme: theme === "light" ? "light" : "dark",
         });
@@ -16,7 +17,8 @@ test.describe("语言、主题和视口矩阵", () => {
           {
             name: "NEXT_LOCALE",
             value: locale,
-            url: "http://localhost:3000",
+            url: absoluteTestUrl("/", baseURL),
+            sameSite: "Lax",
           },
         ]);
         await page.addInitScript((themeMode) => {

--- a/tests/e2e/visual-matrix/screenshots.spec.ts
+++ b/tests/e2e/visual-matrix/screenshots.spec.ts
@@ -15,7 +15,7 @@ test.describe("语言、主题和视口矩阵", () => {
       test(`${locale} / ${theme}`, async ({ baseURL, page }, testInfo) => {
         const prefersDark =
           theme === "dark" ||
-          (theme === "system" && testInfo.project.name === "mobile-chrome");
+          (theme === "system" && testInfo.project.use.isMobile === true);
         await page.emulateMedia({
           colorScheme: prefersDark ? "dark" : "light",
         });

--- a/tests/e2e/visual-matrix/screenshots.spec.ts
+++ b/tests/e2e/visual-matrix/screenshots.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "@playwright/test";
-import { gotoAndWaitForReady } from "../utils/page-ready";
+import {
+  expectNoPageHorizontalOverflow,
+  gotoAndWaitForReady,
+} from "../utils/page-ready";
 import { absoluteTestUrl } from "../utils/request-url";
 import { captureStepScreenshot } from "../utils/screenshot";
 
@@ -41,13 +44,7 @@ test.describe("语言、主题和视口矩阵", () => {
                 : "Start with public campus tools",
           }),
         ).toBeVisible();
-        expect(
-          await page.evaluate(
-            () =>
-              document.documentElement.scrollWidth <=
-              document.documentElement.clientWidth,
-          ),
-        ).toBe(true);
+        await expectNoPageHorizontalOverflow(page);
         await captureStepScreenshot(
           page,
           testInfo,

--- a/tests/e2e/visual-matrix/screenshots.spec.ts
+++ b/tests/e2e/visual-matrix/screenshots.spec.ts
@@ -40,8 +40,8 @@ test.describe("语言、主题和视口矩阵", () => {
             level: 1,
             name:
               locale === "zh-cn"
-                ? "先从公开校园工具开始"
-                : "Start with public campus tools",
+                ? /先从公开校园工具开始/
+                : /start with public campus tools/i,
           }),
         ).toBeVisible();
         await expectNoPageHorizontalOverflow(page);

--- a/tests/e2e/visual-matrix/screenshots.spec.ts
+++ b/tests/e2e/visual-matrix/screenshots.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+import { gotoAndWaitForReady } from "../utils/page-ready";
+import { captureStepScreenshot } from "../utils/screenshot";
+
+const UI_MATRIX_LOCALES = ["zh-cn", "en-us"] as const;
+const UI_MATRIX_THEMES = ["light", "dark", "system"] as const;
+
+test.describe("语言、主题和视口矩阵", () => {
+  for (const locale of UI_MATRIX_LOCALES) {
+    for (const theme of UI_MATRIX_THEMES) {
+      test(`${locale} / ${theme}`, async ({ page }, testInfo) => {
+        await page.emulateMedia({
+          colorScheme: theme === "light" ? "light" : "dark",
+        });
+        await page.context().addCookies([
+          {
+            name: "NEXT_LOCALE",
+            value: locale,
+            url: "http://localhost:3000",
+          },
+        ]);
+        await page.addInitScript((themeMode) => {
+          localStorage.setItem("life-ustc-theme", themeMode);
+        }, theme);
+
+        await gotoAndWaitForReady(page, "/");
+
+        await expect(page.locator("html")).toHaveAttribute("lang", locale);
+        await expect(page.locator("html")).toHaveAttribute(
+          "data-theme",
+          theme === "light" ? "light" : "dark",
+        );
+        await expect(
+          page.getByRole("heading", {
+            level: 1,
+            name:
+              locale === "zh-cn"
+                ? "先从公开校园工具开始"
+                : "Start with public campus tools",
+          }),
+        ).toBeVisible();
+        expect(
+          await page.evaluate(
+            () =>
+              document.documentElement.scrollWidth <=
+              document.documentElement.clientWidth,
+          ),
+        ).toBe(true);
+        await captureStepScreenshot(
+          page,
+          testInfo,
+          `visual-matrix/${testInfo.project.name}-${locale}-${theme}`,
+        );
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- stack the mobile catalog search field and full-width button below 420px so English text is no longer clipped
- localize dashboard week labels through the active locale (`周日/周一` instead of `Sun/Mon` on zh-cn)
- add a deterministic 2 locales × 3 themes × 3 viewports Playwright matrix
- assert resolved locale/theme, critical heading visibility, and absence of horizontal overflow while attaching screenshots in CI

This advances #576 with deterministic cross-product coverage and structural assertions. Pixel baselines/diffs remain deliberately open in that issue.

## Visual verification
- 27 fresh local screenshots inspected under `/tmp/life-ustc-ui-audit-20260722/`
- mobile catalog after: full placeholder and 375px-wide Search action
- signed-in zh-cn tablet dashboard after: localized weekday labels
- false positive rejected: fixed mobile bottom nav does not overlap Save at max scroll

## Verification
- focused E2E: 2/2
- locale/theme/viewport matrix: 18/18
- full unit: 233 files / 1,432 tests
- app prepare, production build, Biome, Svelte check 0/0, three TypeScript projects