### PR TITLE
fix(loader): reassign stale admin class ids safely

### DIFF
--- a/src/static-loader/import.ts
+++ b/src/static-loader/import.ts
@@ -1987,12 +1987,29 @@ async function upsertRooms(
   );
 }
 
-async function upsertAdminClasses(
+export async function upsertAdminClasses(
   tx: Prisma.TransactionClient,
   builds: AdminClassOccurrence[],
 ): Promise<Map<number, number>> {
   const { canonicalBuilds, canonicalJwIdByAlias } =
     canonicalizeAdminClasses(builds);
+  // nameCn is the durable identity; release jwIds still held by an old name
+  // before the unique-name upsert reassigns them.
+  for (const batch of chunks(canonicalBuilds, 500)) {
+    const params: ColumnValue[] = [];
+    const values = batch.map((build) => {
+      params.push(build.nameCn, build.jwId);
+      return `($${params.length - 1}::text, $${params.length}::int)`;
+    });
+    await tx.$executeRawUnsafe(
+      `UPDATE "AdminClass" AS existing
+       SET "jwId" = NULL
+       FROM (VALUES ${values.join(",")}) AS incoming("nameCn", "jwId")
+       WHERE existing."jwId" = incoming."jwId"
+         AND existing."nameCn" <> incoming."nameCn"`,
+      ...params,
+    );
+  }
   const columns = [
     "jwId",
     "code",

--- a/tests/integration/static-import-write-churn.test.ts
+++ b/tests/integration/static-import-write-churn.test.ts
@@ -7,6 +7,7 @@ import { createTestPrisma, disconnectTestPrisma } from "../shared/prisma";
 vi.mock("bun:sqlite", () => ({ Database: class {} }));
 const {
   bulkUpsert,
+  upsertAdminClasses,
   writeAdminClassSections,
   writeSchedules,
   writeSectionTeachers,
@@ -31,6 +32,54 @@ async function tupleId(
 }
 
 describe("static import write churn", () => {
+  it("reassigns AdminClass jwIds without colliding with stale owners", async () => {
+    const rollback = new Error("ROLLBACK_ADMIN_CLASS_IDENTITY_TEST");
+    const marker = 1_600_000_000 + (Date.now() % 100_000_000) * 2;
+
+    try {
+      await prisma.$transaction(async (tx) => {
+        const first = await tx.adminClass.create({
+          data: { jwId: marker, nameCn: `${marker}-first` },
+        });
+        const second = await tx.adminClass.create({
+          data: { jwId: marker + 1, nameCn: `${marker}-second` },
+        });
+
+        const idByJwId = await upsertAdminClasses(tx, [
+          {
+            semesterCode: 461,
+            adminClass: { jwId: marker + 1, nameCn: `${marker}-first` },
+          },
+          {
+            semesterCode: 461,
+            adminClass: { jwId: marker, nameCn: `${marker}-second` },
+          },
+        ]);
+
+        await expect(
+          tx.adminClass.findMany({
+            where: { id: { in: [first.id, second.id] } },
+            orderBy: { nameCn: "asc" },
+            select: { id: true, jwId: true, nameCn: true },
+          }),
+        ).resolves.toEqual([
+          { id: first.id, jwId: marker + 1, nameCn: `${marker}-first` },
+          { id: second.id, jwId: marker, nameCn: `${marker}-second` },
+        ]);
+        expect(idByJwId).toEqual(
+          new Map([
+            [marker, second.id],
+            [marker + 1, first.id],
+          ]),
+        );
+
+        throw rollback;
+      });
+    } catch (error) {
+      if (error !== rollback) throw error;
+    }
+  });
+
   it("skips unchanged bulk upserts while still returning their ids", async () => {
     const rollback = new Error("ROLLBACK_BULK_UPSERT_CHURN_TEST");
     const marker = 1_700_000_000 + (Date.now() % 100_000_000);


### PR DESCRIPTION
## Summary
- release incoming AdminClass `jwId` values that are still owned by a stale `nameCn` before the name-based upsert
- keep reassignment inside the existing transaction
- preserve durable AdminClass rows and their relations instead of deleting/recreating identities
- add a PostgreSQL regression covering two classes swapping unique `jwId` values

## Incident
Two scheduled Static Sync runs failed on the same 17,729-row snapshot with PostgreSQL `23505` / `AdminClass_jwId_key`: [29836010540](https://github.com/Life-USTC/server/actions/runs/29836010540), [29861063163](https://github.com/Life-USTC/server/actions/runs/29861063163).

## Verification
- focused PostgreSQL integration: 4/4
- unit suite: 233 files / 1,432 tests
- app prepare
- Biome (one pre-existing static-loader unused warning)
- Svelte check 0/0
- all three TypeScript projects

Full integration seed was not forced against the shared local database because it contains an unrelated pre-existing `Account_userId_fkey` inconsistency.

Closes #586