### PR TITLE
fix(loader): bound join sync query depth

### DIFF
--- a/src/static-loader/import.ts
+++ b/src/static-loader/import.ts
@@ -2842,7 +2842,7 @@ function mergePlaceholderDepartments(
   return result;
 }
 
-async function syncJoinPairs(
+export async function syncJoinPairs(
   tx: Prisma.TransactionClient,
   table: string,
   scopeColumn: "A" | "B",
@@ -2857,11 +2857,15 @@ async function syncJoinPairs(
     const keepClause =
       scopedPairs.length === 0
         ? ""
-        : ` AND ("A","B") NOT IN (${scopedPairs
-            .map((pair) => `(${pair.a},${pair.b})`)
-            .join(",")})`;
+        : ` AND NOT EXISTS (
+            SELECT 1
+            FROM (VALUES ${scopedPairs
+              .map((pair) => `(${pair.a},${pair.b})`)
+              .join(",")}) AS desired("A","B")
+            WHERE desired."A" = target."A" AND desired."B" = target."B"
+          )`;
     await tx.$executeRawUnsafe(
-      `DELETE FROM "${table}" WHERE "${scopeColumn}" IN (${scopeChunk.join(",")})${keepClause}`,
+      `DELETE FROM "${table}" AS target WHERE target."${scopeColumn}" IN (${scopeChunk.join(",")})${keepClause}`,
     );
   }
 

--- a/src/static-loader/import.ts
+++ b/src/static-loader/import.ts
@@ -1987,12 +1987,29 @@ async function upsertRooms(
   );
 }
 
-async function upsertAdminClasses(
+export async function upsertAdminClasses(
   tx: Prisma.TransactionClient,
   builds: AdminClassOccurrence[],
 ): Promise<Map<number, number>> {
   const { canonicalBuilds, canonicalJwIdByAlias } =
     canonicalizeAdminClasses(builds);
+  // nameCn is the durable identity; release jwIds still held by an old name
+  // before the unique-name upsert reassigns them.
+  for (const batch of chunks(canonicalBuilds, 500)) {
+    const params: ColumnValue[] = [];
+    const values = batch.map((build) => {
+      params.push(build.nameCn, build.jwId);
+      return `($${params.length - 1}::text, $${params.length}::int)`;
+    });
+    await tx.$executeRawUnsafe(
+      `UPDATE "AdminClass" AS existing
+       SET "jwId" = NULL
+       FROM (VALUES ${values.join(",")}) AS incoming("nameCn", "jwId")
+       WHERE existing."jwId" = incoming."jwId"
+         AND existing."nameCn" <> incoming."nameCn"`,
+      ...params,
+    );
+  }
   const columns = [
     "jwId",
     "code",

--- a/tests/integration/static-import-write-churn.test.ts
+++ b/tests/integration/static-import-write-churn.test.ts
@@ -7,6 +7,7 @@ import { createTestPrisma, disconnectTestPrisma } from "../shared/prisma";
 vi.mock("bun:sqlite", () => ({ Database: class {} }));
 const {
   bulkUpsert,
+  syncJoinPairs,
   upsertAdminClasses,
   writeAdminClassSections,
   writeSchedules,
@@ -32,6 +33,56 @@ async function tupleId(
 }
 
 describe("static import write churn", () => {
+  it("syncs production-sized join sets within PostgreSQL stack limits", async () => {
+    const rollback = new Error("ROLLBACK_JOIN_SYNC_STACK_TEST");
+
+    try {
+      await prisma.$transaction(async (tx) => {
+        await tx.$executeRawUnsafe(
+          `CREATE TEMP TABLE "StaticJoinPairProbe" (
+            "A" int NOT NULL,
+            "B" int NOT NULL,
+            PRIMARY KEY ("A", "B")
+          ) ON COMMIT DROP`,
+        );
+        await tx.$executeRawUnsafe(
+          `INSERT INTO "StaticJoinPairProbe" ("A", "B") VALUES (1, 11), (1, 999999)`,
+        );
+        await tx.$executeRawUnsafe("SET LOCAL max_stack_depth = '100kB'");
+
+        const pairs = Array.from({ length: 6_000 }, (_, index) => ({
+          a: Math.floor(index / 6) + 1,
+          b: index + 1,
+        }));
+        await syncJoinPairs(
+          tx,
+          "StaticJoinPairProbe",
+          "A",
+          Array.from({ length: 1_000 }, (_, index) => index + 1),
+          pairs,
+        );
+
+        await expect(
+          tx.$queryRawUnsafe<Array<{ count: bigint }>>(
+            `SELECT COUNT(*) AS count FROM "StaticJoinPairProbe"`,
+          ),
+        ).resolves.toEqual([{ count: 6_000n }]);
+        await expect(
+          tx.$queryRawUnsafe<Array<{ exists: boolean }>>(
+            `SELECT EXISTS (
+              SELECT 1 FROM "StaticJoinPairProbe"
+              WHERE "A" = 1 AND "B" = 999999
+            ) AS exists`,
+          ),
+        ).resolves.toEqual([{ exists: false }]);
+
+        throw rollback;
+      });
+    } catch (error) {
+      if (error !== rollback) throw error;
+    }
+  });
+
   it("reassigns AdminClass jwIds without colliding with stale owners", async () => {
     const rollback = new Error("ROLLBACK_ADMIN_CLASS_IDENTITY_TEST");
     const marker = 1_600_000_000 + (Date.now() % 100_000_000) * 2;

--- a/tests/integration/static-import-write-churn.test.ts
+++ b/tests/integration/static-import-write-churn.test.ts
@@ -7,6 +7,7 @@ import { createTestPrisma, disconnectTestPrisma } from "../shared/prisma";
 vi.mock("bun:sqlite", () => ({ Database: class {} }));
 const {
   bulkUpsert,
+  upsertAdminClasses,
   writeAdminClassSections,
   writeSchedules,
   writeSectionTeachers,
@@ -31,6 +32,54 @@ async function tupleId(
 }
 
 describe("static import write churn", () => {
+  it("reassigns AdminClass jwIds without colliding with stale owners", async () => {
+    const rollback = new Error("ROLLBACK_ADMIN_CLASS_IDENTITY_TEST");
+    const marker = 1_600_000_000 + (Date.now() % 100_000_000) * 2;
+
+    try {
+      await prisma.$transaction(async (tx) => {
+        const first = await tx.adminClass.create({
+          data: { jwId: marker, nameCn: `${marker}-first` },
+        });
+        const second = await tx.adminClass.create({
+          data: { jwId: marker + 1, nameCn: `${marker}-second` },
+        });
+
+        const idByJwId = await upsertAdminClasses(tx, [
+          {
+            semesterCode: 461,
+            adminClass: { jwId: marker + 1, nameCn: `${marker}-first` },
+          },
+          {
+            semesterCode: 461,
+            adminClass: { jwId: marker, nameCn: `${marker}-second` },
+          },
+        ]);
+
+        await expect(
+          tx.adminClass.findMany({
+            where: { id: { in: [first.id, second.id] } },
+            orderBy: { nameCn: "asc" },
+            select: { id: true, jwId: true, nameCn: true },
+          }),
+        ).resolves.toEqual([
+          { id: first.id, jwId: marker + 1, nameCn: `${marker}-first` },
+          { id: second.id, jwId: marker, nameCn: `${marker}-second` },
+        ]);
+        expect(idByJwId).toEqual(
+          new Map([
+            [marker, second.id],
+            [marker + 1, first.id],
+          ]),
+        );
+
+        throw rollback;
+      });
+    } catch (error) {
+      if (error !== rollback) throw error;
+    }
+  });
+
   it("skips unchanged bulk upserts while still returning their ids", async () => {
     const rollback = new Error("ROLLBACK_BULK_UPSERT_CHURN_TEST");
     const marker = 1_700_000_000 + (Date.now() % 100_000_000);


### PR DESCRIPTION
## Summary
- replace the deeply recursive tuple `NOT IN` keep-set with an equivalent `NOT EXISTS` anti-join over `VALUES`
- preserve the current 1,000-scope and insert batches instead of hiding the failure by reducing throughput
- add a PostgreSQL low-stack regression with 1,000 scope IDs and 6,000 desired pairs
- verify stale rows are deleted and all desired rows remain

## Production evidence
[Static Sync dry-run 29863285031](https://github.com/Life-USTC/server/actions/runs/29863285031) confirmed the preceding AdminClass fix, then exposed PostgreSQL `54001` in `writeSchedules`. The current snapshot has 130,811 schedules and a maximum 5,770-pair keep-set per scope chunk.

## Verification
- old SQL reproduces 54001 at `max_stack_depth=100kB` / 6,000 tuples
- new SQL passes that exact load
- isolated full-snapshot dry-run passes; `writeSchedules` ~11.95s
- focused PostgreSQL integration: 5/5
- unit suite: 234 files / 1,436 tests
- app prepare, Biome (one existing warning), Svelte check 0/0, all TypeScript projects

Closes #588