### PR TITLE
perf(todos): bound batch database concurrency

### DIFF
--- a/src/features/todos/lib/todo-batch-concurrency.ts
+++ b/src/features/todos/lib/todo-batch-concurrency.ts
@@ -1,0 +1,20 @@
+export const TODO_BATCH_CONCURRENCY = 5;
+
+export async function mapTodoBatchWithConcurrency<Input, Output>(
+  items: readonly Input[],
+  operation: (item: Input, index: number) => Promise<Output>,
+): Promise<Output[]> {
+  const results = new Array<Output>(items.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(TODO_BATCH_CONCURRENCY, items.length) },
+    async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex++;
+        results[index] = await operation(items[index] as Input, index);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}

--- a/src/features/todos/server/todo-batch-service.ts
+++ b/src/features/todos/server/todo-batch-service.ts
@@ -1,0 +1,46 @@
+import { mapTodoBatchWithConcurrency } from "../lib/todo-batch-concurrency";
+import { deleteOwnedTodo, updateOwnedTodo } from "./todo-service";
+
+export function setTodoCompletionsBatch(
+  userId: string,
+  items: readonly { completed: boolean; todoId: string }[],
+) {
+  return mapTodoBatchWithConcurrency(items, async (item) => {
+    const result = await updateOwnedTodo({
+      id: item.todoId,
+      userId,
+      data: {
+        completed: item.completed,
+        dueAt: undefined,
+        hasDueAt: false,
+      },
+    });
+    if (!result.ok) {
+      return {
+        success: false as const,
+        todoId: item.todoId,
+        completed: item.completed,
+        error: { code: result.error, message: result.error },
+      };
+    }
+    return {
+      success: true as const,
+      todoId: item.todoId,
+      completed: item.completed,
+      todo: result.todo,
+    };
+  });
+}
+
+export function deleteTodosBatch(userId: string, ids: readonly string[]) {
+  return mapTodoBatchWithConcurrency(ids, async (id) => {
+    const result = await deleteOwnedTodo(id, userId);
+    return result.ok
+      ? { success: true as const, id }
+      : {
+          success: false as const,
+          id,
+          error: { code: result.error, message: result.error },
+        };
+  });
+}

--- a/src/lib/api/routes/todo-batch-route.ts
+++ b/src/lib/api/routes/todo-batch-route.ts
@@ -1,7 +1,7 @@
 import {
-  deleteOwnedTodo,
-  updateOwnedTodo,
-} from "@/features/todos/server/todo-service";
+  deleteTodosBatch,
+  setTodoCompletionsBatch,
+} from "@/features/todos/server/todo-batch-service";
 import {
   handleRouteError,
   jsonResponse,
@@ -33,33 +33,7 @@ export async function patchTodoBatchRoute(request: Request) {
   if (body instanceof Response) return body;
 
   try {
-    const results = await Promise.all(
-      body.items.map(async (item) => {
-        const result = await updateOwnedTodo({
-          id: item.todoId,
-          userId: auth.userId,
-          data: {
-            completed: item.completed,
-            dueAt: undefined,
-            hasDueAt: false,
-          },
-        });
-        if (!result.ok) {
-          return {
-            success: false as const,
-            todoId: item.todoId,
-            completed: item.completed,
-            error: { code: result.error, message: result.error },
-          };
-        }
-        return {
-          success: true as const,
-          todoId: item.todoId,
-          completed: item.completed,
-          todo: result.todo,
-        };
-      }),
-    );
+    const results = await setTodoCompletionsBatch(auth.userId, body.items);
 
     return jsonResponse(
       todoCompletionBatchResponseSchema.parse(serializeDatesDeep({ results })),
@@ -84,19 +58,7 @@ export async function deleteTodoBatchRoute(request: Request) {
   if (body instanceof Response) return body;
 
   try {
-    const results = await Promise.all(
-      body.ids.map(async (id) => {
-        const result = await deleteOwnedTodo(id, auth.userId);
-        if (!result.ok) {
-          return {
-            success: false as const,
-            id,
-            error: { code: result.error, message: result.error },
-          };
-        }
-        return { success: true as const, id };
-      }),
-    );
+    const results = await deleteTodosBatch(auth.userId, body.ids);
 
     return jsonResponse(todoBatchDeleteResponseSchema.parse({ results }));
   } catch (error) {

--- a/src/lib/graphql/mutations.ts
+++ b/src/lib/graphql/mutations.ts
@@ -45,6 +45,10 @@ import {
 } from "@/features/subscriptions/server/subscriptions";
 import type { TodoPriorityValue } from "@/features/todos/lib/todo-priority";
 import {
+  deleteTodosBatch,
+  setTodoCompletionsBatch,
+} from "@/features/todos/server/todo-batch-service";
+import {
   createTodo,
   deleteOwnedTodo,
   updateOwnedTodo,
@@ -851,33 +855,12 @@ export const graphqlMutationResolvers = {
         "todo IDs",
         100,
       );
-      const results = await Promise.all(
-        args.items.map(async (item, index) => {
-          const todoId = ids[index];
-          const result = await updateOwnedTodo({
-            id: todoId,
-            userId: principal.userId,
-            data: {
-              completed: item.completed,
-              dueAt: undefined,
-              hasDueAt: false,
-            },
-          });
-          if (!result.ok) {
-            return {
-              success: false as const,
-              todoId,
-              completed: item.completed,
-              error: { code: result.error, message: result.error },
-            };
-          }
-          return {
-            success: true as const,
-            todoId,
-            completed: item.completed,
-            todo: result.todo,
-          };
-        }),
+      const results = await setTodoCompletionsBatch(
+        principal.userId,
+        args.items.map((item, index) => ({
+          completed: item.completed,
+          todoId: ids[index] as string,
+        })),
       );
       return { results };
     },
@@ -890,18 +873,7 @@ export const graphqlMutationResolvers = {
         rateLimitTier: "batch",
       });
       const ids = normalizeBatchIds(args.ids, "todo IDs", 100);
-      const results = await Promise.all(
-        ids.map(async (id) => {
-          const result = await deleteOwnedTodo(id, principal.userId);
-          return result.ok
-            ? { success: true as const, id }
-            : {
-                success: false as const,
-                id,
-                error: { code: result.error, message: result.error },
-              };
-        }),
-      );
+      const results = await deleteTodosBatch(principal.userId, ids);
       return { results };
     },
     async createHomework(

--- a/tests/unit/todo-batch-concurrency.test.ts
+++ b/tests/unit/todo-batch-concurrency.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapTodoBatchWithConcurrency,
+  TODO_BATCH_CONCURRENCY,
+} from "@/features/todos/lib/todo-batch-concurrency";
+
+describe("todo batch concurrency", () => {
+  it("preserves 100-item ordering without exceeding the connection budget", async () => {
+    const releases: Array<() => void> = [];
+    let active = 0;
+    let maxActive = 0;
+    const operation = async (value: number) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise<void>((resolve) => releases.push(resolve));
+      active -= 1;
+      return value * 2;
+    };
+
+    const pending = mapTodoBatchWithConcurrency(
+      Array.from({ length: 100 }, (_, index) => index),
+      operation,
+    );
+    while (releases.length < TODO_BATCH_CONCURRENCY) await Promise.resolve();
+    expect(active).toBe(TODO_BATCH_CONCURRENCY);
+    expect(releases).toHaveLength(TODO_BATCH_CONCURRENCY);
+
+    for (let index = 0; index < 100; index += 1) {
+      while (!releases[index]) await Promise.resolve();
+      releases[index]?.();
+    }
+
+    await expect(pending).resolves.toEqual(
+      Array.from({ length: 100 }, (_, index) => index * 2),
+    );
+    expect(maxActive).toBe(TODO_BATCH_CONCURRENCY);
+  });
+});


### PR DESCRIPTION
## Summary

- route REST and GraphQL todo completion/delete batches through one feature-owned service
- cap per-request database fan-out at five concurrent operations while preserving input order and per-item results
- cover the 100-item contract limit with a deterministic concurrency test

## Verification

- full unit suite: 235 files / 1437 tests
- GraphQL PostgreSQL batch integration: 5 tests
- app/test TypeScript projects
- Biome and `git diff --check`

Closes #581
