### PR TITLE
fix(static-loader): disambiguate conflicting campus IDs

### DIFF
--- a/src/static-loader/campus-identity.ts
+++ b/src/static-loader/campus-identity.ts
@@ -1,0 +1,31 @@
+import type { CampusBuild, SectionBuild } from "./mappers";
+
+export type CampusIdentityMap = {
+  byJwId: Map<number, number>;
+  byName: Map<string, number>;
+};
+
+export function normalizeCampusIdentity(
+  campus: CampusBuild,
+  nameByJwId: Map<number, string>,
+): CampusBuild {
+  if (campus.jwId == null) return campus;
+  const existingName = nameByJwId.get(campus.jwId);
+  if (existingName != null && existingName !== campus.nameCn) {
+    return { ...campus, jwId: undefined };
+  }
+  nameByJwId.set(campus.jwId, campus.nameCn);
+  return campus;
+}
+
+export function resolveSectionCampusDatabaseId(
+  build: Pick<SectionBuild, "campusId" | "campusName">,
+  campusMap: CampusIdentityMap,
+) {
+  return (
+    (build.campusName != null
+      ? campusMap.byName.get(build.campusName)
+      : undefined) ??
+    (build.campusId != null ? campusMap.byJwId.get(build.campusId) : undefined)
+  );
+}

--- a/src/static-loader/import.ts
+++ b/src/static-loader/import.ts
@@ -4,6 +4,11 @@ import {
   canonicalizeAdminClasses,
 } from "./admin-class-identity";
 import {
+  type CampusIdentityMap,
+  normalizeCampusIdentity,
+  resolveSectionCampusDatabaseId,
+} from "./campus-identity";
+import {
   courseIdentitySignature,
   type IncomingCourseIdentityRecord,
   planCourseIdentityImport,
@@ -847,15 +852,7 @@ function loadScheduleInfrastructure(snapshot: Snapshot) {
   const adminClasses: AdminClassOccurrence[] = [];
 
   function addCampus(campus: CampusBuild) {
-    if (campus.jwId != null) {
-      const existingName = campusNameByJwId.get(campus.jwId);
-      if (existingName != null && existingName !== campus.nameCn) {
-        throw new Error(
-          `Campus jwId ${campus.jwId} has conflicting names: ${existingName} vs ${campus.nameCn}`,
-        );
-      }
-      campusNameByJwId.set(campus.jwId, campus.nameCn);
-    }
+    campus = normalizeCampusIdentity(campus, campusNameByJwId);
 
     const existing = campuses.get(campus.nameCn);
     if (existing == null) {
@@ -1870,10 +1867,7 @@ async function upsertCampuses(
   return map;
 }
 
-type CampusMap = {
-  byJwId: Map<number, number>;
-  byName: Map<string, number>;
-};
+type CampusMap = CampusIdentityMap;
 
 async function upsertRoomTypes(
   tx: Prisma.TransactionClient,
@@ -2112,13 +2106,7 @@ async function upsertSections(
     const openDepartmentId = build.openDepartmentCode
       ? departmentMap.get(build.openDepartmentCode)
       : null;
-    const campusId =
-      (build.campusId != null
-        ? campusMap.byJwId.get(build.campusId)
-        : undefined) ??
-      (build.campusName != null
-        ? campusMap.byName.get(build.campusName)
-        : undefined);
+    const campusId = resolveSectionCampusDatabaseId(build, campusMap);
     if (
       campusId == null &&
       (build.campusId != null || build.campusName != null)

--- a/tests/unit/static-campus-identity.test.ts
+++ b/tests/unit/static-campus-identity.test.ts
@@ -59,7 +59,7 @@ describe("static campus identity", () => {
   it("resolves sections that only provide a JW campus ID", () => {
     expect(
       resolveSectionCampusDatabaseId(
-        { campusId: 102, campusName: null },
+        { campusId: 102, campusName: undefined },
         {
           byJwId: new Map([[102, 1]]),
           byName: new Map(),

--- a/tests/unit/static-campus-identity.test.ts
+++ b/tests/unit/static-campus-identity.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeCampusIdentity,
+  resolveSectionCampusDatabaseId,
+} from "@/static-loader/campus-identity";
+
+describe("static campus identity", () => {
+  it("keeps a conflicting catalog campus as name-only", () => {
+    const names = new Map([[102, "太湖路校区"]]);
+
+    expect(
+      normalizeCampusIdentity(
+        { jwId: 102, nameCn: "高新区", nameEn: "High-tech Campus" },
+        names,
+      ),
+    ).toEqual({
+      jwId: undefined,
+      nameCn: "高新区",
+      nameEn: "High-tech Campus",
+    });
+    expect(names).toEqual(new Map([[102, "太湖路校区"]]));
+  });
+
+  it("retains a matching campus ID and records new identities", () => {
+    const names = new Map<number, string>();
+    const campus = { jwId: 102, nameCn: "太湖路校区" };
+
+    expect(normalizeCampusIdentity(campus, names)).toBe(campus);
+    expect(names).toEqual(new Map([[102, "太湖路校区"]]));
+  });
+
+  it("prefers the catalog name when section ID and name disagree", () => {
+    expect(
+      resolveSectionCampusDatabaseId(
+        { campusId: 102, campusName: "高新区" },
+        {
+          byJwId: new Map([[102, 1]]),
+          byName: new Map([
+            ["太湖路校区", 1],
+            ["高新区", 2],
+          ]),
+        },
+      ),
+    ).toBe(2);
+  });
+});

--- a/tests/unit/static-campus-identity.test.ts
+++ b/tests/unit/static-campus-identity.test.ts
@@ -43,4 +43,28 @@ describe("static campus identity", () => {
       ),
     ).toBe(2);
   });
+
+  it("falls back to the JW ID when the catalog name is unknown", () => {
+    expect(
+      resolveSectionCampusDatabaseId(
+        { campusId: 102, campusName: "未知校区" },
+        {
+          byJwId: new Map([[102, 1]]),
+          byName: new Map(),
+        },
+      ),
+    ).toBe(1);
+  });
+
+  it("resolves sections that only provide a JW campus ID", () => {
+    expect(
+      resolveSectionCampusDatabaseId(
+        { campusId: 102, campusName: null },
+        {
+          byJwId: new Map([[102, 1]]),
+          byName: new Map(),
+        },
+      ),
+    ).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #593.

The current snapshot reuses JW campus ID 102 for `太湖路校区` in room/building data while catalog lessons name it `高新区`. Preserve the canonical JW identity, retain the catalog campus as a name-only identity, and resolve section campus by its catalog name before the conflicting numeric ID.

Verification:
- `bunx vitest run tests/unit/static-campus-identity.test.ts tests/unit/static-loader-import.test.ts`
- `bunx tsc -p tsconfig.operational.json --noEmit`
- full current 235 MB production snapshot dry-run against fresh PostgreSQL (130,554 schedules; rolled back successfully)