### PR TITLE
test(graphql): gate dangerous schema evolution

### DIFF
--- a/docs/graphql/schema-evolution.md
+++ b/docs/graphql/schema-evolution.md
@@ -1,0 +1,14 @@
+# GraphQL schema evolution policy
+
+The canonical SDL snapshot and breaking-change gate remain authoritative. CI
+also blocks dangerous changes that can alter existing client behavior:
+
+- enum value and union-member additions;
+- newly implemented interfaces;
+- argument default changes;
+- input-object field default additions, removals, and changes.
+
+Optional argument and optional input-field additions remain additive-safe. They
+are allowed by the compatibility gate but remain visible in the canonical SDL
+diff for normal review. A behavior-changing default must be introduced as an
+explicitly reviewed schema change rather than hidden behind that exception.

--- a/src/lib/graphql/schema-diff.ts
+++ b/src/lib/graphql/schema-diff.ts
@@ -1,11 +1,25 @@
 import {
   BreakingChangeType,
   buildSchema,
+  DangerousChangeType,
   findBreakingChanges,
+  findDangerousChanges,
+  isInputObjectType,
   isInterfaceType,
   isNonNullType,
   isObjectType,
+  print,
 } from "graphql";
+
+const allowedDangerousChangeTypes = new Set<DangerousChangeType>([
+  DangerousChangeType.OPTIONAL_ARG_ADDED,
+  DangerousChangeType.OPTIONAL_INPUT_FIELD_ADDED,
+]);
+
+export type GraphqlDangerousChange = {
+  type: DangerousChangeType | "INPUT_FIELD_DEFAULT_VALUE_CHANGE";
+  description: string;
+};
 
 export function findGraphqlBreakingChanges(
   previousSdl: string,
@@ -40,4 +54,53 @@ export function findGraphqlBreakingChanges(
   }
 
   return changes;
+}
+
+export function classifyGraphqlDangerousChanges(
+  previousSdl: string,
+  nextSdl: string,
+) {
+  const previousSchema = buildSchema(previousSdl);
+  const nextSchema = buildSchema(nextSdl);
+  const detected: GraphqlDangerousChange[] = findDangerousChanges(
+    previousSchema,
+    nextSchema,
+  );
+
+  for (const previousType of Object.values(previousSchema.getTypeMap())) {
+    if (!isInputObjectType(previousType)) continue;
+    const nextType = nextSchema.getType(previousType.name);
+    if (!nextType || !isInputObjectType(nextType)) continue;
+
+    for (const [fieldName, previousField] of Object.entries(
+      previousType.getFields(),
+    )) {
+      const nextField = nextType.getFields()[fieldName];
+      if (!nextField) continue;
+      const previousDefault = previousField.astNode?.defaultValue;
+      const nextDefault = nextField.astNode?.defaultValue;
+      const previousPrinted = previousDefault
+        ? print(previousDefault)
+        : undefined;
+      const nextPrinted = nextDefault ? print(nextDefault) : undefined;
+      if (previousPrinted === nextPrinted) continue;
+      detected.push({
+        type: "INPUT_FIELD_DEFAULT_VALUE_CHANGE",
+        description: `${previousType.name}.${fieldName} default value changed from ${previousPrinted ?? "undefined"} to ${nextPrinted ?? "undefined"}.`,
+      });
+    }
+  }
+
+  return {
+    allowed: detected.filter(
+      (change) =>
+        change.type !== "INPUT_FIELD_DEFAULT_VALUE_CHANGE" &&
+        allowedDangerousChangeTypes.has(change.type),
+    ),
+    blocked: detected.filter(
+      (change) =>
+        change.type === "INPUT_FIELD_DEFAULT_VALUE_CHANGE" ||
+        !allowedDangerousChangeTypes.has(change.type),
+    ),
+  };
 }

--- a/tests/unit/graphql-schema-diff.test.ts
+++ b/tests/unit/graphql-schema-diff.test.ts
@@ -60,11 +60,13 @@ describe("GraphQL dangerous-change policy", () => {
       "enum value additions",
       schema("status: Status", "enum Status { ACTIVE }"),
       schema("status: Status", "enum Status { ACTIVE RETIRED }"),
+      /Status/,
     ],
     [
       "argument default changes",
       schema("course(limit: Int = 10): String"),
       schema("course(limit: Int = 20): String"),
+      /Query\.course/,
     ],
     [
       "input-field default changes",
@@ -76,13 +78,36 @@ describe("GraphQL dangerous-change policy", () => {
         "search(input: SearchInput): String",
         "input SearchInput { limit: Int = 20 }",
       ),
+      /SearchInput\.limit/,
     ],
-  ])("blocks %s with a coordinate in the diagnostic", (_name, previousSdl, nextSdl) => {
+    [
+      "union member additions",
+      schema(
+        "search: SearchResult",
+        "type Course { id: ID! } union SearchResult = Course",
+      ),
+      schema(
+        "search: SearchResult",
+        "type Course { id: ID! } type Teacher { id: ID! } union SearchResult = Course | Teacher",
+      ),
+      /SearchResult|Teacher/,
+    ],
+    [
+      "implemented interface additions",
+      schema(
+        "result: Result",
+        "interface Node { id: ID! } type Result { id: ID! }",
+      ),
+      schema(
+        "result: Result",
+        "interface Node { id: ID! } type Result implements Node { id: ID! }",
+      ),
+      /Result|Node/,
+    ],
+  ])("blocks %s with a coordinate in the diagnostic", (_name, previousSdl, nextSdl, coordinate) => {
     const { blocked } = classifyGraphqlDangerousChanges(previousSdl, nextSdl);
     expect(blocked).not.toHaveLength(0);
-    expect(blocked[0].description).toMatch(
-      /Status|Query\.course|SearchInput\.limit/,
-    );
+    expect(blocked[0].description).toMatch(coordinate);
   });
 
   it.each([

--- a/tests/unit/graphql-schema-diff.test.ts
+++ b/tests/unit/graphql-schema-diff.test.ts
@@ -81,6 +81,30 @@ describe("GraphQL dangerous-change policy", () => {
       /SearchInput\.limit/,
     ],
     [
+      "input-field default additions",
+      schema(
+        "search(input: SearchInput): String",
+        "input SearchInput { limit: Int }",
+      ),
+      schema(
+        "search(input: SearchInput): String",
+        "input SearchInput { limit: Int = 10 }",
+      ),
+      /SearchInput\.limit/,
+    ],
+    [
+      "input-field default removals",
+      schema(
+        "search(input: SearchInput): String",
+        "input SearchInput { limit: Int = 10 }",
+      ),
+      schema(
+        "search(input: SearchInput): String",
+        "input SearchInput { limit: Int }",
+      ),
+      /SearchInput\.limit/,
+    ],
+    [
       "union member additions",
       schema(
         "search: SearchResult",

--- a/tests/unit/graphql-schema-diff.test.ts
+++ b/tests/unit/graphql-schema-diff.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { findGraphqlBreakingChanges } from "@/lib/graphql/schema-diff";
+import {
+  classifyGraphqlDangerousChanges,
+  findGraphqlBreakingChanges,
+} from "@/lib/graphql/schema-diff";
 
 const schema = (queryFields: string, extra = "") => `
   type Query {
@@ -48,5 +51,60 @@ describe("GraphQL schema breaking gate", () => {
         schema("course: String\nsection: String"),
       ),
     ).toHaveLength(0);
+  });
+});
+
+describe("GraphQL dangerous-change policy", () => {
+  it.each([
+    [
+      "enum value additions",
+      schema("status: Status", "enum Status { ACTIVE }"),
+      schema("status: Status", "enum Status { ACTIVE RETIRED }"),
+    ],
+    [
+      "argument default changes",
+      schema("course(limit: Int = 10): String"),
+      schema("course(limit: Int = 20): String"),
+    ],
+    [
+      "input-field default changes",
+      schema(
+        "search(input: SearchInput): String",
+        "input SearchInput { limit: Int = 10 }",
+      ),
+      schema(
+        "search(input: SearchInput): String",
+        "input SearchInput { limit: Int = 20 }",
+      ),
+    ],
+  ])("blocks %s with a coordinate in the diagnostic", (_name, previousSdl, nextSdl) => {
+    const { blocked } = classifyGraphqlDangerousChanges(previousSdl, nextSdl);
+    expect(blocked).not.toHaveLength(0);
+    expect(blocked[0].description).toMatch(
+      /Status|Query\.course|SearchInput\.limit/,
+    );
+  });
+
+  it.each([
+    [
+      "optional arguments",
+      schema("course: String"),
+      schema("course(limit: Int): String"),
+    ],
+    [
+      "optional input fields",
+      schema(
+        "search(input: SearchInput): String",
+        "input SearchInput { query: String }",
+      ),
+      schema(
+        "search(input: SearchInput): String",
+        "input SearchInput { query: String, limit: Int }",
+      ),
+    ],
+  ])("allows additive %s under SDL review", (_name, previousSdl, nextSdl) => {
+    const changes = classifyGraphqlDangerousChanges(previousSdl, nextSdl);
+    expect(changes.blocked).toEqual([]);
+    expect(changes.allowed).not.toHaveLength(0);
   });
 });

--- a/tests/unit/graphql-schema-snapshot.test.ts
+++ b/tests/unit/graphql-schema-snapshot.test.ts
@@ -2,7 +2,10 @@ import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { graphqlSchemaSdl } from "@/lib/graphql/resources";
-import { findGraphqlBreakingChanges } from "@/lib/graphql/schema-diff";
+import {
+  classifyGraphqlDangerousChanges,
+  findGraphqlBreakingChanges,
+} from "@/lib/graphql/schema-diff";
 
 const snapshotRelativePath = "docs/graphql/schema.graphql";
 const snapshotPath = fileURLToPath(
@@ -43,6 +46,17 @@ describe("GraphQL schema snapshot", () => {
     expect(
       breakingChanges,
       breakingChanges
+        .map((change) => `${change.type}: ${change.description}`)
+        .join("\n"),
+    ).toEqual([]);
+
+    const dangerousChanges = classifyGraphqlDangerousChanges(
+      previousSnapshot,
+      graphqlSchemaSdl,
+    ).blocked;
+    expect(
+      dangerousChanges,
+      dangerousChanges
         .map((change) => `${change.type}: ${change.description}`)
         .join("\n"),
     ).toEqual([]);


### PR DESCRIPTION
Closes #582

## Summary
- classify enum additions, union member additions, implemented-interface additions, and argument default changes as dangerous
- detect input-field default additions, removals, and changes with stable coordinates
- fail the schema snapshot gate with explicit change types/descriptions while still allowing optional arguments and optional input fields
- document the canonical SDL review policy

## Verification
- `bunx vitest run tests/unit/graphql-schema-diff.test.ts tests/unit/graphql-schema-snapshot.test.ts` (13 tests)
- `bunx svelte-check --tsconfig ./tsconfig.json`
- Biome check on touched source/tests