### PR TITLE
fix(graphql): account for arbitrary document preflight lifecycle

### DIFF
--- a/src/lib/graphql/context.ts
+++ b/src/lib/graphql/context.ts
@@ -12,6 +12,7 @@ export type GraphqlContext = {
 
 export type GraphqlServerContext = {
   locals: { locale?: AppLocale; requestId?: string };
+  operationObservation?: "caller";
   principal?: GraphqlPrincipal;
 };
 

--- a/src/lib/graphql/document-runner.ts
+++ b/src/lib/graphql/document-runner.ts
@@ -24,6 +24,7 @@ import {
   isWithinGraphqlBodyByteLimit,
 } from "./constants";
 import { formatMaskedGraphqlError } from "./error-masking";
+import { recordGraphqlOperationObservation } from "./observability";
 import {
   analyzeGraphqlOperation,
   type GraphqlOperationAnalysis,
@@ -49,6 +50,13 @@ const mutationScopes = new Map(
     .filter((operation) => operation.operationType === "mutation")
     .map((operation) => [operation.rootField, operation.scopes] as const),
 );
+
+const UNKNOWN_ANALYSIS: GraphqlOperationAnalysis = {
+  estimatedCost: 0,
+  operationName: "unknown",
+  operationType: "unknown",
+  topLevelFieldCount: 0,
+};
 
 type GraphqlResponsePayload = {
   data?: Record<string, unknown> | null;
@@ -80,6 +88,34 @@ function requestBody(input: {
     );
   }
   return body;
+}
+
+function requireDocumentByteLimit(document: string) {
+  if (!isWithinGraphqlBodyByteLimit(document)) {
+    throw new RegisteredGraphqlOperationError(
+      "BAD_USER_INPUT",
+      `GraphQL document must not exceed ${GRAPHQL_LIMITS.bodyBytes} bytes.`,
+    );
+  }
+}
+
+function requireActiveDeadline(
+  deadline: ReturnType<typeof createDeadline>,
+  parentSignal: AbortSignal,
+  expiresAt: number,
+) {
+  if (deadline.timedOut() || Date.now() >= expiresAt) {
+    throw new RegisteredGraphqlOperationError(
+      "REQUEST_TIMEOUT",
+      "GraphQL document timed out.",
+    );
+  }
+  if (deadline.signal.aborted || parentSignal.aborted) {
+    throw new RegisteredGraphqlOperationError(
+      "REQUEST_CANCELLED",
+      "GraphQL document was cancelled.",
+    );
+  }
 }
 
 function parseSelectedOperation(document: string, operationName?: string) {
@@ -265,31 +301,48 @@ export async function runGraphqlDocument(input: {
   signal: AbortSignal;
   variables?: Record<string, unknown>;
 }): Promise<RegisteredGraphqlOperationResult> {
+  const startedAt = Date.now();
   const variables = input.variables ?? {};
-  const { operation, parsed } = parseSelectedOperation(
-    input.document,
-    input.operationName,
-  );
-  requireMutationScopes(parsed, operation, input.principal, variables);
-  if (operation.operation === "mutation" && input.confirmed !== true) {
-    throw new RegisteredGraphqlOperationError(
-      "CONFIRMATION_REQUIRED",
-      "GraphQL mutations require explicit confirmation.",
-    );
-  }
-  const body = requestBody({
-    document: input.document,
-    operationName: input.operationName,
-    variables,
-  });
-  const analysis = analyzeGraphqlOperation({
-    document: parsed,
-    operationName: input.operationName,
-    variables,
-  });
+  let analysis = { ...UNKNOWN_ANALYSIS };
+  let errorCount = 0;
   const deadline = createDeadline(input.signal, GRAPHQL_LIMITS.timeoutMs);
+  const requireActive = () =>
+    requireActiveDeadline(
+      deadline,
+      input.signal,
+      startedAt + GRAPHQL_LIMITS.timeoutMs,
+    );
 
   try {
+    requireActive();
+    requireDocumentByteLimit(input.document);
+    requireActive();
+    const { operation, parsed } = parseSelectedOperation(
+      input.document,
+      input.operationName,
+    );
+    requireActive();
+    analysis = analyzeGraphqlOperation({
+      document: parsed,
+      operationName: input.operationName,
+      variables,
+    });
+    requireActive();
+    requireMutationScopes(parsed, operation, input.principal, variables);
+    requireActive();
+    if (operation.operation === "mutation" && input.confirmed !== true) {
+      throw new RegisteredGraphqlOperationError(
+        "CONFIRMATION_REQUIRED",
+        "GraphQL mutations require explicit confirmation.",
+      );
+    }
+    requireActive();
+    const body = requestBody({
+      document: input.document,
+      operationName: input.operationName,
+      variables,
+    });
+    requireActive();
     const url = safeGraphqlRequestUrl(input.requestInfo?.url);
     url.pathname = GRAPHQL_ENDPOINT;
     url.search = "";
@@ -309,11 +362,17 @@ export async function runGraphqlDocument(input: {
           locale: input.locale,
           requestId: input.requestInfo?.requestId ?? undefined,
         },
+        operationObservation: "caller",
         principal: input.principal,
       },
     );
-    return result(analysis, (await response.json()) as GraphqlResponsePayload);
+    requireActive();
+    const payload = (await response.json()) as GraphqlResponsePayload;
+    requireActive();
+    errorCount = payload.errors?.length ?? 0;
+    return result(analysis, payload);
   } catch (error) {
+    errorCount = 1;
     if (error instanceof RegisteredGraphqlOperationError) throw error;
     if (deadline.timedOut()) {
       throw new RegisteredGraphqlOperationError(
@@ -338,5 +397,12 @@ export async function runGraphqlDocument(input: {
     });
   } finally {
     deadline.cleanup();
+    recordGraphqlOperationObservation({
+      ...analysis,
+      authMode: input.principal.kind,
+      durationMs: Date.now() - startedAt,
+      errorCount,
+      requestId: input.requestInfo?.requestId,
+    });
   }
 }

--- a/src/lib/graphql/observability.ts
+++ b/src/lib/graphql/observability.ts
@@ -122,6 +122,7 @@ export function createGraphqlObservabilityPlugin(): Plugin<
 
   return {
     onRequest({ request, serverContext }) {
+      if (serverContext.operationObservation === "caller") return;
       states.set(request, {
         ...EMPTY_ANALYSIS,
         authMode: initialAuthMode(request),

--- a/tests/unit/graphql-document-runner.test.ts
+++ b/tests/unit/graphql-document-runner.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
+
+const catalogService = vi.hoisted(() => ({
+  getCurrentSemester: vi.fn(),
+}));
+
+vi.mock(
+  "@/features/catalog/server/academic-metadata-read-model",
+  async (importOriginal) => {
+    const original =
+      await importOriginal<
+        typeof import("@/features/catalog/server/academic-metadata-read-model")
+      >();
+    return {
+      ...original,
+      getCurrentSemester: catalogService.getCurrentSemester,
+    };
+  },
+);
+
+import type { GraphqlPrincipal } from "@/lib/graphql/auth";
+import { GRAPHQL_LIMITS } from "@/lib/graphql/constants";
+import { runGraphqlDocument } from "@/lib/graphql/document-runner";
+import type { RegisteredGraphqlOperationError } from "@/lib/graphql/operation-runner";
+
+const sessionPrincipal: GraphqlPrincipal = {
+  kind: "session",
+  userId: "document-runner-user",
+};
+
+function run(
+  document: string,
+  input: {
+    confirmed?: boolean;
+    principal?: GraphqlPrincipal;
+    signal?: AbortSignal;
+    variables?: Record<string, unknown>;
+  } = {},
+) {
+  return runGraphqlDocument({
+    confirmed: input.confirmed,
+    document,
+    locale: "zh-cn",
+    principal: input.principal ?? sessionPrincipal,
+    requestInfo: {
+      requestId: "graphql-document-runner-test",
+      url: "https://example.test/api/mcp",
+    },
+    signal: input.signal ?? new AbortController().signal,
+    variables: input.variables,
+  });
+}
+
+function installAnalytics() {
+  const writeDataPoint = vi.fn();
+  setCloudflareRuntimeEnv({ ANALYTICS: { writeDataPoint } });
+  return writeDataPoint;
+}
+
+describe("arbitrary GraphQL document runner", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    catalogService.getCurrentSemester.mockResolvedValue({
+      id: 1,
+      jwId: 202601,
+      code: "2026SP",
+      nameCn: "2026 春",
+      startDate: new Date("2026-02-01T00:00:00.000Z"),
+      endDate: new Date("2026-06-30T00:00:00.000Z"),
+    });
+  });
+
+  afterEach(() => {
+    setCloudflareRuntimeEnv(undefined);
+    catalogService.getCurrentSemester.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("enforces UTF-8 document and serialized body budgets on direct calls", async () => {
+    const writeDataPoint = installAnalytics();
+    const oversizedDocument = "课".repeat(
+      Math.floor(GRAPHQL_LIMITS.bodyBytes / 3) + 1,
+    );
+
+    await expect(run(oversizedDocument)).rejects.toMatchObject({
+      code: "BAD_USER_INPUT",
+      message: `GraphQL document must not exceed ${GRAPHQL_LIMITS.bodyBytes} bytes.`,
+    } satisfies Partial<RegisteredGraphqlOperationError>);
+    await expect(
+      run("query BodyBudget { currentSemester { jwId } }", {
+        variables: { value: "x".repeat(GRAPHQL_LIMITS.bodyBytes) },
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_USER_INPUT",
+      message: `GraphQL request must not exceed ${GRAPHQL_LIMITS.bodyBytes} bytes.`,
+    } satisfies Partial<RegisteredGraphqlOperationError>);
+
+    expect(writeDataPoint).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a pre-aborted call and records it once", async () => {
+    const writeDataPoint = installAnalytics();
+    const controller = new AbortController();
+    controller.abort(new DOMException("Caller cancelled", "AbortError"));
+
+    await expect(
+      run("query NeverParsed { currentSemester { jwId } }", {
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({
+      code: "REQUEST_CANCELLED",
+    } satisfies Partial<RegisteredGraphqlOperationError>);
+
+    expect(writeDataPoint).toHaveBeenCalledTimes(1);
+    expect(writeDataPoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indexes: ["graphql:unknown"],
+        doubles: [expect.any(Number), 0, 0, 1],
+      }),
+    );
+  });
+
+  it("includes synchronous preflight work in the deadline", async () => {
+    const writeDataPoint = installAnalytics();
+    let clockReads = 0;
+    vi.spyOn(Date, "now").mockImplementation(() =>
+      clockReads++ < 2 ? 0 : GRAPHQL_LIMITS.timeoutMs,
+    );
+
+    await expect(
+      run("query NeverParsed { currentSemester { jwId } }"),
+    ).rejects.toMatchObject({
+      code: "REQUEST_TIMEOUT",
+    } satisfies Partial<RegisteredGraphqlOperationError>);
+
+    expect(writeDataPoint).toHaveBeenCalledTimes(1);
+  });
+
+  it("records parse, confirmation, and scope preflight failures", async () => {
+    const writeDataPoint = installAnalytics();
+    const mutation = /* GraphQL */ `
+      mutation CreateTodo($title: String!) {
+        createTodo(input: { title: $title }) {
+          todo { id }
+        }
+      }
+    `;
+
+    await expect(run("query Broken { currentSemester(")).rejects.toMatchObject({
+      code: "BAD_USER_INPUT",
+    } satisfies Partial<RegisteredGraphqlOperationError>);
+    await expect(
+      run(mutation, { variables: { title: "confirmation" } }),
+    ).rejects.toMatchObject({
+      code: "CONFIRMATION_REQUIRED",
+    } satisfies Partial<RegisteredGraphqlOperationError>);
+    await expect(
+      run(mutation, {
+        confirmed: true,
+        principal: {
+          kind: "oauth",
+          userId: "document-runner-user",
+          resource: "https://example.test/api/mcp",
+          scopes: new Set(),
+        },
+        variables: { title: "scope" },
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      requiredScopes: ["todo:write"],
+    } satisfies Partial<RegisteredGraphqlOperationError>);
+
+    expect(writeDataPoint).toHaveBeenCalledTimes(3);
+    expect(writeDataPoint).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        indexes: ["graphql:unknown"],
+        doubles: [expect.any(Number), 0, 0, 1],
+      }),
+    );
+    for (const call of [2, 3]) {
+      expect(writeDataPoint).toHaveBeenNthCalledWith(
+        call,
+        expect.objectContaining({
+          indexes: ["graphql:mutation"],
+          blobs: expect.arrayContaining(["CreateTodo", "mutation"]),
+          doubles: [expect.any(Number), 1, 3, 1],
+        }),
+      );
+    }
+  });
+
+  it("records a successful Yoga execution exactly once", async () => {
+    const writeDataPoint = installAnalytics();
+
+    await expect(
+      run("query CurrentSemester { currentSemester { jwId } }"),
+    ).resolves.toMatchObject({
+      success: true,
+      operationName: "CurrentSemester",
+      operationType: "query",
+      data: { currentSemester: { jwId: 202601 } },
+    });
+
+    expect(writeDataPoint).toHaveBeenCalledTimes(1);
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      indexes: ["graphql:query"],
+      blobs: [
+        "graphql_operation",
+        "CurrentSemester",
+        "query",
+        "session",
+        "graphql-document-runner-test",
+      ],
+      doubles: [expect.any(Number), 1, 3, 0],
+    });
+  });
+});


### PR DESCRIPTION
## Goal

Make the arbitrary-document GraphQL runner own one complete lifecycle from entry through Yoga response parsing, including cancellation, byte budgets, deadline accounting, and sanitized semantic observation.

Closes #611

## Changed Surfaces

- Start the five-second deadline before direct document validation and preflight.
- Enforce pre-aborted signals, UTF-8 document bytes, and serialized request-body bytes inside runGraphqlDocument.
- Include parse, analysis, mutation scope preflight, confirmation, Yoga execution, and response parsing in the same deadline.
- Mark nested Yoga calls as caller-observed so each arbitrary document records exactly one semantic observation.
- Add direct runner unit coverage for boundary failures and successful execution.

## Evidence

- DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc bun run app:prepare — passed.
- bunx vitest run tests/unit/graphql-document-runner.test.ts tests/unit/graphql-observability.test.ts tests/unit/graphql-input-boundaries.test.ts — 3 files, 30 tests passed.
- bunx biome check src/lib/graphql/context.ts src/lib/graphql/document-runner.ts src/lib/graphql/observability.ts tests/unit/graphql-document-runner.test.ts — passed.
- bunx tsc --noEmit -p tsconfig.typecheck.json — passed.
- bunx tsc --noEmit -p tsconfig.typecheck.tests.json — passed.
- git diff --check — passed.
- Full static suite: Svelte check passed with 0 errors and 0 warnings; all three TypeScript checks passed; full Vitest passed with 240 files and 1465 tests.
- Fresh PostgreSQL database: 49 migrations passed; seed passed twice and the second run inserted no duplicate fixed records.
- Full integration suite: 40 files passed and 3 skipped; 238 tests passed and 10 skipped.
- Local full Playwright was intentionally not run because of #608; the canonical four-shard GitHub E2E workflow is the browser gate.

## Docs / Contracts

No docs or contract update is needed: the GraphQL SDL, MCP tool input/output shape, permissions, and public error codes remain unchanged. This fixes internal enforcement and observation completeness.

## Risk Areas

- GraphQL/MCP observability ownership: the internal server context marker disables only the nested Yoga observation; the runner records success, Yoga errors, and pre-Yoga failures.
- Timeout classification now includes synchronous preflight elapsed time.
- No Prisma, migration, auth policy, RLS, UI, i18n, seed, or production configuration changes.

## Cleanup

No scratch artifacts, unrelated rewrites, or manual generated-file edits remain. The branch contains one focused commit.
