### PR TITLE
fix(dashboard): use native grid lanes for semesters

### DIFF
--- a/docs/contracts/subscription.json
+++ b/docs/contracts/subscription.json
@@ -204,7 +204,7 @@
           "A standalone quick-add dialog searches section codes, course codes, localized course names, and localized teacher names within one semester, shows matching sections as checkbox options, and subscribes the selected sections without entering the batch-import confirmation flow",
           "A separate batch-import dialog accepts pasted course and section codes for one selected semester",
           "Batch subscribe, unsubscribe, and replace/update actions",
-          "Subscribed sections are grouped by semester into separate responsive tables ordered by proximity to today; the layout stays single-column until an extra-wide viewport can show a row-ordered two-column grid without squeezing or placing a more distant semester above a nearer one",
+          "Subscribed sections are grouped by semester into separate responsive tables ordered from the latest semester to the earliest; the layout stays single-column until an extra-wide viewport, where supporting browsers use native CSS Grid Lanes to pack tables into two columns and other browsers fall back to a row-ordered two-column grid",
           "Long course names and teacher lists are visually truncated inside table rows without changing the complete text shown in the section details dialog",
           "Each table row opens a details dialog with section metadata, a course-homepage link, and an unsubscribe action guarded by a destructive confirmation dialog",
           "Matched quick-add options show course, code, semester, campus, and teachers; already-subscribed sections cannot be selected again",

--- a/src/features/dashboard/components/SubscriptionsList.svelte
+++ b/src/features/dashboard/components/SubscriptionsList.svelte
@@ -69,7 +69,10 @@ async function confirmRemoveSection() {
 </script>
 
 {#if subscriptions.length > 0}
-  <div class="grid min-w-0 gap-4 2xl:grid-cols-2 2xl:items-start">
+  <div
+    class="subscription-semester-groups grid min-w-0 gap-4 2xl:grid-cols-2 2xl:items-start"
+    data-testid="subscription-semester-groups"
+  >
     {#each sectionGroups as group}
       <section class="grid min-w-0 gap-2">
         <div class="flex flex-wrap items-center justify-between gap-2 text-sm">
@@ -154,6 +157,16 @@ async function confirmRemoveSection() {
     ]}
   />
 {/if}
+
+<style>
+@media (min-width: 96rem) {
+  @supports (display: grid-lanes) {
+    .subscription-semester-groups {
+      display: grid-lanes;
+    }
+  }
+}
+</style>
 
 <Dialog.Root
   open={selectedSection !== null}

--- a/src/features/dashboard/lib/subscription-section-utils.ts
+++ b/src/features/dashboard/lib/subscription-section-utils.ts
@@ -1,51 +1,17 @@
 type SectionWithSemester = {
   semester?: {
-    endDate?: string | null;
     id?: number | string | null;
     nameCn?: string | null;
     startDate?: string | null;
   } | null;
 };
 
-function timestamp(value: string | null) {
-  if (!value) return null;
-  const parsed = Date.parse(value);
-  return Number.isNaN(parsed) ? null : parsed;
-}
-
-function distanceFromDateRange(
-  startDate: string | null,
-  endDate: string | null,
-  referenceTime: number,
-) {
-  const startTime = timestamp(startDate);
-  const endTime = timestamp(endDate);
-
-  if (startTime !== null && endTime !== null) {
-    if (referenceTime < startTime) return startTime - referenceTime;
-    if (referenceTime > endTime) return referenceTime - endTime;
-    return 0;
-  }
-  if (startTime !== null) return Math.abs(referenceTime - startTime);
-  if (endTime !== null) return Math.abs(referenceTime - endTime);
-  return Number.POSITIVE_INFINITY;
-}
-
 export function groupSubscribedSectionsBySemester<
   Section extends SectionWithSemester,
->(
-  sections: Section[],
-  fallbackLabel: string,
-  referenceDate: Date | string = new Date(),
-) {
-  const referenceTime =
-    referenceDate instanceof Date
-      ? referenceDate.getTime()
-      : Date.parse(referenceDate);
+>(sections: Section[], fallbackLabel: string) {
   const groups = new Map<
     string,
     {
-      endDate: string | null;
       key: string;
       label: string;
       startDate: string | null;
@@ -56,7 +22,6 @@ export function groupSubscribedSectionsBySemester<
   for (const section of sections) {
     const key = section.semester?.id?.toString() ?? "unknown";
     const existing = groups.get(key) ?? {
-      endDate: section.semester?.endDate ?? null,
       key,
       label: section.semester?.nameCn ?? fallbackLabel,
       startDate: section.semester?.startDate ?? null,
@@ -67,11 +32,6 @@ export function groupSubscribedSectionsBySemester<
   }
 
   return Array.from(groups.values()).sort((left, right) => {
-    const distance =
-      distanceFromDateRange(left.startDate, left.endDate, referenceTime) -
-      distanceFromDateRange(right.startDate, right.endDate, referenceTime);
-    if (distance !== 0) return distance;
-
     if (left.startDate && right.startDate)
       return right.startDate.localeCompare(left.startDate);
     if (left.startDate) return -1;

--- a/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
+++ b/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
@@ -180,14 +180,32 @@ test.describe("仪表盘关注班级", () => {
     );
   });
 
-  test("超宽屏按时间接近度分表并使用双栏布局", async ({ page }, testInfo) => {
+  test("超宽屏按时间倒序分表并渐进增强为瀑布流", async ({ page }, testInfo) => {
     await page.setViewportSize({ height: 1000, width: 1700 });
     await signInAsDebugUser(page, "/dashboard/subscriptions");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/dashboard/subscriptions");
 
     const tables = page.locator("#main-content table");
+    const semesterGroups = page.getByTestId("subscription-semester-groups");
+    const semesterHeadings = semesterGroups.locator(":scope > section h3");
     await expect(tables).toHaveCount(2);
+    await expect(semesterGroups).toBeVisible();
+    await expect(semesterHeadings.nth(0)).toContainText(
+      DEV_SEED.semesterNameCn,
+    );
+    await expect(semesterHeadings.nth(1)).toContainText(
+      DEV_SEED.previousSemesterNameCn,
+    );
+    expect(
+      await semesterGroups.evaluate(
+        (element) => getComputedStyle(element).display,
+      ),
+    ).toBe(
+      await page.evaluate(() =>
+        CSS.supports("display", "grid-lanes") ? "grid-lanes" : "grid",
+      ),
+    );
     const firstTable = await tables.nth(0).boundingBox();
     const secondTable = await tables.nth(1).boundingBox();
     expect(firstTable).not.toBeNull();

--- a/tests/unit/subscription-section-utils.test.ts
+++ b/tests/unit/subscription-section-utils.test.ts
@@ -12,7 +12,7 @@ const section = (
 });
 
 describe("groupSubscribedSectionsBySemester", () => {
-  it("orders semester groups by proximity to the reference date", () => {
+  it("orders semester groups from latest to earliest", () => {
     const groups = groupSubscribedSectionsBySemester(
       [
         section(1, "较远的未来学期", "2027-09-01", "2028-01-15"),
@@ -21,14 +21,13 @@ describe("groupSubscribedSectionsBySemester", () => {
         section(4, "较近的过去学期", "2025-09-01", "2026-01-15"),
       ],
       "未知学期",
-      "2026-07-01",
     );
 
     expect(groups.map((group) => group.label)).toEqual([
-      "当前学期",
-      "最近的未来学期",
-      "较近的过去学期",
       "较远的未来学期",
+      "最近的未来学期",
+      "当前学期",
+      "较近的过去学期",
     ]);
   });
 
@@ -39,7 +38,6 @@ describe("groupSubscribedSectionsBySemester", () => {
         section(2, "已知学期", "2026-02-20", "2026-07-15"),
       ],
       "未知学期",
-      "2026-07-01",
     );
 
     expect(groups.map((group) => group.label)).toEqual([


### PR DESCRIPTION
## Goal

Use native CSS Grid Lanes for the extra-wide subscription semester layout while preserving a deterministic latest-to-earliest fallback order.

## Changed Surfaces

- Dashboard subscription semester tables use `display: grid-lanes` at `2xl` when supported.
- Unsupported browsers retain the existing row-major two-column Grid fallback.
- Semester groups now sort by start date from latest to earliest in DOM order.
- Focused unit/E2E coverage asserts ordering and the supported/fallback display path.

## Evidence

- `bun run app:prepare`
- `bunx biome check`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- all three TypeScript check configs
- `bunx vitest run` (244 files, 1485 tests)
- integration Vitest (40 files / 238 tests passed; 3 files / 13 skipped)
- `bun run build`
- focused subscriptions Playwright (13/13) in default Chromium fallback
- focused wide-layout Playwright (1/1) with experimental web platform features, confirming computed `display: grid-lanes`

## Docs / Contracts

Updated `docs/contracts/subscription.json` with native Grid Lanes, fallback, and latest-to-earliest ordering semantics. No REST, GraphQL, MCP, database, or message shape changed.

## Risk Areas

Grid Lanes browser support remains limited; the standard row-major Grid fallback is retained. No auth, data mutation, migration, or privacy behavior changed.

## Cleanup

Temporary Playwright config/results were removed. Screenshots are stored outside the repository. The worktree contains only the five intentional tracked changes.