### PR TITLE
fix(observability): close remaining correlation gaps

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -32,6 +32,13 @@ high-cardinality resource IDs.
   GraphQL observations correlated without passing request metadata through
   domain APIs. MCP JSON-RPC IDs remain protocol identifiers and are not used as
   HTTP request IDs.
+- Request-scoped fields are authoritative and cannot be replaced by nested log
+  context. Standalone API and GraphQL helpers generate or use only server-owned
+  correlation IDs; inbound `x-request-id` and timing headers are never trusted.
+- Opt-in OAuth diagnostics use the shared application logger. Redirects retain
+  only origin, host, path, and query-key names; query values and user IDs are
+  never logged. Fail-closed grant, code-binding, and rate-limit infrastructure
+  errors emit safe operational events without token or user identifiers.
 - GraphQL observations distinguish expected GraphQL errors from
   `INTERNAL_SERVER_ERROR`; only the latter are logged at error severity.
 - Request IDs propagate through page, data, action, and REST responses that
@@ -79,8 +86,10 @@ storage investigations.
 ## Worker configuration drift
 
 `worker-configuration.d.ts` is generated from `wrangler.jsonc` with
-`bunx wrangler types --include-runtime=false`. CI runs the matching `--check`
-command so binding or variable changes cannot drift from the generated
-environment contract. Run generation after `bun run app:prepare` and before a
-production build so Wrangler does not couple the binding contract to a local
-generated Worker entrypoint.
+`bunx wrangler types --include-runtime=false --env-file /dev/null`. The empty
+environment file prevents local `.env` variable names from entering the
+generated production binding contract. CI runs the matching `--check` command
+without a local `.env`, so binding or variable changes cannot drift. Run
+generation after `bun run app:prepare` and before a production build so
+Wrangler does not couple the binding contract to a local generated Worker
+entrypoint.

--- a/src/features/auth/server/signin-page-server.ts
+++ b/src/features/auth/server/signin-page-server.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/auth/provider-ids";
 import { hasRequestAuthSignal } from "@/lib/auth/request-auth-signal";
 import { signInFromSvelteAction } from "@/lib/auth/svelte-auth-actions";
+import { logServerActionError } from "@/lib/log/app-logger";
 import {
   parseTermsNotice,
   providerNames,
@@ -100,6 +101,11 @@ export async function signInPageDefaultAction({
     ) {
       throw error;
     }
+    logServerActionError("auth.signin.failed", error, {
+      action: "signin",
+      requestId: locals.requestId,
+      route: "/signin",
+    });
     return fail(400, {
       message: signInMessages[locals.locale].errorGeneric,
     });

--- a/src/features/settings/server/settings-account-actions.ts
+++ b/src/features/settings/server/settings-account-actions.ts
@@ -8,6 +8,7 @@ import {
   linkAccountFromSvelteAction,
 } from "@/lib/auth/svelte-auth-actions";
 import { prisma } from "@/lib/db/prisma";
+import { logServerActionError } from "@/lib/log/app-logger";
 import { deleteOwnAccount } from "./account-deletion-service";
 
 export async function unlinkSettingsAccountAction({
@@ -49,8 +50,9 @@ export async function linkSettingsAccountAction({
   cookies,
   locale,
   request,
+  requestId,
   url,
-}: SettingsActionInput & { cookies: Cookies }) {
+}: SettingsActionInput & { cookies: Cookies; requestId: string }) {
   const copy = getSettingsCopy(locale);
   await requireSettingsUser(request, url);
   const form = await request.formData();
@@ -72,6 +74,11 @@ export async function linkSettingsAccountAction({
     ) {
       throw error;
     }
+    logServerActionError("settings.account-link.failed", error, {
+      action: "link-account",
+      requestId,
+      route: "/settings/accounts",
+    });
     return fail(400, {
       kind: "accounts",
       message: copy.profile.connectFailed,

--- a/src/features/settings/server/settings-page-actions.ts
+++ b/src/features/settings/server/settings-page-actions.ts
@@ -34,7 +34,13 @@ export const settingsPageActions = {
   unlinkAccount: async ({ locals, request, url }: SettingsActionEvent) =>
     unlinkSettingsAccountAction({ locale: locals.locale, request, url }),
   linkAccount: async ({ cookies, locals, request, url }: SettingsActionEvent) =>
-    linkSettingsAccountAction({ cookies, locale: locals.locale, request, url }),
+    linkSettingsAccountAction({
+      cookies,
+      locale: locals.locale,
+      request,
+      requestId: locals.requestId,
+      url,
+    }),
   revokeAuthorization: async ({ locals, request, url }: SettingsActionEvent) =>
     revokeSettingsAuthorizationAction({
       locale: locals.locale,

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -21,6 +21,7 @@ import {
   setApiRequestObservabilityContext,
 } from "@/lib/log/api-observability";
 import { normalizeApiRoutePath } from "@/lib/log/api-observability-path";
+import { logAppEvent } from "@/lib/log/app-logger";
 import { getSafeErrorName } from "@/lib/log/safe-error-name";
 import {
   type PageAuthMode,
@@ -99,6 +100,12 @@ function isApiRequest(pathname: string) {
   return pathname === "/api" || pathname.startsWith("/api/");
 }
 
+function observedRoute(pathname: string, routeId: string | null) {
+  return isApiRequest(pathname)
+    ? normalizeApiRoutePath(pathname)
+    : (routeId ?? "unmatched");
+}
+
 function isHtmlResponse(response: Response) {
   return response.headers.get("content-type")?.includes("text/html");
 }
@@ -165,9 +172,7 @@ const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
   setCloudflareRequestContext({
     method: event.request.method,
     requestId,
-    route: isApiRequest(event.url.pathname)
-      ? normalizeApiRoutePath(event.url.pathname)
-      : (event.route.id ?? "unmatched"),
+    route: observedRoute(event.url.pathname, event.route.id),
   });
   const startMs = Date.now();
   const hasAuthSignal = hasRequestAuthSignal(event.request.headers);
@@ -270,9 +275,7 @@ const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
       "app.sveltekit.resolve",
       {
         "http.request.method": event.request.method,
-        "http.route": isApiRequest(event.url.pathname)
-          ? normalizeApiRoutePath(event.url.pathname)
-          : (event.route.id ?? "unmatched"),
+        "http.route": observedRoute(event.url.pathname, event.route.id),
       },
       () =>
         resolve(event, {
@@ -339,19 +342,19 @@ export const handle: Handle = async (input) =>
         ?.context,
   );
 
-function serializeServerError(error: unknown) {
-  return { name: getSafeErrorName(error) };
-}
-
 export const handleError: HandleServerError = ({ error, event, status }) => {
-  console.error(
-    JSON.stringify({
+  logAppEvent(
+    "error",
+    "sveltekit.server-error",
+    {
       event: "sveltekit.server-error",
       method: event.request.method,
-      path: event.url.pathname,
+      requestId: event.locals.requestId,
+      route: observedRoute(event.url.pathname, event.route.id),
+      source: "sveltekit",
       status,
-      error: serializeServerError(error),
-    }),
+    },
+    error,
   );
 
   return { message: "Internal Error" };

--- a/src/lib/api/routes/auth-token-device-grant.ts
+++ b/src/lib/api/routes/auth-token-device-grant.ts
@@ -5,6 +5,7 @@ import {
 } from "@/features/oauth/server/device-grant-policy.server";
 import { issueDeviceGrantTokens } from "@/features/oauth/server/device-token-issuer.server";
 import { prisma } from "@/lib/db/prisma";
+import { logAppEvent } from "@/lib/log/app-logger";
 import { logOAuthDebug } from "@/lib/log/oauth-debug";
 import { deviceAuthJsonError } from "./auth-device-authorization-helpers";
 import { deviceCodeError } from "./auth-token-device-errors";
@@ -52,6 +53,12 @@ export async function handleDeviceCodeGrant(
     prisma,
   });
   if ("error" in recordResult) {
+    if ((recordResult.error.status ?? 400) >= 500) {
+      logAppEvent("error", "oauth.device-token.grant-resolution-failed", {
+        event: "oauth.device-token.grant-resolution-failed",
+        phase: "resolve-grant",
+      });
+    }
     return deviceCodeError(
       recordResult.error.code,
       recordResult.error.status ?? 400,
@@ -86,7 +93,6 @@ export async function handleDeviceCodeGrant(
   logOAuthDebug("device-token.success", request, {
     clientIdPrefix: clientId.slice(0, 8),
     resourceCount: record.resources.length,
-    userId,
     scopeCount: record.scopes.length,
   });
 

--- a/src/lib/api/routes/auth.ts
+++ b/src/lib/api/routes/auth.ts
@@ -13,17 +13,20 @@ import {
 import { isTrustedAuthOrigin } from "@/lib/auth/auth-origins";
 import { verifyAccessTokenJwt } from "@/lib/auth/jwt-verification";
 import { prisma } from "@/lib/db/prisma";
+import { logAppEvent } from "@/lib/log/app-logger";
 import {
   logOAuthDebug,
   summarizeOAuthForwardingHeaders,
   summarizeOAuthRedirectUri,
   withBetterAuthOAuthDebug,
 } from "@/lib/log/oauth-debug";
+import { getSafeErrorName } from "@/lib/log/safe-error-name";
 import {
   getJwksUrlForOAuthVerification,
   getOAuthProviderValidAudiences,
   getOAuthTokenVerificationIssuers,
 } from "@/lib/mcp/urls";
+import { writeOAuthEventAnalytics } from "@/lib/metrics/analytics-engine";
 import {
   hasActiveOAuthUserGrant,
   resolveActiveOAuthUserGrant,
@@ -32,6 +35,36 @@ import { findDuplicateOAuthFormParameter } from "@/lib/oauth/form-parameters";
 import { resolveEquivalentLoopbackRedirectUri } from "@/lib/oauth/loopback-redirect";
 import { rewriteOAuthResourceAliases } from "@/lib/oauth/resource-aliases";
 import { hashOAuthClientSecretForDbStorage } from "@/lib/oauth/utils";
+
+function recordOAuthRouteFailure(input: {
+  error: unknown;
+  event: string;
+  phase: string;
+  request: Request;
+  startMs: number;
+}) {
+  const url = new URL(input.request.url);
+  logAppEvent(
+    "error",
+    input.event,
+    {
+      event: input.event,
+      method: input.request.method,
+      phase: input.phase,
+      source: "oauth",
+    },
+    input.error,
+  );
+  writeOAuthEventAnalytics({
+    errorName: getSafeErrorName(input.error),
+    event: input.event,
+    ioObservedDurationMs: Date.now() - input.startMs,
+    method: input.request.method,
+    path: url.pathname,
+    phase: input.phase,
+    status: 500,
+  });
+}
 
 function isOAuthClientRegistrationRequest(request: Request) {
   return new URL(request.url).pathname.endsWith("/oauth2/register");
@@ -353,6 +386,7 @@ async function resolveOpaqueIntrospectionGrant(
 }
 
 async function enforceIntrospectionGrant(
+  request: Request,
   params: URLSearchParams,
   response: Response,
 ) {
@@ -365,6 +399,7 @@ async function enforceIntrospectionGrant(
 
   const token = params.get("token");
   if (!token) return inactiveIntrospectionResponse(response);
+  const startMs = Date.now();
 
   try {
     if (token.split(".").length === 3) {
@@ -407,8 +442,15 @@ async function enforceIntrospectionGrant(
     ) {
       return response;
     }
-  } catch {
+  } catch (error) {
     // Introspection must fail closed when the grant cannot be verified.
+    recordOAuthRouteFailure({
+      error,
+      event: "oauth.introspection.grant-verification-failed",
+      phase: "grant-verification",
+      request,
+      startMs,
+    });
   }
 
   return inactiveIntrospectionResponse(response);
@@ -498,7 +540,6 @@ async function enforceAuthorizationCodeGrantBinding(
   const location = response.headers.get("location");
   if (location) {
     return enforceAuthorizationCodeRedirectBinding({
-      baseUrl: request.url,
       expectedClientId: expectation
         ? expectation.clientId
         : isAuthorize
@@ -507,6 +548,7 @@ async function enforceAuthorizationCodeGrantBinding(
       expectedGrantId: expectation?.grantId,
       consentUpdatedBefore: expectation?.consentUpdatedBefore,
       location,
+      request,
       response,
     });
   }
@@ -520,7 +562,6 @@ async function enforceAuthorizationCodeGrantBinding(
   if (!body || typeof body.url !== "string") return response;
 
   const bound = await enforceAuthorizationCodeRedirectBinding({
-    baseUrl: request.url,
     expectedClientId: expectation
       ? expectation.clientId
       : isAuthorize
@@ -529,6 +570,7 @@ async function enforceAuthorizationCodeGrantBinding(
     expectedGrantId: expectation?.grantId,
     consentUpdatedBefore: expectation?.consentUpdatedBefore,
     location: body.url,
+    request,
     response,
   });
   const rewrittenLocation = bound.headers.get("location");
@@ -594,7 +636,14 @@ async function resolveAuthorizationCodeGrantExpectation(request: Request) {
       consentUpdatedBefore,
       ...(grant?.kind === "consent" ? { grantId: grant.grantId } : {}),
     };
-  } catch {
+  } catch (error) {
+    recordOAuthRouteFailure({
+      error,
+      event: "oauth.authorization.grant-expectation-failed",
+      phase: "grant-expectation",
+      request,
+      startMs: consentUpdatedBefore.getTime(),
+    });
     return { clientId, consentUpdatedBefore };
   }
 }
@@ -622,36 +671,55 @@ async function getSignedOAuthQueryFromRequest(request: Request) {
 }
 
 async function enforceAuthorizationCodeRedirectBinding(input: {
-  baseUrl: string;
   expectedClientId: string | null | undefined;
   consentUpdatedBefore?: Date;
   expectedGrantId?: string;
   location: string;
+  request: Request;
   response: Response;
 }) {
   let target: URL;
   try {
-    target = new URL(input.location, input.baseUrl);
+    target = new URL(input.location, input.request.url);
   } catch {
     return input.response;
   }
   if (!target.searchParams.has("code")) return input.response;
 
   let bound = false;
+  let bindingError: unknown;
+  const startMs = Date.now();
   try {
     bound =
       input.expectedClientId !== null &&
       (await bindOAuthAuthorizationCodeRedirectToActiveGrant(
         input.location,
         input.expectedClientId,
-        input.baseUrl,
+        input.request.url,
         input.expectedGrantId,
         input.consentUpdatedBefore,
       ));
-  } catch {
+  } catch (error) {
+    bindingError = error;
     bound = false;
   }
   if (bound) return input.response;
+  if (bindingError) {
+    recordOAuthRouteFailure({
+      error: bindingError,
+      event: "oauth.authorization.code-binding-failed",
+      phase: "code-binding",
+      request: input.request,
+      startMs,
+    });
+  } else {
+    logAppEvent("warn", "oauth.authorization.code-binding-rejected", {
+      event: "oauth.authorization.code-binding-rejected",
+      method: input.request.method,
+      phase: "code-binding",
+      source: "oauth",
+    });
+  }
 
   target.searchParams.delete("code");
   target.searchParams.set("error", "server_error");
@@ -716,7 +784,11 @@ export const authPostRoute = async (request: Request) => {
   );
   const finalized =
     introspection && "params" in introspection
-      ? enforceIntrospectionGrant(introspection.params, restored)
+      ? enforceIntrospectionGrant(
+          prepared.request,
+          introspection.params,
+          restored,
+        )
       : restored;
   return enforceAuthorizationCodeGrantBinding(
     prepared.request,

--- a/src/lib/graphql/observability.ts
+++ b/src/lib/graphql/observability.ts
@@ -174,10 +174,7 @@ export function createGraphqlObservabilityPlugin(): Plugin<
         internalErrorCount: 0,
         operationAttempted: false,
         recorded: false,
-        requestId: safeRequestId(
-          serverContext.locals?.requestId ??
-            request.headers.get("x-request-id"),
-        ),
+        requestId: safeRequestId(serverContext.locals?.requestId),
         startMs: Date.now(),
       });
     },

--- a/src/lib/graphql/server.ts
+++ b/src/lib/graphql/server.ts
@@ -16,6 +16,17 @@ import { createGraphqlSecurityPlugins } from "./security";
 
 class GraphqlBodyTooLargeError extends Error {}
 
+async function cancelReader(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reason?: unknown,
+) {
+  try {
+    await reader.cancel(reason);
+  } catch {
+    // Cancellation is cleanup; the primary request failure remains authoritative.
+  }
+}
+
 function graphqlErrorResponse(
   status: number,
   code: string,
@@ -63,7 +74,7 @@ async function readBodyWithinLimit(
   const chunks: Uint8Array[] = [];
   let total = 0;
   const onAbort = () => {
-    void reader.cancel(signal.reason);
+    void cancelReader(reader, signal.reason);
   };
   signal.addEventListener("abort", onAbort, { once: true });
 
@@ -75,7 +86,7 @@ async function readBodyWithinLimit(
 
       total += value.byteLength;
       if (total > GRAPHQL_LIMITS.bodyBytes) {
-        await reader.cancel();
+        await cancelReader(reader);
         throw new GraphqlBodyTooLargeError();
       }
       chunks.push(value);

--- a/src/lib/log/api-observability-context.ts
+++ b/src/lib/log/api-observability-context.ts
@@ -24,17 +24,14 @@ export function setApiRequestObservabilityContext(
 function getRequestId(request: Request) {
   return (
     apiRequestObservabilityContexts.get(request)?.requestId ??
-    request.headers.get("x-request-id") ??
-    "unknown"
+    crypto.randomUUID()
   );
 }
 
 function getRequestStartMs(request: Request) {
   const contextStartMs = apiRequestObservabilityContexts.get(request)?.startMs;
   if (contextStartMs) return contextStartMs;
-
-  const value = Number(request.headers.get("x-request-start-ms"));
-  return Number.isFinite(value) && value > 0 ? value : Date.now();
+  return Date.now();
 }
 
 function inferAuthMode(request: Request) {

--- a/src/lib/log/app-logger.ts
+++ b/src/lib/log/app-logger.ts
@@ -19,11 +19,11 @@ export function logAppEvent(
   if (!shouldLog(level)) return;
 
   const payload = {
+    ...context,
     ...baseLogPayload(),
     runtime: typeof window === "undefined" ? "server" : "client",
     ...getCloudflareRequestContext(),
     message,
-    ...context,
   };
 
   emitLog("[app]", level, payload, error);
@@ -40,12 +40,12 @@ export function logApiRequest(
   if (!shouldLog(level)) return;
 
   const payload = {
+    ...context,
     ...baseLogPayload(),
     method,
     path,
     status,
     ...(ioObservedDurationMs === undefined ? {} : { ioObservedDurationMs }),
-    ...context,
   };
 
   emitLog("[api]", level, payload);

--- a/src/lib/log/oauth-debug-mode.ts
+++ b/src/lib/log/oauth-debug-mode.ts
@@ -1,6 +1,6 @@
 import { getOptionalTrimmedEnv } from "@/app-env";
 import { getApiRequestObservabilityRequestId } from "@/lib/log/api-observability-context";
-import { formatShanghaiTimestamp } from "@/lib/time/shanghai-format";
+import { logAppEvent } from "@/lib/log/app-logger";
 
 export type OAuthDebugMode = "off" | "standard" | "verbose";
 
@@ -24,9 +24,10 @@ export function oauthDebugCorrelationId(request: Request): string {
   if (requestId) return requestId;
 
   return (
-    safeCorrelationId(request.headers.get("x-request-id")) ??
-    request.headers.get("cf-ray") ??
-    request.headers.get("traceparent")?.slice(0, 55) ??
+    safeCorrelationId(request.headers.get("cf-ray")) ??
+    safeCorrelationId(
+      request.headers.get("traceparent")?.slice(0, 55) ?? null,
+    ) ??
     "no-correlation-id"
   );
 }
@@ -42,15 +43,14 @@ export function logOAuthDebug(
 ): void {
   if (!isOAuthDebugLogging()) return;
 
-  const payload: Record<string, unknown> = {
-    ts: formatShanghaiTimestamp(new Date()),
-    event,
+  const context: Record<string, unknown> = {
     ...fields,
+    event,
   };
 
   if (request) {
-    payload.correlationId = oauthDebugCorrelationId(request);
+    context.correlationId = oauthDebugCorrelationId(request);
   }
 
-  console.info(JSON.stringify(payload));
+  logAppEvent("info", event, context);
 }

--- a/src/lib/log/oauth-debug-sanitize.ts
+++ b/src/lib/log/oauth-debug-sanitize.ts
@@ -1,16 +1,6 @@
-const SENSITIVE_QUERY_KEYS = new Set([
-  "code",
-  "access_token",
-  "refresh_token",
-  "id_token",
-  "token",
-  "session",
-  "session_token",
-  "client_secret",
-]);
-
 export function summarizeOAuthRedirectUri(
   redirect: string | null,
+  base?: string,
 ): Record<string, unknown> {
   if (!redirect) {
     return {
@@ -24,7 +14,7 @@ export function summarizeOAuthRedirectUri(
   }
 
   try {
-    const redirectUrl = new URL(redirect);
+    const redirectUrl = new URL(redirect, base);
     return {
       redirectOrigin: redirectUrl.origin,
       redirectHost: redirectUrl.host,
@@ -61,23 +51,13 @@ export function summarizeOAuthForwardingHeaders(
   };
 }
 
-/** Redact sensitive query parameters in a redirect URL for logs. */
-export function sanitizeOAuthRedirectLocation(
+/** Summarize a redirect URL without retaining any query values. */
+export function summarizeOAuthRedirectLocation(
   location: string | undefined,
   requestUrl: string,
-): string | null {
+): Record<string, unknown> | null {
   if (!location) return null;
-  try {
-    const u = new URL(location, requestUrl);
-    for (const key of [...u.searchParams.keys()]) {
-      if (SENSITIVE_QUERY_KEYS.has(key.toLowerCase())) {
-        u.searchParams.set(key, "[REDACTED]");
-      }
-    }
-    return u.toString();
-  } catch {
-    return "[invalid-redirect-location]";
-  }
+  return summarizeOAuthRedirectUri(location, requestUrl);
 }
 
 export function summarizeOAuthAuthorizeUrl(

--- a/src/lib/log/oauth-debug-wrapper.ts
+++ b/src/lib/log/oauth-debug-wrapper.ts
@@ -8,9 +8,9 @@ import {
   oauthDebugCorrelationId,
 } from "./oauth-debug-mode";
 import {
-  sanitizeOAuthRedirectLocation,
   summarizeOAuthAuthorizeUrl,
   summarizeOAuthForwardingHeaders,
+  summarizeOAuthRedirectLocation,
 } from "./oauth-debug-sanitize";
 import { tokenErrorBody, tokenRequestFingerprint } from "./oauth-debug-token";
 
@@ -119,9 +119,9 @@ export async function withBetterAuthOAuthDebug(
   try {
     const res = await run(request);
     const location = res.headers.get("location");
-    const redirectTo =
+    const redirectSummary =
       res.status >= 300 && res.status < 400
-        ? sanitizeOAuthRedirectLocation(location ?? undefined, request.url)
+        ? summarizeOAuthRedirectLocation(location ?? undefined, request.url)
         : null;
     const errorBody =
       res.status >= 400 && path === OAUTH_TOKEN_ENDPOINT_PATH
@@ -134,8 +134,8 @@ export async function withBetterAuthOAuthDebug(
       path,
       status: res.status,
       ioObservedDurationMs: Date.now() - start,
-      ...(redirectTo ? { redirectTo } : {}),
-      ...(location && !redirectTo ? { locationPresent: true } : {}),
+      ...(redirectSummary ? { redirectSummary } : {}),
+      ...(location && !redirectSummary ? { locationPresent: true } : {}),
       ...(errorBody ? { errorBody } : {}),
     });
     recordBetterAuthResponseAnalytics({

--- a/src/lib/security/user-mutation-rate-limit.ts
+++ b/src/lib/security/user-mutation-rate-limit.ts
@@ -2,6 +2,7 @@ import {
   getCloudflareUserMutationRateLimiter,
   hasCloudflareRuntimeEnv,
 } from "@/lib/adapters/cloudflare-runtime";
+import { logAppEvent } from "@/lib/log/app-logger";
 
 export const USER_MUTATION_RATE_LIMIT_PERIOD_SECONDS = 60;
 
@@ -20,6 +21,26 @@ function rateLimitKey(input: { action: string; host: string; userId: string }) {
   ]);
 }
 
+function logUnavailableRateLimiter(
+  action: string,
+  tier: UserMutationRateLimitTier,
+  reason: "binding-error" | "binding-missing",
+  error?: unknown,
+) {
+  logAppEvent(
+    "error",
+    "user-mutation-rate-limit.unavailable",
+    {
+      action,
+      event: "user-mutation-rate-limit.unavailable",
+      reason,
+      source: "rate-limit",
+      tier,
+    },
+    error,
+  );
+}
+
 /**
  * Enforce a per-deployment, per-user, per-action mutation budget.
  *
@@ -36,9 +57,9 @@ export async function checkUserMutationRateLimit(input: {
   const tier = input.tier ?? "write";
   const limiter = getCloudflareUserMutationRateLimiter(tier);
   if (limiter == null) {
-    return hasCloudflareRuntimeEnv()
-      ? { allowed: false, reason: "unavailable" }
-      : { allowed: true };
+    if (!hasCloudflareRuntimeEnv()) return { allowed: true };
+    logUnavailableRateLimiter(input.action, tier, "binding-missing");
+    return { allowed: false, reason: "unavailable" };
   }
 
   try {
@@ -46,7 +67,8 @@ export async function checkUserMutationRateLimit(input: {
     return outcome.success
       ? { allowed: true }
       : { allowed: false, reason: "limited" };
-  } catch {
+  } catch (error) {
+    logUnavailableRateLimiter(input.action, tier, "binding-error", error);
     return { allowed: false, reason: "unavailable" };
   }
 }

--- a/tests/unit/api-observability.test.ts
+++ b/tests/unit/api-observability.test.ts
@@ -65,7 +65,7 @@ describe("API 可观测性", () => {
     );
   });
 
-  it("记录响应状态、耗时和认证模式", async () => {
+  it("记录响应状态、耗时和认证模式且不信任客户端观测头", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-07T00:00:01.000Z"));
     const info = vi.spyOn(console, "info").mockImplementation(() => {});
@@ -75,7 +75,7 @@ describe("API 可观测性", () => {
       new Request("https://example.test/api/todos/123", {
         headers: {
           authorization: "Bearer token-value",
-          "x-request-id": "request-1",
+          "x-request-id": "client-request-id",
           "x-request-start-ms": "1780790400000",
         },
       }),
@@ -87,13 +87,14 @@ describe("API 可观测性", () => {
       expect.objectContaining({
         authMode: "bearer",
         event: "request.finish",
-        ioObservedDurationMs: 1000,
+        ioObservedDurationMs: 0,
         method: "GET",
         path: "/api/todos/:id",
-        requestId: "request-1",
+        requestId: expect.stringMatching(/^[0-9a-f-]{36}$/i),
         status: 200,
       }),
     );
+    expect(JSON.stringify(info.mock.calls)).not.toContain("client-request-id");
   });
 
   it("向 Cloudflare Analytics Engine 写入安全的请求结束数据点", async () => {
@@ -112,7 +113,7 @@ describe("API 可观测性", () => {
         {
           headers: {
             authorization: "Bearer token-value",
-            "x-request-id": "request-1",
+            "x-request-id": "client-request-id",
             "x-request-start-ms": "1780790400000",
           },
         },
@@ -130,7 +131,7 @@ describe("API 可观测性", () => {
         "2xx",
         "bearer",
       ],
-      doubles: [1000, 204],
+      doubles: [0, 204],
     });
     expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain(
       "feed-token-0123456789",
@@ -168,7 +169,7 @@ describe("API 可观测性", () => {
         new Request("https://example.test/api/todos/123", {
           headers: {
             cookie: "better-auth.session_token=session-token",
-            "x-request-id": "request-1",
+            "x-request-id": "client-request-id",
             "x-request-start-ms": "1780790400000",
           },
         }),
@@ -181,13 +182,14 @@ describe("API 可观测性", () => {
         authMode: "cookie",
         errorName: "Error",
         event: "request.error",
-        ioObservedDurationMs: 1000,
+        ioObservedDurationMs: 0,
         method: "GET",
         path: "/api/todos/:id",
-        requestId: "request-1",
+        requestId: expect.stringMatching(/^[0-9a-f-]{36}$/i),
         status: 500,
       }),
     );
+    expect(JSON.stringify(error.mock.calls)).not.toContain("client-request-id");
   });
 
   it("logs returned 5xx responses at error severity", async () => {

--- a/tests/unit/app-logger.test.ts
+++ b/tests/unit/app-logger.test.ts
@@ -104,4 +104,29 @@ describe("应用日志记录器", () => {
       route: "/api/todos/:id",
     });
   });
+
+  it("请求上下文字段不被局部日志上下文覆盖或清空", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    await runWithCloudflareRuntimeEnv({}, () => {
+      setCloudflareRequestContext({
+        method: "POST",
+        requestId: "request-context-id",
+        route: "/api/todos/:id",
+      });
+      logAppEvent("info", "test.event", {
+        method: "DELETE",
+        requestId: undefined,
+        route: "/api/other/:id",
+      });
+    });
+
+    const [payload] = infoSpy.mock.calls[0] ?? [];
+    expect(JSON.parse(String(payload))).toMatchObject({
+      method: "POST",
+      requestId: "request-context-id",
+      route: "/api/todos/:id",
+    });
+  });
 });

--- a/tests/unit/auth-page-action-logging.test.ts
+++ b/tests/unit/auth-page-action-logging.test.ts
@@ -1,0 +1,124 @@
+import type { Cookies } from "@sveltejs/kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  linkAccountFromSvelteActionMock,
+  logServerActionErrorMock,
+  requireSettingsUserMock,
+  signInFromSvelteActionMock,
+} = vi.hoisted(() => ({
+  linkAccountFromSvelteActionMock: vi.fn(),
+  logServerActionErrorMock: vi.fn(),
+  requireSettingsUserMock: vi.fn(),
+  signInFromSvelteActionMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/svelte-auth-actions", () => ({
+  applyAuthResponseCookies: vi.fn(),
+  linkAccountFromSvelteAction: linkAccountFromSvelteActionMock,
+  signInFromSvelteAction: signInFromSvelteActionMock,
+}));
+
+vi.mock("@/lib/log/app-logger", () => ({
+  logServerActionError: logServerActionErrorMock,
+}));
+
+vi.mock("@/features/settings/server/settings-page-data", () => ({
+  requireSettingsUser: requireSettingsUserMock,
+}));
+
+vi.mock("@/lib/auth/core", () => ({
+  authApi: { signOut: vi.fn() },
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    $transaction: vi.fn(),
+    account: {
+      delete: vi.fn(),
+      findMany: vi.fn(),
+    },
+    verifiedEmail: {
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/features/settings/server/account-deletion-service", () => ({
+  deleteOwnAccount: vi.fn(),
+}));
+
+import { signInPageDefaultAction } from "@/features/auth/server/signin-page-server";
+import { linkSettingsAccountAction } from "@/features/settings/server/settings-account-actions";
+
+const cookies = {} as Cookies;
+
+describe("auth page action logging", () => {
+  beforeEach(() => {
+    linkAccountFromSvelteActionMock.mockReset();
+    logServerActionErrorMock.mockReset();
+    requireSettingsUserMock.mockReset();
+    signInFromSvelteActionMock.mockReset();
+    requireSettingsUserMock.mockResolvedValue({ id: "user-1" });
+  });
+
+  it("records unexpected sign-in action failures with the request id", async () => {
+    const privateError = new TypeError("private provider detail");
+    signInFromSvelteActionMock.mockRejectedValue(privateError);
+
+    const result = await signInPageDefaultAction({
+      cookies,
+      locals: {
+        authUser: null,
+        locale: "zh-cn",
+        requestId: "request-1",
+      },
+      request: new Request("https://life.example/signin", {
+        body: new URLSearchParams({
+          callbackUrl: "/",
+          providerId: "github",
+        }),
+        method: "POST",
+      }),
+    });
+
+    expect(result.status).toBe(400);
+    expect(logServerActionErrorMock).toHaveBeenCalledWith(
+      "auth.signin.failed",
+      privateError,
+      {
+        action: "signin",
+        requestId: "request-1",
+        route: "/signin",
+      },
+    );
+  });
+
+  it("records unexpected account-link failures with the request id", async () => {
+    const privateError = new TypeError("private provider detail");
+    linkAccountFromSvelteActionMock.mockRejectedValue(privateError);
+    const request = new Request("https://life.example/settings/accounts", {
+      body: new URLSearchParams({ providerId: "github" }),
+      method: "POST",
+    });
+
+    const result = await linkSettingsAccountAction({
+      cookies,
+      locale: "zh-cn",
+      request,
+      requestId: "request-2",
+      url: new URL(request.url),
+    });
+
+    expect(result.status).toBe(400);
+    expect(logServerActionErrorMock).toHaveBeenCalledWith(
+      "settings.account-link.failed",
+      privateError,
+      {
+        action: "link-account",
+        requestId: "request-2",
+        route: "/settings/accounts",
+      },
+    );
+  });
+});

--- a/tests/unit/graphql-observability.test.ts
+++ b/tests/unit/graphql-observability.test.ts
@@ -234,6 +234,35 @@ describe("GraphQL semantic observability", () => {
     );
   });
 
+  it("does not trust a request ID header when server locals are absent", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    const writeDataPoint = installAnalytics();
+
+    await executeWithContext(
+      { query: "query HeaderOnly { courses { items { jwId } } }" },
+      (request) => contextWithPrincipal(request, { kind: "anonymous" }),
+      {
+        headers: { "x-request-id": "client-controlled-request-id" },
+        requestId: "",
+      },
+    );
+
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      indexes: ["graphql:query"],
+      blobs: [
+        "graphql_operation_v2",
+        "HeaderOnly",
+        "query",
+        "anonymous",
+        "unknown",
+      ],
+      doubles: [expect.any(Number), 1, 100, 0, 0],
+    });
+    expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain(
+      "client-controlled-request-id",
+    );
+  });
+
   it("records parse, validation, and resolver errors returned with HTTP 200", async () => {
     const info = vi.spyOn(console, "info").mockImplementation(() => {});
     const error = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/tests/unit/oauth-authorization-route.test.ts
+++ b/tests/unit/oauth-authorization-route.test.ts
@@ -7,12 +7,18 @@ const {
   authHandlerMock,
   bindCodeRedirectMock,
   getSessionFromHeadersMock,
+  logAppEventMock,
   resolveActiveGrantMock,
 } = vi.hoisted(() => ({
   authHandlerMock: vi.fn(),
   bindCodeRedirectMock: vi.fn(),
   getSessionFromHeadersMock: vi.fn(),
+  logAppEventMock: vi.fn(),
   resolveActiveGrantMock: vi.fn(),
+}));
+
+vi.mock("@/lib/log/app-logger", () => ({
+  logAppEvent: logAppEventMock,
 }));
 
 vi.mock("@/lib/auth/core", () => ({
@@ -64,6 +70,7 @@ describe("OAuth authorization route grant binding", () => {
     authHandlerMock.mockReset();
     bindCodeRedirectMock.mockReset();
     getSessionFromHeadersMock.mockReset();
+    logAppEventMock.mockReset();
     resolveActiveGrantMock.mockReset();
     getSessionFromHeadersMock.mockResolvedValue({ user: { id: "user-1" } });
     resolveActiveGrantMock.mockResolvedValue({
@@ -145,6 +152,40 @@ describe("OAuth authorization route grant binding", () => {
     expect(location.searchParams.has("code")).toBe(false);
     expect(location.searchParams.get("error")).toBe("server_error");
     expect(location.searchParams.get("state")).toBe("state-1");
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "warn",
+      "oauth.authorization.code-binding-rejected",
+      expect.objectContaining({
+        event: "oauth.authorization.code-binding-rejected",
+        phase: "code-binding",
+      }),
+    );
+  });
+
+  it("records authorization-code binding infrastructure failures", async () => {
+    const privateError = new TypeError("private database detail");
+    bindCodeRedirectMock.mockRejectedValue(privateError);
+    const { authGetRoute } = await import("@/lib/api/routes/auth");
+
+    const response = await authGetRoute(
+      new Request(
+        "https://life.example/api/auth/oauth2/authorize?client_id=client-1",
+      ),
+    );
+    const location = new URL(response.headers.get("location") ?? "");
+
+    expect(location.searchParams.has("code")).toBe(false);
+    expect(location.searchParams.get("error")).toBe("server_error");
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "error",
+      "oauth.authorization.code-binding-failed",
+      expect.objectContaining({
+        event: "oauth.authorization.code-binding-failed",
+        phase: "code-binding",
+      }),
+      privateError,
+    );
+    expect(JSON.stringify(logAppEventMock.mock.calls)).not.toContain("code-1");
   });
 
   it("binds authorization codes returned by the continue endpoint", async () => {

--- a/tests/unit/oauth-debug.test.ts
+++ b/tests/unit/oauth-debug.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  runWithCloudflareRuntimeEnv,
+  setCloudflareRequestContext,
+} from "@/lib/adapters/cloudflare-runtime";
+import {
   getOAuthDebugMode,
-  sanitizeOAuthRedirectLocation,
+  logOAuthDebug,
+  oauthDebugCorrelationId,
   summarizeOAuthAuthorizeUrl,
+  summarizeOAuthRedirectLocation,
   summarizeOAuthRedirectUri,
 } from "@/lib/log/oauth-debug";
 import {
@@ -35,15 +41,20 @@ describe("oauth 调试日志", () => {
     expect(getOAuthDebugMode()).toBe("standard");
   });
 
-  it("编辑敏感的重定向查询值", () => {
+  it("仅汇总重定向结构而不保留任何查询值", () => {
     expect(
-      sanitizeOAuthRedirectLocation(
-        "/callback?code=secret&state=ok&access_token=token",
+      summarizeOAuthRedirectLocation(
+        "/callback?code=secret&state=private-state&custom=private-value",
         "https://life.example.com/api/auth",
       ),
-    ).toBe(
-      "https://life.example.com/callback?code=%5BREDACTED%5D&state=ok&access_token=%5BREDACTED%5D",
-    );
+    ).toEqual({
+      redirectOrigin: "https://life.example.com",
+      redirectHost: "life.example.com",
+      redirectHostname: "life.example.com",
+      redirectPort: null,
+      redirectPath: "/callback",
+      redirectQueryKeys: ["code", "custom", "state"],
+    });
   });
 
   it("汇总重定向 URL 结构而不包含查询值", () => {
@@ -77,11 +88,18 @@ describe("oauth 调试日志", () => {
     const privateResource = "https://private-resource.example/secret";
 
     expect(
-      sanitizeOAuthRedirectLocation(
+      summarizeOAuthRedirectLocation(
         privateInvalidLocation,
         "https://life.example.com/api/auth",
       ),
-    ).toBe("[invalid-redirect-location]");
+    ).toEqual({
+      redirectOrigin: null,
+      redirectHost: "invalid_redirect_uri",
+      redirectHostname: null,
+      redirectPort: null,
+      redirectPath: null,
+      redirectQueryKeys: [],
+    });
     const summary = summarizeOAuthAuthorizeUrl(
       new URL(
         `https://life.example.com/api/auth/oauth2/authorize?resource=${encodeURIComponent(privateResource)}`,
@@ -134,5 +152,41 @@ describe("oauth 调试日志", () => {
     });
     expect(JSON.stringify([fingerprint, errorBody])).not.toContain("private");
     expect(JSON.stringify(fingerprint)).not.toContain(privateIp);
+  });
+
+  it("通过共享日志器继承规范请求上下文", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("OAUTH_DEBUG_LOGGING", "1");
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    await runWithCloudflareRuntimeEnv({}, () => {
+      setCloudflareRequestContext({
+        method: "POST",
+        requestId: "request-1",
+        route: "/api/auth/:id",
+      });
+      logOAuthDebug("oauth.test", undefined, { status: 400 });
+    });
+
+    const [payload] = info.mock.calls[0] ?? [];
+    expect(JSON.parse(String(payload))).toMatchObject({
+      prefix: "[app]",
+      event: "oauth.test",
+      method: "POST",
+      requestId: "request-1",
+      route: "/api/auth/:id",
+      status: 400,
+    });
+  });
+
+  it("不使用客户端 request ID 作为调试关联 ID", () => {
+    const request = new Request("https://life.example/api/auth", {
+      headers: {
+        "cf-ray": "trusted-edge-ray",
+        "x-request-id": "client-controlled-request-id",
+      },
+    });
+
+    expect(oauthDebugCorrelationId(request)).toBe("trusted-edge-ray");
   });
 });

--- a/tests/unit/oauth-device-token-grant.test.ts
+++ b/tests/unit/oauth-device-token-grant.test.ts
@@ -10,6 +10,8 @@ import { DEVICE_CODE_STATUS } from "@/lib/oauth/device-code";
 const findUniqueMock = vi.fn();
 const updateMock = vi.fn();
 const issueDeviceGrantTokensMock = vi.fn();
+const logOAuthDebugMock = vi.fn();
+const logAppEventMock = vi.fn();
 
 vi.mock("@/lib/db/prisma", () => ({
   prisma: {
@@ -25,7 +27,10 @@ vi.mock("@/features/oauth/server/device-token-issuer.server", () => ({
 }));
 
 vi.mock("@/lib/log/oauth-debug", () => ({
-  logOAuthDebug: vi.fn(),
+  logOAuthDebug: logOAuthDebugMock,
+}));
+vi.mock("@/lib/log/app-logger", () => ({
+  logAppEvent: logAppEventMock,
 }));
 
 vi.mock("@/lib/mcp/urls", () => ({
@@ -61,6 +66,8 @@ describe("设备令牌授予", () => {
     findUniqueMock.mockReset();
     updateMock.mockReset();
     issueDeviceGrantTokensMock.mockReset();
+    logOAuthDebugMock.mockReset();
+    logAppEventMock.mockReset();
     updateMock.mockResolvedValue({});
     issueDeviceGrantTokensMock.mockResolvedValue({
       accessToken: "access-token",
@@ -91,6 +98,11 @@ describe("设备令牌授予", () => {
         resources: ["https://life.example/api/mcp"],
       }),
     );
+    expect(logOAuthDebugMock).toHaveBeenCalledWith(
+      "device-token.success",
+      expect.any(Request),
+      expect.not.objectContaining({ userId: expect.anything() }),
+    );
   });
 
   it("拒绝更改已批准资源集的令牌轮询", async () => {
@@ -117,5 +129,35 @@ describe("设备令牌授予", () => {
       error: "invalid_target",
     });
     expect(issueDeviceGrantTokensMock).not.toHaveBeenCalled();
+  });
+
+  it("记录批准状态缺少用户的服务端状态异常", async () => {
+    findUniqueMock.mockResolvedValue({
+      ...approvedDeviceRecord(),
+      userId: null,
+    });
+    const { handleDeviceCodeGrant } = await import(
+      "@/lib/api/routes/auth-token-device-grant"
+    );
+
+    const response = await handleDeviceCodeGrant(
+      new Request("https://life.example/api/auth/oauth2/token", {
+        method: "POST",
+      }),
+      new URLSearchParams({
+        client_id: "client-1",
+        device_code: "device-code-1",
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "error",
+      "oauth.device-token.grant-resolution-failed",
+      {
+        event: "oauth.device-token.grant-resolution-failed",
+        phase: "resolve-grant",
+      },
+    );
   });
 });

--- a/tests/unit/oauth-introspection-grant.test.ts
+++ b/tests/unit/oauth-introspection-grant.test.ts
@@ -5,6 +5,7 @@ const {
   betterAuthHandlerMock,
   decodeJwtMock,
   hasActiveOAuthUserGrantMock,
+  logAppEventMock,
   refreshFindUniqueMock,
   verifyAccessTokenJwtMock,
 } = vi.hoisted(() => ({
@@ -12,8 +13,13 @@ const {
   betterAuthHandlerMock: vi.fn(),
   decodeJwtMock: vi.fn(),
   hasActiveOAuthUserGrantMock: vi.fn(),
+  logAppEventMock: vi.fn(),
   refreshFindUniqueMock: vi.fn(),
   verifyAccessTokenJwtMock: vi.fn(),
+}));
+
+vi.mock("@/lib/log/app-logger", () => ({
+  logAppEvent: logAppEventMock,
 }));
 
 vi.mock("jose", () => ({
@@ -60,6 +66,7 @@ describe("OAuth JWT introspection grant state", () => {
     accessFindUniqueMock.mockReset();
     decodeJwtMock.mockReset();
     hasActiveOAuthUserGrantMock.mockReset();
+    logAppEventMock.mockReset();
     refreshFindUniqueMock.mockReset();
     verifyAccessTokenJwtMock.mockReset();
     betterAuthHandlerMock.mockResolvedValue(Response.json({ active: true }));
@@ -108,6 +115,29 @@ describe("OAuth JWT introspection grant state", () => {
     const response = await authPostRoute(introspectionRequest());
 
     await expect(response.json()).resolves.toEqual({ active: true });
+  });
+
+  it("fails closed and records unexpected grant verification failures", async () => {
+    const privateError = new TypeError("private database detail");
+    hasActiveOAuthUserGrantMock.mockRejectedValue(privateError);
+    const { authPostRoute } = await import("@/lib/api/routes/auth");
+
+    const response = await authPostRoute(introspectionRequest());
+
+    await expect(response.json()).resolves.toEqual({ active: false });
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "error",
+      "oauth.introspection.grant-verification-failed",
+      expect.objectContaining({
+        event: "oauth.introspection.grant-verification-failed",
+        method: "POST",
+        phase: "grant-verification",
+      }),
+      privateError,
+    );
+    expect(JSON.stringify(logAppEventMock.mock.calls)).not.toContain(
+      "header.payload.signature",
+    );
   });
 
   it("uses trusted opaque reference generations when applying replay-tombstone state", async () => {

--- a/tests/unit/page-request-lifecycle.test.ts
+++ b/tests/unit/page-request-lifecycle.test.ts
@@ -7,14 +7,16 @@ vi.mock("@/app-env", () => ({
   loadEnv: vi.fn(),
 }));
 
-import { handle } from "@/hooks.server";
+import { handle, handleError } from "@/hooks.server";
 
 function handleInput(
   resolve: Parameters<Handle>[0]["resolve"],
   input: {
+    headers?: HeadersInit;
     method?: string;
     pathname?: string;
     routeId?: Parameters<Handle>[0]["event"]["route"]["id"];
+    spanNames?: string[];
   } = {},
 ) {
   const url = new URL(
@@ -56,8 +58,25 @@ function handleInput(
       requestId: "",
     },
     params: {},
-    platform: undefined,
-    request: new Request(url, { method: input.method ?? "GET" }),
+    platform: input.spanNames
+      ? {
+          context: {
+            tracing: {
+              enterSpan: (
+                name: string,
+                callback: (span: { setAttribute: () => void }) => unknown,
+              ) => {
+                input.spanNames?.push(name);
+                return callback({ setAttribute: () => {} });
+              },
+            },
+          },
+        }
+      : undefined,
+    request: new Request(url, {
+      headers: input.headers,
+      method: input.method ?? "GET",
+    }),
     route: { id: input.routeId ?? "/catalog-page-data/[kind]" },
     setHeaders: vi.fn(),
     tracing: {
@@ -177,5 +196,90 @@ describe("SvelteKit page request lifecycle", () => {
         expect.objectContaining({ event: "request.finish", path: "/api" }),
       ]),
     ]);
+  });
+
+  it("records server errors with the request id and normalized route", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { event } = handleInput(async () => new Response(), {
+      pathname: "/sections/159446",
+      routeId: "/sections/[jwId]",
+    });
+    event.locals.requestId = "request-1";
+
+    expect(
+      handleError({
+        error: new TypeError("private database detail"),
+        event,
+        message: "Internal Error",
+        status: 500,
+      }),
+    ).toEqual({ message: "Internal Error" });
+
+    expect(error).toHaveBeenCalledWith(
+      "[app]",
+      expect.objectContaining({
+        event: "sveltekit.server-error",
+        method: "GET",
+        requestId: "request-1",
+        route: "/sections/[jwId]",
+        status: 500,
+      }),
+      expect.anything(),
+    );
+    expect(JSON.stringify(error.mock.calls)).not.toContain("/sections/159446");
+  });
+
+  it("wires the SvelteKit dispatch through the Worker trace span", async () => {
+    const spanNames: string[] = [];
+    vi.spyOn(console, "info").mockImplementation(() => {});
+
+    await handle(
+      handleInput(async () => Response.json({ ok: true }), { spanNames }),
+    );
+
+    expect(spanNames).toContain("app.sveltekit.resolve");
+  });
+
+  it("records a thrown API request exactly once with a server request id", async () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      handle(
+        handleInput(
+          async () => {
+            throw new TypeError("private database detail");
+          },
+          {
+            headers: { "x-request-id": "client-controlled-request-id" },
+            pathname: "/api/todos/123",
+            routeId: "/api/todos/[id]",
+          },
+        ),
+      ),
+    ).rejects.toThrow("private database detail");
+
+    const events = apiEvents([...info.mock.calls, ...error.mock.calls]);
+    expect(
+      events.filter(
+        ([, value]) =>
+          typeof value === "object" &&
+          value !== null &&
+          "event" in value &&
+          value.event === "request.start",
+      ),
+    ).toHaveLength(1);
+    expect(
+      events.filter(
+        ([, value]) =>
+          typeof value === "object" &&
+          value !== null &&
+          "event" in value &&
+          value.event === "request.error",
+      ),
+    ).toHaveLength(1);
+    expect(JSON.stringify(events)).not.toContain(
+      "client-controlled-request-id",
+    );
   });
 });

--- a/tests/unit/user-mutation-rate-limit.test.ts
+++ b/tests/unit/user-mutation-rate-limit.test.ts
@@ -4,7 +4,10 @@ import { checkUserMutationRateLimit } from "@/lib/security/user-mutation-rate-li
 
 describe("user mutation rate limits", () => {
   beforeEach(() => setCloudflareRuntimeEnv(undefined));
-  afterEach(() => setCloudflareRuntimeEnv(undefined));
+  afterEach(() => {
+    setCloudflareRuntimeEnv(undefined);
+    vi.restoreAllMocks();
+  });
 
   it("explicitly bypasses the gate outside a Cloudflare runtime", async () => {
     await expect(
@@ -80,6 +83,7 @@ describe("user mutation rate limits", () => {
       },
     },
   ])("fails closed when the Cloudflare binding is missing or errors", async (env) => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
     setCloudflareRuntimeEnv(env);
 
     await expect(
@@ -89,5 +93,16 @@ describe("user mutation rate limits", () => {
         userId: "user-1",
       }),
     ).resolves.toEqual({ allowed: false, reason: "unavailable" });
+
+    expect(error).toHaveBeenCalledOnce();
+    expect(error.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        action: "comment:write",
+        event: "user-mutation-rate-limit.unavailable",
+        source: "rate-limit",
+        tier: "write",
+      }),
+    );
+    expect(JSON.stringify(error.mock.calls)).not.toContain("user-1");
   });
 });


### PR DESCRIPTION
## Goal

Close the remaining log and trace correlation gaps found in the final production observability audit, while preserving public behavior and the accepted calendar-feed constraint.

## Changed Surfaces

- Make server-owned request IDs, routes, and canonical logger fields authoritative.
- Route SvelteKit errors and OAuth debug output through the shared structured logger.
- Remove OAuth redirect query values and user IDs from debug logs.
- Add safe diagnostics for OAuth post-processing, device grants, unavailable rate-limit bindings, and failed sign-in/account-link actions.
- Make GraphQL stream cancellation cleanup rejection-safe.
- Add focused unit and request-lifecycle regression coverage.

## Evidence

- `bun run app:prepare`
- `bunx biome check .`
- `bun run check`
- all three TypeScript project checks
- unit suite: 248 files / 1509 tests passed
- integration suite: 40 files passed, 3 skipped / 239 tests passed, 13 skipped
- production build passed
- focused E2E: 34/34 passed across health, GraphQL, MCP, OAuth device, sign-in, and settings/accounts
- request-ID black-box probe confirmed unique UUID v4 IDs, forged inbound IDs rejected, and response/start/finish correlation
- `bunx wrangler deploy --dry-run` passed with all bindings resolved
- `bunx wrangler types --include-runtime=false --check --env-file /dev/null`

## Docs / Contracts

Updated `docs/observability.md` for correlation authority, OAuth safe summaries, operational error events, and reproducible Worker type checks. No API, GraphQL, MCP, Prisma, or generated Worker contract shape changed.

## Risk Areas

OAuth/MCP and request observability paths are touched. Public error/status behavior remains unchanged; authorization-code and introspection enforcement still fail closed. Logs avoid tokens, redirect query values, and raw user IDs. Calendar-feed URL authentication behavior is intentionally unchanged.

## Cleanup

No scratch artifacts, one-time probes, generated-file edits, test databases, containers, networks, volumes, or build output remain.