### PR TITLE
fix(metadata): configure favicon

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,6 +11,12 @@ $: socialMetadata = $page.data.socialMetadata;
 
 <svelte:head>
   <title>Life@USTC</title>
+  <link
+    rel="icon"
+    type="image/png"
+    sizes="32x32"
+    href="/images/ustc_favicon.png"
+  />
   <link rel="canonical" href={socialMetadata.canonicalUrl} />
   <meta name="description" content={socialMetadata.description} />
   <meta property="og:title" content={socialMetadata.title} />

--- a/tests/e2e/src/app/courses/social-metadata.test.ts
+++ b/tests/e2e/src/app/courses/social-metadata.test.ts
@@ -6,6 +6,7 @@ import { captureStepScreenshot } from "../../../utils/screenshot";
 const metadataSelectors = {
   canonical: 'link[rel="canonical"]',
   description: 'meta[name="description"]',
+  favicon: 'link[rel="icon"]',
   ogDescription: 'meta[property="og:description"]',
   ogImage: 'meta[property="og:image"]',
   ogImageAlt: 'meta[property="og:image:alt"]',
@@ -108,6 +109,7 @@ function expectCompleteSocialMetadata(
   expect(metadata.contentLanguage).toBe(expected.locale);
   expect(metadata.values.canonical[0]).toBe(canonicalUrl);
   expect(metadata.values.description[0]).toBe(expected.description);
+  expect(metadata.values.favicon[0]).toBe("/images/ustc_favicon.png");
   expect(metadata.values.ogTitle[0]).toBe(expected.title);
   expect(metadata.values.ogDescription[0]).toBe(expected.description);
   expect(metadata.values.ogType[0]).toBe("website");


### PR DESCRIPTION
## Goal

Configure the existing 32×32 Life@USTC favicon in the root document metadata so browsers do not fall back to the missing `/favicon.ico` path.

## Changed Surfaces

- Root SvelteKit document metadata: declare `/images/ustc_favicon.png` as the PNG favicon.
- Existing SSR social-metadata E2E coverage: require exactly one favicon link and verify its href.

## Evidence

- `bun run app:prepare`
- `bunx biome check`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` — 247 files, 1497 tests passed
- `bun run build` — Cloudflare production build passed
- `bunx playwright test tests/e2e/src/app/courses/social-metadata.test.ts --project=chromium` — 7/7 passed against an isolated seeded database
- Browser-content screenshot: N/A; the change is document-head metadata and is verified from raw SSR HTML.

## Docs / Contracts

No docs or contract update is needed. This restores existing browser metadata using an already-shipped public asset and does not change API, permission, data, or user workflow contracts.

## Risk Areas

Low risk. No auth, database schema, migration, upload, i18n, API, or privacy/security behavior changed.

## Cleanup

Confirmed only the two intentional files are changed. Temporary E2E database/configuration and the failed empty Compose resources were removed; no screenshots, traces, generated artifacts, or unrelated rewrites remain.