### PR TITLE
fix(metadata): use app icon for favicon

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { page } from "$app/stores";
+import appIconUrl from "$lib/assets/life-ustc-icon-192.png";
 import AppShell from "$lib/components/shell/AppShell.svelte";
 import "./svelte.css";
 import type { LayoutData } from "./$types";
@@ -14,8 +15,8 @@ $: socialMetadata = $page.data.socialMetadata;
   <link
     rel="icon"
     type="image/png"
-    sizes="32x32"
-    href="/images/ustc_favicon.png"
+    sizes="192x192"
+    href={appIconUrl}
   />
   <link rel="canonical" href={socialMetadata.canonicalUrl} />
   <meta name="description" content={socialMetadata.description} />

--- a/tests/e2e/src/app/courses/social-metadata.test.ts
+++ b/tests/e2e/src/app/courses/social-metadata.test.ts
@@ -109,7 +109,9 @@ function expectCompleteSocialMetadata(
   expect(metadata.contentLanguage).toBe(expected.locale);
   expect(metadata.values.canonical[0]).toBe(canonicalUrl);
   expect(metadata.values.description[0]).toBe(expected.description);
-  expect(metadata.values.favicon[0]).toBe("/images/ustc_favicon.png");
+  expect(metadata.values.favicon[0]).toMatch(
+    /\/life-ustc-icon-192\.[A-Za-z0-9_-]+\.png$/,
+  );
   expect(metadata.values.ogTitle[0]).toBe(expected.title);
   expect(metadata.values.ogDescription[0]).toBe(expected.description);
   expect(metadata.values.ogType[0]).toBe("website");


### PR DESCRIPTION
## Goal

Replace the incorrectly selected USTC OAuth provider favicon with the canonical Life@USTC application icon.

## Changed Surfaces

- Root SvelteKit metadata now imports the same `life-ustc-icon-192.png` asset already used by the shell, OAuth, device, and mobile-app UI.
- Existing SSR metadata E2E coverage now requires the emitted hashed favicon URL to resolve from that canonical asset.

No `.ico` conversion is necessary: the canonical source is a square 192×192 RGBA PNG, which browsers support natively as a favicon. Importing it avoids a duplicate generated asset and delegates fingerprinting/cache invalidation to Vite.

## Evidence

- `bun run app:prepare`
- `bunx biome check`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` — 248 files, 1509 tests passed
- `bun run build` — Cloudflare production build passed and emitted one fingerprinted `life-ustc-icon-192.<hash>.png`
- `bunx playwright test tests/e2e/src/app/courses/social-metadata.test.ts --project=chromium` — 7/7 passed against an isolated seeded database

## Docs / Contracts

No docs or contract update is needed. This corrects the implementation asset without changing API, permission, data, or workflow contracts.

## Risk Areas

Low risk. No auth, database schema, migration, upload, i18n, API, or privacy/security behavior changed.

## Cleanup

Only the root metadata and its existing E2E assertion changed. Temporary E2E database/configuration was removed; no copied icons, generated ICO files, traces, screenshots, or unrelated rewrites remain.