### PR TITLE
fix(auth): preserve rolling browser sessions

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -130,6 +130,12 @@ function responseWithSecurityHeaders(response: Response) {
   return mutableResponse;
 }
 
+function appendSessionCookies(target: Headers, source?: Headers) {
+  for (const cookie of source?.getSetCookie() ?? []) {
+    target.append("set-cookie", cookie);
+  }
+}
+
 function prepareApiObservability(
   request: Request,
   pathname: string,
@@ -240,16 +246,18 @@ const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
     }
 
     const authStartMs = Date.now();
-    const session = hasAuthSignal
+    const sessionResult = hasAuthSignal
       ? await runCloudflareTraceSpan(
           "app.auth.session",
           { "app.auth.signal_present": true },
           () =>
-            import("@/lib/auth/core").then(({ getSessionFromHeaders }) =>
-              getSessionFromHeaders(event.request.headers),
+            import("@/lib/auth/core").then(
+              ({ getSessionFromHeadersWithResponseHeaders }) =>
+                getSessionFromHeadersWithResponseHeaders(event.request.headers),
             ),
         )
       : null;
+    const session = sessionResult?.session ?? null;
     authIoObservedDurationMs = Date.now() - authStartMs;
     event.locals.authUser = session?.user ?? null;
     pageAuthMode = session?.user.id ? "authenticated" : "anonymous";
@@ -291,6 +299,7 @@ const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
     const shouldSetCsp = isHtmlResponse(response);
 
     const mutableResponse = responseWithSecurityHeaders(response);
+    appendSessionCookies(mutableResponse.headers, sessionResult?.headers);
     if (apiObservability) {
       recordObservedApiResponse(event.request, mutableResponse.status);
       mutableResponse.headers.set("x-request-id", apiObservability.requestId);

--- a/src/lib/auth/better-auth-schema-options.ts
+++ b/src/lib/auth/better-auth-schema-options.ts
@@ -38,6 +38,8 @@ export const betterAuthAccountOptions = {
 
 export const betterAuthSessionOptions = {
   storeSessionInDatabase: true,
+  expiresIn: 60 * 60 * 24 * 30,
+  updateAge: 60 * 60 * 24,
   fields: {
     token: "sessionToken",
     expiresAt: "expires",

--- a/src/lib/auth/core.ts
+++ b/src/lib/auth/core.ts
@@ -7,9 +7,13 @@ function createAuthInstance() {
 }
 
 type BetterAuthInstance = ReturnType<typeof createAuthInstance>;
+type SessionResult = {
+  headers: Headers;
+  session: AppSession | null;
+};
 
 let authInstance: BetterAuthInstance | undefined;
-const sessionByHeaders = new WeakMap<Headers, Promise<AppSession | null>>();
+const sessionByHeaders = new WeakMap<Headers, Promise<SessionResult>>();
 
 function getAuthInstance(): BetterAuthInstance {
   if (!authInstance) {
@@ -42,15 +46,16 @@ export const betterAuthInstance = new Proxy({} as BetterAuthInstance, {
   },
 });
 
-export async function getSessionFromHeaders(
-  headers: Headers,
-): Promise<AppSession | null> {
+async function resolveSession(headers: Headers): Promise<SessionResult> {
   const cached = sessionByHeaders.get(headers);
   if (cached) return cached;
 
   const pending = getAuthInstance()
-    .api.getSession({ headers })
-    .then((session) => (session ? mapAppSession(session) : null));
+    .api.getSession({ headers, returnHeaders: true })
+    .then(({ headers: responseHeaders, response }) => ({
+      headers: responseHeaders,
+      session: response ? mapAppSession(response) : null,
+    }));
   sessionByHeaders.set(headers, pending);
   try {
     return await pending;
@@ -58,4 +63,14 @@ export async function getSessionFromHeaders(
     sessionByHeaders.delete(headers);
     throw error;
   }
+}
+
+export async function getSessionFromHeaders(
+  headers: Headers,
+): Promise<AppSession | null> {
+  return (await resolveSession(headers)).session;
+}
+
+export function getSessionFromHeadersWithResponseHeaders(headers: Headers) {
+  return resolveSession(headers);
 }

--- a/tests/unit/auth-core-session-cache.test.ts
+++ b/tests/unit/auth-core-session-cache.test.ts
@@ -26,7 +26,14 @@ describe("request-scoped session resolution", () => {
   });
 
   it("shares one Better Auth lookup for the same request headers", async () => {
-    getSessionMock.mockResolvedValue(rawSession);
+    const responseHeaders = new Headers({
+      "set-cookie":
+        "better-auth.session_token=refreshed-token; Path=/; HttpOnly",
+    });
+    getSessionMock.mockResolvedValue({
+      headers: responseHeaders,
+      response: rawSession,
+    });
     const { getSessionFromHeaders } = await import("@/lib/auth/core");
     const headers = new Headers({
       cookie: "better-auth.session_token=session-token",
@@ -40,15 +47,42 @@ describe("request-scoped session resolution", () => {
     expect(first?.user.id).toBe("user-1");
     expect(second).toEqual(first);
     expect(getSessionMock).toHaveBeenCalledOnce();
+    expect(getSessionMock).toHaveBeenCalledWith({
+      headers,
+      returnHeaders: true,
+    });
   });
 
   it("does not share sessions across different request header objects", async () => {
-    getSessionMock.mockResolvedValue(rawSession);
+    getSessionMock.mockResolvedValue({
+      headers: new Headers(),
+      response: rawSession,
+    });
     const { getSessionFromHeaders } = await import("@/lib/auth/core");
 
     await getSessionFromHeaders(new Headers({ cookie: "session-token" }));
     await getSessionFromHeaders(new Headers({ cookie: "session-token" }));
 
     expect(getSessionMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("exposes rolling session cookies from Better Auth", async () => {
+    getSessionMock.mockResolvedValue({
+      headers: new Headers({
+        "set-cookie":
+          "better-auth.session_token=refreshed-token; Path=/; HttpOnly",
+      }),
+      response: rawSession,
+    });
+    const { getSessionFromHeadersWithResponseHeaders } = await import(
+      "@/lib/auth/core"
+    );
+
+    const result = await getSessionFromHeadersWithResponseHeaders(
+      new Headers({ cookie: "better-auth.session_token=session-token" }),
+    );
+
+    expect(result.session?.user.id).toBe("user-1");
+    expect(result.headers.get("set-cookie")).toContain("refreshed-token");
   });
 });

--- a/tests/unit/better-auth-options.test.ts
+++ b/tests/unit/better-auth-options.test.ts
@@ -76,6 +76,10 @@ describe("Better Auth options", () => {
       },
     });
     expect(options.trustedOrigins).toEqual(["https://life.example.com"]);
+    expect(options.session).toMatchObject({
+      expiresIn: 60 * 60 * 24 * 30,
+      updateAge: 60 * 60 * 24,
+    });
     expect(options.advanced).toMatchObject({
       disableCSRFCheck: false,
       disableOriginCheck: false,

--- a/tests/unit/detail-page-loader-critical-path.test.ts
+++ b/tests/unit/detail-page-loader-critical-path.test.ts
@@ -31,6 +31,7 @@ vi.mock("@/app-env", () => ({
 
 vi.mock("@/lib/auth/core", () => ({
   getSessionFromHeaders: getSessionFromHeadersMock,
+  getSessionFromHeadersWithResponseHeaders: getSessionFromHeadersMock,
 }));
 
 vi.mock("@/features/catalog/server/course-page-data", () => ({
@@ -282,14 +283,21 @@ describe("detail request session resolution", () => {
   ])("parses a signed-in %s session once in the hook and reuses locals in the detail loader", async (_authKind, headers) => {
     vi.spyOn(console, "info").mockImplementation(() => {});
     getSessionFromHeadersMock.mockResolvedValue({
-      session: { id: "session-1" },
-      user: signedInUser,
+      headers: new Headers({
+        "set-cookie":
+          "better-auth.session_token=refreshed-token; Path=/; HttpOnly",
+      }),
+      session: {
+        session: { id: "session-1" },
+        user: signedInUser,
+      },
     });
 
     const response = await resolveCourseThroughHook(headers);
 
     expect(response.status).toBe(200);
     expect(getSessionFromHeadersMock).toHaveBeenCalledOnce();
+    expect(response.headers.get("set-cookie")).toContain("refreshed-token");
     expect(getViewerContextMock).toHaveBeenCalledWith({
       userId: signedInUser.id,
     });


### PR DESCRIPTION
## Summary

- forward Better Auth rolling-session `Set-Cookie` headers from server-side session resolution to browser responses
- keep request-scoped session resolution deduplicated while exposing response headers to the SvelteKit hook
- extend the explicit session lifetime from Better Auth's 7-day default to 30 days, with daily rolling refresh
- add regression coverage for cookie forwarding, request-scoped caching, and session duration

## Root cause

The application called `auth.api.getSession({ headers })` only for the response body. Better Auth refreshes active database sessions after `updateAge`, but its refreshed browser cookie is returned in response headers. Those headers were discarded, so the database expiry rolled forward while the browser cookie retained its original expiry. This made active users sign in again after roughly seven days and happened to correlate with frequent deployments.

Cloudflare production has a persistent `AUTH_SECRET` binding, and Worker deploys preserve secrets, so deployments were not rotating the signing key.

## Impact

Active browser sessions now roll forward correctly, and the initial inactivity window is 30 days. Existing valid sessions remain valid; no secret or database migration is required.

## Validation

- targeted Vitest suite: 15 tests passed
- `bunx biome check` on all changed files
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `git diff --check`