### PR TITLE
fix(mobile-app): stop clamping card copy and balance hero title

### DIFF
--- a/src/features/mobile-app/components/MobileAppPage.svelte
+++ b/src/features/mobile-app/components/MobileAppPage.svelte
@@ -169,7 +169,7 @@ $: stats = [
             <p class="font-medium text-muted-foreground text-xs uppercase tracking-normal">
               {pageCopy.eyebrow}
             </p>
-            <h1 class="font-semibold text-2xl leading-tight tracking-normal sm:text-3xl">
+            <h1 class="text-balance font-semibold text-2xl leading-tight tracking-normal sm:text-3xl">
               {pageCopy.title}
             </h1>
           </div>
@@ -273,8 +273,10 @@ $: stats = [
                 <svelte:component this={item.icon} />
               </Item.Media>
               <Item.Content>
-                <Item.Title>{item.copy.title}</Item.Title>
-                <Item.Description>{item.copy.description}</Item.Description>
+                <Item.Title class="line-clamp-none">{item.copy.title}</Item.Title>
+                <Item.Description class="line-clamp-none break-words">
+                  {item.copy.description}
+                </Item.Description>
               </Item.Content>
             </Item.Root>
           {/each}
@@ -296,8 +298,10 @@ $: stats = [
                     <svelte:component this={item.icon} />
                   </Item.Media>
                   <Item.Content>
-                    <Item.Title>{item.copy.title}</Item.Title>
-                    <Item.Description>{item.copy.description}</Item.Description>
+                    <Item.Title class="line-clamp-none">{item.copy.title}</Item.Title>
+                    <Item.Description class="line-clamp-none break-words">
+                      {item.copy.description}
+                    </Item.Description>
                   </Item.Content>
                   <Item.Actions>
                     <ExternalLinkIcon />

--- a/src/features/mobile-app/components/MobileAppPage.svelte
+++ b/src/features/mobile-app/components/MobileAppPage.svelte
@@ -187,8 +187,8 @@ $: stats = [
           {#each stats as item}
             <Item.Root class="items-start" size="sm" variant="muted">
               <Item.Content>
-                <Item.Title>{item.value}</Item.Title>
-                <Item.Description>{item.label}</Item.Description>
+                <Item.Title class="line-clamp-none">{item.value}</Item.Title>
+                <Item.Description class="line-clamp-none break-words">{item.label}</Item.Description>
               </Item.Content>
             </Item.Root>
           {/each}
@@ -225,7 +225,7 @@ $: stats = [
             <SmartphoneIcon />
           </Item.Media>
           <div class="min-w-0">
-            <Card.Title class="truncate">{pageCopy.previewTitle}</Card.Title>
+            <Card.Title>{pageCopy.previewTitle}</Card.Title>
             <Card.Description>{pageCopy.previewSubtitle}</Card.Description>
           </div>
         </div>
@@ -236,8 +236,10 @@ $: stats = [
             <BellIcon />
           </Item.Media>
           <Item.Content>
-            <Item.Title>{pageCopy.previewStatusTitle}</Item.Title>
-            <Item.Description>{pageCopy.previewStatusDescription}</Item.Description>
+            <Item.Title class="line-clamp-none">{pageCopy.previewStatusTitle}</Item.Title>
+            <Item.Description class="line-clamp-none break-words">
+              {pageCopy.previewStatusDescription}
+            </Item.Description>
           </Item.Content>
         </Item.Root>
 
@@ -248,7 +250,7 @@ $: stats = [
                 <svelte:component this={item.icon} />
               </Item.Media>
               <Item.Content>
-                <Item.Title>{item.label}</Item.Title>
+                <Item.Title class="line-clamp-none">{item.label}</Item.Title>
               </Item.Content>
               <Item.Actions class="shrink-0">
                 {item.status}


### PR DESCRIPTION
## Summary

Root cause: the shared `Item.Title`/`Item.Description` primitives hardcode `line-clamp-1`/`line-clamp-2`, so the longer `en-us` copy on `/mobile-app` was truncated (visibly mid-word) while the shorter `zh-cn` copy fit. The hero `<h1>` also wrapped awkwardly on narrow screens (`移动应用` split as `移 / 动应用`; `en-us` hero wrapped to 3 short lines).

Fix (primitives untouched, per-issue constraints):
- (a) Added `class="line-clamp-none break-words"` to the `Item.Description` usages in the feature cards and quick-links cards, plus `line-clamp-none` on the matching `Item.Title` usages — mirroring the existing override pattern in `src/features/dashboard/components/DashboardLinkVisitAction.svelte:52`. `cn()`/tailwind-merge makes the override win over the hardcoded clamp.
- (b) Added `text-balance` to the hero `<h1>` (the cleaner minimal option vs. restacking the hero row), so both locales wrap at balanced points.

Fixes #637

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run app:prepare` (svelte-kit sync + prisma generate)
- [x] `bunx biome check src/features/mobile-app/components/MobileAppPage.svelte` — clean
- [x] `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors, 0 warnings
- [ ] Visual verification (Playwright e2e / screenshot pass) — deliberately NOT run: full e2e/build was skipped to avoid port/DB contention with parallel work; a follow-up capture pass should confirm the `zh-cn`/`en-us` hero wrapping and un-clamped card copy on desktop + mobile viewports.