### PR TITLE
fix(ui): use accent token for toggle on-state

### DIFF
--- a/src/lib/components/ui/toggle/toggle.svelte
+++ b/src/lib/components/ui/toggle/toggle.svelte
@@ -2,7 +2,7 @@
 	import { type VariantProps, tv } from "tailwind-variants";
 
 	export const toggleVariants = tv({
-		base: "hover:text-foreground aria-pressed:bg-muted focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[state=on]:bg-muted gap-1 rounded-lg text-sm font-medium transition-all [&_svg:not([class*='size-'])]:size-4 group/toggle hover:bg-muted inline-flex items-center justify-center whitespace-nowrap outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: "hover:text-foreground aria-pressed:bg-muted focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[state=on]:bg-accent data-[state=on]:text-accent-foreground gap-1 rounded-lg text-sm font-medium transition-all [&_svg:not([class*='size-'])]:size-4 group/toggle hover:bg-muted inline-flex items-center justify-center whitespace-nowrap outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
 				default: "bg-transparent",


### PR DESCRIPTION
## Summary

Fixes #641

**Root cause:** `src/lib/components/ui/toggle/toggle.svelte` styled the on-state with `data-[state=on]:bg-muted`. In the light theme `--muted` (#f4f4f5) is nearly identical to `--background` (#f6f8fa) — about 1.02:1 contrast — so an active toggle looked unselected (e.g. the /workspace/exams status filter). Dark theme was unaffected.

**Fix:** Switch the on-state to the stock shadcn styling, `data-[state=on]:bg-accent data-[state=on]:text-accent-foreground`. The repo's `--accent` token is a visible cyan (#d8f5f7 / #174044 light, oklch(0.24 0.05 185) / oklch(0.92 0.012 185) dark, see `src/routes/svelte.css`), so the active state is clearly visible in both themes. Because every toggle-group item composes `toggleVariants` (`toggle-group-item.svelte`), this one-line change fixes all toggle groups at once (exams, todos, homeworks, links, calendar, section-detail, settings, admin). `--muted` was deliberately left unchanged (wide blast radius); no usage overrides the on-state classes (verified via grep for `data-[state=on]`).

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run app:prepare` (svelte-kit sync + prisma generate)
- [x] `bunx biome check` — passes (1 pre-existing warning in unrelated `src/static-loader/import.ts`)
- [x] `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors, 0 warnings
- [x] `bunx vitest run tests/unit/section-detail-homework-toggle-action.test.ts tests/unit/dashboard-homework-actions.test.ts` — 4/4 pass
- [ ] Visual verification (screenshot of active toggle in light theme) — pending a follow-up capture pass; full Playwright e2e not run per parallel-worktree constraints