### PR TITLE
fix(admin): let /admin/bus Active stat ellipsize instead of hard-clipping

### DIFF
--- a/src/features/admin/components/AdminBusSummaryStats.svelte
+++ b/src/features/admin/components/AdminBusSummaryStats.svelte
@@ -21,7 +21,9 @@ const stats = [
   {
     getValue: () => summary.active ?? copy.statNone,
     label: () => copy.statActive,
-    valueClass: "max-w-full truncate text-base",
+    // block + w-full override Item.Title's flex base so truncate can render
+    // a text-overflow ellipsis instead of hard-clipping the flex container.
+    valueClass: "block w-full max-w-full truncate text-base",
   },
   {
     getValue: () => summary.versions,


### PR DESCRIPTION
## Summary

**Root cause:** `AdminBusSummaryStats.svelte` renders the Active stat value inside `Item.Title`, which is `display: flex` (`src/lib/components/ui/item/item-title.svelte`). `text-overflow: ellipsis` (from Tailwind's `truncate`) cannot render on a flex container, so a long value like "Static Structured Bus…" was hard-clipped with no ellipsis.

**Fix:** only in `AdminBusSummaryStats.svelte`, add `block w-full` to the Active stat's `valueClass`. `cn()`/tailwind-merge drops the conflicting `flex`/`w-fit` base classes, so the value becomes block-level and `truncate` ellipsizes correctly. The shared `Item.Title` component is deliberately untouched. Even if `line-clamp-1`'s `display: -webkit-box` wins the cascade over `block`, single-line clamping also renders an ellipsis — either outcome fixes the hard-clip.

Fixes #635

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bunx biome check src/features/admin/components/AdminBusSummaryStats.svelte` — clean
- [x] `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors, 0 warnings
- [x] Verified merged class output with twMerge: `flex`/`w-fit` are dropped in favor of `block w-full`
- [ ] Visual/browser verification of a long Active value ellipsizing — **pending a follow-up capture pass** (Playwright e2e / `bun run build` intentionally skipped to avoid port/DB contention with parallel work)