### PR TITLE
fix(guides): wrap markdown guide code snippets and add scroll cue to preview pre blocks

### DIFF
--- a/src/lib/components/markdown-preview.css
+++ b/src/lib/components/markdown-preview.css
@@ -37,12 +37,44 @@
 }
 
 .markdown-preview pre {
-  background: var(--color-muted);
+  background:
+    linear-gradient(to right, var(--color-muted), var(--color-muted)),
+    linear-gradient(to left, var(--color-muted), var(--color-muted)) 100% 0,
+    linear-gradient(
+      to right,
+      color-mix(in srgb, var(--color-foreground) 20%, transparent),
+      transparent
+    ),
+    linear-gradient(
+      to left,
+      color-mix(in srgb, var(--color-foreground) 20%, transparent),
+      transparent
+    )
+    100% 0;
+  background-attachment: local, local, scroll, scroll;
+  background-color: var(--color-muted);
+  background-repeat: no-repeat;
+  background-size:
+    2rem 100%,
+    2rem 100%,
+    0.75rem 100%,
+    0.75rem 100%;
   border: 1px solid var(--color-border);
   border-radius: 0.375rem;
   font-size: 0.75rem;
   overflow-x: auto;
   padding: 0.75rem;
+  scrollbar-color: var(--color-border) transparent;
+  scrollbar-width: thin;
+}
+
+.markdown-preview pre::-webkit-scrollbar {
+  height: 0.375rem;
+}
+
+.markdown-preview pre::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: 0.1875rem;
 }
 
 .markdown-preview code {

--- a/src/routes/guides/markdown-support/MarkdownGuideSection.svelte
+++ b/src/routes/guides/markdown-support/MarkdownGuideSection.svelte
@@ -22,7 +22,7 @@ export let section: {
       <Card.Description>{section.description}</Card.Description>
     </Card.Header>
     <Card.Content>
-      <pre class="overflow-x-auto rounded-md border border-border bg-muted p-4 font-mono text-sm"><code>{section.code}</code></pre>
+      <pre class="overflow-x-auto wrap-anywhere whitespace-pre-wrap rounded-md border border-border bg-muted p-4 font-mono text-sm"><code>{section.code}</code></pre>
     </Card.Content>
   </Card.Root>
 


### PR DESCRIPTION
## Summary

Fixes #642

Root cause: two code-block surfaces clipped at mobile widths with no wrap and no visible scroll cue:
- `src/routes/guides/markdown-support/MarkdownGuideSection.svelte` — the guide's source `<pre>` (e.g. the `{width=96 align=center}` example) only had `overflow-x-auto`, making snippets unreadable at 412px.
- `src/lib/components/markdown-preview.css` — `.markdown-preview pre` (rendered user comments) had `overflow-x: auto` but no affordance indicating horizontal scroll.

Fix:
- Guide source `<pre>`: add `whitespace-pre-wrap` + `wrap-anywhere`. These are short instructional snippets meant to be read in full, so wrapping is preferred over scrolling.
- `.markdown-preview pre`: add a persistent thin scrollbar (`scrollbar-width: thin` + `::-webkit-scrollbar` styling) and edge-fade shadows via layered background gradients (`local` covers over `scroll` shadows) that only appear when the block is actually scrollable. Wide code/tables on desktop keep their existing horizontal-scroll behavior; non-overflowing blocks are visually unchanged.

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run app:prepare` (with placeholder `DATABASE_URL`; generate does not connect)
- [x] `bunx biome check` on changed files (auto-formatted, then clean)
- [x] `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors, 0 warnings
- [x] `bunx vitest run tests/unit/markdown-renderer.test.ts` — 4/4 passed
- [ ] Full Playwright e2e suite — intentionally not run (port/DB contention with parallel work)
- [ ] Visual verification at 412px viewport (guide page + comment code blocks) — pending a follow-up capture pass