### PR TITLE
fix(dashboard): localize overview week strip and stop Today card stretch

### DIFF
--- a/src/features/dashboard/components/OverviewTodayOverdueCards.svelte
+++ b/src/features/dashboard/components/OverviewTodayOverdueCards.svelte
@@ -32,7 +32,7 @@ export let overdueTodos: DashboardTodoItem[];
 export let sessionHref: (session: DashboardSessionItem) => string;
 </script>
 
-<div class="grid gap-4 lg:grid-cols-2">
+<div class="grid items-start gap-4 lg:grid-cols-2">
   <OverviewTodayCard
     {copy}
     {dashboardCopy}

--- a/src/features/dashboard/components/overview-tab-week-days.ts
+++ b/src/features/dashboard/components/overview-tab-week-days.ts
@@ -22,7 +22,7 @@ export function overviewCalendarWeekDays(
     const timelineItems = calendarTimelineItemsForDay(events);
     return {
       key: dayKey,
-      label: overviewDayLabel(dayKey),
+      label: overviewDayLabel(dayKey, locale),
       sublabel: formatCampusDate(dayKey, dayKey, locale, {
         weekday: "short",
       }),

--- a/src/features/dashboard/lib/calendar-display-overview.ts
+++ b/src/features/dashboard/lib/calendar-display-overview.ts
@@ -14,8 +14,8 @@ export function dashboardOverviewWeekStart(
   );
 }
 
-export function overviewDayLabel(dayKey: string) {
-  return formatCampusDate(dayKey, dayKey, undefined, {
+export function overviewDayLabel(dayKey: string, locale?: string | string[]) {
+  return formatCampusDate(dayKey, dayKey, locale, {
     month: "short",
     day: "numeric",
   });

--- a/tests/unit/dashboard-calendar-display-overview.test.ts
+++ b/tests/unit/dashboard-calendar-display-overview.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { overviewUpcomingExams } from "@/features/dashboard/lib/calendar-display-overview";
+import {
+  overviewDayLabel,
+  overviewUpcomingExams,
+} from "@/features/dashboard/lib/calendar-display-overview";
 
 describe("仪表盘概览考试展示", () => {
   it("仅显示仍可出现在近期时间线中的考试", () => {
@@ -46,5 +49,12 @@ describe("仪表盘概览考试展示", () => {
       "untimed-today",
       "future",
     ]);
+  });
+});
+
+describe("仪表盘概览星期标签", () => {
+  it("按传入语言环境格式化日期", () => {
+    expect(overviewDayLabel("2026-07-19", "zh-cn")).toBe("7月19日");
+    expect(overviewDayLabel("2026-07-19", "en-us")).toBe("Jul 19");
   });
 });


### PR DESCRIPTION
## Summary

Two one-line-scoped UI fixes on `/workspace/overview`:

- **#638 — week strip locale**: `overviewDayLabel()` in `src/features/dashboard/lib/calendar-display-overview.ts` passed `undefined` as the locale to `formatCampusDate`, so on zh-cn pages the week strip showed English `Jul 19` above Chinese weekday labels (`周日`). Added a `locale` parameter and threaded the locale already available at the only call site (`src/features/dashboard/components/overview-tab-week-days.ts`), mirroring how the adjacent `sublabel` weekday formatting already passes `locale`.
- **#639 — Today card stretch**: the Today/Overdue grid in `src/features/dashboard/components/OverviewTodayOverdueCards.svelte` used default `stretch` alignment, so an empty Today card stretched to match the tall Overdue column on desktop (`lg:grid-cols-2`). Added `items-start`.

Fixes #638
Fixes #639

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run app:prepare` (`svelte-kit sync` succeeded; `prisma generate` needs `DATABASE_URL`, ran separately with a local dummy DSN — no DB touched)
- [x] `bunx biome check` on the 4 changed files — clean
- [x] `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors, 0 warnings
- [x] `bunx tsc --noEmit` for `tsconfig.typecheck.json`, `tsconfig.typecheck.tests.json`, `tsconfig.typecheck.operational.json` — all exit 0
- [x] `bunx vitest run tests/unit/dashboard-calendar-display-overview.test.ts` — 2/2 pass, including a new test asserting `overviewDayLabel("2026-07-19", "zh-cn")` → `7月19日` and `"en-us"` → `Jul 19`
- [ ] Full Playwright e2e / `bun run build` — intentionally skipped (port/DB contention with parallel work); visual verification of the week strip and card alignment is pending a follow-up capture pass