### PR TITLE
fix(admin): let desktop admin tables scroll horizontally instead of clipping

### DIFF
--- a/src/features/admin/components/AdminBusVersions.svelte
+++ b/src/features/admin/components/AdminBusVersions.svelte
@@ -26,7 +26,7 @@ export let versions: AdminBusVersion[];
       {copy.versionsDescription}
     </Card.Description>
   </Card.Header>
-  <Card.Content class="grid gap-4">
+  <Card.Content class="grid grid-cols-[minmax(0,1fr)] gap-4">
     <AdminBusVersionsMobileList
       {copy}
       {enhancedAction}

--- a/src/features/admin/components/AdminBusVersionsTable.svelte
+++ b/src/features/admin/components/AdminBusVersionsTable.svelte
@@ -21,7 +21,7 @@ export let pendingAction: string | null;
 export let versions: AdminBusVersion[];
 </script>
 
-<div class="hidden md:block">
+<div class="hidden min-w-0 md:block">
   <Table.Root>
     <Table.Header>
       <Table.Row>

--- a/src/features/admin/components/AdminModerationComments.svelte
+++ b/src/features/admin/components/AdminModerationComments.svelte
@@ -19,7 +19,7 @@ export let targetHref: AdminModerationCommentFormatter;
 export let targetLabel: AdminModerationCommentFormatter;
 </script>
 
-<section class="grid gap-3">
+<section class="grid grid-cols-[minmax(0,1fr)] gap-3">
   {#if comments.length > 0}
     <AdminModerationCommentsMobile
       {commentAuthorLabel}

--- a/src/features/admin/components/AdminModerationCommentsTable.svelte
+++ b/src/features/admin/components/AdminModerationCommentsTable.svelte
@@ -18,7 +18,7 @@ export let targetHref: AdminModerationCommentFormatter;
 export let targetLabel: AdminModerationCommentFormatter;
 </script>
 
-<div class="hidden md:block">
+<div class="hidden min-w-0 md:block">
   <Table.Root>
     <Table.Header>
       <Table.Row>

--- a/src/features/admin/components/AdminModerationDescriptionTable.svelte
+++ b/src/features/admin/components/AdminModerationDescriptionTable.svelte
@@ -21,7 +21,7 @@ export let onManage: (description: AdminModerationDescription) => void;
 export let targetLabel: (description: AdminModerationDescription) => string;
 </script>
 
-<div class="hidden md:block">
+<div class="hidden min-w-0 md:block">
   <Table.Root>
     <Table.Header>
       <Table.Row>

--- a/src/features/admin/components/AdminModerationDescriptions.svelte
+++ b/src/features/admin/components/AdminModerationDescriptions.svelte
@@ -27,7 +27,7 @@ export let onManage: (description: AdminModerationDescription) => void;
 export let targetLabel: (description: AdminModerationDescription) => string;
 </script>
 
-<section class="grid gap-3">
+<section class="grid grid-cols-[minmax(0,1fr)] gap-3">
   <AdminModerationDescriptionSummary
     {copy}
     {descriptionContentFilter}

--- a/src/features/admin/components/AdminUsersDesktopTable.svelte
+++ b/src/features/admin/components/AdminUsersDesktopTable.svelte
@@ -17,7 +17,7 @@ export let suspensionLabel: AdminUserFormatter;
 export let users: AdminUserRow[];
 </script>
 
-<div class="hidden md:block">
+<div class="hidden min-w-0 md:block">
   <Table.Root>
     <Table.Header>
       <Table.Row>

--- a/src/features/admin/components/AdminUsersTableCard.svelte
+++ b/src/features/admin/components/AdminUsersTableCard.svelte
@@ -44,7 +44,7 @@ export let users: AdminUserRow[];
       </Badge>
     </Card.Action>
   </Card.Header>
-  <Card.Content class="grid gap-4">
+  <Card.Content class="grid grid-cols-[minmax(0,1fr)] gap-4">
     {#if users.length === 0}
       <Empty.Root class="min-h-24">
         <Empty.Header>

--- a/src/features/admin/components/AdminWorkspace.svelte
+++ b/src/features/admin/components/AdminWorkspace.svelte
@@ -12,7 +12,7 @@ type Props = {
 let { children, controls, feedback, header, summary }: Props = $props();
 </script>
 
-<section class="grid gap-5" data-testid="admin-workspace">
+<section class="grid grid-cols-[minmax(0,1fr)] gap-5" data-testid="admin-workspace">
   {@render header()}
   {#if feedback}{@render feedback()}{/if}
   {#if summary}{@render summary()}{/if}


### PR DESCRIPTION
## Summary

Admin tables on `/admin/moderation`, `/admin/bus`, and `/admin/users` overflowed the 1280px desktop viewport and were hard-clipped at the right edge.

**Root cause:** the grid ancestors used default `minmax(auto, 1fr)` implicit tracks and the desktop table wrapper divs lacked `min-w-0`, so the table's own `overflow-x-auto` (`src/lib/components/ui/table/table.svelte`, unchanged) never engaged.

**Fix:**
- Add `min-w-0` to the desktop table wrappers: `AdminModerationCommentsTable.svelte`, `AdminModerationDescriptionTable.svelte`, `AdminBusVersionsTable.svelte`, `AdminUsersDesktopTable.svelte`
- Constrain the grid chain with `grid-cols-[minmax(0,1fr)]`: `AdminWorkspace.svelte`, `AdminModerationComments.svelte`, `AdminBusVersions.svelte` (`Card.Content`), `AdminUsersTableCard.svelte` (`Card.Content`)
- Also applied the same grid constraint to `AdminModerationDescriptions.svelte`, whose section wraps the descriptions table the same way — without it the descriptions tab would keep clipping.

Fixes #634

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run app:prepare` (svelte-kit sync + prisma generate)
- [x] `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors, 0 warnings
- [x] `bunx biome check` on all 9 changed files — clean
- [ ] Unit tests: none cover these presentational components (verified no test references them); change is CSS-class-only
- [ ] Visual verification (1280px screenshot pass on the three admin pages): pending a follow-up capture pass — full Playwright e2e / `bun run build` intentionally not run here to avoid port/DB contention with parallel work