### PR TITLE
fix(admin): add overflow cues to admin sub-nav

### DIFF
--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -4,13 +4,16 @@ import Gavel from "@lucide/svelte/icons/gavel";
 import KeyRound from "@lucide/svelte/icons/key-round";
 import Shield from "@lucide/svelte/icons/shield";
 import Users from "@lucide/svelte/icons/users";
-import { tick } from "svelte";
+import { onMount, tick } from "svelte";
 import { page } from "$app/stores";
 import { Button } from "$lib/components/ui/button/index.js";
+import { cn } from "$lib/utils.js";
 import type { LayoutData } from "./$types";
 
 export let data: LayoutData;
 
+let canScrollNavLeft = false;
+let canScrollNavRight = false;
 let navigation: HTMLElement | null = null;
 
 $: pathname = $page.url.pathname;
@@ -48,23 +51,51 @@ function isActive(href: string, currentPathname: string) {
     : currentPathname === href || currentPathname.startsWith(`${href}/`);
 }
 
+function centerNavigationItem(node: HTMLElement) {
+  if (!navigation) return;
+  const navigationBox = navigation.getBoundingClientRect();
+  const nodeBox = node.getBoundingClientRect();
+  navigation.scrollLeft +=
+    nodeBox.left +
+    nodeBox.width / 2 -
+    (navigationBox.left + navigationBox.width / 2);
+  updateNavigationOverflow();
+}
+
 function revealActive(node: HTMLElement, active: boolean) {
   function reveal(isCurrent: boolean) {
     if (!isCurrent) return;
-    void tick().then(() => {
-      if (!navigation) return;
-      const navigationBox = navigation.getBoundingClientRect();
-      const nodeBox = node.getBoundingClientRect();
-      navigation.scrollLeft +=
-        nodeBox.left +
-        nodeBox.width / 2 -
-        (navigationBox.left + navigationBox.width / 2);
-    });
+    void tick().then(() => centerNavigationItem(node));
   }
 
   reveal(active);
   return { update: reveal };
 }
+
+function updateNavigationOverflow() {
+  if (!navigation) return;
+  canScrollNavLeft = navigation.scrollLeft > 1;
+  canScrollNavRight =
+    navigation.scrollLeft + navigation.clientWidth < navigation.scrollWidth - 1;
+}
+
+onMount(() => {
+  if (!navigation) return;
+  const nav = navigation;
+  const resizeObserver = new ResizeObserver(updateNavigationOverflow);
+  resizeObserver.observe(nav);
+  nav.addEventListener("scroll", updateNavigationOverflow, { passive: true });
+  void tick().then(() => {
+    const activeLink = nav.querySelector<HTMLElement>('a[aria-current="page"]');
+    if (activeLink) centerNavigationItem(activeLink);
+    else updateNavigationOverflow();
+  });
+
+  return () => {
+    resizeObserver.disconnect();
+    nav.removeEventListener("scroll", updateNavigationOverflow);
+  };
+});
 </script>
 
 {#if data.user?.isAdmin}
@@ -72,30 +103,42 @@ function revealActive(node: HTMLElement, active: boolean) {
     class="grid min-w-0 gap-5 lg:grid-cols-[12rem_minmax(0,1fr)] lg:items-start lg:gap-6"
     data-testid="admin-layout"
   >
-    <nav
-      aria-label={data.copy.nav.groups.adminTools}
-      bind:this={navigation}
-      class="-mx-4 overflow-x-auto px-4 pb-1 sm:-mx-5 sm:px-5 lg:sticky lg:top-4 lg:mx-0 lg:overflow-visible lg:px-0 lg:pb-0"
-      data-testid="admin-navigation"
+    <div
+      class={cn(
+        "relative -mx-4 min-w-0 sm:-mx-5 lg:sticky lg:top-4 lg:mx-0",
+        canScrollNavLeft &&
+          "before:pointer-events-none before:absolute before:inset-y-0 before:left-0 before:z-10 before:w-8 before:bg-gradient-to-r before:from-background before:to-transparent lg:before:hidden",
+        canScrollNavRight &&
+          "after:pointer-events-none after:absolute after:inset-y-0 after:right-0 after:z-10 after:w-8 after:bg-gradient-to-l after:from-background after:to-transparent lg:after:hidden",
+      )}
+      data-overflow-left={canScrollNavLeft}
+      data-overflow-right={canScrollNavRight}
     >
-      <ul class="flex min-w-max gap-2 pr-4 lg:grid lg:min-w-0 lg:pr-0">
-        {#each links as link}
-          {@const Icon = link.icon}
-          {@const active = isActive(link.href, pathname)}
-          <li class="lg:min-w-0" use:revealActive={active}>
-            <Button
-              aria-current={active ? "page" : undefined}
-              class="justify-start lg:w-full"
-              href={link.href}
-              variant={active ? "secondary" : "ghost"}
-            >
-              <Icon aria-hidden="true" data-icon="inline-start" />
-              {link.label}
-            </Button>
-          </li>
-        {/each}
-      </ul>
-    </nav>
+      <nav
+        aria-label={data.copy.nav.groups.adminTools}
+        bind:this={navigation}
+        class="overflow-x-auto px-4 pb-1 sm:px-5 lg:overflow-visible lg:px-0 lg:pb-0"
+        data-testid="admin-navigation"
+      >
+        <ul class="flex min-w-max gap-2 pr-8 lg:grid lg:min-w-0 lg:pr-0">
+          {#each links as link}
+            {@const Icon = link.icon}
+            {@const active = isActive(link.href, pathname)}
+            <li class="lg:min-w-0" use:revealActive={active}>
+              <Button
+                aria-current={active ? "page" : undefined}
+                class="justify-start lg:w-full"
+                href={link.href}
+                variant={active ? "secondary" : "ghost"}
+              >
+                <Icon aria-hidden="true" data-icon="inline-start" />
+                {link.label}
+              </Button>
+            </li>
+          {/each}
+        </ul>
+      </nav>
+    </div>
 
     <div class="min-w-0" data-testid="admin-active-panel">
       <slot />

--- a/tests/e2e/src/app/admin/test.ts
+++ b/tests/e2e/src/app/admin/test.ts
@@ -110,6 +110,41 @@ test("/admin 二级导航响应式布局且支持键盘切换", async ({ page },
   await captureStepScreenshot(page, testInfo, "admin/navigation-desktop");
 });
 
+test("/admin 二级导航在移动端显示滚动溢出提示", async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await signInAsDevAdmin(page, "/admin");
+
+  const navigation = page.getByTestId("admin-navigation");
+  const wrapper = navigation.locator("..");
+
+  // First tab active at scrollLeft 0: no left cue, right cue while scrollable.
+  await expect
+    .poll(() =>
+      Promise.all([
+        wrapper.getAttribute("data-overflow-left"),
+        wrapper.getAttribute("data-overflow-right"),
+      ]),
+    )
+    .toEqual(["false", "true"]);
+
+  // Last tab active clamps to max scroll: left cue on, right cue off.
+  await gotoAndWaitForReady(page, "/admin/bus");
+  await expect(navigation.locator('a[aria-current="page"]')).toHaveAttribute(
+    "href",
+    "/admin/bus",
+  );
+  await expect
+    .poll(() =>
+      Promise.all([
+        wrapper.getAttribute("data-overflow-left"),
+        wrapper.getAttribute("data-overflow-right"),
+      ]),
+    )
+    .toEqual(["true", "false"]);
+
+  await captureStepScreenshot(page, testInfo, "admin/navigation-overflow-cues");
+});
+
 test("/admin 管理员访问成功并显示所有导航卡片", async ({ page }, testInfo) => {
   await signInAsDevAdmin(page, "/admin");
   await expect(page).toHaveURL(/\/admin(?:\?.*)?$/);


### PR DESCRIPTION
## Summary

The admin sub-nav (`src/routes/admin/+layout.svelte`) had `overflow-x-auto` but no scroll affordance, and `revealActive` centered the active tab on mount, so the strip could start scrolled-left with the first tab clipped and no visual hint that more tabs exist.

Fix replicates the settings navigation pattern (`SettingsPageController.svelte` / `DetailSectionNav.svelte`):

- Track `canScrollNavLeft`/`canScrollNavRight` with a `ResizeObserver` + passive scroll listener on the nav viewport.
- Refresh the overflow state after `revealActive` centering (extracted into `centerNavigationItem`, mirroring settings).
- Wrap the nav in a relative container with gradient fade cues (`::before`/`::after`, `from-background`) gated on those states, hidden on `lg:` where the nav is a non-scrolling sidebar. Exposes `data-overflow-left`/`data-overflow-right` for tests.
- `ul` trailing padding `pr-4` → `pr-8` so the last tab clears the right fade, matching settings.

Fixes #633

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run app:prepare` (Prisma client + SvelteKit sync)
- [x] `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors, 0 warnings
- [x] `bunx biome check` on changed files — clean after `--write` format fix
- [x] Added e2e coverage: `tests/e2e/src/app/admin/test.ts` asserts `data-overflow-left/right` on mobile at first tab (`false/true`) and last tab clamped to max scroll (`true/false`)
- [ ] Full Playwright e2e run and visual screenshot verification — pending a follow-up capture pass (skipped locally to avoid port/DB contention with parallel work); CI e2e covers it