### PR TITLE
fix(dashboard): render overdue homework ETA badge with destructive variant

### DIFF
--- a/src/features/dashboard/components/HomeworksCardsView.svelte
+++ b/src/features/dashboard/components/HomeworksCardsView.svelte
@@ -8,6 +8,9 @@ import * as Empty from "$lib/components/ui/empty/index.js";
 type HomeworkDateFormatter = (
   value: Date | string | null | undefined,
 ) => string;
+type HomeworkOverduePredicate = (
+  value: Date | string | null | undefined,
+) => boolean;
 type HomeworkAction = (homework: DashboardHomeworkItem) => string;
 
 export let filteredHomeworkItems: DashboardHomeworkItem[];
@@ -15,6 +18,7 @@ export let fmtDate: HomeworkDateFormatter;
 export let homeworkCompletionActionLabel: HomeworkAction;
 export let homeworkCopy: Record<string, string>;
 export let homeworkEtaLabel: HomeworkDateFormatter;
+export let homeworkIsOverdue: HomeworkOverduePredicate;
 export let homeworksCopy: Record<string, string>;
 export let homeworkSavingById: Record<string, boolean>;
 export let selectedHomework: DashboardHomeworkItem | null;
@@ -56,7 +60,7 @@ export let toggleHomeworkCompletion: (
       </Card.Header>
       <Card.Content>
         <div class="flex flex-wrap gap-2">
-          <Badge variant="ghost">{homeworkEtaLabel(homework.submissionDueAt)}</Badge>
+          <Badge variant={homeworkIsOverdue(homework.submissionDueAt) ? "destructive" : "ghost"}>{homeworkEtaLabel(homework.submissionDueAt)}</Badge>
           {#if homework.isMajor}<Badge variant="secondary">{homeworksCopy.tagMajor}</Badge>{/if}
           {#if homework.requiresTeam}<Badge variant="secondary">{homeworksCopy.tagTeam}</Badge>{/if}
         </div>

--- a/src/features/dashboard/components/HomeworksListView.svelte
+++ b/src/features/dashboard/components/HomeworksListView.svelte
@@ -9,6 +9,9 @@ import * as Table from "$lib/components/ui/table/index.js";
 type HomeworkDateFormatter = (
   value: Date | string | null | undefined,
 ) => string;
+type HomeworkOverduePredicate = (
+  value: Date | string | null | undefined,
+) => boolean;
 type HomeworkAction = (homework: DashboardHomeworkItem) => string;
 
 export let filteredHomeworkItems: DashboardHomeworkItem[];
@@ -16,6 +19,7 @@ export let fmtDate: HomeworkDateFormatter;
 export let homeworkCompletionActionLabel: HomeworkAction;
 export let homeworkCopy: Record<string, string>;
 export let homeworkEtaLabel: HomeworkDateFormatter;
+export let homeworkIsOverdue: HomeworkOverduePredicate;
 export let homeworksCopy: Record<string, string>;
 export let homeworkSavingById: Record<string, boolean>;
 export let selectedHomework: DashboardHomeworkItem | null;
@@ -61,7 +65,9 @@ export let toggleHomeworkCompletion: (
         </Table.Cell>
         <Table.Cell>
           <div class="flex flex-wrap items-center gap-1.5">
-            <Badge variant="ghost">
+            <Badge
+              variant={homeworkIsOverdue(homework.submissionDueAt) ? "destructive" : "ghost"}
+            >
               {homeworkEtaLabel(homework.submissionDueAt)}
             </Badge>
             {#if homework.completion}

--- a/src/features/dashboard/components/HomeworksTab.svelte
+++ b/src/features/dashboard/components/HomeworksTab.svelte
@@ -30,6 +30,9 @@ import HomeworksTabToolbar from "./HomeworksTabToolbar.svelte";
 type HomeworkDateFormatter = (
   value: Date | string | null | undefined,
 ) => string;
+type HomeworkOverduePredicate = (
+  value: Date | string | null | undefined,
+) => boolean;
 type HomeworkAction = (homework: DashboardHomeworkItem) => string;
 type HomeworkCopy = DashboardMyHomeworksCopy;
 type HomeworksCopy = DashboardHomeworksCopy;
@@ -77,6 +80,7 @@ let homeworkCompletionActionLabel: HomeworkAction;
 let homeworkCourseLabel: HomeworkAction;
 let homeworkDetailHref: HomeworkAction;
 let homeworkEtaLabel: HomeworkDateFormatter;
+let homeworkIsOverdue: HomeworkOverduePredicate;
 let homeworkSectionHref: HomeworkAction;
 let homeworkSectionLabel: (section: DashboardHomeworkCreateSection) => string;
 let homeworkStatus: HomeworkAction;
@@ -92,6 +96,7 @@ $: ({
   homeworkCourseLabel,
   homeworkDetailHref,
   homeworkEtaLabel,
+  homeworkIsOverdue,
   homeworkSectionHref,
   homeworkSectionLabel,
   homeworkStatus,
@@ -138,6 +143,7 @@ $: ({
           {homeworkCompletionActionLabel}
           {homeworkCopy}
           {homeworkEtaLabel}
+          {homeworkIsOverdue}
           {homeworksCopy}
           {homeworkSavingById}
           bind:selectedHomework
@@ -151,6 +157,7 @@ $: ({
           {homeworkCompletionActionLabel}
           {homeworkCopy}
           {homeworkEtaLabel}
+          {homeworkIsOverdue}
           {homeworksCopy}
           {homeworkSavingById}
           bind:selectedHomework
@@ -164,6 +171,7 @@ $: ({
         {homeworkCompletionActionLabel}
         {homeworkCopy}
         {homeworkEtaLabel}
+        {homeworkIsOverdue}
         {homeworksCopy}
         {homeworkSavingById}
         bind:selectedHomework

--- a/src/features/dashboard/lib/date-formatters.ts
+++ b/src/features/dashboard/lib/date-formatters.ts
@@ -24,6 +24,14 @@ export function formatDashboardDueRelativeTime(
   return formatDueRelativeTime(value, new Date(referenceDate), locale);
 }
 
+export function isDashboardDueOverdue(
+  value: Date | string | null | undefined,
+  referenceDate: Date | string,
+) {
+  if (!value) return false;
+  return new Date(value).getTime() <= new Date(referenceDate).getTime();
+}
+
 export function dashboardDateTimeLocalValue(
   value: Date | string | null | undefined,
 ) {

--- a/src/features/dashboard/lib/homeworks-tab-display.ts
+++ b/src/features/dashboard/lib/homeworks-tab-display.ts
@@ -7,6 +7,7 @@ import { dashboardTabHref } from "./dashboard-nav";
 import {
   formatDashboardDateTime,
   formatDashboardDueRelativeTime,
+  isDashboardDueOverdue,
 } from "./date-formatters";
 import {
   homeworkCompletionActionLabel as buildHomeworkCompletionActionLabel,
@@ -76,6 +77,8 @@ export function createHomeworkTabDisplayActions({
         referenceDate,
         locale,
       ),
+    homeworkIsOverdue: (value: Date | string | null | undefined) =>
+      isDashboardDueOverdue(value, referenceDate),
     homeworkSectionHref: (homework: DashboardHomeworkItem) =>
       buildHomeworkSectionHref(homework, returnTo),
     homeworkSectionLabel: (section: HomeworkSectionOption) =>

--- a/tests/unit/dashboard-homeworks-tab-display.test.ts
+++ b/tests/unit/dashboard-homeworks-tab-display.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type {
+  DashboardDashboardCopy,
+  DashboardSectionCopy,
+} from "@/features/dashboard/lib/dashboard-controller-types";
+import { createHomeworkTabDisplayActions } from "@/features/dashboard/lib/homeworks-tab-display";
+
+const referenceDate = "2026-05-22T10:30:00+08:00";
+
+function buildActions(locale = "zh-cn") {
+  return createHomeworkTabDisplayActions({
+    dashboardCopy: {} as DashboardDashboardCopy,
+    homeworkCopy: { section: "Section" },
+    homeworksCopy: { markComplete: "完成", markIncomplete: "取消完成" },
+    locale,
+    referenceDate,
+    sectionCopy: { dateTBD: "待定" } as DashboardSectionCopy,
+  });
+}
+
+describe("仪表盘作业逾期展示", () => {
+  it("将已过截止时间的作业标记为逾期", () => {
+    const { homeworkIsOverdue, homeworkEtaLabel } = buildActions();
+
+    expect(homeworkIsOverdue("2026-05-22T10:30:00+08:00")).toBe(true);
+    expect(homeworkIsOverdue("2026-05-21T23:59:00+08:00")).toBe(true);
+    expect(homeworkEtaLabel("2026-05-21T23:59:00+08:00")).toBe("已逾期");
+  });
+
+  it("未逾期的截止时间保持普通样式", () => {
+    const { homeworkIsOverdue } = buildActions();
+
+    expect(homeworkIsOverdue("2026-05-22T10:31:00+08:00")).toBe(false);
+    expect(homeworkIsOverdue("2026-06-01T00:00:00+08:00")).toBe(false);
+  });
+
+  it("缺失截止时间不视为逾期", () => {
+    const { homeworkIsOverdue } = buildActions();
+
+    expect(homeworkIsOverdue(null)).toBe(false);
+    expect(homeworkIsOverdue(undefined)).toBe(false);
+  });
+
+  it("英文区域同样标记逾期", () => {
+    const { homeworkIsOverdue, homeworkEtaLabel } = buildActions("en-us");
+
+    expect(homeworkIsOverdue("2026-05-21T23:59:00+08:00")).toBe(true);
+    expect(homeworkEtaLabel("2026-05-21T23:59:00+08:00")).toBe("Overdue");
+  });
+});


### PR DESCRIPTION
## Summary

On `/workspace/homeworks`, the ETA badge for overdue items rendered as plain unstyled text while sibling badges appeared as pills.

**Root cause:** `HomeworksCardsView.svelte` and `HomeworksListView.svelte` hardcoded `<Badge variant="ghost">` for the ETA label. The `ghost` variant has no static background (only hover styles), so the "Overdue / 已逾期" label looked like bare text.

**Fix:** make the variant conditional on overdue state — `destructive` when overdue, `ghost` otherwise — in both views. The overdue predicate is sourced from a new `homeworkIsOverdue` action in `createHomeworkTabDisplayActions` (closing over the same `referenceDate` as `homeworkEtaLabel`), backed by `isDashboardDueOverdue` in `date-formatters.ts`, so the badge variant always agrees with the "Overdue" label text.

Fixes #640

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run app:prepare` (Prisma client + SvelteKit sync)
- [x] `bunx biome check` on all changed files — clean
- [x] `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors, 0 warnings
- [x] `bunx vitest run tests/unit/dashboard-homeworks-tab-display.test.ts` — 4/4 pass (overdue boundary, non-overdue, null due date, en-us locale)
- [ ] Visual verification (Playwright screenshot of /workspace/homeworks) — pending a follow-up capture pass; e2e suite and `bun run build` intentionally not run locally to avoid port/DB contention with parallel work