### PR TITLE
fix(ui): localize semester names on en-us pages

### DIFF
--- a/src/features/catalog/components/SectionsPageController.svelte
+++ b/src/features/catalog/components/SectionsPageController.svelte
@@ -5,6 +5,8 @@ import {
   catalogSecondaryName as secondaryName,
   catalogNames as teacherNames,
 } from "@/features/catalog/lib/catalog-list-display";
+import { formatSemesterName } from "@/lib/text/format-semester-name";
+import { page } from "$app/stores";
 import CatalogMobileFilters from "./CatalogMobileFilters.svelte";
 import CatalogPageHeader from "./CatalogPageHeader.svelte";
 import CatalogPagination from "./CatalogPagination.svelte";
@@ -56,6 +58,7 @@ let isSectionFilterOpen = false;
 let sectionSearch = data.filters.search ?? "";
 
 $: totalPages = data.pagination.totalPages;
+$: locale = $page.data.locale ?? "zh-cn";
 $: sectionSearch = data.filters.search ?? "";
 $: commonLabels = data.labels.common;
 $: sectionLabels = data.labels.sections;
@@ -63,10 +66,13 @@ $: selectedSemester =
   data.filterOptions.semesters.find(
     (semester) => data.filters.semesterId === String(semester.id),
   ) ?? null;
-$: semesterOptions = namedOptions(
-  data.filterOptions.semesters,
-  commonLabels.allSemesters,
-);
+$: semesterOptions = [
+  { value: "", label: commonLabels.allSemesters },
+  ...data.filterOptions.semesters.map((semester) => ({
+    value: String(semester.id),
+    label: formatSemesterName(locale, semester.nameCn),
+  })),
+];
 $: campusOptions = namedOptions(
   data.filterOptions.campuses,
   `${sectionLabels.filters.any} · ${sectionLabels.campus}`,
@@ -102,7 +108,7 @@ $: sectionActiveFilters = [
   data.filters.semesterId
     ? {
         href: sectionFilterHref({ semesterId: "" }),
-        label: `${sectionLabels.semester}: ${selectedSemester?.nameCn ?? data.filters.semesterId}`,
+        label: `${sectionLabels.semester}: ${selectedSemester ? formatSemesterName(locale, selectedSemester.nameCn) : data.filters.semesterId}`,
       }
     : null,
   textFilter("teacher", sectionLabels.teachers),
@@ -237,7 +243,7 @@ function sectionEmptyDescription() {
   if (selectedSemester) {
     return sectionLabels.inSemester.replace(
       "{semester}",
-      selectedSemester.nameCn,
+      formatSemesterName(locale, selectedSemester.nameCn),
     );
   }
   return sectionLabels.subtitle;

--- a/src/features/catalog/components/SectionsResults.svelte
+++ b/src/features/catalog/components/SectionsResults.svelte
@@ -4,6 +4,8 @@ import {
   catalogShowingSummary,
   optionalCatalogFilterSummary,
 } from "@/features/catalog/lib/catalog-results-summary";
+import { formatSemesterName } from "@/lib/text/format-semester-name";
+import { page as appPage } from "$app/stores";
 import TruncatedCode from "$lib/components/TruncatedCode.svelte";
 import TruncatedText from "$lib/components/TruncatedText.svelte";
 import * as Item from "$lib/components/ui/item/index.js";
@@ -30,6 +32,7 @@ export let teacherNames: (teachers: CatalogNamed[]) => string;
 export let totalPages: number;
 
 $: filters = data.filters as SectionListFilters;
+$: locale = $appPage.data.locale ?? "zh-cn";
 $: pagination = data.pagination as SectionListPagination;
 $: sectionSummaryBase = catalogShowingSummary(
   sectionLabels.showing,
@@ -42,7 +45,10 @@ $: sectionSearchSummary = optionalCatalogFilterSummary(
   "{query}",
 );
 $: sectionSemesterSummary = selectedSemester
-  ? sectionLabels.inSemester.replace("{semester}", selectedSemester.nameCn)
+  ? sectionLabels.inSemester.replace(
+      "{semester}",
+      formatSemesterName(locale, selectedSemester.nameCn),
+    )
   : "";
 </script>
 
@@ -68,7 +74,7 @@ $: sectionSemesterSummary = selectedSemester
                     <Item.Description>{secondaryName(section.course)}</Item.Description>
                   {/if}
                   <Item.Description>
-                    {section.semester?.nameCn ?? sectionLabels.noSemester}
+                    {section.semester?.nameCn ? formatSemesterName(locale, section.semester.nameCn) : sectionLabels.noSemester}
                     · {teacherNames(section.teachers) || "-"}
                   </Item.Description>
                 </Item.Content>
@@ -106,7 +112,7 @@ $: sectionSemesterSummary = selectedSemester
               <Table.Cell class="p-0 align-top">
                 <CatalogTableLink href={sectionHref} nowrap>
                   <TruncatedText
-                    text={section.semester?.nameCn ?? sectionLabels.noSemester}
+                    text={section.semester?.nameCn ? formatSemesterName(locale, section.semester.nameCn) : sectionLabels.noSemester}
                   />
                 </CatalogTableLink>
               </Table.Cell>

--- a/src/features/dashboard/components/SubscriptionsList.svelte
+++ b/src/features/dashboard/components/SubscriptionsList.svelte
@@ -6,6 +6,8 @@ import type {
   SubscriptionsData,
 } from "@/features/dashboard/lib/dashboard-controller-types";
 import { groupSubscribedSectionsBySemester } from "@/features/dashboard/lib/subscriptions";
+import { formatSemesterName } from "@/lib/text/format-semester-name";
+import { page } from "$app/stores";
 import TruncatedText from "$lib/components/TruncatedText.svelte";
 import * as AlertDialog from "$lib/components/ui/alert-dialog/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
@@ -33,10 +35,12 @@ export let openQuickAddDialog: () => void;
 let selectedSection: SubscriptionSection | null = null;
 let removeConfirmOpen = false;
 
+$: locale = $page.data.locale ?? "zh-cn";
 $: sectionGroups = subscriptions.flatMap((subscription) =>
   groupSubscribedSectionsBySemester(
     subscription.sections,
     dashboardCopy.notAvailable,
+    locale,
   ),
 );
 
@@ -198,7 +202,7 @@ async function confirmRemoveSection() {
         <div class="grid gap-1">
           <dt class="text-sm text-muted-foreground">{subscriptionsCopy.semester}</dt>
           <dd class="font-medium">
-            {selectedSection.semester?.nameCn ?? dashboardCopy.notAvailable}
+            {selectedSection.semester?.nameCn ? formatSemesterName(locale, selectedSection.semester.nameCn) : dashboardCopy.notAvailable}
           </dd>
         </div>
         <div class="grid gap-1">

--- a/src/features/dashboard/lib/subscription-section-utils.ts
+++ b/src/features/dashboard/lib/subscription-section-utils.ts
@@ -1,3 +1,5 @@
+import { formatSemesterName } from "@/lib/text/format-semester-name";
+
 type SectionWithSemester = {
   semester?: {
     id?: number | string | null;
@@ -8,7 +10,7 @@ type SectionWithSemester = {
 
 export function groupSubscribedSectionsBySemester<
   Section extends SectionWithSemester,
->(sections: Section[], fallbackLabel: string) {
+>(sections: Section[], fallbackLabel: string, locale: string) {
   const groups = new Map<
     string,
     {
@@ -23,7 +25,9 @@ export function groupSubscribedSectionsBySemester<
     const key = section.semester?.id?.toString() ?? "unknown";
     const existing = groups.get(key) ?? {
       key,
-      label: section.semester?.nameCn ?? fallbackLabel,
+      label: section.semester?.nameCn
+        ? formatSemesterName(locale, section.semester.nameCn)
+        : fallbackLabel,
       startDate: section.semester?.startDate ?? null,
       sections: [],
     };

--- a/src/features/dashboard/server/dashboard-overview-data.ts
+++ b/src/features/dashboard/server/dashboard-overview-data.ts
@@ -1,4 +1,5 @@
 import { listSubscribedHomeworks } from "@/features/subscriptions/server/subscription-read-model";
+import { formatSemesterName } from "@/lib/text/format-semester-name";
 import { buildSemesterCalendarPayload } from "./dashboard-overview-calendar";
 import { resolveDashboardOverviewContext } from "./dashboard-overview-context";
 import { getDashboardOverviewLinksData } from "./dashboard-overview-links";
@@ -110,7 +111,9 @@ export async function getDashboardOverviewData(
 
   const defaultCalendarSemesterId = currentSemester?.id ?? null;
   const activeCalendarSemesterId = gridSemesterRow?.id ?? null;
-  const activeCalendarSemesterName = gridSemesterRow?.nameCn ?? null;
+  const activeCalendarSemesterName = gridSemesterRow?.nameCn
+    ? formatSemesterName(locale, gridSemesterRow.nameCn)
+    : null;
 
   return {
     user: {

--- a/src/features/section-detail/components/SectionBasicInfoFacts.svelte
+++ b/src/features/section-detail/components/SectionBasicInfoFacts.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { formatSemesterName } from "@/lib/text/format-semester-name";
+import { page } from "$app/stores";
 import type {
   SectionBasicInfo,
   SectionBasicInfoCopy,
@@ -9,6 +11,8 @@ export let notAvailable: string;
 export let primaryName: SectionPrimaryName;
 export let section: SectionBasicInfo;
 export let sectionCopy: SectionBasicInfoCopy;
+
+$: locale = $page.data.locale ?? "zh-cn";
 </script>
 
 <dl class="grid gap-x-8 gap-y-4 text-sm sm:grid-cols-2 xl:grid-cols-3">
@@ -18,7 +22,7 @@ export let sectionCopy: SectionBasicInfoCopy;
   </div>
   <div class="min-w-0 py-1.5 sm:min-h-14">
     <dt class="text-muted-foreground text-xs">{sectionCopy.semester}</dt>
-    <dd class="mt-1 font-medium">{section.semester?.nameCn ?? notAvailable}</dd>
+    <dd class="mt-1 font-medium">{section.semester?.nameCn ? formatSemesterName(locale, section.semester.nameCn) : notAvailable}</dd>
   </div>
   <div class="min-w-0 py-1.5 sm:min-h-14">
     <dt class="text-muted-foreground text-xs">{sectionCopy.credits}</dt>

--- a/src/features/section-detail/components/SectionBasicInfoRelatedSections.svelte
+++ b/src/features/section-detail/components/SectionBasicInfoRelatedSections.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { formatSemesterName } from "@/lib/text/format-semester-name";
+import { page } from "$app/stores";
 import TruncatedCode from "$lib/components/TruncatedCode.svelte";
 import * as Accordion from "$lib/components/ui/accordion/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
@@ -12,6 +14,8 @@ export let notAvailable: string;
 export let section: SectionBasicInfo;
 export let sectionCopy: SectionBasicInfoCopy;
 export let sectionTeachersLabel: SectionTeachersLabel;
+
+$: locale = $page.data.locale ?? "zh-cn";
 </script>
 
 {#if section.sameSemesterOtherTeachers.length > 0 || section.sameTeacherOtherSemesters.length > 0}
@@ -39,7 +43,7 @@ export let sectionTeachersLabel: SectionTeachersLabel;
               <div class="flex flex-wrap gap-2">
                 {#each section.sameTeacherOtherSemesters.slice(0, 10) as related}
                   <Button class="h-auto min-h-8 whitespace-normal px-2 py-1 text-left" href={`/catalog/sections/${related.jwId}`} variant="outline">
-                    <span>{related.semester?.nameCn ?? notAvailable}</span>
+                    <span>{related.semester?.nameCn ? formatSemesterName(locale, related.semester.nameCn) : notAvailable}</span>
                     <TruncatedCode text={related.code} />
                   </Button>
                 {/each}

--- a/src/features/section-detail/components/SectionDetailHeader.svelte
+++ b/src/features/section-detail/components/SectionDetailHeader.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 import type { SubmitFunction } from "@sveltejs/kit";
+import { formatSemesterName } from "@/lib/text/format-semester-name";
+import { page } from "$app/stores";
 import PageHeader from "$lib/components/PageHeader.svelte";
 import TruncatedCode from "$lib/components/TruncatedCode.svelte";
 import * as Alert from "$lib/components/ui/alert/index.js";
@@ -51,6 +53,8 @@ export let subscriptionAction: (
 ) => SubmitFunction;
 export let subscriptionPendingAction: SubscriptionActionKey | null;
 export let viewer: SectionHeaderViewer;
+
+$: locale = $page.data.locale ?? "zh-cn";
 </script>
 
 <PageHeader
@@ -79,7 +83,7 @@ export let viewer: SectionHeaderViewer;
   {#snippet after()}
     <div class="grid gap-4">
       <div class="flex flex-wrap gap-2">
-        {#if section.semester}<Badge variant="ghost">{section.semester.nameCn}</Badge>{/if}
+        {#if section.semester}<Badge variant="ghost">{formatSemesterName(locale, section.semester.nameCn ?? "")}</Badge>{/if}
         {#if section.campus}<Badge variant="ghost">{primaryName(section.campus)}</Badge>{/if}
         {#if section.stdCount !== null || section.limitCount !== null}
           <Badge variant="ghost">{section.stdCount ?? 0} / {section.limitCount ?? notAvailable}</Badge>

--- a/src/lib/text/format-semester-name.ts
+++ b/src/lib/text/format-semester-name.ts
@@ -1,0 +1,18 @@
+const SEMESTER_NAME_PATTERN = /^(\d{4})年(春|秋)季学期$/;
+
+const SEASON_NAMES: Record<string, string> = {
+  春: "Spring",
+  秋: "Fall",
+};
+
+/**
+ * Semesters only carry a Chinese name from upstream JW data; derive an
+ * English display name ("2026年春季学期" -> "Spring 2026") for en-us pages,
+ * falling back to the original name when the pattern does not match.
+ */
+export function formatSemesterName(locale: string, nameCn: string) {
+  if (locale !== "en-us") return nameCn;
+  const match = SEMESTER_NAME_PATTERN.exec(nameCn.trim());
+  if (!match) return nameCn;
+  return `${SEASON_NAMES[match[2]]} ${match[1]}`;
+}

--- a/tests/e2e/src/app/dashboard/test.ts
+++ b/tests/e2e/src/app/dashboard/test.ts
@@ -16,6 +16,7 @@
  * - Invalid `?tab=` values do not select another public resource.
  */
 import { expect, test } from "@playwright/test";
+import { formatSemesterName } from "@/lib/text/format-semester-name";
 import { signInAsDebugUser } from "../../../utils/auth";
 import { DEV_SEED } from "../../../utils/dev-seed";
 import {
@@ -173,7 +174,14 @@ test.describe("仪表盘", () => {
         name: /^(教学班订阅|Section Subscriptions)$/i,
       }),
     ).toBeVisible();
-    await expect(page.getByText(DEV_SEED.semesterNameCn).first()).toBeVisible();
+    await expect(
+      page
+        .getByText(DEV_SEED.semesterNameCn)
+        .or(
+          page.getByText(formatSemesterName("en-us", DEV_SEED.semesterNameCn)),
+        )
+        .first(),
+    ).toBeVisible();
     await captureStepScreenshot(page, testInfo, "dashboard-subscriptions-path");
   });
 

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -34,6 +34,7 @@
  * - Comment CRUD with reactions, replies, attachments
  */
 import { expect, type Locator, type Page, test } from "@playwright/test";
+import { formatSemesterName } from "@/lib/text/format-semester-name";
 import { signInAsDebugUser, signInAsDevAdmin } from "../../../../utils/auth";
 import { cleanupCommentsForE2e } from "../../../../utils/comments";
 import { DEV_SEED } from "../../../../utils/dev-seed";
@@ -156,8 +157,15 @@ test.describe("/catalog/sections/[jwId] 班级详情页", () => {
   test("显示学期、校区与教师信息", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, SECTION_URL);
 
-    // section.semester.nameCn
-    await expect(page.getByText(DEV_SEED.semesterNameCn).first()).toBeVisible();
+    // section.semester.nameCn (locale-dependent: English short name on en-us)
+    await expect(
+      page
+        .getByText(DEV_SEED.semesterNameCn)
+        .or(
+          page.getByText(formatSemesterName("en-us", DEV_SEED.semesterNameCn)),
+        )
+        .first(),
+    ).toBeVisible();
     // section.campus.namePrimary (locale-dependent)
     await expect(
       page

--- a/tests/unit/format-semester-name.test.ts
+++ b/tests/unit/format-semester-name.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+import { formatSemesterName } from "@/lib/text/format-semester-name";
+
+describe("formatSemesterName", () => {
+  test.each([
+    ["en-us", "2026年春季学期", "Spring 2026"],
+    ["en-us", "2025年秋季学期", "Fall 2025"],
+    ["zh-cn", "2026年春季学期", "2026年春季学期"],
+    ["zh-cn", "2025年秋季学期", "2025年秋季学期"],
+    ["en-us", "2026年夏季学期", "2026年夏季学期"],
+    ["en-us", "2026年春季", "2026年春季"],
+    ["en-us", "未知学期", "未知学期"],
+    ["en-us", " 2026年春季学期 ", "Spring 2026"],
+  ])("formatSemesterName(%s, %s) = %s", (locale, nameCn, expected) => {
+    expect(formatSemesterName(locale, nameCn)).toBe(expected);
+  });
+});

--- a/tests/unit/subscription-section-utils.test.ts
+++ b/tests/unit/subscription-section-utils.test.ts
@@ -21,6 +21,7 @@ describe("groupSubscribedSectionsBySemester", () => {
         section(4, "较近的过去学期", "2025-09-01", "2026-01-15"),
       ],
       "未知学期",
+      "zh-cn",
     );
 
     expect(groups.map((group) => group.label)).toEqual([
@@ -38,11 +39,30 @@ describe("groupSubscribedSectionsBySemester", () => {
         section(2, "已知学期", "2026-02-20", "2026-07-15"),
       ],
       "未知学期",
+      "zh-cn",
     );
 
     expect(groups.map((group) => group.label)).toEqual([
       "已知学期",
       "未知学期",
+    ]);
+  });
+
+  it("localizes semester group labels on en-us pages", () => {
+    const groups = groupSubscribedSectionsBySemester(
+      [
+        section(1, "2026年春季学期", "2026-02-20", "2026-07-15"),
+        section(2, "2025年秋季学期", "2025-09-01", "2026-01-15"),
+        { id: 3, semester: null },
+      ],
+      "Unknown semester",
+      "en-us",
+    );
+
+    expect(groups.map((group) => group.label)).toEqual([
+      "Spring 2026",
+      "Fall 2025",
+      "Unknown semester",
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #636.

Semester records only carry a Chinese name (`nameCn`) from upstream JW data — there is no `nameEn` to select, so en-us pages rendered strings like "2026年春季学期" / "2025年秋季学期".

**Fix:** new shared helper `formatSemesterName(locale, nameCn)` (`src/lib/text/format-semester-name.ts`) that, for `en-us`, derives "Spring 2026" / "Fall 2025" from the `YYYY年(春|秋)季学期` pattern and falls back to the original name for anything unmatched (zh-cn output is unchanged). Applied at every user-visible semester render site in the affected flows:

- `/catalog/sections` — table + mobile card rows, results summary, semester filter dropdown, active-filter chip, empty-state description (`SectionsResults.svelte`, `SectionsPageController.svelte`)
- `/catalog/sections/[id]` — header chip, Semester fact field, related-sections buttons (`SectionDetailHeader.svelte`, `SectionBasicInfoFacts.svelte`, `SectionBasicInfoRelatedSections.svelte`)
- `/workspace/calendar` — semester tab label via `activeCalendarSemesterName` formatted server-side with the request locale (`dashboard-overview-data.ts`)
- `/workspace/subscriptions` — semester group headers (`groupSubscribedSectionsBySemester` now takes a locale) and the section detail dialog (`SubscriptionsList.svelte`)

No schema or localization-extension changes. Client components read the locale from root layout data via `$page.data.locale`, matching the existing pattern in `CommentsPanel.svelte`.

## Test plan

- [x] `bun run app:prepare`
- [x] `bunx biome check` on all changed files — clean
- [x] `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors, 0 warnings
- [x] `bunx tsc --noEmit -p tsconfig.typecheck.json` and `tsconfig.typecheck.tests.json` — pass
- [x] `bunx vitest run tests/unit/format-semester-name.test.ts tests/unit/subscription-section-utils.test.ts` — 11 tests pass (new table tests for the formatter + en-us grouping case)
- [x] Related suites: `dashboard-overview-serialization`, `dashboard-calendar-display-overview`, `subscription-semester-filters`, `sections-page-helpers`, `public-catalog-locale`, `section-detail-controller-mount` — 21 tests pass
- [ ] Visual verification (screenshots of the four surfaces on en-us) — pending a follow-up capture pass; Playwright e2e and `bun run build` intentionally not run locally to avoid port/DB contention with parallel work

## Deliberately not changed

- Course/teacher detail section tables (`CourseDetailSections*`, `TeacherDetailSections*`) also show `semester.nameCn`, but those pages are outside the flows in #636; the shared helper makes them a one-line follow-up each if wanted.
- MCP/GraphQL/REST payloads still expose raw `nameCn`; the issue is scoped to UI rendering.