### PR TITLE
fix(db): reuse PrismaClient across requests in the Cloudflare runtime

### DIFF
--- a/src/lib/db/prisma.ts
+++ b/src/lib/db/prisma.ts
@@ -1,7 +1,7 @@
 import { getOptionalTrimmedEnv } from "@/app-env";
 import type { PrismaClient } from "@/generated/prisma/client";
 import {
-  getCloudflareRuntimeContext,
+  getCloudflareHyperdriveConnectionString,
   hasCloudflareRuntimeEnv,
 } from "@/lib/adapters/cloudflare-runtime";
 import { localizedNamesExtension } from "@/lib/db/prisma-localized-names";
@@ -19,39 +19,9 @@ const globalForPrisma = globalThis as unknown as {
 
 let basePrisma: PrismaClient | undefined;
 
-const cloudflarePrismaCacheKey = Symbol("life-ustc.cloudflare.prisma");
-
-type CloudflarePrismaCache = {
-  base?: PrismaClient;
-  extended: Map<string, unknown>;
-  queryLoggerAttached?: boolean;
-};
-
-function getCloudflarePrismaCache() {
-  const context = getCloudflareRuntimeContext();
-  if (!context) return undefined;
-
-  const cached = context.cache.get(cloudflarePrismaCacheKey) as
-    | CloudflarePrismaCache
-    | undefined;
-  if (cached) return cached;
-
-  const cache: CloudflarePrismaCache = { extended: new Map() };
-  context.cache.set(cloudflarePrismaCacheKey, cache);
-  return cache;
-}
-
-function createPrismaClient(cache?: CloudflarePrismaCache) {
+function createPrismaClient() {
   const client = createBasePrisma();
   if (!shouldEnablePrismaQueryLogging()) {
-    return client;
-  }
-
-  if (cache) {
-    if (!cache.queryLoggerAttached) {
-      (client as PrismaClient<"query">).$on("query", logPrismaQuery);
-      cache.queryLoggerAttached = true;
-    }
     return client;
   }
 
@@ -62,15 +32,32 @@ function createPrismaClient(cache?: CloudflarePrismaCache) {
   return client;
 }
 
+// Isolate-scope client cache for the Cloudflare runtime. Creating a
+// PrismaClient (and its pg pool) costs significant CPU, so it must be reused
+// across requests instead of being rebuilt inside the per-request runtime
+// context. Keyed by connection string so a changed runtime env still gets a
+// fresh client.
+let cloudflareBasePrisma:
+  | { client: PrismaClient; connectionString: string | undefined }
+  | undefined;
+
+function getCloudflareBasePrisma() {
+  const connectionString = getCloudflareHyperdriveConnectionString();
+  if (
+    cloudflareBasePrisma &&
+    cloudflareBasePrisma.connectionString === connectionString
+  ) {
+    return cloudflareBasePrisma.client;
+  }
+
+  const client = createPrismaClient();
+  cloudflareBasePrisma = { client, connectionString };
+  return client;
+}
+
 function getBasePrisma() {
   if (hasCloudflareRuntimeEnv()) {
-    const cache = getCloudflarePrismaCache();
-    if (cache) {
-      cache.base ??= createPrismaClient(cache);
-      return cache.base;
-    }
-
-    return createPrismaClient();
+    return getCloudflareBasePrisma();
   }
 
   const cached = globalForPrisma.prisma ?? basePrisma;
@@ -111,21 +98,19 @@ const _makeExtendedClient = (locale: string) =>
 type ExtendedPrismaClient = ReturnType<typeof _makeExtendedClient>;
 
 const extendedClientCache = new Map<string, ExtendedPrismaClient>();
+const cloudflareExtendedClientCache = new Map<string, ExtendedPrismaClient>();
 
 export const getPrisma = (locale: string): ExtendedPrismaClient => {
   if (hasCloudflareRuntimeEnv()) {
-    const cache = getCloudflarePrismaCache();
-    if (cache) {
-      const cached = cache.extended.get(locale) as
-        | ExtendedPrismaClient
-        | undefined;
-      if (cached) return cached;
-      const extended = _makeExtendedClient(locale);
-      cache.extended.set(locale, extended);
-      return extended;
-    }
-
-    return _makeExtendedClient(locale);
+    // Reuse extended clients across requests in the isolate; key by the
+    // connection string as well so a changed runtime env cannot hand out a
+    // client built on a stale base client.
+    const cacheKey = `${getCloudflareHyperdriveConnectionString() ?? ""}:${locale}`;
+    const cached = cloudflareExtendedClientCache.get(cacheKey);
+    if (cached) return cached;
+    const extended = _makeExtendedClient(locale);
+    cloudflareExtendedClientCache.set(cacheKey, extended);
+    return extended;
   }
 
   const cached = extendedClientCache.get(locale);

--- a/tests/unit/prisma-client-isolate-reuse.test.ts
+++ b/tests/unit/prisma-client-isolate-reuse.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
+import { getPrisma } from "@/lib/db/prisma";
+
+const HYPERDRIVE_ENV = (connectionString: string) => ({
+  HYPERDRIVE: { connectionString },
+});
+
+describe("getPrisma in the Cloudflare runtime", () => {
+  afterEach(() => setCloudflareRuntimeEnv(undefined));
+
+  it("reuses the extended client across requests in the same isolate", () => {
+    setCloudflareRuntimeEnv(
+      HYPERDRIVE_ENV("postgresql://u:p@db.example:5432/a"),
+    );
+
+    const first = getPrisma("zh-cn");
+    const second = getPrisma("zh-cn");
+
+    expect(second).toBe(first);
+  });
+
+  it("keeps one extended client per locale", () => {
+    setCloudflareRuntimeEnv(
+      HYPERDRIVE_ENV("postgresql://u:p@db.example:5432/a"),
+    );
+
+    const zh = getPrisma("zh-cn");
+    const en = getPrisma("en");
+
+    expect(en).not.toBe(zh);
+    expect(getPrisma("en")).toBe(en);
+  });
+
+  it("rebuilds the client when the connection string changes", () => {
+    setCloudflareRuntimeEnv(
+      HYPERDRIVE_ENV("postgresql://u:p@db.example:5432/a"),
+    );
+    const before = getPrisma("zh-cn");
+
+    setCloudflareRuntimeEnv(
+      HYPERDRIVE_ENV("postgresql://u:p@db.example:5432/b"),
+    );
+
+    expect(getPrisma("zh-cn")).not.toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #653.

On Cloudflare Workers, the base `PrismaClient`, its pg pool, and the per-locale extended clients were cached inside the **per-request** runtime context (`runWithCloudflareRuntimeEnv` creates a fresh `cache: Map` per request and clears it in `finally`). As a result every single request rebuilt the Prisma client and paid the instantiation CPU cost — a major contributor to the 100–600 ms CPU times observed across DB-backed routes.

## Change

`src/lib/db/prisma.ts`:

- Base client is now cached at **isolate (module) scope** for the Cloudflare runtime, keyed by the Hyperdrive connection string. A changed connection string (e.g. in tests) still produces a fresh client.
- Per-locale extended clients (`$extends`) are likewise cached at isolate scope, keyed by `connectionString:locale` so a client built on a stale base can never be handed out.
- The per-request ALS cache (`cloudflarePrismaCacheKey` / `getCloudflarePrismaCache`) is removed from this module; the runtime context itself is untouched and still carries request-scoped state (request id, tracing).
- Non-Cloudflare (Node/test) behavior is unchanged.
- RLS semantics are unchanged: `getUserRlsTransactionClient()` still takes precedence per operation and `withUserDbContext` still creates transactional clients on demand.

## Tests

- New `tests/unit/prisma-client-isolate-reuse.test.ts`: same-locale reuse across requests, per-locale separation, rebuild on connection-string change.
- Full unit suite: **250 files / 1516 tests passing**; `biome check`, `tsc -p tsconfig.typecheck.json` and `tsconfig.typecheck.tests.json` clean.

## Expected impact

Removes per-request PrismaClient/pg-pool construction from the hot path; should materially cut billed CPU on all DB-backed routes (SSR pages and `/api/*`).
