### PR TITLE
fix(catalog): let the CDN cache anonymous catalog pages

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -33,6 +33,10 @@ import {
   OAUTH_TOKEN_ENDPOINT_PATH,
 } from "@/lib/oauth/constants";
 import {
+  PRIVATE_LOCALE_CATALOG_HEADERS,
+  PUBLIC_LOCALE_CATALOG_HEADERS,
+} from "@/lib/public-cache-control";
+import {
   buildContentSecurityPolicy,
   createScriptNonce,
   formActionSourceFromOAuthRedirectUri,
@@ -108,6 +112,35 @@ function observedRoute(pathname: string, routeId: string | null) {
 
 function isHtmlResponse(response: Response) {
   return response.headers.get("content-type")?.includes("text/html");
+}
+
+function isCatalogPageRequest(event: Parameters<Handle>[0]["event"]) {
+  return (
+    event.request.method === "GET" &&
+    (event.url.pathname === "/catalog" ||
+      event.url.pathname.startsWith("/catalog/"))
+  );
+}
+
+// Catalog pages render identical content for every anonymous viewer, so let
+// the CDN cache them briefly instead of re-running SSR for every crawler hit.
+// Requests carrying an auth signal stay private/no-store so personalized
+// renders can never be cached.
+function applyCatalogCacheControl(
+  headers: Headers,
+  input: { hasAuthSignal: boolean; isCatalogPage: boolean },
+) {
+  if (!input.isCatalogPage) {
+    headers.set("Cache-Control", "no-store");
+    return;
+  }
+
+  const catalogHeaders = input.hasAuthSignal
+    ? PRIVATE_LOCALE_CATALOG_HEADERS
+    : PUBLIC_LOCALE_CATALOG_HEADERS;
+  for (const [name, value] of Object.entries(catalogHeaders)) {
+    headers.set(name, value);
+  }
 }
 
 function addScriptNonce(html: string, nonce: string) {
@@ -313,7 +346,10 @@ const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
 
     mutableResponse.headers.set("Content-Language", locale);
     if (!mutableResponse.headers.has("Cache-Control")) {
-      mutableResponse.headers.set("Cache-Control", "no-store");
+      applyCatalogCacheControl(mutableResponse.headers, {
+        hasAuthSignal,
+        isCatalogPage: isCatalogPageRequest(event),
+      });
     }
     setContentSignal(mutableResponse.headers);
     mutableResponse.headers.set(

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -34,7 +34,7 @@ import {
 } from "@/lib/oauth/constants";
 import {
   PRIVATE_LOCALE_CATALOG_HEADERS,
-  PUBLIC_LOCALE_CATALOG_HEADERS,
+  PUBLIC_LOCALE_CATALOG_PAGE_HEADERS,
 } from "@/lib/public-cache-control";
 import {
   buildContentSecurityPolicy,
@@ -137,7 +137,7 @@ function applyCatalogCacheControl(
 
   const catalogHeaders = input.hasAuthSignal
     ? PRIVATE_LOCALE_CATALOG_HEADERS
-    : PUBLIC_LOCALE_CATALOG_HEADERS;
+    : PUBLIC_LOCALE_CATALOG_PAGE_HEADERS;
   for (const [name, value] of Object.entries(catalogHeaders)) {
     headers.set(name, value);
   }

--- a/src/lib/public-cache-control.ts
+++ b/src/lib/public-cache-control.ts
@@ -19,3 +19,13 @@ export const PRIVATE_LOCALE_CATALOG_HEADERS = {
   "Cloudflare-CDN-Cache-Control": "no-store",
   Vary: "Accept-Language, Cookie",
 } as const;
+
+// HTML page variant: no stale-while-revalidate for the browser. Browsers may
+// serve an SWR-cached document without revalidating, which breaks flows that
+// mutate state and expect a fresh render on the next navigation (locale
+// switch, login, subscribe). The edge keeps its own SWR window.
+export const PUBLIC_LOCALE_CATALOG_PAGE_HEADERS = {
+  "Cache-Control": "public, max-age=0",
+  "Cloudflare-CDN-Cache-Control": PUBLIC_CATALOG_CDN_CACHE_CONTROL,
+  Vary: "Accept-Language, Cookie",
+} as const;

--- a/tests/unit/catalog-cache-control.test.ts
+++ b/tests/unit/catalog-cache-control.test.ts
@@ -75,9 +75,7 @@ describe("catalog page cache control", () => {
 
     const response = await handle(handleInput(async () => htmlResponse()));
 
-    expect(response.headers.get("Cache-Control")).toBe(
-      "public, max-age=0, stale-while-revalidate=300",
-    );
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=0");
     expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
       "public, max-age=60, stale-while-revalidate=300",
     );

--- a/tests/unit/catalog-cache-control.test.ts
+++ b/tests/unit/catalog-cache-control.test.ts
@@ -1,0 +1,127 @@
+import type { Handle } from "@sveltejs/kit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app-env", () => ({
+  getOptionalTrimmedEnv: (name: string) =>
+    name === "NODE_ENV" ? "development" : undefined,
+  loadEnv: vi.fn(),
+}));
+
+// Avoid building a real better-auth instance when a request carries an auth
+// signal; cache-control decisions only depend on the signal, not the session.
+vi.mock("@/lib/auth/core", () => ({
+  getSessionFromHeadersWithResponseHeaders: async () => null,
+}));
+
+import { handle } from "@/hooks.server";
+
+function htmlResponse(headers?: HeadersInit) {
+  return new Response('<html lang="zh-CN"><body>catalog</body></html>', {
+    headers: { "content-type": "text/html; charset=utf-8", ...headers },
+  });
+}
+
+function handleInput(
+  resolve: Parameters<Handle>[0]["resolve"],
+  input: {
+    headers?: HeadersInit;
+    method?: string;
+    pathname?: string;
+    routeId?: Parameters<Handle>[0]["event"]["route"]["id"];
+  } = {},
+) {
+  const url = new URL(
+    `https://life.example${input.pathname ?? "/catalog/sections/161022"}`,
+  );
+  const event: Parameters<Handle>[0]["event"] = {
+    cookies: {
+      delete: vi.fn(),
+      get: vi.fn(),
+      getAll: vi.fn(() => []),
+      serialize: vi.fn(() => ""),
+      set: vi.fn(),
+    },
+    fetch,
+    getClientAddress: () => "127.0.0.1",
+    isDataRequest: false,
+    isRemoteRequest: false,
+    isSubRequest: false,
+    locals: {
+      authUser: null,
+      locale: "zh-cn",
+      requestId: "",
+    },
+    params: {},
+    platform: undefined,
+    request: new Request(url, {
+      headers: input.headers,
+      method: input.method ?? "GET",
+    }),
+    route: { id: input.routeId ?? "/catalog/sections/[jwId]" },
+    setHeaders: vi.fn(),
+    tracing: undefined,
+    url,
+  } as unknown as Parameters<Handle>[0]["event"];
+  return { event, resolve };
+}
+
+describe("catalog page cache control", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lets the CDN briefly cache anonymous catalog pages", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const response = await handle(handleInput(async () => htmlResponse()));
+
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=0, stale-while-revalidate=300",
+    );
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
+      "public, max-age=60, stale-while-revalidate=300",
+    );
+    expect(response.headers.get("Vary")).toBe("Accept-Language, Cookie");
+  });
+
+  it("keeps authenticated catalog pages private and uncacheable", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const response = await handle(
+      handleInput(async () => htmlResponse(), {
+        headers: { cookie: "better-auth.session_token=token-value" },
+      }),
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
+      "no-store",
+    );
+  });
+
+  it("keeps non-catalog pages on the no-store default", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const response = await handle(
+      handleInput(async () => htmlResponse(), {
+        pathname: "/account/sign-in",
+        routeId: "/account/sign-in",
+      }),
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+  });
+
+  it("never overrides an explicit Cache-Control from the route", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const response = await handle(
+      handleInput(async () =>
+        htmlResponse({ "Cache-Control": "public, max-age=300" }),
+      ),
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=300");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #654.

Anonymous GETs for public catalog pages (`/catalog`, `/catalog/*`) previously fell through to the blanket `Cache-Control: no-store` in `hooks.server.ts`, so every request — including the heavy AI-crawler traffic from #652 — ran the full Worker pipeline (hooks, Postgres queries, SSR) with zero edge caching.

## Change

`src/hooks.server.ts` + `src/lib/public-cache-control.ts`:

- Anonymous `GET` requests to `/catalog` / `/catalog/*` that don't already set `Cache-Control` now get the new `PUBLIC_LOCALE_CATALOG_PAGE_HEADERS`:
  - `Cache-Control: public, max-age=0` — browsers must revalidate every navigation (no `stale-while-revalidate`; see below)
  - `Cloudflare-CDN-Cache-Control: public, max-age=60, stale-while-revalidate=300` — the edge keeps a short TTL + SWR window
  - `Vary: Accept-Language, Cookie`
- Catalog requests **carrying an auth signal** (better-auth/session cookie or bearer header, via the existing `hasRequestAuthSignal` check) get `PRIVATE_LOCALE_CATALOG_HEADERS` instead: `private, no-store` + `Cloudflare-CDN-Cache-Control: no-store`, so personalized renders can never be cached.
- Non-catalog routes keep the `no-store` default; routes that set their own `Cache-Control` (robots.txt, sitemap.xml, API routes) are untouched.
- Scope is deliberately limited to HTML page responses; JSON/`__data` requests are unaffected.

### Why no `stale-while-revalidate` for the browser

The first version of this PR sent `public, max-age=0, stale-while-revalidate=300` to browsers and failed the catalog E2E shards deterministically: Chromium may serve an SWR-cached document **without revalidating**, so flows that mutate state and expect a fresh SSR on the next navigation (locale switch, login, subscribe/unsubscribe, preference autosave) acted on stale pages. SWR now lives only on `Cloudflare-CDN-Cache-Control`, where it is safe.

## Deploy note (infra step, not in this PR)

Cloudflare does not cache extensionless HTML by default, so the `Cloudflare-CDN-Cache-Control` header only takes effect once a zone Cache Rule makes these paths eligible for cache, e.g.:

- Expression: `http.host eq "life-ustc.tiankaima.dev" and starts_with(http.request.uri.path, "/catalog") and not http.cookie contains "better-auth." and not http.cookie contains "session"`
- Action: eligible for cache, Edge TTL = respect origin

The cookie guard in the rule mirrors the origin-side auth check, so logged-in users can never be served cached anonymous HTML. Until the rule exists this PR is a no-op at the CDN (headers only).

## Tests

- New `tests/unit/catalog-cache-control.test.ts`: anonymous catalog → public CDN headers; authenticated catalog → private/no-store; non-catalog → no-store; explicit route `Cache-Control` preserved.
- Full unit suite, `biome check`, `tsc` (typecheck + tests configs), and catalog E2E shards — see CI.

## Expected impact

Crawler/bot traffic on catalog pages becomes mostly edge cache hits (~0 ms Worker CPU) instead of full SSR renders.
