### PR TITLE
fix(worker): preserve cached 404 mode

### DIFF
--- a/src/lib/cloudflare/public-ssr-gateway.ts
+++ b/src/lib/cloudflare/public-ssr-gateway.ts
@@ -3,6 +3,7 @@ export const PUBLIC_SSR_LOCALE_HEADER = "x-life-public-ssr-locale";
 export const PUBLIC_SSR_MODE_HEADER = "x-life-public-ssr-mode";
 export const PUBLIC_SSR_NONCE_PLACEHOLDER = "life-ustc-public-ssr-nonce";
 export const PUBLIC_SSR_LOCALE_CACHE_PARAM = "__life_locale";
+export const PUBLIC_SSR_MODE_CACHE_PARAM = "__life_mode";
 
 export type PublicSsrMode = "page" | "not-found";
 export type PublicSsrLocale = "en-us" | "zh-cn";

--- a/src/worker.js
+++ b/src/worker.js
@@ -107,8 +107,7 @@ function directRequest(request) {
   return new Request(request, { headers });
 }
 
-function publicSsrRequest(request, mode) {
-  const locale = resolvePublicSsrLocale(request);
+function publicSsrRequest(request, mode, locale) {
   const url = new URL(request.url);
   const canonicalQuery = new URLSearchParams();
   if (mode === "page") {
@@ -144,19 +143,16 @@ function svelteKitPublicSsrRequest(request) {
 
 export class PublicSsr extends WorkerEntrypoint {
   async fetch(request) {
-    const cacheUrl = new URL(request.url);
     const response = await app.fetch(
       svelteKitPublicSsrRequest(request),
       this.env,
       this.ctx,
     );
-    const mode = cacheUrl.searchParams.get(PUBLIC_SSR_MODE_CACHE_PARAM);
+    const { locale, mode } = this.ctx.props;
     return prepareCachedRepresentation(
       response,
       mode === "not-found" ? "not-found" : "page",
-      cacheUrl.searchParams.get(PUBLIC_SSR_LOCALE_CACHE_PARAM) === "en-us"
-        ? "en-us"
-        : "zh-cn",
+      locale === "en-us" ? "en-us" : "zh-cn",
       request.method === "HEAD",
     );
   }
@@ -167,9 +163,14 @@ export default {
     const mode = resolvePublicSsrMode(request);
     if (!mode) return app.fetch(directRequest(request), env, context);
 
-    const response = await context.exports.PublicSsr.fetch(
-      publicSsrRequest(request, mode),
-    );
+    const locale = resolvePublicSsrLocale(request);
+    const cachedRequest = publicSsrRequest(request, mode, locale);
+    const cacheUrl = new URL(cachedRequest.url);
+    const response = await context.exports
+      .PublicSsr({ props: { locale, mode } })
+      .fetch(cachedRequest, {
+        cf: { cacheKey: cacheUrl.pathname + cacheUrl.search },
+      });
     return personalizeCachedResponse(response);
   },
 };

--- a/src/worker.js
+++ b/src/worker.js
@@ -5,6 +5,7 @@ import {
   PUBLIC_SSR_HEADER,
   PUBLIC_SSR_LOCALE_CACHE_PARAM,
   PUBLIC_SSR_LOCALE_HEADER,
+  PUBLIC_SSR_MODE_CACHE_PARAM,
   PUBLIC_SSR_MODE_HEADER,
   PUBLIC_SSR_NONCE_PLACEHOLDER,
   removePublicSsrHeaders,
@@ -118,6 +119,7 @@ function publicSsrRequest(request, mode) {
   }
   url.search = canonicalQuery.toString();
   url.searchParams.set(PUBLIC_SSR_LOCALE_CACHE_PARAM, locale);
+  url.searchParams.set(PUBLIC_SSR_MODE_CACHE_PARAM, mode);
   const headers = new Headers(request.headers);
   headers.delete("authorization");
   headers.delete("cookie");
@@ -136,21 +138,23 @@ function publicSsrRequest(request, mode) {
 function svelteKitPublicSsrRequest(request) {
   const url = new URL(request.url);
   url.searchParams.delete(PUBLIC_SSR_LOCALE_CACHE_PARAM);
+  url.searchParams.delete(PUBLIC_SSR_MODE_CACHE_PARAM);
   return new Request(url, request);
 }
 
 export class PublicSsr extends WorkerEntrypoint {
   async fetch(request) {
+    const cacheUrl = new URL(request.url);
     const response = await app.fetch(
       svelteKitPublicSsrRequest(request),
       this.env,
       this.ctx,
     );
-    const mode = request.headers.get(PUBLIC_SSR_MODE_HEADER);
+    const mode = cacheUrl.searchParams.get(PUBLIC_SSR_MODE_CACHE_PARAM);
     return prepareCachedRepresentation(
       response,
       mode === "not-found" ? "not-found" : "page",
-      request.headers.get(PUBLIC_SSR_LOCALE_HEADER) === "en-us"
+      cacheUrl.searchParams.get(PUBLIC_SSR_LOCALE_CACHE_PARAM) === "en-us"
         ? "en-us"
         : "zh-cn",
       request.method === "HEAD",


### PR DESCRIPTION
## Summary
- pass anonymous SSR mode and locale through trusted ctx.props on the cached named entrypoint
- set an explicit canonical cache key for the loopback call
- strip the internal URL metadata before SvelteKit renders

## Why
Production verification after #658 showed anonymous public pages caching correctly, but unknown routes still returned the full hydrated SvelteKit 404. Cloudflare documents ctx.props as the trusted context channel for named entrypoints and includes it in the cache key; cf.cacheKey explicitly controls the path/query portion.

Docs: https://developers.cloudflare.com/workers/runtime-apis/context/#specifying-ctxprops-when-using-ctxexports
Docs: https://developers.cloudflare.com/workers/cache/cache-keys/

## Verification
- biome check on both changed files
- focused unit suite: 22 passed
- production build succeeded
- Wrangler production upload dry-run succeeded
- local Wrangler: unknown route with arbitrary query returned 404, 814 bytes, script-free, correctly localized on repeated requests
- Cloudflare PR build succeeded; production remains on main until merge, so live verification will run after the main deployment
- no API endpoint added