### PR TITLE
perf(worker): return unknown 404s at gateway

### DIFF
--- a/src/lib/cloudflare/public-ssr-gateway.ts
+++ b/src/lib/cloudflare/public-ssr-gateway.ts
@@ -17,6 +17,13 @@ const STATIC_PUBLIC_PATHS = new Set([
   "/terms",
 ]);
 const STATIC_PUBLIC_ROOTS = ["/api/docs"];
+const DIRECT_REQUEST_PATHS = new Set([
+  "/",
+  "/error",
+  "/llms.txt",
+  "/robots.txt",
+  "/sitemap.xml",
+]);
 
 const CATALOG_QUERY_KEYS: Record<string, ReadonlySet<string>> = {
   "/catalog/courses": new Set([
@@ -51,6 +58,7 @@ const DYNAMIC_OR_PRIVATE_ROOTS = [
   "/api",
   "/catalog",
   "/community",
+  "/e2e",
   "/oauth",
   "/workspace",
 ];
@@ -93,7 +101,7 @@ export function resolvePublicSsrMode(request: Request): PublicSsrMode | null {
   }
 
   if (
-    url.pathname === "/" ||
+    DIRECT_REQUEST_PATHS.has(url.pathname) ||
     url.pathname.startsWith("/_app/") ||
     url.pathname.startsWith("/.well-known/") ||
     DYNAMIC_OR_PRIVATE_ROOTS.some((root) => matchesPathRoot(url.pathname, root))

--- a/src/lib/cloudflare/public-ssr-gateway.ts
+++ b/src/lib/cloudflare/public-ssr-gateway.ts
@@ -11,6 +11,7 @@ export type PublicSsrLocale = "en-us" | "zh-cn";
 const STATIC_PUBLIC_PATHS = new Set([
   "/catalog/bus/map",
   "/guides/markdown-support",
+  "/api-docs",
   "/mobile-app",
   "/privacy",
   "/terms",

--- a/src/worker.js
+++ b/src/worker.js
@@ -12,6 +12,8 @@ import {
   resolvePublicSsrLocale,
   resolvePublicSsrMode,
 } from "./lib/cloudflare/public-ssr-gateway";
+import { buildContentSecurityPolicy } from "./lib/security/csp";
+import { CONTENT_SIGNAL } from "./lib/seo/content-signal";
 
 const app = svelteKitWorker;
 
@@ -51,6 +53,27 @@ function prepareCachedRepresentation(response, mode, locale, headRequest) {
 function createNonce() {
   const bytes = crypto.getRandomValues(new Uint8Array(16));
   return btoa(String.fromCharCode(...bytes));
+}
+
+function publicNotFoundResponse(locale, headRequest) {
+  const body = buildPublicNotFoundHtml(locale);
+  return new Response(headRequest ? null : body, {
+    status: 404,
+    headers: {
+      "Cache-Control": "private, no-store",
+      "Cloudflare-CDN-Cache-Control": "no-store",
+      "Content-Language": locale,
+      "Content-Security-Policy": buildContentSecurityPolicy(createNonce()),
+      "Content-Signal": CONTENT_SIGNAL,
+      "Content-Type": "text/html; charset=utf-8",
+      "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+      "Referrer-Policy": "strict-origin-when-cross-origin",
+      Vary: "Accept-Language, Cookie",
+      "X-Content-Type-Options": "nosniff",
+      "X-Frame-Options": "SAMEORIGIN",
+      "x-request-id": crypto.randomUUID(),
+    },
+  });
 }
 
 class ScriptNonceRewriter {
@@ -164,6 +187,9 @@ export default {
     if (!mode) return app.fetch(directRequest(request), env, context);
 
     const locale = resolvePublicSsrLocale(request);
+    if (mode === "not-found") {
+      return publicNotFoundResponse(locale, request.method === "HEAD");
+    }
     const cachedRequest = publicSsrRequest(request, mode, locale);
     const cacheUrl = new URL(cachedRequest.url);
     const response = await context.exports

--- a/tests/unit/public-ssr-gateway.test.ts
+++ b/tests/unit/public-ssr-gateway.test.ts
@@ -18,6 +18,7 @@ describe("public SSR gateway", () => {
     "/catalog/sections?semesterId=301&teacher=Li",
     "/catalog/teachers?departmentId=1",
     "/catalog/bus/map",
+    "/api-docs",
     "/api/docs/rest/catalog",
     "/mobile-app",
     "/privacy",

--- a/tests/unit/public-ssr-gateway.test.ts
+++ b/tests/unit/public-ssr-gateway.test.ts
@@ -36,6 +36,11 @@ describe("public SSR gateway", () => {
     "/catalog/courses?unknown=value",
     "/catalog/courses?__life_locale=en-us",
     "/community/users/example",
+    "/e2e/oauth/callback?code=example&state=test",
+    "/error?error=access_denied",
+    "/llms.txt",
+    "/robots.txt",
+    "/sitemap.xml",
     "/workspace/overview",
   ])("bypasses private or mixed route %s", (path) => {
     expect(resolvePublicSsrMode(request(path))).toBeNull();


### PR DESCRIPTION
## Summary
- return deterministic unknown-root 404 documents directly from the outer Worker gateway
- preserve locale negotiation, CSP, privacy/cache directives, content signal, security headers, and unique request IDs
- preserve every known top-level SvelteKit route, including legacy /api-docs, /error, /e2e, robots, sitemap, and llms.txt
- bypass SvelteKit SSR, auth/database work, hydration payloads, and the named cache only for confirmed unknown roots

## Why
Post-merge production verification of #658 and #659 proved that the cache-enabled named entrypoint cached unknown 404 responses but did not replace the SvelteKit body with the lightweight document. A static 808/814-byte localized response does not benefit from an inner cache and is faster and more reliable when generated directly at the gateway.

## Verification
- Biome and diff checks passed
- focused public SSR unit suite: 28 passed
- production build passed
- local Wrangler unknown GET: 404, 808/814 bytes, script-free, localized, private/no-store
- local Wrangler unknown HEAD: 404 with no body and the same security/cache headers
- local Wrangler /api-docs: 308 to /api/docs/tag/catalog-section
- local Wrangler /error and /e2e/oauth/callback: 200 with app hydration shell
- local Wrangler /robots.txt: 200 text/plain
- no API endpoint added