### PR TITLE
fix(worker): route application paths through gateway

### DIFF
--- a/tests/unit/wrangler-rate-limit-config.test.ts
+++ b/tests/unit/wrangler-rate-limit-config.test.ts
@@ -17,6 +17,27 @@ async function readRateLimits(fileName: string): Promise<RateLimitBinding[]> {
 }
 
 describe("Wrangler mutation rate-limit bindings", () => {
+  it.each([
+    "wrangler.jsonc",
+    "wrangler.e2e.jsonc",
+  ])("routes application requests through the gateway while keeping static assets direct in %s", async (fileName) => {
+    const source = await readFile(
+      new URL(`../../${fileName}`, import.meta.url),
+      "utf8",
+    );
+    const config = JSON.parse(source) as {
+      assets?: { run_worker_first?: string[] };
+    };
+
+    expect(config.assets?.run_worker_first).toEqual([
+      "/*",
+      "!/_app/*",
+      "!/images/*",
+      "!/static/*",
+      "!/openapi.generated.json",
+    ]);
+  });
+
   it("keeps public workers.dev and automatic request metadata logs disabled", async () => {
     const source = await readFile(
       new URL("../../wrangler.jsonc", import.meta.url),

--- a/wrangler.e2e.jsonc
+++ b/wrangler.e2e.jsonc
@@ -29,7 +29,14 @@
   },
   "assets": {
     "directory": ".svelte-kit/cloudflare",
-    "binding": "ASSETS"
+    "binding": "ASSETS",
+    "run_worker_first": [
+      "/*",
+      "!/_app/*",
+      "!/images/*",
+      "!/static/*",
+      "!/openapi.generated.json"
+    ]
   },
   "observability": {
     "enabled": false

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,7 +21,14 @@
   },
   "assets": {
     "directory": ".svelte-kit/cloudflare",
-    "binding": "ASSETS"
+    "binding": "ASSETS",
+    "run_worker_first": [
+      "/*",
+      "!/_app/*",
+      "!/images/*",
+      "!/static/*",
+      "!/openapi.generated.json"
+    ]
   },
   "observability": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- invoke the outer Worker for application routes, including unmatched paths
- keep immutable app bundles and public asset directories on Cloudflare Static Assets
- mirror production routing in E2E and lock the route patterns with a unit test

## Why
Cloudflare production metadata showed `raw_run_worker_first: false`, and live unmatched requests bypassed the outer gateway even though the direct 404 branch was deployed. Selective `assets.run_worker_first` guarantees the gateway runs for app routes without charging Worker CPU for static bundles and images.

## Verification
- `bunx vitest run` (254 files, 1568 tests)
- `bun run build`
- `bunx wrangler deploy --dry-run --config wrangler.jsonc`
- local Wrangler: unknown route = 404, 808 bytes, no script; `/_app/version.json` and `/images/icon.png` remain static responses
- `bunx biome check .` (passes with one pre-existing unused-parameter warning)