### PR TITLE
perf(worker): reduce remaining request hot paths

### DIFF
--- a/docs/rendering-and-cache.md
+++ b/docs/rendering-and-cache.md
@@ -6,33 +6,44 @@ component at a time.
 | Route class | Initial HTML | Viewer state | Shared HTML cache |
 |-------------|--------------|--------------|-------------------|
 | Public and viewer-independent | Anonymous SSR | Existing Better Auth session endpoint after hydration | Workers Cache named entrypoint |
-| Public with page-specific viewer data | SSR with the current viewer | Included by the page loader | No store until that viewer data has a client overlay |
+| Canonical catalog detail without an auth signal or query | Anonymous SSR | Anonymous baseline; existing Better Auth session endpoint after hydration | Workers Cache named entrypoint |
+| Public with page-specific viewer data, including catalog detail with an auth signal | SSR with the current viewer | Included by the page loader | Never |
 | Account, workspace, admin, and OAuth | Authenticated SSR | Included by the page loader | Never |
 
 The currently cacheable public set is intentionally explicit: the course,
-section, and teacher list pages; the bus map; mobile app, privacy, terms,
-Markdown guide, and API documentation pages. Unknown paths outside known app
-route roots use the same path only when the result is a 404. Public detail,
-links, bus planner, community, and home pages stay dynamic because they still
-contain page-specific viewer behavior.
+section, and teacher list pages; canonical anonymous course, section, and
+teacher detail pages; the bus map; mobile app, privacy, terms, Markdown guide,
+and API documentation pages. Catalog detail cache admission requires a positive
+decimal ID without leading zeroes, no query or trailing slash, and either the
+base overview path or a supported tab. Course and teacher tabs are
+`introduction`, `sections`, and `comments`; section tabs are `introduction`,
+`calendar`, `exams`, `homework`, `teachers`, and `comments`. Any recognized
+Bearer or session-cookie auth signal keeps the detail request on dynamic SSR.
+Unknown paths outside known app route roots use a small script-free 404 response
+without entering SvelteKit or the shared cache. Links, bus planner, community,
+and home pages stay dynamic because they still contain page-specific viewer
+behavior.
 
 ## Request flow
 
 1. The default Worker entrypoint always receives the browser request. It
    rejects private routes, SvelteKit data requests, non-document requests, and
-   unknown query fields before making a cached call.
+   unknown query fields before making a cached call. Catalog detail additionally
+   rejects auth signals, every query, non-canonical IDs, trailing slashes, and
+   unknown tabs; these requests continue through the normal dynamic Worker.
 2. For an allowlisted page, it resolves the locale, removes Cookie and
    Authorization, canonicalizes allowlisted query fields, and adds the locale
    to an internal URL cache key.
 3. The `PublicSsr` named entrypoint renders the anonymous SvelteKit document.
    Successful allowlisted pages are fresh for 60 seconds with a five-minute
-   stale-while-revalidate window. Confirmed unknown 404s are fresh for five
-   minutes with a one-hour stale window. Cache entries do not cross Worker
+   stale-while-revalidate window. `stale-if-error=0` is explicit because the
+   Cloudflare default can otherwise serve an old successful response
+   indefinitely when a refresh fails. Cache entries do not cross Worker
    versions, so a deployment invalidates the previous representation; normal
    catalog freshness is bounded by the short TTL and existing runtime data
-   cache. Confirmed 404s are replaced with a small script-free document before
-   they are stored, so scanners and browsers do not download or hydrate the
-   full application shell.
+   cache. Unknown routes instead return a small script-free, private/no-store
+   response directly, so scanners do not render or hydrate the full application
+   shell and cannot populate attacker-controlled high-cardinality cache keys.
 4. The default entrypoint rewrites the cached CSP nonce placeholder and request
    ID for every browser response, then marks that outer response private and
    no-store so zone rules cannot bypass the gateway. Raw session headers never
@@ -43,14 +54,24 @@ contain page-specific viewer behavior.
    introduced. Direct dynamic SSR already knows the viewer state and does not
    repeat this client request.
 
+Client navigation preloads route code on hover, but waits until tap/click intent
+before preloading page data. This preserves code warming without issuing
+uncached `__data.json` requests, authentication work, or database reads for
+links that the visitor only moves across.
+
 The generated SvelteKit Worker remains an internal build artifact selected by
 `wrangler.adapter.jsonc`. Production and E2E use `src/worker.js` as the public
 entrypoint, so direct requests cannot opt into internal cache headers.
 
 ## Adding a route
 
-A route may enter the public cache allowlist only when its full SSR payload is
-identical for anonymous and signed-in visitors. If a page has viewer-specific
-controls or data, first move that state behind an existing authenticated client
-request and render a deterministic anonymous/skeleton baseline. Unknown query
-fields must bypass the cache until they are reviewed and allowlisted.
+A route may enter the public cache allowlist when its full SSR payload is
+viewer-independent, or when admission is limited to requests without a
+recognized auth signal and the resulting SSR payload is a deterministic
+anonymous baseline. Viewer-specific requests must keep using dynamic SSR unless
+that state has moved behind an existing authenticated client request. Unknown
+query fields must bypass the cache until they are reviewed and allowlisted.
+
+The auth-signal detector is coupled to the Better Auth cookie configuration.
+Changing Better Auth's cookie prefix or session-cookie name requires updating
+the detector and its cache-boundary tests in the same change.

--- a/src/app.html
+++ b/src/app.html
@@ -28,7 +28,10 @@
     </script>
     %sveltekit.head%
   </head>
-  <body data-sveltekit-preload-data="hover">
+  <body
+    data-sveltekit-preload-code="hover"
+    data-sveltekit-preload-data="tap"
+  >
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/src/features/catalog/server/catalog-detail-comments.ts
+++ b/src/features/catalog/server/catalog-detail-comments.ts
@@ -4,17 +4,21 @@ import type { ViewerContext } from "@/lib/auth/viewer-context";
 
 export async function loadCatalogDetailCommentsData({
   includeComments,
+  includeDescriptionHistory,
   targetId,
   type,
   viewer,
 }: {
   includeComments: boolean;
+  includeDescriptionHistory: boolean;
   targetId: number;
   type: "course" | "teacher";
   viewer: ViewerContext;
 }) {
   const [descriptionData, comments] = await Promise.all([
-    getDescriptionPayload(type, targetId, viewer),
+    getDescriptionPayload(type, targetId, viewer, {
+      includeHistory: includeDescriptionHistory,
+    }),
     includeComments
       ? getCommentsPayload({ type, targetId }, viewer, { pageSize: 20 })
       : Promise.resolve(null),

--- a/src/features/catalog/server/catalog-detail-page-server.ts
+++ b/src/features/catalog/server/catalog-detail-page-server.ts
@@ -75,6 +75,7 @@ export async function loadCourseDetailPage({
   const { commentsData, descriptionData } = await loadCatalogDetailCommentsData(
     {
       includeComments: detailSection === "comments",
+      includeDescriptionHistory: detailSection === "introduction",
       targetId: course.id,
       type: "course",
       viewer,
@@ -140,6 +141,7 @@ export async function loadTeacherDetailPage({
   const { commentsData, descriptionData } = await loadCatalogDetailCommentsData(
     {
       includeComments: detailSection === "comments",
+      includeDescriptionHistory: detailSection === "introduction",
       targetId: teacher.id,
       type: "teacher",
       viewer,

--- a/src/features/descriptions/server/descriptions-server.ts
+++ b/src/features/descriptions/server/descriptions-server.ts
@@ -20,6 +20,7 @@ export async function getDescriptionPayload(
   targetType: DescriptionTargetType,
   targetId: number | string,
   viewerOverride?: DescriptionViewer,
+  options: { includeHistory?: boolean } = {},
 ): Promise<DescriptionPayload> {
   const target = resolveDescriptionTarget(targetType, targetId);
   const viewer =
@@ -29,12 +30,13 @@ export async function getDescriptionPayload(
     return emptyDescriptionPayload(viewer);
   }
 
-  return getResolvedDescriptionPayload(target, viewer);
+  return getResolvedDescriptionPayload(target, viewer, options);
 }
 
 export async function getResolvedDescriptionPayload(
   target: ResolvedDescriptionTarget,
   viewerOverride?: DescriptionViewer,
+  { includeHistory = true }: { includeHistory?: boolean } = {},
 ): Promise<DescriptionPayload> {
   const viewer =
     viewerOverride ?? (await getViewerContext({ includeAdmin: false }));
@@ -48,18 +50,19 @@ export async function getResolvedDescriptionPayload(
     },
   });
 
-  const history = description
-    ? await prisma.descriptionEdit.findMany({
-        where: { descriptionId: description.id },
-        include: {
-          editor: {
-            select: { id: true, name: true, image: true, username: true },
+  const history =
+    description && includeHistory
+      ? await prisma.descriptionEdit.findMany({
+          where: { descriptionId: description.id },
+          include: {
+            editor: {
+              select: { id: true, name: true, image: true, username: true },
+            },
           },
-        },
-        orderBy: { createdAt: "desc" },
-        take: 20,
-      })
-    : [];
+          orderBy: { createdAt: "desc" },
+          take: 20,
+        })
+      : [];
 
   return {
     description: serializeDescriptionRecord(description),

--- a/src/features/section-detail/server/section-detail-comments-data.ts
+++ b/src/features/section-detail/server/section-detail-comments-data.ts
@@ -9,13 +9,17 @@ export async function getSectionDetailDescriptionAndComments(
     teachers: { id: number }[];
   },
   userId: string | null,
-  { includeComments }: { includeComments: boolean },
+  {
+    includeComments,
+    includeDescriptionHistory,
+  }: { includeComments: boolean; includeDescriptionHistory: boolean },
 ) {
   const descriptionViewer = await getViewerContext({ userId });
   const descriptionDataPromise = getDescriptionPayload(
     "section",
     section.id,
     descriptionViewer,
+    { includeHistory: includeDescriptionHistory },
   );
   if (!includeComments) {
     return {

--- a/src/features/section-detail/server/section-detail-page-server.ts
+++ b/src/features/section-detail/server/section-detail-page-server.ts
@@ -82,6 +82,7 @@ export async function loadSectionDetailPage({
         : null,
       getSectionDetailDescriptionAndComments(section, userId, {
         includeComments: detailSection === "comments",
+        includeDescriptionHistory: detailSection === "introduction",
       }),
       detailSection === "homework"
         ? getSectionHomeworkData(section.id, userId)

--- a/src/lib/api/routes/calendar-subscriptions.ts
+++ b/src/lib/api/routes/calendar-subscriptions.ts
@@ -1,3 +1,4 @@
+import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import {
   badRequest,
   handleRouteError,
@@ -19,18 +20,24 @@ import { requireAuth } from "@/lib/auth/api-auth";
 
 export async function getCurrentCalendarSubscriptionRoute(request: Request) {
   try {
-    const auth = await requireAuth(request, {
-      bearerScope: { feature: "workspace.subscription", action: "read" },
-    });
+    const auth = await runCloudflareTraceSpan(
+      "workspace.subscriptions.current.auth",
+      {},
+      () =>
+        requireAuth(request, {
+          bearerScope: { feature: "workspace.subscription", action: "read" },
+        }),
+    );
     if (auth instanceof Response) return auth;
     const { userId } = auth;
 
     const { getUserCalendarSubscription } = await import(
       "@/features/subscriptions/server/subscription-read-model"
     );
-    const subscription = await getUserCalendarSubscription(
-      userId,
-      getRequestLocale(request),
+    const subscription = await runCloudflareTraceSpan(
+      "workspace.subscriptions.current.read",
+      {},
+      () => getUserCalendarSubscription(userId, getRequestLocale(request)),
     );
 
     if (!subscription) {

--- a/src/lib/api/routes/homework-subscribed-read-route.ts
+++ b/src/lib/api/routes/homework-subscribed-read-route.ts
@@ -1,11 +1,17 @@
+import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import { handleRouteError, jsonResponse } from "@/lib/api/helpers";
 import { getRequestLocale } from "@/lib/api/routes/request-locale";
 import { requireAuth } from "@/lib/auth/api-auth";
 
 export async function getSubscribedHomeworksRoute(request: Request) {
-  const auth = await requireAuth(request, {
-    bearerScope: { feature: "workspace.homework", action: "read" },
-  });
+  const auth = await runCloudflareTraceSpan(
+    "workspace.homeworks.auth",
+    {},
+    () =>
+      requireAuth(request, {
+        bearerScope: { feature: "workspace.homework", action: "read" },
+      }),
+  );
   if (auth instanceof Response) return auth;
   const { userId } = auth;
   const locale = getRequestLocale(request);
@@ -24,12 +30,17 @@ export async function getSubscribedHomeworksRoute(request: Request) {
     } = subscriptionReadModel;
     const { withHomeworkItemState } = homeworkItemState;
 
-    const viewer = await getViewerContext({
-      includeAdmin: true,
-      userId,
-    });
-
-    const sectionIds = await getSubscribedSectionIds(userId);
+    const [viewer, sectionIds] = await Promise.all([
+      runCloudflareTraceSpan("workspace.homeworks.viewer", {}, () =>
+        getViewerContext({
+          includeAdmin: true,
+          userId,
+        }),
+      ),
+      runCloudflareTraceSpan("workspace.homeworks.section_ids", {}, () =>
+        getSubscribedSectionIds(userId),
+      ),
+    ]);
 
     if (sectionIds.length === 0) {
       return jsonResponse({
@@ -41,15 +52,23 @@ export async function getSubscribedHomeworksRoute(request: Request) {
     }
 
     const [homeworks, auditLogs] = await Promise.all([
-      listSubscribedHomeworks(userId, {
-        locale,
-        includeEditors: true,
-        sectionIds,
-      }),
-      listSubscribedHomeworkAuditLogs(userId, 50, sectionIds),
+      runCloudflareTraceSpan("workspace.homeworks.read", {}, () =>
+        listSubscribedHomeworks(userId, {
+          locale,
+          includeEditors: true,
+          sectionIds,
+        }),
+      ),
+      runCloudflareTraceSpan("workspace.homeworks.audit", {}, () =>
+        listSubscribedHomeworkAuditLogs(userId, 50, sectionIds),
+      ),
     ]);
 
-    const responseHomeworks = await withHomeworkItemState(homeworks);
+    const responseHomeworks = await runCloudflareTraceSpan(
+      "workspace.homeworks.item_state",
+      {},
+      () => withHomeworkItemState(homeworks),
+    );
 
     return jsonResponse({
       viewer,

--- a/src/lib/cloudflare/public-ssr-gateway.ts
+++ b/src/lib/cloudflare/public-ssr-gateway.ts
@@ -1,9 +1,15 @@
+import { hasRequestAuthSignal } from "@/lib/auth/request-auth-signal";
+
 export const PUBLIC_SSR_HEADER = "x-life-public-ssr";
 export const PUBLIC_SSR_LOCALE_HEADER = "x-life-public-ssr-locale";
 export const PUBLIC_SSR_MODE_HEADER = "x-life-public-ssr-mode";
 export const PUBLIC_SSR_NONCE_PLACEHOLDER = "life-ustc-public-ssr-nonce";
 export const PUBLIC_SSR_LOCALE_CACHE_PARAM = "__life_locale";
 export const PUBLIC_SSR_MODE_CACHE_PARAM = "__life_mode";
+export const PUBLIC_SSR_BROWSER_CACHE_CONTROL =
+  "public, max-age=0, stale-while-revalidate=300, stale-if-error=0";
+export const PUBLIC_SSR_PAGE_EDGE_CACHE_CONTROL =
+  "public, max-age=60, stale-while-revalidate=300, stale-if-error=0";
 
 export type PublicSsrMode = "page" | "not-found";
 export type PublicSsrLocale = "en-us" | "zh-cn";
@@ -52,6 +58,21 @@ const CATALOG_QUERY_KEYS: Record<string, ReadonlySet<string>> = {
   "/catalog/teachers": new Set(["departmentId", "page", "search"]),
 };
 
+const CATALOG_DETAIL_PATH =
+  /^\/catalog\/(courses|sections|teachers)\/([1-9]\d*)(?:\/([^/]+))?$/;
+const CATALOG_DETAIL_SECTIONS: Record<string, ReadonlySet<string>> = {
+  courses: new Set(["introduction", "sections", "comments"]),
+  sections: new Set([
+    "introduction",
+    "calendar",
+    "exams",
+    "homework",
+    "teachers",
+    "comments",
+  ]),
+  teachers: new Set(["introduction", "sections", "comments"]),
+};
+
 const DYNAMIC_OR_PRIVATE_ROOTS = [
   "/account",
   "/admin",
@@ -91,6 +112,15 @@ function hasOnlyAllowedQuery(url: URL, allowed: ReadonlySet<string>) {
   return Array.from(url.searchParams.keys()).every((key) => allowed.has(key));
 }
 
+function isCanonicalCatalogDetailPath(pathname: string) {
+  const match = CATALOG_DETAIL_PATH.exec(pathname);
+  if (!match) return false;
+  const [, collection, identifier, section] = match;
+  const id = Number(identifier);
+  if (!Number.isSafeInteger(id)) return false;
+  return !section || CATALOG_DETAIL_SECTIONS[collection]?.has(section) === true;
+}
+
 export function resolvePublicSsrMode(request: Request): PublicSsrMode | null {
   if (request.method !== "GET" && request.method !== "HEAD") return null;
   if (!acceptsHtml(request)) return null;
@@ -101,6 +131,12 @@ export function resolvePublicSsrMode(request: Request): PublicSsrMode | null {
   const catalogQueryKeys = CATALOG_QUERY_KEYS[url.pathname];
   if (catalogQueryKeys) {
     return hasOnlyAllowedQuery(url, catalogQueryKeys) ? "page" : null;
+  }
+
+  if (isCanonicalCatalogDetailPath(url.pathname)) {
+    return !url.search && !hasRequestAuthSignal(request.headers)
+      ? "page"
+      : null;
   }
 
   if (

--- a/src/worker.js
+++ b/src/worker.js
@@ -2,12 +2,14 @@ import { WorkerEntrypoint } from "cloudflare:workers";
 import svelteKitWorker from "life-ustc-sveltekit-worker";
 import {
   buildPublicNotFoundHtml,
+  PUBLIC_SSR_BROWSER_CACHE_CONTROL,
   PUBLIC_SSR_HEADER,
   PUBLIC_SSR_LOCALE_CACHE_PARAM,
   PUBLIC_SSR_LOCALE_HEADER,
   PUBLIC_SSR_MODE_CACHE_PARAM,
   PUBLIC_SSR_MODE_HEADER,
   PUBLIC_SSR_NONCE_PLACEHOLDER,
+  PUBLIC_SSR_PAGE_EDGE_CACHE_CONTROL,
   removePublicSsrHeaders,
   resolveLegacyCatalogRedirect,
   resolvePublicSsrLocale,
@@ -18,37 +20,31 @@ import { CONTENT_SIGNAL } from "./lib/seo/content-signal";
 
 const app = svelteKitWorker;
 
-function cacheablePublicResponse(response, mode) {
-  const isExpectedStatus =
-    (mode === "page" && response.status >= 200 && response.status < 300) ||
-    (mode === "not-found" && response.status === 404);
+function cacheablePublicResponse(response) {
   return (
-    isExpectedStatus &&
+    response.status >= 200 &&
+    response.status < 300 &&
     response.headers.get("content-type")?.includes("text/html") &&
     !response.headers.has("set-cookie")
   );
 }
 
-function prepareCachedRepresentation(response, mode, locale, headRequest) {
-  if (!cacheablePublicResponse(response, mode)) return response;
+function prepareCachedRepresentation(response) {
+  if (!cacheablePublicResponse(response)) return response;
 
   const headers = new Headers(response.headers);
-  headers.set("Cache-Control", "public, max-age=0, stale-while-revalidate=300");
+  headers.set("Cache-Control", PUBLIC_SSR_BROWSER_CACHE_CONTROL);
   headers.set(
     "Cloudflare-CDN-Cache-Control",
-    mode === "not-found"
-      ? "public, max-age=300, stale-while-revalidate=3600"
-      : "public, max-age=60, stale-while-revalidate=300",
+    PUBLIC_SSR_PAGE_EDGE_CACHE_CONTROL,
   );
   headers.delete("Vary");
   headers.delete("Content-Length");
-  if (mode === "not-found") headers.delete("Content-Encoding");
-  return new Response(
-    mode === "not-found" && !headRequest
-      ? buildPublicNotFoundHtml(locale)
-      : response.body,
-    { headers, status: response.status, statusText: response.statusText },
-  );
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
 }
 
 function createNonce() {
@@ -172,13 +168,7 @@ export class PublicSsr extends WorkerEntrypoint {
       this.env,
       this.ctx,
     );
-    const { locale, mode } = this.ctx.props;
-    return prepareCachedRepresentation(
-      response,
-      mode === "not-found" ? "not-found" : "page",
-      locale === "en-us" ? "en-us" : "zh-cn",
-      request.method === "HEAD",
-    );
+    return prepareCachedRepresentation(response);
   }
 }
 

--- a/tests/unit/description-history-critical-path.test.ts
+++ b/tests/unit/description-history-critical-path.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { descriptionFindFirstMock, historyFindManyMock } = vi.hoisted(() => ({
+  descriptionFindFirstMock: vi.fn(),
+  historyFindManyMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    description: { findFirst: descriptionFindFirstMock },
+    descriptionEdit: { findMany: historyFindManyMock },
+  },
+}));
+
+const viewer = {
+  image: null,
+  isAdmin: false,
+  isAuthenticated: false,
+  isSuspended: false,
+  name: null,
+  suspensionExpiresAt: null,
+  suspensionReason: null,
+  userId: null,
+};
+
+const target = {
+  ensureExists: vi.fn(),
+  targetId: 1,
+  where: { courseId: 1 },
+};
+
+describe("description history critical path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    descriptionFindFirstMock.mockResolvedValue({
+      content: "Current description",
+      id: "description-1",
+      lastEditedAt: null,
+      lastEditedBy: null,
+      updatedAt: new Date("2026-07-29T00:00:00Z"),
+    });
+    historyFindManyMock.mockResolvedValue([
+      {
+        createdAt: new Date("2026-07-28T00:00:00Z"),
+        editor: null,
+        id: "history-1",
+        nextContent: "Current description",
+        previousContent: "Previous description",
+      },
+    ]);
+  });
+
+  it("skips history when the active detail tab cannot render it", async () => {
+    const { getResolvedDescriptionPayload } = await import(
+      "@/features/descriptions/server/descriptions-server"
+    );
+
+    const result = await getResolvedDescriptionPayload(target, viewer, {
+      includeHistory: false,
+    });
+
+    expect(result.description.content).toBe("Current description");
+    expect(result.history).toEqual([]);
+    expect(historyFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps history enabled by default", async () => {
+    const { getResolvedDescriptionPayload } = await import(
+      "@/features/descriptions/server/descriptions-server"
+    );
+
+    const result = await getResolvedDescriptionPayload(target, viewer);
+
+    expect(result.history).toHaveLength(1);
+    expect(historyFindManyMock).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/detail-page-loader-critical-path.test.ts
+++ b/tests/unit/detail-page-loader-critical-path.test.ts
@@ -196,6 +196,12 @@ describe("catalog detail loader critical path", () => {
     expect(result.descriptionData).toBe(descriptionData);
     expect(result.structuredDataJson).toContain("Primary SSR description");
     expect(result.commentsData).toBeNull();
+    expect(getDescriptionPayloadMock).toHaveBeenCalledWith(
+      "course",
+      course.id,
+      anonymousViewer,
+      { includeHistory: false },
+    );
     expect(getCommentsPayloadMock).not.toHaveBeenCalled();
   });
 
@@ -219,6 +225,28 @@ describe("catalog detail loader critical path", () => {
       { targetId: course.id, type: "course" },
       anonymousViewer,
       { pageSize: 20 },
+    );
+  });
+
+  it("loads description history only for the introduction section", async () => {
+    const { loadCourseDetailPage } = await import(
+      "@/features/catalog/server/catalog-detail-page-server"
+    );
+
+    await loadCourseDetailPage({
+      locals: locals(),
+      params: { jwId: String(course.jwId), section: "introduction" },
+      request: request(`/catalog/courses/${course.jwId}/introduction`),
+      url: new URL(
+        `https://example.test/catalog/courses/${course.jwId}/introduction`,
+      ),
+    });
+
+    expect(getDescriptionPayloadMock).toHaveBeenCalledWith(
+      "course",
+      course.id,
+      anonymousViewer,
+      { includeHistory: true },
     );
   });
 
@@ -347,6 +375,17 @@ describe("section detail loader critical path", () => {
     expect(result.structuredDataJson).toContain("Primary SSR description");
     expect(result.commentsData).toBeNull();
     expect(result.homeworkData.homeworks).toEqual([]);
+    expect(result.viewer).toEqual({
+      isSubscribed: false,
+      signedIn: false,
+      subscriptionIcsUrl: null,
+    });
+    expect(getDescriptionPayloadMock).toHaveBeenCalledWith(
+      "section",
+      section.id,
+      anonymousViewer,
+      { includeHistory: false },
+    );
     expect(getCommentsPayloadMock).not.toHaveBeenCalled();
     expect(getSectionHomeworkDataMock).not.toHaveBeenCalled();
     expect(getUserSectionSubscriptionStateMock).not.toHaveBeenCalled();

--- a/tests/unit/public-ssr-detail-safety.test.ts
+++ b/tests/unit/public-ssr-detail-safety.test.ts
@@ -1,0 +1,112 @@
+import { getCookies } from "better-auth/cookies";
+import { describe, expect, test } from "vitest";
+import { buildVisibleCommentNode } from "@/features/comments/server/serialized-comment-node";
+import { homeworkItemIncludeForViewer } from "@/features/homeworks/server/homework-read-model";
+import { getViewerContext } from "@/lib/auth/viewer-context";
+import { resolvePublicSsrMode } from "@/lib/cloudflare/public-ssr-gateway";
+
+const anonymousViewer = {
+  image: null,
+  isAdmin: false,
+  isAuthenticated: false,
+  isSuspended: false,
+  name: null,
+  suspensionExpiresAt: null,
+  suspensionReason: null,
+  userId: null,
+};
+
+function detailRequest(headers: HeadersInit = {}) {
+  return new Request("https://life-ustc.test/catalog/sections/159446", {
+    headers: { accept: "text/html", ...headers },
+  });
+}
+
+describe("public SSR detail safety invariants", () => {
+  test("admits only the anonymous document request", () => {
+    expect(resolvePublicSsrMode(detailRequest())).toBe("page");
+    expect(
+      resolvePublicSsrMode(
+        detailRequest({ authorization: "Bearer access-token" }),
+      ),
+    ).toBeNull();
+    expect(
+      resolvePublicSsrMode(
+        detailRequest({ cookie: "better-auth.session_token=session-token" }),
+      ),
+    ).toBeNull();
+  });
+
+  test("recognizes Better Auth's configured default production cookie", () => {
+    const { sessionToken } = getCookies({ baseURL: "https://life-ustc.test" });
+
+    expect(sessionToken.name).toBe("__Secure-better-auth.session_token");
+    expect(
+      resolvePublicSsrMode(
+        detailRequest({ cookie: `${sessionToken.name}=session-token` }),
+      ),
+    ).toBeNull();
+  });
+
+  test("uses a deterministic anonymous viewer baseline", async () => {
+    await expect(getViewerContext({ userId: null })).resolves.toEqual(
+      anonymousViewer,
+    );
+  });
+
+  test("does not select per-user homework completion state", () => {
+    expect(homeworkItemIncludeForViewer(null)).not.toHaveProperty(
+      "homeworkCompletions",
+    );
+  });
+
+  test("does not expose anonymous reaction or moderation capabilities", () => {
+    const node = buildVisibleCommentNode({
+      comment: {
+        body: "Public comment",
+        createdAt: new Date("2026-07-29T00:00:00Z"),
+        id: "comment-1",
+        reactions: [
+          { type: "heart", userId: "user-1" },
+          { type: "heart", userId: "user-2" },
+        ],
+        status: "active",
+        updatedAt: new Date("2026-07-29T00:00:00Z"),
+        userId: "user-1",
+        visibility: "public",
+      },
+      hasDescendant: false,
+      viewer: anonymousViewer,
+    });
+
+    expect(node).toMatchObject({
+      canDelete: false,
+      canEdit: false,
+      canModerate: false,
+      canReact: false,
+      canReply: false,
+      isAuthor: false,
+      reactions: [{ count: 2, type: "heart", viewerHasReacted: false }],
+    });
+  });
+
+  test.each([
+    { status: "softbanned" as const, visibility: "public" as const },
+    { status: "active" as const, visibility: "logged_in_only" as const },
+  ])("hides non-public comment state from the anonymous baseline", (state) => {
+    expect(
+      buildVisibleCommentNode({
+        comment: {
+          ...state,
+          body: "Private comment",
+          createdAt: new Date("2026-07-29T00:00:00Z"),
+          id: "comment-private",
+          updatedAt: new Date("2026-07-29T00:00:00Z"),
+          userId: "user-1",
+        },
+        hasDescendant: false,
+        viewer: anonymousViewer,
+      }),
+    ).toBeNull();
+  });
+});

--- a/tests/unit/public-ssr-gateway.test.ts
+++ b/tests/unit/public-ssr-gateway.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "vitest";
 import {
   buildPublicNotFoundHtml,
+  PUBLIC_SSR_BROWSER_CACHE_CONTROL,
+  PUBLIC_SSR_PAGE_EDGE_CACHE_CONTROL,
   resolveLegacyCatalogRedirect,
   resolvePublicSsrLocale,
   resolvePublicSsrMode,
@@ -13,6 +15,13 @@ function request(path: string, headers: HeadersInit = {}) {
 }
 
 describe("public SSR gateway", () => {
+  test.each([
+    PUBLIC_SSR_BROWSER_CACHE_CONTROL,
+    PUBLIC_SSR_PAGE_EDGE_CACHE_CONTROL,
+  ])("bounds stale-on-error cache fallback in %s", (cacheControl) => {
+    expect(cacheControl).toContain("stale-if-error=0");
+  });
+
   test.each([
     ["/sections/159446/comments", "/catalog/sections/159446/comments"],
     ["/courses/456?page=2", "/catalog/courses/456?page=2"],
@@ -47,13 +56,50 @@ describe("public SSR gateway", () => {
   });
 
   test.each([
+    "/catalog/courses/11145",
+    "/catalog/courses/11145/introduction",
+    "/catalog/courses/11145/sections",
+    "/catalog/courses/11145/comments",
+    "/catalog/teachers/42",
+    "/catalog/teachers/42/introduction",
+    "/catalog/teachers/42/sections",
+    "/catalog/teachers/42/comments",
+    "/catalog/sections/159446",
+    "/catalog/sections/159446/introduction",
+    "/catalog/sections/159446/calendar",
+    "/catalog/sections/159446/exams",
+    "/catalog/sections/159446/homework",
+    "/catalog/sections/159446/teachers",
+    "/catalog/sections/159446/comments",
+  ])("caches canonical anonymous catalog detail page %s", (path) => {
+    expect(resolvePublicSsrMode(request(path))).toBe("page");
+  });
+
+  test("caches a canonical anonymous catalog detail HEAD request", () => {
+    expect(
+      resolvePublicSsrMode(
+        new Request("https://life-ustc.test/catalog/courses/11145", {
+          headers: { accept: "text/html" },
+          method: "HEAD",
+        }),
+      ),
+    ).toBe("page");
+  });
+
+  test.each([
     "/",
     "/account/sign-in",
     "/admin",
     "/api/auth/get-session",
     "/catalog/courses/011145",
+    "/catalog/courses/11145/",
+    "/catalog/courses/11145/calendar",
+    "/catalog/courses/11145/comments?sort=latest",
+    "/catalog/courses/11145/__data.json",
     "/catalog/courses?unknown=value",
     "/catalog/courses?__life_locale=en-us",
+    "/catalog/sections/159446/unknown",
+    "/catalog/teachers/not-an-id",
     "/community/users/example",
     "/e2e/oauth/callback?code=example&state=test",
     "/error?error=access_denied",
@@ -63,6 +109,46 @@ describe("public SSR gateway", () => {
     "/workspace/overview",
   ])("bypasses private or mixed route %s", (path) => {
     expect(resolvePublicSsrMode(request(path))).toBeNull();
+  });
+
+  test.each<Record<string, string>>([
+    { authorization: "Bearer access-token" },
+    { authorization: "bEaReR access-token" },
+    { cookie: "better-auth.session_token=session-token" },
+    { cookie: "__Secure-better-auth.session_token=session-token" },
+    { cookie: "session=private" },
+  ])("bypasses catalog detail requests with auth signal %j", (headers) => {
+    expect(
+      resolvePublicSsrMode(request("/catalog/courses/11145", headers)),
+    ).toBeNull();
+  });
+
+  test("keeps viewer-independent catalog list caching with auth signals", () => {
+    expect(
+      resolvePublicSsrMode(
+        request("/catalog/courses", {
+          cookie: "better-auth.session_token=session-token",
+        }),
+      ),
+    ).toBe("page");
+  });
+
+  test("bypasses non-read and non-document catalog detail requests", () => {
+    expect(
+      resolvePublicSsrMode(
+        new Request("https://life-ustc.test/catalog/courses/11145", {
+          headers: { accept: "text/html" },
+          method: "POST",
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      resolvePublicSsrMode(
+        new Request("https://life-ustc.test/catalog/courses/11145", {
+          headers: { accept: "application/json" },
+        }),
+      ),
+    ).toBeNull();
   });
 
   test("caches only the 404 representation for unknown roots", () => {

--- a/tests/unit/workspace-route-tracing.test.ts
+++ b/tests/unit/workspace-route-tracing.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getSubscribedSectionIdsMock,
+  getUserCalendarSubscriptionMock,
+  getViewerContextMock,
+  listSubscribedHomeworkAuditLogsMock,
+  listSubscribedHomeworksMock,
+  requireAuthMock,
+  runCloudflareTraceSpanMock,
+  withHomeworkItemStateMock,
+} = vi.hoisted(() => ({
+  getSubscribedSectionIdsMock: vi.fn(),
+  getUserCalendarSubscriptionMock: vi.fn(),
+  getViewerContextMock: vi.fn(),
+  listSubscribedHomeworkAuditLogsMock: vi.fn(),
+  listSubscribedHomeworksMock: vi.fn(),
+  requireAuthMock: vi.fn(),
+  runCloudflareTraceSpanMock: vi.fn(),
+  withHomeworkItemStateMock: vi.fn(),
+}));
+
+vi.mock("@/lib/adapters/cloudflare-runtime", () => ({
+  runCloudflareTraceSpan: runCloudflareTraceSpanMock,
+}));
+
+vi.mock("@/lib/auth/api-auth", () => ({
+  requireAuth: requireAuthMock,
+}));
+
+vi.mock("@/lib/auth/viewer-context", () => ({
+  getViewerContext: getViewerContextMock,
+}));
+
+vi.mock("@/features/subscriptions/server/subscription-read-model", () => ({
+  getSubscribedSectionIds: getSubscribedSectionIdsMock,
+  getUserCalendarSubscription: getUserCalendarSubscriptionMock,
+  listSubscribedHomeworkAuditLogs: listSubscribedHomeworkAuditLogsMock,
+  listSubscribedHomeworks: listSubscribedHomeworksMock,
+}));
+
+vi.mock("@/features/homeworks/server/homework-item-state", () => ({
+  withHomeworkItemState: withHomeworkItemStateMock,
+}));
+
+describe("workspace route tracing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runCloudflareTraceSpanMock.mockImplementation(
+      (_name: string, _attributes: object, callback: () => unknown) =>
+        callback(),
+    );
+    requireAuthMock.mockResolvedValue({ userId: "user-1" });
+  });
+
+  it("separates subscribed-homework reads without trace attributes", async () => {
+    getViewerContextMock.mockResolvedValue({ userId: "user-1" });
+    getSubscribedSectionIdsMock.mockResolvedValue([12]);
+    listSubscribedHomeworksMock.mockResolvedValue([{ id: "homework-1" }]);
+    listSubscribedHomeworkAuditLogsMock.mockResolvedValue([]);
+    withHomeworkItemStateMock.mockResolvedValue([{ id: "homework-1" }]);
+    const { getSubscribedHomeworksRoute } = await import(
+      "@/lib/api/routes/homework-subscribed-read-route"
+    );
+
+    const response = await getSubscribedHomeworksRoute(
+      new Request("https://example.test/api/workspace/homeworks"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      auditLogs: [],
+      homeworks: [{ id: "homework-1" }],
+      sectionIds: [12],
+      viewer: { userId: "user-1" },
+    });
+    expect(
+      runCloudflareTraceSpanMock.mock.calls.map(([name, attributes]) => [
+        name,
+        attributes,
+      ]),
+    ).toEqual([
+      ["workspace.homeworks.auth", {}],
+      ["workspace.homeworks.viewer", {}],
+      ["workspace.homeworks.section_ids", {}],
+      ["workspace.homeworks.read", {}],
+      ["workspace.homeworks.audit", {}],
+      ["workspace.homeworks.item_state", {}],
+    ]);
+  });
+
+  it("separates current-subscription auth from its read", async () => {
+    const subscription = { id: "subscription-1" };
+    getUserCalendarSubscriptionMock.mockResolvedValue(subscription);
+    const { getCurrentCalendarSubscriptionRoute } = await import(
+      "@/lib/api/routes/calendar-subscriptions"
+    );
+
+    const response = await getCurrentCalendarSubscriptionRoute(
+      new Request("https://example.test/api/workspace/subscriptions/current"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ subscription });
+    expect(
+      runCloudflareTraceSpanMock.mock.calls.map(([name, attributes]) => [
+        name,
+        attributes,
+      ]),
+    ).toEqual([
+      ["workspace.subscriptions.current.auth", {}],
+      ["workspace.subscriptions.current.read", {}],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- cache exact anonymous course, teacher, and section detail documents through the existing named-entrypoint PublicSsr gateway
- keep Cookie/Bearer, query-bearing, non-canonical, unknown-tab, data, action, and non-document requests on dynamic SSR
- preserve locale isolation and generate a fresh outer CSP nonce/request ID with `private, no-store`
- explicitly set `stale-if-error=0` so Cloudflare refresh failures cannot serve old public SSR indefinitely
- preload route code on hover but page data only on tap, avoiding uncached hover-only `__data.json` work
- skip description edit history on detail tabs that cannot render it
- add low-cardinality trace spans around the two synchronized workspace hotspots and overlap two independent homework reads

No API endpoint is added and authenticated reads remain uncached.

## Production evidence

In the complete post-v1.77.21 12-hour baseline:

- section detail tabs: 2,110 anonymous 200s, CPU avg/p50/p95 202.8/166/474 ms
- section overview: 1,968 anonymous 200s, CPU 206.3/169/520 ms
- all target detail requests: PublicSsr HIT 0
- workspace homeworks/subscription polling: exactly 12 calls/hour each, with a shared persistent ~20:00Z wall/I/O step tracked separately in #672

## Cache safety

Focused contracts cover canonical admission, Better Auth secure/default cookies, Bearer bypass, locale/cache keys, anonymous viewer/subscription/completion/reaction/moderation shape, private-comment filtering, and fresh outer response behavior. The cache retains the reviewed 60-second freshness + 300-second SWR window. Cloudflare's documented indefinite stale-on-error default is disabled explicitly.

## Verification

- Biome: 2,096 files
- Svelte check: 0 errors / 0 warnings
- all three TypeScript checks
- unit: 262 files / 1,627 tests
- integration: 239 passed / 13 skipped
- production build + OpenAPI sync
- E2E: 751 passed / 1 screenshot-only skip / 0 failed
- independent cache/auth/OpenAPI/SSR-hydration review: no findings

Refs #530
Refs #671
Refs #672
Closes #673