### PR TITLE
perf(catalog): remove duplicate detail payload work

### DIFF
--- a/src/features/catalog/server/course-page-data.ts
+++ b/src/features/catalog/server/course-page-data.ts
@@ -1,6 +1,5 @@
 import type { CourseDetailSection } from "@/features/catalog/components/catalog-detail-component-types";
 import { getPrisma } from "@/lib/db/prisma";
-import { toLoadData } from "@/lib/load-data-utils";
 import { resolveCourseIdByJwId } from "./course-jw-id";
 
 const coursePageSectionsSelect = {
@@ -77,9 +76,6 @@ export async function getCoursePage(
           nameSecondary: true,
         },
       },
-      description: {
-        select: { content: true, updatedAt: true, lastEditedAt: true },
-      },
       _count: { select: { sections: true } },
       sections:
         options.includeSections === false
@@ -94,11 +90,11 @@ export async function getCoursePage(
   if (!course) return null;
 
   const { _count, sections, ...data } = course;
-  return toLoadData({
+  return {
     ...data,
     sectionCount: _count.sections,
     sections: (options.includeSections === false
       ? []
       : sections) as unknown as CourseDetailSection[],
-  });
+  };
 }

--- a/src/features/catalog/server/course-page-data.ts
+++ b/src/features/catalog/server/course-page-data.ts
@@ -1,5 +1,6 @@
 import type { CourseDetailSection } from "@/features/catalog/components/catalog-detail-component-types";
 import { getPrisma } from "@/lib/db/prisma";
+import { toLoadData } from "@/lib/load-data-utils";
 import { resolveCourseIdByJwId } from "./course-jw-id";
 
 const coursePageSectionsSelect = {
@@ -90,11 +91,11 @@ export async function getCoursePage(
   if (!course) return null;
 
   const { _count, sections, ...data } = course;
-  return {
+  return toLoadData({
     ...data,
     sectionCount: _count.sections,
     sections: (options.includeSections === false
       ? []
       : sections) as unknown as CourseDetailSection[],
-  };
+  });
 }

--- a/src/features/catalog/server/teacher-page-data.ts
+++ b/src/features/catalog/server/teacher-page-data.ts
@@ -1,5 +1,6 @@
 import type { TeacherDetailSection } from "@/features/catalog/components/catalog-detail-component-types";
 import { getPrisma } from "@/lib/db/prisma";
+import { toLoadData } from "@/lib/load-data-utils";
 
 const teacherPageSectionsSelect = {
   jwId: true,
@@ -67,11 +68,11 @@ export async function getTeacherPage(
   if (!teacher) return null;
 
   const { _count, sections, ...data } = teacher;
-  return {
+  return toLoadData({
     ...data,
     sectionCount: _count.sections,
     sections: (options.includeSections === false
       ? []
       : sections) as unknown as TeacherDetailSection[],
-  };
+  });
 }

--- a/src/features/catalog/server/teacher-page-data.ts
+++ b/src/features/catalog/server/teacher-page-data.ts
@@ -1,6 +1,5 @@
 import type { TeacherDetailSection } from "@/features/catalog/components/catalog-detail-component-types";
 import { getPrisma } from "@/lib/db/prisma";
-import { toLoadData } from "@/lib/load-data-utils";
 
 const teacherPageSectionsSelect = {
   jwId: true,
@@ -51,9 +50,6 @@ export async function getTeacherPage(
           nameSecondary: true,
         },
       },
-      description: {
-        select: { content: true, updatedAt: true, lastEditedAt: true },
-      },
       _count: { select: { sections: true } },
       sections:
         options.includeSections === false
@@ -71,11 +67,11 @@ export async function getTeacherPage(
   if (!teacher) return null;
 
   const { _count, sections, ...data } = teacher;
-  return toLoadData({
+  return {
     ...data,
     sectionCount: _count.sections,
     sections: (options.includeSections === false
       ? []
       : sections) as unknown as TeacherDetailSection[],
-  });
+  };
 }

--- a/src/features/section-detail/lib/section-detail-controller-types.ts
+++ b/src/features/section-detail/lib/section-detail-controller-types.ts
@@ -78,7 +78,6 @@ export type SectionDetailSection = {
   limitCount?: number | null;
   machinePeriods?: number | null;
   openDepartment?: SectionDetailNamed | null;
-  otherSections?: SectionDetailRelatedSection[];
   period?: number | null;
   periodsPerWeek?: number | null;
   practicePeriods?: number | null;

--- a/src/features/section-detail/server/section-page-data.ts
+++ b/src/features/section-detail/server/section-page-data.ts
@@ -38,7 +38,6 @@ export async function getSectionPage(
   const relatedData =
     options.includeRelated === false
       ? {
-          otherSections: [],
           sameSemesterOtherTeachers: [],
           sameTeacherOtherSemesters: [],
         }

--- a/src/features/section-detail/server/section-page-related-data.ts
+++ b/src/features/section-detail/server/section-page-related-data.ts
@@ -69,7 +69,6 @@ export async function getSectionPageRelatedData({
     ]);
 
   return {
-    otherSections: [...sameSemesterOtherTeachers, ...sameTeacherOtherSemesters],
     sameSemesterOtherTeachers,
     sameTeacherOtherSemesters,
   };

--- a/src/features/section-detail/server/section-page-select.ts
+++ b/src/features/section-detail/server/section-page-select.ts
@@ -53,9 +53,6 @@ export const sectionPageSelect = {
   roomType: {
     select: localizedNameSelect,
   },
-  description: {
-    select: { content: true, updatedAt: true, lastEditedAt: true },
-  },
   teachers: {
     select: {
       ...entityNameSelect,

--- a/tests/unit/catalog-detail-page-data.test.ts
+++ b/tests/unit/catalog-detail-page-data.test.ts
@@ -49,13 +49,9 @@ describe("catalog detail page data", () => {
       sectionCount: 3,
       sections: [],
     });
-    expect(courseFindUniqueMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        select: expect.objectContaining({
-          sections: false,
-        }),
-      }),
-    );
+    const courseSelect = courseFindUniqueMock.mock.calls[0]?.[0]?.select;
+    expect(courseSelect).not.toHaveProperty("description");
+    expect(courseSelect?.sections).toBe(false);
     expect(result).not.toHaveProperty("commentCount");
     expect(result).not.toHaveProperty("latestComments");
   });
@@ -82,7 +78,39 @@ describe("catalog detail page data", () => {
       sectionCount: 2,
       sections: [],
     });
+    const teacherSelect = teacherFindUniqueMock.mock.calls[0]?.[0]?.select;
+    expect(teacherSelect).not.toHaveProperty("description");
+    expect(teacherSelect?.sections).toBe(false);
     expect(result).not.toHaveProperty("commentCount");
     expect(result).not.toHaveProperty("latestComments");
+  });
+
+  it("returns JSON-native section selections without a redundant deep copy", async () => {
+    const courseSections = [{ code: "001", jwId: 301 }];
+    courseFindManyMock.mockResolvedValue([{ aliases: [], id: 11, jwId: 101 }]);
+    courseFindUniqueMock.mockResolvedValue({
+      _count: { sections: 1 },
+      id: 11,
+      jwId: 101,
+      sections: courseSections,
+    });
+    const teacherSections = [{ code: "002", jwId: 302 }];
+    teacherFindUniqueMock.mockResolvedValue({
+      _count: { sections: 1 },
+      id: 21,
+      sections: teacherSections,
+    });
+
+    const [{ getCoursePage }, { getTeacherPage }] = await Promise.all([
+      import("@/features/catalog/server/course-page-data"),
+      import("@/features/catalog/server/teacher-page-data"),
+    ]);
+    const [courseResult, teacherResult] = await Promise.all([
+      getCoursePage(101),
+      getTeacherPage(21),
+    ]);
+
+    expect(courseResult?.sections).toBe(courseSections);
+    expect(teacherResult?.sections).toBe(teacherSections);
   });
 });

--- a/tests/unit/catalog-detail-page-data.test.ts
+++ b/tests/unit/catalog-detail-page-data.test.ts
@@ -85,19 +85,22 @@ describe("catalog detail page data", () => {
     expect(result).not.toHaveProperty("latestComments");
   });
 
-  it("returns JSON-native section selections without a redundant deep copy", async () => {
+  it("strips Prisma extension symbols before returning load data", async () => {
+    const localizedNameSymbol = Symbol("localizedName");
     const courseSections = [{ code: "001", jwId: 301 }];
     courseFindManyMock.mockResolvedValue([{ aliases: [], id: 11, jwId: 101 }]);
     courseFindUniqueMock.mockResolvedValue({
       _count: { sections: 1 },
       id: 11,
       jwId: 101,
+      [localizedNameSymbol]: "course",
       sections: courseSections,
     });
     const teacherSections = [{ code: "002", jwId: 302 }];
     teacherFindUniqueMock.mockResolvedValue({
       _count: { sections: 1 },
       id: 21,
+      [localizedNameSymbol]: "teacher",
       sections: teacherSections,
     });
 
@@ -110,7 +113,13 @@ describe("catalog detail page data", () => {
       getTeacherPage(21),
     ]);
 
-    expect(courseResult?.sections).toBe(courseSections);
-    expect(teacherResult?.sections).toBe(teacherSections);
+    expect(courseResult?.sections).toEqual(courseSections);
+    expect(teacherResult?.sections).toEqual(teacherSections);
+    expect(Reflect.ownKeys(courseResult ?? {})).not.toContain(
+      localizedNameSymbol,
+    );
+    expect(Reflect.ownKeys(teacherResult ?? {})).not.toContain(
+      localizedNameSymbol,
+    );
   });
 });

--- a/tests/unit/section-page-data-selection.test.ts
+++ b/tests/unit/section-page-data-selection.test.ts
@@ -34,22 +34,18 @@ describe("section page data selection", () => {
       includeSchedules: false,
     });
 
-    expect(sectionFindUnique).toHaveBeenCalledWith(
-      expect.objectContaining({
-        select: expect.objectContaining({
-          exams: false,
-          schedules: false,
-        }),
-      }),
-    );
+    const select = sectionFindUnique.mock.calls[0]?.[0]?.select;
+    expect(select).not.toHaveProperty("description");
+    expect(select?.exams).toBe(false);
+    expect(select?.schedules).toBe(false);
     expect(result).toMatchObject({
       examCount: 4,
       exams: [],
-      otherSections: [],
       sameSemesterOtherTeachers: [],
       sameTeacherOtherSemesters: [],
       scheduleCount: 18,
       schedules: [],
     });
+    expect(result).not.toHaveProperty("otherSections");
   });
 });

--- a/tests/unit/section-page-related-data.test.ts
+++ b/tests/unit/section-page-related-data.test.ts
@@ -39,6 +39,9 @@ describe("section page related data", () => {
         }),
       }),
     );
-    expect(result.otherSections).toEqual([{ id: 2 }, { id: 3 }]);
+    expect(result).toEqual({
+      sameSemesterOtherTeachers: [{ id: 2 }],
+      sameTeacherOtherSemesters: [{ id: 3 }],
+    });
   });
 });


### PR DESCRIPTION
## Goal

Remove code-proven duplicate query and payload work from catalog detail SSR. Closes #676.

## Changed Surfaces

- Course, teacher, and section base queries no longer select the description relation already returned through `descriptionData`.
- Section related data returns only the two categorized arrays consumed by the UI instead of serializing a combined duplicate.
- Course and teacher retain `toLoadData`: CI proved Prisma locale extensions attach symbolic keys that SvelteKit cannot serialize directly.
- Focused unit coverage locks the selected fields, related-data shape, and required symbolic-key sanitization.

## Evidence

- Full local gate after the CI fix: app prepare, Biome, Svelte check, all three TypeScript projects, and Vitest passed (262 files / 1,628 tests). Biome reports one pre-existing warning in `src/static-loader/import.ts`.
- Production build passed.
- Targeted Workerd/Playwright checks passed: course and teacher page contracts (2/2) plus all social metadata/JSON-LD scenarios (7/7).
- The first CI run found deterministic course/teacher 500s: SvelteKit reported `Cannot stringify POJOs with symbolic keys`. The unsafe direct-return optimization was reverted and a symbol-stripping regression test was added.
- A representative synthetic payload with a 4KiB description and 20 related sections shrank from 41,499 to 35,187 encoded bytes (6,312 bytes / 15.2%); exact savings depend on row/content size.
- Read-only consumer audit found no UI, SSR metadata, JSON-LD, REST, GraphQL, or MCP consumer of the removed description/duplicate-related fields.

## Docs / Contracts

No docs/contracts update: this changes only internal Prisma selections and duplicate page-load fields; user-visible behavior and public interfaces are unchanged.

## Risk Areas

Low. Auth, locale, cache admission, mutations, Prisma schema, migrations, and SvelteKit serialization semantics are unchanged. The required JSON sanitizer is now covered explicitly.

## Cleanup

The branch contains only the nine intentional source/test files. No generated output, scratch benchmark, screenshots, or unrelated rewrites are committed.