### PR TITLE
perf(catalog): canonicalize list queries

### DIFF
--- a/docs/rendering-and-cache.md
+++ b/docs/rendering-and-cache.md
@@ -24,6 +24,16 @@ without entering SvelteKit or the shared cache. Links, bus planner, community,
 and home pages stay dynamic because they still contain page-specific viewer
 behavior.
 
+Catalog list cache admission also requires one value per query key and the
+canonical non-empty value form. Empty controls emitted by the existing GET
+filter forms are removed from the internal cache key. Page 1 is omitted; later
+pages use a positive decimal up to 5,000. Search terms are trimmed and limited
+to 256 characters, section text filters to 128 characters, and ID filters use
+positive 32-bit decimals. Section sorts require an explicit `asc` or `desc`
+order, and numeric filters use their canonical decimal form. Other
+non-canonical requests continue through dynamic SSR, where the same
+normalization bounds database input and runtime cache keys.
+
 ## Request flow
 
 1. The default Worker entrypoint always receives the browser request. It

--- a/src/features/catalog/lib/catalog-list-query.ts
+++ b/src/features/catalog/lib/catalog-list-query.ts
@@ -1,0 +1,192 @@
+export const CATALOG_MAX_PAGE = 5_000;
+export const CATALOG_MAX_ID = 2_147_483_647;
+export const CATALOG_SEARCH_MAX_LENGTH = 256;
+export const CATALOG_TEXT_FILTER_MAX_LENGTH = 128;
+
+export type CatalogListPath =
+  | "/catalog/courses"
+  | "/catalog/sections"
+  | "/catalog/teachers";
+
+const COURSE_ID_KEYS = [
+  "categoryId",
+  "classTypeId",
+  "educationLevelId",
+] as const;
+const SECTION_ID_KEYS = [
+  "campusId",
+  "categoryId",
+  "classTypeId",
+  "departmentId",
+  "educationLevelId",
+  "semesterId",
+] as const;
+const SECTION_TEXT_KEYS = ["courseCode", "sectionCode", "teacher"] as const;
+const SECTION_SORT_VALUES = new Set([
+  "campus",
+  "capacity",
+  "code",
+  "course",
+  "credits",
+  "semester",
+  "teacher",
+]);
+
+const CATALOG_ALLOWED_QUERY_KEYS: Record<
+  CatalogListPath,
+  ReadonlySet<string>
+> = {
+  "/catalog/courses": new Set([...COURSE_ID_KEYS, "page", "search"]),
+  "/catalog/sections": new Set([
+    ...SECTION_ID_KEYS,
+    ...SECTION_TEXT_KEYS,
+    "credits",
+    "order",
+    "page",
+    "search",
+    "sort",
+  ]),
+  "/catalog/teachers": new Set(["departmentId", "page", "search"]),
+};
+
+const DECIMAL_INTEGER = /^\d+$/;
+const DECIMAL_NUMBER = /^\d+(?:\.\d+)?$/;
+
+export function isCatalogListPath(
+  pathname: string,
+): pathname is CatalogListPath {
+  return Object.hasOwn(CATALOG_ALLOWED_QUERY_KEYS, pathname);
+}
+
+function positiveDecimal(value: string | null, maximum: number) {
+  const trimmed = value?.trim();
+  if (!trimmed || !DECIMAL_INTEGER.test(trimmed)) return undefined;
+
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > maximum) {
+    return undefined;
+  }
+  return String(parsed);
+}
+
+function boundedPage(value: string | null) {
+  const trimmed = value?.trim();
+  if (!trimmed || !DECIMAL_INTEGER.test(trimmed)) return undefined;
+
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return undefined;
+  return String(Math.min(parsed, CATALOG_MAX_PAGE));
+}
+
+function boundedText(value: string | null, maximumLength: number) {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return trimmed.slice(0, maximumLength);
+}
+
+function decimalNumber(value: string | null) {
+  const trimmed = value?.trim();
+  if (!trimmed || !DECIMAL_NUMBER.test(trimmed)) return undefined;
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) return undefined;
+  const canonical = String(parsed);
+  return DECIMAL_NUMBER.test(canonical) ? canonical : undefined;
+}
+
+function setNormalized(
+  result: URLSearchParams,
+  key: string,
+  value: string | undefined,
+) {
+  if (value !== undefined) result.set(key, value);
+}
+
+export function normalizeCatalogListQuery(
+  pathname: CatalogListPath,
+  searchParams: URLSearchParams,
+) {
+  const normalized = new URLSearchParams();
+  const page = boundedPage(searchParams.get("page"));
+  if (page !== "1") setNormalized(normalized, "page", page);
+  setNormalized(
+    normalized,
+    "search",
+    boundedText(searchParams.get("search"), CATALOG_SEARCH_MAX_LENGTH),
+  );
+
+  if (pathname === "/catalog/courses") {
+    for (const key of COURSE_ID_KEYS) {
+      setNormalized(
+        normalized,
+        key,
+        positiveDecimal(searchParams.get(key), CATALOG_MAX_ID),
+      );
+    }
+  } else if (pathname === "/catalog/teachers") {
+    setNormalized(
+      normalized,
+      "departmentId",
+      positiveDecimal(searchParams.get("departmentId"), CATALOG_MAX_ID),
+    );
+  } else {
+    for (const key of SECTION_ID_KEYS) {
+      setNormalized(
+        normalized,
+        key,
+        positiveDecimal(searchParams.get(key), CATALOG_MAX_ID),
+      );
+    }
+    for (const key of SECTION_TEXT_KEYS) {
+      setNormalized(
+        normalized,
+        key,
+        boundedText(searchParams.get(key), CATALOG_TEXT_FILTER_MAX_LENGTH),
+      );
+    }
+    setNormalized(
+      normalized,
+      "credits",
+      decimalNumber(searchParams.get("credits")),
+    );
+
+    const requestedSort = searchParams.get("sort")?.trim().toLowerCase();
+    if (requestedSort && SECTION_SORT_VALUES.has(requestedSort)) {
+      normalized.set("sort", requestedSort);
+      normalized.set(
+        "order",
+        searchParams.get("order")?.trim() === "desc" ? "desc" : "asc",
+      );
+    }
+  }
+
+  normalized.sort();
+  return normalized;
+}
+
+export function isCacheableCatalogListQuery(
+  pathname: CatalogListPath,
+  searchParams: URLSearchParams,
+) {
+  const allowedKeys = CATALOG_ALLOWED_QUERY_KEYS[pathname];
+  const seen = new Set<string>();
+  const received = new URLSearchParams();
+  for (const [key, value] of searchParams) {
+    if (!allowedKeys.has(key) || seen.has(key)) return false;
+    seen.add(key);
+    if (value !== "") received.set(key, value);
+  }
+
+  received.sort();
+  return (
+    received.toString() ===
+    normalizeCatalogListQuery(pathname, searchParams).toString()
+  );
+}
+
+export function resolveCatalogListPublicSsrMode(url: URL) {
+  if (!isCatalogListPath(url.pathname)) return undefined;
+  return isCacheableCatalogListQuery(url.pathname, url.searchParams)
+    ? ("page" as const)
+    : null;
+}

--- a/src/features/catalog/server/public-course-list-data.ts
+++ b/src/features/catalog/server/public-course-list-data.ts
@@ -1,3 +1,4 @@
+import { normalizeCatalogListQuery } from "@/features/catalog/lib/catalog-list-query";
 import { CATALOG_PAGE_SIZE } from "@/features/catalog/server/catalog-page-constants";
 import { listCourseSummaries } from "@/features/catalog/server/course-section-queries";
 import { type AppLocale, DEFAULT_LOCALE } from "@/i18n/config";
@@ -19,24 +20,26 @@ export async function getCourseListPage(
   url: URL,
   locale: AppLocale = DEFAULT_LOCALE,
 ) {
+  const searchParams = normalizeCatalogListQuery(
+    "/catalog/courses",
+    url.searchParams,
+  );
   return cachedPublicRuntimeData(
-    publicRuntimeCacheKey(`course-list:${locale}`, url.searchParams),
+    publicRuntimeCacheKey(`page:course-list:${locale}`, searchParams),
     COURSE_LIST_CACHE_TTL_MS,
-    () => getUncachedCourseListPage(url, locale),
+    () => getUncachedCourseListPage(searchParams, locale),
   );
 }
 
 async function getUncachedCourseListPage(
-  url: URL,
+  searchParams: URLSearchParams,
   locale: AppLocale = DEFAULT_LOCALE,
 ) {
-  const page = parsePositivePage(url.searchParams.get("page"));
-  const search = optionalValue(url.searchParams.get("search"));
-  const educationLevelId = optionalValue(
-    url.searchParams.get("educationLevelId"),
-  );
-  const categoryId = optionalValue(url.searchParams.get("categoryId"));
-  const classTypeId = optionalValue(url.searchParams.get("classTypeId"));
+  const page = parsePositivePage(searchParams.get("page"));
+  const search = optionalValue(searchParams.get("search"));
+  const educationLevelId = optionalValue(searchParams.get("educationLevelId"));
+  const categoryId = optionalValue(searchParams.get("categoryId"));
+  const classTypeId = optionalValue(searchParams.get("classTypeId"));
   const prisma = getPrisma(locale);
 
   const [result, educationLevels, categories, classTypes, messages] =

--- a/src/features/catalog/server/public-section-list-data.ts
+++ b/src/features/catalog/server/public-section-list-data.ts
@@ -1,3 +1,4 @@
+import { normalizeCatalogListQuery } from "@/features/catalog/lib/catalog-list-query";
 import { CATALOG_PAGE_SIZE } from "@/features/catalog/server/catalog-page-constants";
 import { listSectionSummaries } from "@/features/catalog/server/course-section-queries";
 import { type AppLocale, DEFAULT_LOCALE } from "@/i18n/config";
@@ -19,35 +20,39 @@ export async function getSectionListPage(
   url: URL,
   locale: AppLocale = DEFAULT_LOCALE,
 ) {
+  const searchParams = normalizeCatalogListQuery(
+    "/catalog/sections",
+    url.searchParams,
+  );
   return cachedPublicRuntimeData(
-    publicRuntimeCacheKey(`section-list:${locale}`, url.searchParams),
+    publicRuntimeCacheKey(`page:section-list:${locale}`, searchParams),
     SECTION_LIST_CACHE_TTL_MS,
-    () => getUncachedSectionListPage(url, locale),
+    () => getUncachedSectionListPage(searchParams, locale),
   );
 }
 
 async function getUncachedSectionListPage(
-  url: URL,
+  searchParams: URLSearchParams,
   locale: AppLocale = DEFAULT_LOCALE,
 ) {
-  const page = parsePositivePage(url.searchParams.get("page"));
-  const orderParam = optionalValue(url.searchParams.get("order"));
+  const page = parsePositivePage(searchParams.get("page"));
+  const orderParam = optionalValue(searchParams.get("order"));
   const order: "asc" | "desc" | undefined =
     orderParam === "asc" || orderParam === "desc" ? orderParam : undefined;
   const filters = {
-    campusId: optionalValue(url.searchParams.get("campusId")),
-    categoryId: optionalValue(url.searchParams.get("categoryId")),
-    classTypeId: optionalValue(url.searchParams.get("classTypeId")),
-    courseCode: optionalValue(url.searchParams.get("courseCode")),
-    credits: optionalValue(url.searchParams.get("credits")),
-    departmentId: optionalValue(url.searchParams.get("departmentId")),
-    educationLevelId: optionalValue(url.searchParams.get("educationLevelId")),
+    campusId: optionalValue(searchParams.get("campusId")),
+    categoryId: optionalValue(searchParams.get("categoryId")),
+    classTypeId: optionalValue(searchParams.get("classTypeId")),
+    courseCode: optionalValue(searchParams.get("courseCode")),
+    credits: optionalValue(searchParams.get("credits")),
+    departmentId: optionalValue(searchParams.get("departmentId")),
+    educationLevelId: optionalValue(searchParams.get("educationLevelId")),
     order,
-    search: optionalValue(url.searchParams.get("search")),
-    sectionCode: optionalValue(url.searchParams.get("sectionCode")),
-    semesterId: optionalValue(url.searchParams.get("semesterId")),
-    sort: optionalValue(url.searchParams.get("sort")),
-    teacher: optionalValue(url.searchParams.get("teacher")),
+    search: optionalValue(searchParams.get("search")),
+    sectionCode: optionalValue(searchParams.get("sectionCode")),
+    semesterId: optionalValue(searchParams.get("semesterId")),
+    sort: optionalValue(searchParams.get("sort")),
+    teacher: optionalValue(searchParams.get("teacher")),
   };
   const prisma = getPrisma(locale);
 

--- a/src/features/catalog/server/public-teacher-list-data.ts
+++ b/src/features/catalog/server/public-teacher-list-data.ts
@@ -1,3 +1,4 @@
+import { normalizeCatalogListQuery } from "@/features/catalog/lib/catalog-list-query";
 import { paginatedTeacherQuery } from "@/features/catalog/server/academic-paginated-queries";
 import { CATALOG_PAGE_SIZE } from "@/features/catalog/server/catalog-page-constants";
 import { buildTeacherWhere } from "@/features/catalog/server/teacher-query";
@@ -16,17 +17,24 @@ import {
 const TEACHER_LIST_CACHE_TTL_MS = 60_000;
 
 export async function getTeacherListPage(url: URL, locale = "zh-cn") {
+  const searchParams = normalizeCatalogListQuery(
+    "/catalog/teachers",
+    url.searchParams,
+  );
   return cachedPublicRuntimeData(
-    publicRuntimeCacheKey(`teacher-list:${locale}`, url.searchParams),
+    publicRuntimeCacheKey(`page:teacher-list:${locale}`, searchParams),
     TEACHER_LIST_CACHE_TTL_MS,
-    () => getUncachedTeacherListPage(url, locale),
+    () => getUncachedTeacherListPage(searchParams, locale),
   );
 }
 
-async function getUncachedTeacherListPage(url: URL, locale = "zh-cn") {
-  const page = parsePositivePage(url.searchParams.get("page"));
-  const search = optionalValue(url.searchParams.get("search"));
-  const departmentId = optionalValue(url.searchParams.get("departmentId"));
+async function getUncachedTeacherListPage(
+  searchParams: URLSearchParams,
+  locale = "zh-cn",
+) {
+  const page = parsePositivePage(searchParams.get("page"));
+  const search = optionalValue(searchParams.get("search"));
+  const departmentId = optionalValue(searchParams.get("departmentId"));
   const where = buildTeacherWhere({ departmentId, search });
 
   const prisma = getPrisma(locale);

--- a/src/lib/cloudflare/public-ssr-gateway.ts
+++ b/src/lib/cloudflare/public-ssr-gateway.ts
@@ -13,6 +13,9 @@ export const PUBLIC_SSR_PAGE_EDGE_CACHE_CONTROL =
 
 export type PublicSsrMode = "page" | "not-found";
 export type PublicSsrLocale = "en-us" | "zh-cn";
+export type PublicSsrRouteResolver = (
+  url: URL,
+) => PublicSsrMode | null | undefined;
 
 const STATIC_PUBLIC_PATHS = new Set([
   "/catalog/bus/map",
@@ -30,33 +33,6 @@ const DIRECT_REQUEST_PATHS = new Set([
   "/robots.txt",
   "/sitemap.xml",
 ]);
-
-const CATALOG_QUERY_KEYS: Record<string, ReadonlySet<string>> = {
-  "/catalog/courses": new Set([
-    "categoryId",
-    "classTypeId",
-    "educationLevelId",
-    "page",
-    "search",
-  ]),
-  "/catalog/sections": new Set([
-    "campusId",
-    "categoryId",
-    "classTypeId",
-    "courseCode",
-    "credits",
-    "departmentId",
-    "educationLevelId",
-    "order",
-    "page",
-    "search",
-    "sectionCode",
-    "semesterId",
-    "sort",
-    "teacher",
-  ]),
-  "/catalog/teachers": new Set(["departmentId", "page", "search"]),
-};
 
 const CATALOG_DETAIL_PATH =
   /^\/catalog\/(courses|sections|teachers)\/([1-9]\d*)(?:\/([^/]+))?$/;
@@ -108,10 +84,6 @@ function acceptsHtml(request: Request) {
   );
 }
 
-function hasOnlyAllowedQuery(url: URL, allowed: ReadonlySet<string>) {
-  return Array.from(url.searchParams.keys()).every((key) => allowed.has(key));
-}
-
 function isCanonicalCatalogDetailPath(pathname: string) {
   const match = CATALOG_DETAIL_PATH.exec(pathname);
   if (!match) return false;
@@ -121,17 +93,18 @@ function isCanonicalCatalogDetailPath(pathname: string) {
   return !section || CATALOG_DETAIL_SECTIONS[collection]?.has(section) === true;
 }
 
-export function resolvePublicSsrMode(request: Request): PublicSsrMode | null {
+export function resolvePublicSsrMode(
+  request: Request,
+  resolveFeatureRoute?: PublicSsrRouteResolver,
+): PublicSsrMode | null {
   if (request.method !== "GET" && request.method !== "HEAD") return null;
   if (!acceptsHtml(request)) return null;
 
   const url = new URL(request.url);
   if (url.pathname.endsWith("/__data.json")) return null;
 
-  const catalogQueryKeys = CATALOG_QUERY_KEYS[url.pathname];
-  if (catalogQueryKeys) {
-    return hasOnlyAllowedQuery(url, catalogQueryKeys) ? "page" : null;
-  }
+  const featureMode = resolveFeatureRoute?.(url);
+  if (featureMode !== undefined) return featureMode;
 
   if (isCanonicalCatalogDetailPath(url.pathname)) {
     return !url.search && !hasRequestAuthSignal(request.headers)

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,6 +1,11 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import svelteKitWorker from "life-ustc-sveltekit-worker";
 import {
+  isCatalogListPath,
+  normalizeCatalogListQuery,
+  resolveCatalogListPublicSsrMode,
+} from "./features/catalog/lib/catalog-list-query";
+import {
   buildPublicNotFoundHtml,
   PUBLIC_SSR_BROWSER_CACHE_CONTROL,
   PUBLIC_SSR_HEADER,
@@ -129,8 +134,11 @@ function directRequest(request) {
 
 function publicSsrRequest(request, mode, locale) {
   const url = new URL(request.url);
-  const canonicalQuery = new URLSearchParams();
-  if (mode === "page") {
+  const catalogListPath = isCatalogListPath(url.pathname);
+  const canonicalQuery = catalogListPath
+    ? normalizeCatalogListQuery(url.pathname, url.searchParams)
+    : new URLSearchParams();
+  if (mode === "page" && !catalogListPath) {
     for (const key of Array.from(new Set(url.searchParams.keys())).sort()) {
       const value = url.searchParams.get(key);
       if (value !== null) canonicalQuery.set(key, value);
@@ -184,7 +192,7 @@ export default {
         },
       });
     }
-    const mode = resolvePublicSsrMode(request);
+    const mode = resolvePublicSsrMode(request, resolveCatalogListPublicSsrMode);
     if (!mode) return app.fetch(directRequest(request), env, context);
 
     const locale = resolvePublicSsrLocale(request);

--- a/tests/unit/catalog-list-query.test.ts
+++ b/tests/unit/catalog-list-query.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "vitest";
+import {
+  CATALOG_MAX_ID,
+  CATALOG_MAX_PAGE,
+  CATALOG_SEARCH_MAX_LENGTH,
+  CATALOG_TEXT_FILTER_MAX_LENGTH,
+  isCacheableCatalogListQuery,
+  normalizeCatalogListQuery,
+} from "@/features/catalog/lib/catalog-list-query";
+
+describe("catalog list query normalization", () => {
+  test("normalizes direct course loader input to bounded canonical values", () => {
+    const search = "x".repeat(CATALOG_SEARCH_MAX_LENGTH + 20);
+    const normalized = normalizeCatalogListQuery(
+      "/catalog/courses",
+      new URLSearchParams(
+        `page=999999&search=%20${search}%20&categoryId=0007&unknown=value`,
+      ),
+    );
+
+    expect(normalized.get("page")).toBe(String(CATALOG_MAX_PAGE));
+    expect(normalized.get("search")).toBe(
+      "x".repeat(CATALOG_SEARCH_MAX_LENGTH),
+    );
+    expect(normalized.get("categoryId")).toBe("7");
+    expect(normalized.has("unknown")).toBe(false);
+  });
+
+  test("normalizes section text, numeric, sort, and order values", () => {
+    const normalized = normalizeCatalogListQuery(
+      "/catalog/sections",
+      new URLSearchParams({
+        campusId: String(CATALOG_MAX_ID + 1),
+        courseCode: `  ${"C".repeat(CATALOG_TEXT_FILTER_MAX_LENGTH + 5)}  `,
+        credits: "02.50",
+        order: "asc",
+        semesterId: "0003",
+        sort: "CREDITS",
+      }),
+    );
+
+    expect(normalized.get("campusId")).toBeNull();
+    expect(normalized.get("courseCode")).toBe(
+      "C".repeat(CATALOG_TEXT_FILTER_MAX_LENGTH),
+    );
+    expect(normalized.get("credits")).toBe("2.5");
+    expect(normalized.get("semesterId")).toBe("3");
+    expect(normalized.get("sort")).toBe("credits");
+    expect(normalized.get("order")).toBe("asc");
+  });
+
+  test("uses the first duplicate value for uncached loader normalization", () => {
+    const normalized = normalizeCatalogListQuery(
+      "/catalog/teachers",
+      new URLSearchParams("departmentId=0007&departmentId=8"),
+    );
+
+    expect(normalized.toString()).toBe("departmentId=7");
+  });
+});
+
+describe("catalog list shared-cache admission", () => {
+  test.each([
+    ["/catalog/courses", ""],
+    ["/catalog/courses", "search=data+science&page=2&categoryId=7"],
+    ["/catalog/courses", "search=&educationLevelId=&categoryId=&classTypeId="],
+    ["/catalog/sections", "semesterId=3&credits=2.5&sort=credits&order=asc"],
+    [
+      "/catalog/sections",
+      "search=&semesterId=3&teacher=&courseCode=&sectionCode=&campusId=&departmentId=&credits=&categoryId=&educationLevelId=&classTypeId=&sort=",
+    ],
+    ["/catalog/teachers", `departmentId=${CATALOG_MAX_ID}&page=5000`],
+  ] as const)("accepts canonical %s query %s", (pathname, query) => {
+    expect(
+      isCacheableCatalogListQuery(pathname, new URLSearchParams(query)),
+    ).toBe(true);
+  });
+
+  test.each([
+    ["/catalog/courses", "search=math&search=physics"],
+    ["/catalog/courses", "unknown=value"],
+    ["/catalog/courses", "page=1"],
+    ["/catalog/courses", "page=01"],
+    ["/catalog/courses", "page=5001"],
+    ["/catalog/courses", "search=%20math"],
+    ["/catalog/courses", `search=${"x".repeat(CATALOG_SEARCH_MAX_LENGTH + 1)}`],
+    ["/catalog/courses", "categoryId=01"],
+    ["/catalog/courses", `categoryId=${CATALOG_MAX_ID + 1}`],
+    ["/catalog/teachers", "departmentId=0"],
+    ["/catalog/sections", "courseCode=%20MATH"],
+    [
+      "/catalog/sections",
+      `teacher=${"x".repeat(CATALOG_TEXT_FILTER_MAX_LENGTH + 1)}`,
+    ],
+    ["/catalog/sections", "credits=02.50"],
+    ["/catalog/sections", "credits=2e0"],
+    ["/catalog/sections", "sort=credits"],
+    ["/catalog/sections", "sort=CREDITS&order=asc"],
+    ["/catalog/sections", "sort=unknown&order=asc"],
+    ["/catalog/sections", "order=desc"],
+  ] as const)("rejects non-canonical %s query %s", (pathname, query) => {
+    expect(
+      isCacheableCatalogListQuery(pathname, new URLSearchParams(query)),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/public-catalog-list-data.test.ts
+++ b/tests/unit/public-catalog-list-data.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  CATALOG_MAX_PAGE,
+  CATALOG_SEARCH_MAX_LENGTH,
+  CATALOG_TEXT_FILTER_MAX_LENGTH,
+} from "@/features/catalog/lib/catalog-list-query";
+import { getCourseListPage } from "@/features/catalog/server/public-course-list-data";
+import { getSectionListPage } from "@/features/catalog/server/public-section-list-data";
+import { getTeacherListPage } from "@/features/catalog/server/public-teacher-list-data";
+
+const mocks = vi.hoisted(() => {
+  const findMany = vi.fn().mockResolvedValue([]);
+  return {
+    cache: vi.fn((_key: string, _ttlMs: number, load: () => Promise<unknown>) =>
+      load(),
+    ),
+    findMany,
+    listCourseSummaries: vi.fn().mockResolvedValue({
+      data: [],
+      pagination: { page: 1, total: 0, totalPages: 0 },
+    }),
+    listSectionSummaries: vi.fn().mockResolvedValue({
+      data: [],
+      pagination: { page: 1, total: 0, totalPages: 0 },
+    }),
+    paginatedTeacherQuery: vi.fn().mockResolvedValue({
+      data: [],
+      pagination: { page: 1, total: 0, totalPages: 0 },
+    }),
+  };
+});
+
+vi.mock("@/lib/public-runtime-cache", () => ({
+  cachedPublicRuntimeData: mocks.cache,
+  publicRuntimeCacheKey: (prefix: string, params: URLSearchParams) =>
+    `${prefix}:${params.toString()}`,
+}));
+
+vi.mock("@/features/catalog/server/course-section-queries", () => ({
+  listCourseSummaries: mocks.listCourseSummaries,
+  listSectionSummaries: mocks.listSectionSummaries,
+}));
+
+vi.mock("@/features/catalog/server/academic-paginated-queries", () => ({
+  paginatedTeacherQuery: mocks.paginatedTeacherQuery,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  getPrisma: () => ({
+    campus: { findMany: mocks.findMany },
+    classType: { findMany: mocks.findMany },
+    courseCategory: { findMany: mocks.findMany },
+    department: { findMany: mocks.findMany },
+    educationLevel: { findMany: mocks.findMany },
+    semester: { findMany: mocks.findMany },
+  }),
+}));
+
+vi.mock("@/i18n/messages.server", () => ({
+  getMessages: vi.fn().mockResolvedValue({
+    common: {},
+    courses: {},
+    sectionDetail: { close: "close" },
+    sections: {},
+    teachers: {},
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("public catalog list loaders", () => {
+  test("bounds course page/search and keys the runtime cache by normalized values", async () => {
+    const search = "x".repeat(CATALOG_SEARCH_MAX_LENGTH + 20);
+    const firstUrl = new URL(
+      `https://life-ustc.test/catalog/courses?page=999999&search=%20${search}%20&categoryId=0007&unknown=value`,
+    );
+    const canonicalUrl = new URL(
+      `https://life-ustc.test/catalog/courses?categoryId=7&page=${CATALOG_MAX_PAGE}&search=${"x".repeat(CATALOG_SEARCH_MAX_LENGTH)}`,
+    );
+
+    await getCourseListPage(firstUrl);
+    await getCourseListPage(canonicalUrl);
+
+    expect(mocks.listCourseSummaries).toHaveBeenNthCalledWith(1, {
+      filters: {
+        categoryId: "7",
+        classTypeId: undefined,
+        educationLevelId: undefined,
+        search: "x".repeat(CATALOG_SEARCH_MAX_LENGTH),
+      },
+      locale: "zh-cn",
+      pagination: { page: CATALOG_MAX_PAGE, pageSize: 20 },
+    });
+    expect(mocks.cache.mock.calls[0]?.[0]).toBe(mocks.cache.mock.calls[1]?.[0]);
+    expect(mocks.cache.mock.calls[0]?.[0]).toMatch(/^page:course-list:zh-cn:/);
+  });
+
+  test("bounds teacher page/search and canonicalizes the ID before querying", async () => {
+    const search = "t".repeat(CATALOG_SEARCH_MAX_LENGTH + 1);
+    await getTeacherListPage(
+      new URL(
+        `https://life-ustc.test/catalog/teachers?page=999999&search=${search}&departmentId=0007`,
+      ),
+    );
+
+    expect(mocks.paginatedTeacherQuery).toHaveBeenCalledWith(
+      CATALOG_MAX_PAGE,
+      20,
+      expect.objectContaining({ departmentId: 7 }),
+      { nameCn: "asc" },
+      "zh-cn",
+    );
+    expect(mocks.cache.mock.calls[0]?.[0]).toContain(
+      `page=${CATALOG_MAX_PAGE}`,
+    );
+    expect(mocks.cache.mock.calls[0]?.[0]).toContain(
+      `search=${"t".repeat(CATALOG_SEARCH_MAX_LENGTH)}`,
+    );
+    expect(mocks.cache.mock.calls[0]?.[0]).toMatch(/^page:teacher-list:zh-cn:/);
+  });
+
+  test("bounds section input and queries from the normalized runtime key", async () => {
+    const search = "s".repeat(CATALOG_SEARCH_MAX_LENGTH + 1);
+    const teacher = "t".repeat(CATALOG_TEXT_FILTER_MAX_LENGTH + 1);
+    await getSectionListPage(
+      new URL(
+        `https://life-ustc.test/catalog/sections?page=999999&search=${search}&teacher=${teacher}&courseCode=%20MATH%20&semesterId=0003&campusId=2147483648&credits=02.50&sort=CREDITS&order=asc`,
+      ),
+    );
+
+    expect(mocks.listSectionSummaries).toHaveBeenCalledWith({
+      filters: {
+        campusId: undefined,
+        categoryId: undefined,
+        classTypeId: undefined,
+        courseCode: "MATH",
+        credits: "2.5",
+        departmentId: undefined,
+        educationLevelId: undefined,
+        order: "asc",
+        search: "s".repeat(CATALOG_SEARCH_MAX_LENGTH),
+        sectionCode: undefined,
+        semesterId: "3",
+        sort: "credits",
+        teacher: "t".repeat(CATALOG_TEXT_FILTER_MAX_LENGTH),
+      },
+      locale: "zh-cn",
+      pagination: { page: CATALOG_MAX_PAGE, pageSize: 20 },
+    });
+    expect(mocks.cache.mock.calls[0]?.[0]).not.toContain("campusId");
+    expect(mocks.cache.mock.calls[0]?.[0]).toContain("courseCode=MATH");
+    expect(mocks.cache.mock.calls[0]?.[0]).toContain("credits=2.5");
+    expect(mocks.cache.mock.calls[0]?.[0]).toMatch(/^page:section-list:zh-cn:/);
+  });
+});

--- a/tests/unit/public-ssr-gateway.test.ts
+++ b/tests/unit/public-ssr-gateway.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, test } from "vitest";
+import { resolveCatalogListPublicSsrMode } from "@/features/catalog/lib/catalog-list-query";
 import {
   buildPublicNotFoundHtml,
   PUBLIC_SSR_BROWSER_CACHE_CONTROL,
   PUBLIC_SSR_PAGE_EDGE_CACHE_CONTROL,
+  resolvePublicSsrMode as resolveBasePublicSsrMode,
   resolveLegacyCatalogRedirect,
   resolvePublicSsrLocale,
-  resolvePublicSsrMode,
 } from "@/lib/cloudflare/public-ssr-gateway";
+
+function resolvePublicSsrMode(request: Request) {
+  return resolveBasePublicSsrMode(request, resolveCatalogListPublicSsrMode);
+}
 
 function request(path: string, headers: HeadersInit = {}) {
   return new Request(`https://life-ustc.test${path}`, {
@@ -43,7 +48,11 @@ describe("public SSR gateway", () => {
   test.each([
     "/catalog/courses",
     "/catalog/courses?page=2&search=math",
+    "/catalog/courses?page=5000&categoryId=7",
+    "/catalog/courses?search=&educationLevelId=&categoryId=7&classTypeId=",
     "/catalog/sections?semesterId=301&teacher=Li",
+    "/catalog/sections?credits=2.5&sort=credits&order=asc",
+    "/catalog/sections?semesterId=301&teacher=&courseCode=&sectionCode=&campusId=&departmentId=&credits=&categoryId=&educationLevelId=&classTypeId=&sort=",
     "/catalog/teachers?departmentId=1",
     "/catalog/bus/map",
     "/api-docs",
@@ -98,6 +107,14 @@ describe("public SSR gateway", () => {
     "/catalog/courses/11145/__data.json",
     "/catalog/courses?unknown=value",
     "/catalog/courses?__life_locale=en-us",
+    "/catalog/courses?page=1",
+    "/catalog/courses?page=5001",
+    "/catalog/courses?page=2&page=3",
+    "/catalog/courses?search=%20math",
+    "/catalog/courses?categoryId=01",
+    "/catalog/sections?sort=credits",
+    "/catalog/sections?sort=unknown&order=asc",
+    "/catalog/teachers?departmentId=0",
     "/catalog/sections/159446/unknown",
     "/catalog/teachers/not-an-id",
     "/community/users/example",


### PR DESCRIPTION
## Summary

- define one canonical query grammar for public course, section, and teacher list pages
- bound page, search, IDs, section text, numeric filters, and sort values before database work
- reject duplicate and non-canonical shared-cache values while collapsing safe empty GET form controls into one canonical edge key
- key the runtime data cache from normalized parameters with low-cardinality page namespaces
- document and test gateway, Worker cache-key, and direct-loader behavior

No endpoint, auth boundary, locale behavior, or database schema changes.

## Evidence

Production has 4,460 courses, 3,421 teachers, and 29,240 active sections. At 20 rows per page, the current maxima are 223, 172, and 1,462 pages. The 5,000-page cap still provides more than 3.4x headroom over the largest catalog while preventing arbitrary OFFSET work and cache-key fragmentation.

Existing GET filter forms submit empty successful controls. These values are removed only from the internal cache key; duplicate, whitespace, invalid, non-canonical, or out-of-bound non-empty values still bypass shared HTML caching and are bounded by the loader normalizer.

## Verification

- `bun run app:prepare`
- `bunx biome check` (one pre-existing static-loader warning)
- `bunx svelte-check --tsconfig ./tsconfig.json` (0/0)
- all three TypeScript project checks
- Vitest: 264 files, 1,670 tests
- production build
- focused query/gateway/loader tests: 105

Closes #675