### PR TITLE
perf(catalog): reuse anonymous detail core data

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -62,7 +62,8 @@ high-cardinality resource IDs.
   `graphql_operation_v2`) preserve this explicit meaning.
 - Public runtime cache datapoints use explicit, low-cardinality resource
   namespaces. Full cache keys, including search and filter values, never enter
-  the Analytics Engine writer.
+  the Analytics Engine writer. Catalog detail cache namespaces likewise omit
+  entity IDs.
 
 ## Endpoints
 

--- a/docs/rendering-and-cache.md
+++ b/docs/rendering-and-cache.md
@@ -54,6 +54,12 @@ normalization bounds database input and runtime cache keys.
    cache. Unknown routes instead return a small script-free, private/no-store
    response directly, so scanners do not render or hydrate the full application
    shell and cannot populate attacker-controlled high-cardinality cache keys.
+   Inside this trusted anonymous entrypoint, catalog detail loaders also coalesce
+   public entity core reads for 60 seconds per entity and locale. Course and
+   teacher section-list shapes, section calendar/exam shapes, nulls, and failures
+   are not retained. Section overview related-course queries stay outside the
+   core cache, as do all viewer, description, comment, homework, and subscription
+   reads. Dynamic and authenticated SSR never use this runtime detail cache.
 4. The default entrypoint rewrites the cached CSP nonce placeholder and request
    ID for every browser response, then marks that outer response private and
    no-store so zone rules cannot bypass the gateway. Raw session headers never

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -6,6 +6,7 @@ declare global {
     interface Locals {
       authUser: AppSession["user"] | null;
       locale: AppLocale;
+      publicSsr: boolean;
       requestId: string;
     }
   }

--- a/src/features/catalog/server/catalog-detail-page-server.ts
+++ b/src/features/catalog/server/catalog-detail-page-server.ts
@@ -8,6 +8,7 @@ import {
 import { getCoursePage } from "@/features/catalog/server/course-page-data";
 import { getTeacherPage } from "@/features/catalog/server/teacher-page-data";
 import { getViewerContext } from "@/lib/auth/viewer-context";
+import { cachedPublicRuntimeData } from "@/lib/public-runtime-cache";
 import {
   buildSocialMetadata,
   formatSocialMetadataMessage,
@@ -36,6 +37,8 @@ const catalogDetailRouteSections = new Set([
   "comments",
 ]);
 
+const PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS = 60_000;
+
 function resolveCatalogDetailRouteSection(
   section: string | undefined,
 ): CourseDetailRouteSection | null {
@@ -60,10 +63,19 @@ export async function loadCourseDetailPage({
   if (!detailSection) error(404, copy.notFound.description);
   const jwId = Number(params.jwId);
   if (!Number.isInteger(jwId)) error(404, copy.notFound.description);
+  const includeSections = detailSection === "sections";
+  const loadCourse = () =>
+    getCoursePage(jwId, locals.locale, { includeSections });
   const [course, viewer] = await Promise.all([
-    getCoursePage(jwId, locals.locale, {
-      includeSections: detailSection === "sections",
-    }),
+    locals.publicSsr && !locals.authUser && !includeSections
+      ? cachedPublicRuntimeData(
+          `page:course-detail:${locals.locale}`,
+          `catalog-detail:course:${locals.locale}:${jwId}`,
+          PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS,
+          loadCourse,
+          { shouldCacheResult: (result) => result !== null },
+        )
+      : loadCourse(),
     getViewerContext({ userId: locals.authUser?.id ?? null }),
   ]);
   if (!course) error(404, copy.notFound.description);
@@ -130,10 +142,19 @@ export async function loadTeacherDetailPage({
   if (!detailSection) error(404, copy.notFound.description);
   const id = Number(params.id);
   if (!Number.isInteger(id)) error(404, copy.notFound.description);
+  const includeSections = detailSection === "sections";
+  const loadTeacher = () =>
+    getTeacherPage(id, locals.locale, { includeSections });
   const [teacher, viewer] = await Promise.all([
-    getTeacherPage(id, locals.locale, {
-      includeSections: detailSection === "sections",
-    }),
+    locals.publicSsr && !locals.authUser && !includeSections
+      ? cachedPublicRuntimeData(
+          `page:teacher-detail:${locals.locale}`,
+          `catalog-detail:teacher:${locals.locale}:${id}`,
+          PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS,
+          loadTeacher,
+          { shouldCacheResult: (result) => result !== null },
+        )
+      : loadTeacher(),
     getViewerContext({ userId: locals.authUser?.id ?? null }),
   ]);
   if (!teacher) error(404, copy.notFound.description);

--- a/src/features/section-detail/server/section-detail-page-server.ts
+++ b/src/features/section-detail/server/section-detail-page-server.ts
@@ -7,7 +7,11 @@ import {
   formatMessage,
   primaryName,
 } from "@/features/section-detail/lib/display";
-import { getSectionPage } from "@/features/section-detail/server/section-page-data";
+import {
+  getSectionPage,
+  withSectionPageRelatedData,
+} from "@/features/section-detail/server/section-page-data";
+import { cachedPublicRuntimeData } from "@/lib/public-runtime-cache";
 import {
   buildSocialMetadata,
   formatSocialMetadataMessage,
@@ -41,6 +45,8 @@ const sectionDetailRouteSections = new Set([
   "comments",
 ]);
 
+const PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS = 60_000;
+
 function resolveSectionDetailRouteSection(
   section: string | undefined,
 ): SectionDetailRouteSection | null {
@@ -65,12 +71,32 @@ export async function loadSectionDetailPage({
   const jwId = parseSectionJwId(params.jwId);
   if (jwId === null) error(404, "Section not found");
   const userId = locals.authUser?.id ?? null;
-  const section = await getSectionPage(jwId, locals.locale, {
-    includeExams: detailSection === "calendar" || detailSection === "exams",
-    includeRelated: detailSection === "overview",
-    includeSchedules: detailSection === "calendar",
-  });
-  if (!section) error(404, "Section not found");
+  const includeExams =
+    detailSection === "calendar" || detailSection === "exams";
+  const includeRelated = detailSection === "overview";
+  const includeSchedules = detailSection === "calendar";
+  const cachePublicCore =
+    locals.publicSsr && !userId && !includeExams && !includeSchedules;
+  const loadSection = () =>
+    getSectionPage(jwId, locals.locale, {
+      includeExams,
+      includeRelated: cachePublicCore ? false : includeRelated,
+      includeSchedules,
+    });
+  const sectionCore = cachePublicCore
+    ? await cachedPublicRuntimeData(
+        `page:section-detail:${locals.locale}`,
+        `catalog-detail:section:${locals.locale}:${jwId}`,
+        PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS,
+        loadSection,
+        { shouldCacheResult: (result) => result !== null },
+      )
+    : await loadSection();
+  if (!sectionCore) error(404, "Section not found");
+  const section =
+    cachePublicCore && includeRelated
+      ? await withSectionPageRelatedData(sectionCore, locals.locale)
+      : sectionCore;
   const copy = getSectionDetailPageCopy(locals.locale);
   const courseName = primaryName(section.course) || section.code;
   const [subscriptionState, descriptionAndComments, homeworkData] =

--- a/src/features/section-detail/server/section-page-data.ts
+++ b/src/features/section-detail/server/section-page-data.ts
@@ -57,3 +57,12 @@ export async function getSectionPage(
 
   return buildSectionPageLoadData(normalizedSection, relatedData);
 }
+
+export async function withSectionPageRelatedData(
+  section: NonNullable<Awaited<ReturnType<typeof getSectionPage>>>,
+  locale = "zh-cn",
+) {
+  const prisma = getPrisma(locale);
+  const relatedData = await getSectionPageRelatedData({ prisma, section });
+  return buildSectionPageLoadData(section, relatedData);
+}

--- a/src/features/section-detail/server/section-page-data.ts
+++ b/src/features/section-detail/server/section-page-data.ts
@@ -5,6 +5,7 @@ import {
 } from "@/features/section-detail/server/section-page-shape";
 import type { Prisma } from "@/generated/prisma/client";
 import { getPrisma } from "@/lib/db/prisma";
+import { toLoadData } from "@/lib/load-data-utils";
 
 type SectionPageRecord = Prisma.SectionGetPayload<{
   select: typeof sectionPageSelect;
@@ -64,5 +65,5 @@ export async function withSectionPageRelatedData(
 ) {
   const prisma = getPrisma(locale);
   const relatedData = await getSectionPageRelatedData({ prisma, section });
-  return buildSectionPageLoadData(section, relatedData);
+  return { ...section, ...toLoadData(relatedData) };
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -17,6 +17,7 @@ import { hasRequestAuthSignal } from "@/lib/auth/request-auth-signal";
 import {
   PUBLIC_SSR_HEADER,
   PUBLIC_SSR_LOCALE_HEADER,
+  PUBLIC_SSR_MODE_HEADER,
   PUBLIC_SSR_NONCE_PLACEHOLDER,
 } from "@/lib/cloudflare/public-ssr-gateway";
 import {
@@ -167,8 +168,11 @@ function oauthAuthorizeFormActionSources(url: URL) {
 }
 
 const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
-  const publicSsr = event.request.headers.get(PUBLIC_SSR_HEADER) === "1";
   const publicSsrLocale = event.request.headers.get(PUBLIC_SSR_LOCALE_HEADER);
+  const publicSsr =
+    event.request.headers.get(PUBLIC_SSR_HEADER) === "1" &&
+    event.request.headers.get(PUBLIC_SSR_MODE_HEADER) === "page" &&
+    (publicSsrLocale === "en-us" || publicSsrLocale === "zh-cn");
   const locale =
     publicSsr && (publicSsrLocale === "en-us" || publicSsrLocale === "zh-cn")
       ? publicSsrLocale
@@ -186,6 +190,7 @@ const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
   });
   const startMs = Date.now();
   const hasAuthSignal = hasRequestAuthSignal(event.request.headers);
+  event.locals.publicSsr = publicSsr && !hasAuthSignal;
   const apiObservability = prepareApiObservability(
     event.request,
     event.url.pathname,

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -74,8 +74,11 @@ export type PublicRuntimeCacheAnalyticsNamespace =
       | "api:courses"
       | "api:sections"
       | "api:teachers"
+      | "page:course-detail"
       | "page:course-list"
+      | "page:section-detail"
       | "page:section-list"
+      | "page:teacher-detail"
       | "page:teacher-list"}:${AppLocale}`;
 
 type CacheEventAnalyticsInput = {

--- a/src/lib/public-runtime-cache.ts
+++ b/src/lib/public-runtime-cache.ts
@@ -8,6 +8,10 @@ type CacheEntry<T> = {
   value: Promise<T>;
 };
 
+type PublicRuntimeCacheOptions<T> = {
+  shouldCacheResult?: (result: T) => boolean;
+};
+
 const MAX_ENTRIES = 100;
 
 const globalForPublicRuntimeCache = globalThis as typeof globalThis & {
@@ -35,6 +39,16 @@ function pruneOldest(store: Map<string, CacheEntry<unknown>>) {
   }
 }
 
+function deleteCurrentEntry(
+  store: Map<string, CacheEntry<unknown>>,
+  key: string,
+  value: Promise<unknown>,
+) {
+  if (store.get(key)?.value === value) {
+    store.delete(key);
+  }
+}
+
 export function publicRuntimeCacheKey(
   prefix: string,
   searchParams: URLSearchParams,
@@ -49,6 +63,7 @@ export function cachedPublicRuntimeData<T>(
   key: string,
   ttlMs: number,
   load: () => Promise<T>,
+  options: PublicRuntimeCacheOptions<T> = {},
 ): Promise<T> {
   const now = Date.now();
   const start = Date.now();
@@ -74,8 +89,12 @@ export function cachedPublicRuntimeData<T>(
     storeSize: store.size,
     ttlMs,
   });
-  const value = load()
+  let value: Promise<T>;
+  value = load()
     .then((result) => {
+      if (options.shouldCacheResult && !options.shouldCacheResult(result)) {
+        deleteCurrentEntry(store, key, value);
+      }
       writeCacheEventAnalytics({
         event: "load_success",
         ioObservedDurationMs: Date.now() - start,
@@ -86,7 +105,7 @@ export function cachedPublicRuntimeData<T>(
       return result;
     })
     .catch((error) => {
-      store.delete(key);
+      deleteCurrentEntry(store, key, value);
       writeCacheEventAnalytics({
         event: "load_error",
         ioObservedDurationMs: Date.now() - start,

--- a/tests/unit/analytics-engine-runtime-events.test.ts
+++ b/tests/unit/analytics-engine-runtime-events.test.ts
@@ -250,6 +250,11 @@ describe("Cloudflare Analytics Engine runtime events", () => {
       namespace: "api:sections:en-us" as const,
       surface: "section API",
     },
+    {
+      key: "catalog-detail:course:en-us:679123",
+      namespace: "page:course-detail:en-us" as const,
+      surface: "catalog detail core",
+    },
   ])("writes explicit $surface cache namespaces without raw query cache keys", async ({
     key,
     namespace,

--- a/tests/unit/auth-page-action-logging.test.ts
+++ b/tests/unit/auth-page-action-logging.test.ts
@@ -71,6 +71,7 @@ describe("auth page action logging", () => {
       locals: {
         authUser: null,
         locale: "zh-cn",
+        publicSsr: false,
         requestId: "request-1",
       },
       request: new Request("https://life.example/signin", {

--- a/tests/unit/detail-page-loader-critical-path.test.ts
+++ b/tests/unit/detail-page-loader-critical-path.test.ts
@@ -12,6 +12,7 @@ const {
   getTeacherPageMock,
   getUserSectionSubscriptionStateMock,
   getViewerContextMock,
+  withSectionPageRelatedDataMock,
 } = vi.hoisted(() => ({
   getCommentsPayloadMock: vi.fn(),
   getCoursePageMock: vi.fn(),
@@ -22,6 +23,7 @@ const {
   getTeacherPageMock: vi.fn(),
   getUserSectionSubscriptionStateMock: vi.fn(),
   getViewerContextMock: vi.fn(),
+  withSectionPageRelatedDataMock: vi.fn(),
 }));
 
 vi.mock("@/app-env", () => ({
@@ -52,6 +54,7 @@ vi.mock("@/features/descriptions/server/descriptions-server", () => ({
 
 vi.mock("@/features/section-detail/server/section-page-data", () => ({
   getSectionPage: getSectionPageMock,
+  withSectionPageRelatedData: withSectionPageRelatedDataMock,
 }));
 
 vi.mock(
@@ -129,10 +132,15 @@ const signedInUser = {
   username: "user",
 };
 
-function locals(authUser: App.Locals["authUser"] = null): App.Locals {
+function locals(
+  authUser: App.Locals["authUser"] = null,
+  publicSsr = false,
+  locale: App.Locals["locale"] = "en-us",
+): App.Locals {
   return {
     authUser,
-    locale: "en-us",
+    locale,
+    publicSsr,
     requestId: "detail-loader-test",
   };
 }
@@ -142,6 +150,11 @@ function request(path: string) {
 }
 
 beforeEach(() => {
+  delete (
+    globalThis as typeof globalThis & {
+      __lifeUstcPublicRuntimeCache?: unknown;
+    }
+  ).__lifeUstcPublicRuntimeCache;
   vi.clearAllMocks();
   getCommentsPayloadMock.mockResolvedValue({
     comments: [],
@@ -164,6 +177,9 @@ beforeEach(() => {
     subscriptionIcsUrl: null,
   });
   getViewerContextMock.mockResolvedValue(anonymousViewer);
+  withSectionPageRelatedDataMock.mockImplementation(
+    async (value: typeof section) => value,
+  );
 });
 
 describe("catalog detail loader critical path", () => {
@@ -248,6 +264,116 @@ describe("catalog detail loader critical path", () => {
       anonymousViewer,
       { includeHistory: true },
     );
+  });
+
+  it("coalesces the same anonymous PublicSsr course core across default and introduction tabs", async () => {
+    let resolveCourse: ((value: typeof course) => void) | undefined;
+    getCoursePageMock.mockReturnValue(
+      new Promise<typeof course>((resolve) => {
+        resolveCourse = resolve;
+      }),
+    );
+    const { loadCourseDetailPage } = await import(
+      "@/features/catalog/server/catalog-detail-page-server"
+    );
+
+    const overview = loadCourseDetailPage({
+      locals: locals(null, true),
+      params: { jwId: String(course.jwId) },
+      request: request(`/catalog/courses/${course.jwId}`),
+      url: new URL(`https://example.test/catalog/courses/${course.jwId}`),
+    });
+    const introduction = loadCourseDetailPage({
+      locals: locals(null, true),
+      params: { jwId: String(course.jwId), section: "introduction" },
+      request: request(`/catalog/courses/${course.jwId}/introduction`),
+      url: new URL(
+        `https://example.test/catalog/courses/${course.jwId}/introduction`,
+      ),
+    });
+
+    await vi.waitFor(() => expect(getCoursePageMock).toHaveBeenCalledOnce());
+    resolveCourse?.(course);
+    await Promise.all([overview, introduction]);
+
+    expect(getCoursePageMock).toHaveBeenCalledWith(course.jwId, "en-us", {
+      includeSections: false,
+    });
+  });
+
+  it("separates public detail core entries by locale and entity", async () => {
+    getCoursePageMock.mockImplementation(async (jwId: number) => ({
+      ...course,
+      id: jwId,
+      jwId,
+    }));
+    const { loadCourseDetailPage } = await import(
+      "@/features/catalog/server/catalog-detail-page-server"
+    );
+    const load = (jwId: number, locale: App.Locals["locale"]) =>
+      loadCourseDetailPage({
+        locals: locals(null, true, locale),
+        params: { jwId: String(jwId) },
+        request: request(`/catalog/courses/${jwId}`),
+        url: new URL(`https://example.test/catalog/courses/${jwId}`),
+      });
+
+    await load(course.jwId, "en-us");
+    await load(course.jwId, "zh-cn");
+    await load(course.jwId + 1, "en-us");
+    await load(course.jwId, "en-us");
+
+    expect(getCoursePageMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("caches the final anonymous PublicSsr teacher core but bypasses the sections shape", async () => {
+    const { loadTeacherDetailPage } = await import(
+      "@/features/catalog/server/catalog-detail-page-server"
+    );
+    const load = (section?: "sections") =>
+      loadTeacherDetailPage({
+        locals: locals(null, true),
+        params: { id: String(teacher.id), section },
+        request: request(
+          `/catalog/teachers/${teacher.id}${section ? `/${section}` : ""}`,
+        ),
+        url: new URL(
+          `https://example.test/catalog/teachers/${teacher.id}${section ? `/${section}` : ""}`,
+        ),
+      });
+
+    await load();
+    await load();
+    await load("sections");
+    await load("sections");
+
+    expect(getTeacherPageMock).toHaveBeenCalledTimes(3);
+    expect(getTeacherPageMock).toHaveBeenNthCalledWith(1, teacher.id, "en-us", {
+      includeSections: false,
+    });
+    expect(getTeacherPageMock).toHaveBeenNthCalledWith(2, teacher.id, "en-us", {
+      includeSections: true,
+    });
+  });
+
+  it("bypasses public detail core caching for default dynamic and authenticated SSR", async () => {
+    const { loadCourseDetailPage } = await import(
+      "@/features/catalog/server/catalog-detail-page-server"
+    );
+    const load = (loadLocals: App.Locals) =>
+      loadCourseDetailPage({
+        locals: loadLocals,
+        params: { jwId: String(course.jwId) },
+        request: request(`/catalog/courses/${course.jwId}`),
+        url: new URL(`https://example.test/catalog/courses/${course.jwId}`),
+      });
+
+    await load(locals());
+    await load(locals());
+    await load(locals(signedInUser, true));
+    await load(locals(signedInUser, true));
+
+    expect(getCoursePageMock).toHaveBeenCalledTimes(4);
   });
 
   it("skips comments outside the teacher comments section", async () => {
@@ -341,6 +467,21 @@ describe("detail request session resolution", () => {
     expect(response.status).toBe(200);
     expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
     expect(getViewerContextMock).toHaveBeenCalledWith({ userId: null });
+  });
+
+  it("enables the core cache only for the internal anonymous PublicSsr marker", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    const publicSsrHeaders = {
+      "x-life-public-ssr": "1",
+      "x-life-public-ssr-locale": "en-us",
+      "x-life-public-ssr-mode": "page",
+    };
+
+    await resolveCourseThroughHook(publicSsrHeaders);
+    await resolveCourseThroughHook(publicSsrHeaders);
+
+    expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
+    expect(getCoursePageMock).toHaveBeenCalledOnce();
   });
 });
 
@@ -455,5 +596,59 @@ describe("section detail loader critical path", () => {
     });
     expect(getCommentsPayloadMock).not.toHaveBeenCalled();
     expect(getSectionHomeworkDataMock).not.toHaveBeenCalled();
+  });
+
+  it("caches the anonymous PublicSsr section core but always loads overview related data outside it", async () => {
+    const relatedSection = {
+      ...section,
+      sameSemesterOtherTeachers: [{ id: 32 }],
+      sameTeacherOtherSemesters: [],
+    };
+    withSectionPageRelatedDataMock.mockResolvedValue(relatedSection);
+    const { loadSectionDetailPage } = await import(
+      "@/features/section-detail/server/section-detail-page-server"
+    );
+    const load = () =>
+      loadSectionDetailPage({
+        locals: locals(null, true),
+        params: { jwId: String(section.jwId) },
+        request: request(`/catalog/sections/${section.jwId}`),
+        url: new URL(`https://example.test/catalog/sections/${section.jwId}`),
+      });
+
+    const [first, second] = await Promise.all([load(), load()]);
+
+    expect(getSectionPageMock).toHaveBeenCalledOnce();
+    expect(getSectionPageMock).toHaveBeenCalledWith(section.jwId, "en-us", {
+      includeExams: false,
+      includeRelated: false,
+      includeSchedules: false,
+    });
+    expect(withSectionPageRelatedDataMock).toHaveBeenCalledTimes(2);
+    expect(first.section).toBe(relatedSection);
+    expect(second.section).toBe(relatedSection);
+  });
+
+  it.each([
+    "calendar",
+    "exams",
+  ] as const)("does not cache the section %s tab shape", async (detailSection) => {
+    const { loadSectionDetailPage } = await import(
+      "@/features/section-detail/server/section-detail-page-server"
+    );
+    const load = () =>
+      loadSectionDetailPage({
+        locals: locals(null, true),
+        params: { jwId: String(section.jwId), section: detailSection },
+        request: request(`/catalog/sections/${section.jwId}/${detailSection}`),
+        url: new URL(
+          `https://example.test/catalog/sections/${section.jwId}/${detailSection}`,
+        ),
+      });
+
+    await load();
+    await load();
+
+    expect(getSectionPageMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/page-request-lifecycle.test.ts
+++ b/tests/unit/page-request-lifecycle.test.ts
@@ -55,6 +55,7 @@ function handleInput(
     locals: {
       authUser: null,
       locale: "zh-cn",
+      publicSsr: false,
       requestId: "",
     },
     params: {},

--- a/tests/unit/public-runtime-cache.test.ts
+++ b/tests/unit/public-runtime-cache.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cachedPublicRuntimeData } from "@/lib/public-runtime-cache";
+
+function clearPublicRuntimeCache() {
+  delete (
+    globalThis as typeof globalThis & {
+      __lifeUstcPublicRuntimeCache?: unknown;
+    }
+  ).__lifeUstcPublicRuntimeCache;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("public runtime cache", () => {
+  beforeEach(() => {
+    clearPublicRuntimeCache();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    clearPublicRuntimeCache();
+    vi.useRealTimers();
+  });
+
+  it("returns one in-flight promise for concurrent callers of the same key", async () => {
+    const pending = deferred<{ source: string }>();
+    const load = vi.fn(() => pending.promise);
+
+    const first = cachedPublicRuntimeData(
+      "api:metadata",
+      "same-key",
+      60_000,
+      load,
+    );
+    const second = cachedPublicRuntimeData(
+      "api:metadata",
+      "same-key",
+      60_000,
+      load,
+    );
+
+    expect(first).toBe(second);
+    await Promise.resolve();
+    expect(load).toHaveBeenCalledOnce();
+    pending.resolve({ source: "shared" });
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { source: "shared" },
+      { source: "shared" },
+    ]);
+  });
+
+  it("does not retain null results", async () => {
+    const load = vi.fn(async () => null);
+    const options = { shouldCacheResult: (result: null) => result !== null };
+
+    await cachedPublicRuntimeData(
+      "api:metadata",
+      "nullable",
+      60_000,
+      load,
+      options,
+    );
+    await cachedPublicRuntimeData(
+      "api:metadata",
+      "nullable",
+      60_000,
+      load,
+      options,
+    );
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let an expired null load delete its successor", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const expired = deferred<{ source: string } | null>();
+    const successor = deferred<{ source: string } | null>();
+    const options = {
+      shouldCacheResult: (result: { source: string } | null) => result !== null,
+    };
+
+    const first = cachedPublicRuntimeData(
+      "api:metadata",
+      "null-race",
+      60_000,
+      () => expired.promise,
+      options,
+    );
+    await Promise.resolve();
+    vi.setSystemTime(60_001);
+    const second = cachedPublicRuntimeData(
+      "api:metadata",
+      "null-race",
+      60_000,
+      () => successor.promise,
+      options,
+    );
+    await Promise.resolve();
+
+    expired.resolve(null);
+    await expect(first).resolves.toBeNull();
+    successor.resolve({ source: "successor" });
+    await expect(second).resolves.toEqual({ source: "successor" });
+    await expect(
+      cachedPublicRuntimeData(
+        "api:metadata",
+        "null-race",
+        60_000,
+        vi.fn(async () => ({ source: "unexpected" })),
+        options,
+      ),
+    ).resolves.toEqual({ source: "successor" });
+  });
+
+  it("does not let an expired failed load delete its successor", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const expired = deferred<{ source: string }>();
+    const successor = deferred<{ source: string }>();
+
+    const first = cachedPublicRuntimeData(
+      "api:metadata",
+      "error-race",
+      60_000,
+      () => expired.promise,
+    );
+    const firstResult = expect(first).rejects.toThrow("expired failure");
+    await Promise.resolve();
+    vi.setSystemTime(60_001);
+    const second = cachedPublicRuntimeData(
+      "api:metadata",
+      "error-race",
+      60_000,
+      () => successor.promise,
+    );
+    await Promise.resolve();
+
+    expired.reject(new Error("expired failure"));
+    await firstResult;
+    successor.resolve({ source: "successor" });
+    await expect(second).resolves.toEqual({ source: "successor" });
+    await expect(
+      cachedPublicRuntimeData(
+        "api:metadata",
+        "error-race",
+        60_000,
+        vi.fn(async () => ({ source: "unexpected" })),
+      ),
+    ).resolves.toEqual({ source: "successor" });
+  });
+});

--- a/tests/unit/section-page-data-selection.test.ts
+++ b/tests/unit/section-page-data-selection.test.ts
@@ -1,18 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { sectionFindUnique } = vi.hoisted(() => ({
+const { sectionFindMany, sectionFindUnique } = vi.hoisted(() => ({
+  sectionFindMany: vi.fn(),
   sectionFindUnique: vi.fn(),
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
   getPrisma: () => ({
-    section: { findUnique: sectionFindUnique },
+    section: {
+      findMany: sectionFindMany,
+      findUnique: sectionFindUnique,
+    },
   }),
 }));
 
 describe("section page data selection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sectionFindMany.mockResolvedValue([]);
     sectionFindUnique.mockResolvedValue({
       _count: { exams: 4, schedules: 18 },
       courseId: 10,
@@ -71,5 +76,55 @@ describe("section page data selection", () => {
     });
 
     expect(Reflect.ownKeys(result ?? {})).not.toContain(localizedNameSymbol);
+  });
+
+  it("sanitizes only related data when merging it into an already clean base", async () => {
+    const localizedNameSymbol = Symbol("localizedName");
+    sectionFindUnique.mockResolvedValue({
+      _count: { exams: 4, schedules: 18 },
+      course: { id: 10, jwId: 100, namePrimary: "Calculus" },
+      courseId: 10,
+      exams: [],
+      id: 20,
+      schedules: [],
+      semesterId: 20261,
+      teachers: [],
+    });
+    sectionFindMany.mockResolvedValue([
+      {
+        code: "002",
+        id: 21,
+        jwId: 31,
+        semester: {
+          endDate: new Date("2026-07-01T00:00:00.000Z"),
+          nameCn: "2026春",
+          startDate: new Date("2026-02-01T00:00:00.000Z"),
+        },
+        semesterId: 20261,
+        teachers: [],
+        [localizedNameSymbol]: "related section",
+      },
+    ]);
+    const { getSectionPage, withSectionPageRelatedData } = await import(
+      "@/features/section-detail/server/section-page-data"
+    );
+    const base = await getSectionPage(30, "zh-cn", {
+      includeExams: false,
+      includeRelated: false,
+      includeSchedules: false,
+    });
+    if (!base) throw new Error("expected section base");
+
+    const result = await withSectionPageRelatedData(base, "zh-cn");
+    const related = result.sameSemesterOtherTeachers[0];
+
+    expect(result).not.toBe(base);
+    expect(result.course).toBe(base.course);
+    expect(result.teachers).toBe(base.teachers);
+    expect(result.exams).toBe(base.exams);
+    expect(result.schedules).toBe(base.schedules);
+    expect(related?.semester?.startDate).toBe("2026-02-01T00:00:00.000Z");
+    expect(related?.semester?.endDate).toBe("2026-07-01T00:00:00.000Z");
+    expect(Reflect.ownKeys(related ?? {})).not.toContain(localizedNameSymbol);
   });
 });

--- a/tests/unit/section-page-data-selection.test.ts
+++ b/tests/unit/section-page-data-selection.test.ts
@@ -48,4 +48,28 @@ describe("section page data selection", () => {
     });
     expect(result).not.toHaveProperty("otherSections");
   });
+
+  it("returns a JSON-clean base shape before it can enter the public cache", async () => {
+    const localizedNameSymbol = Symbol("localizedName");
+    sectionFindUnique.mockResolvedValue({
+      _count: { exams: 4, schedules: 18 },
+      courseId: 10,
+      exams: [],
+      id: 20,
+      schedules: [],
+      teachers: [],
+      [localizedNameSymbol]: "section",
+    });
+    const { getSectionPage } = await import(
+      "@/features/section-detail/server/section-page-data"
+    );
+
+    const result = await getSectionPage(30, "zh-cn", {
+      includeExams: false,
+      includeRelated: false,
+      includeSchedules: false,
+    });
+
+    expect(Reflect.ownKeys(result ?? {})).not.toContain(localizedNameSymbol);
+  });
 });


### PR DESCRIPTION
## Summary

Production attribution found catalog detail roots account for 28,309/29,108ms (97.25%) of sampled root CPU in the complete six-hour window. Whole-document reuse is low because tabs are high-cardinality, but those tabs repeat the same public entity core.

This change:

- coalesces and retains JSON-clean catalog detail core values for 60 seconds only inside the trusted anonymous `PublicSsr` entrypoint
- caches course/teacher only when `includeSections=false`
- caches section base only when exams and schedules are not requested; overview related-section data remains outside the core cache
- bypasses dynamic/authenticated SSR and all viewer, subscription, description, comment, homework, calendar, exam, and section-list shapes
- coalesces concurrent null/error loads but does not retain them, with promise-identity eviction so an expired old load cannot delete its successor
- emits explicit low-cardinality analytics namespaces without entity IDs
- avoids re-sanitizing the already JSON-clean Section core when related overview data is merged

Closes #678.

## Verification

- `bun run app:prepare`
- `bunx biome check` (one pre-existing static-loader warning)
- `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors / 0 warnings
- all three TypeScript typecheck configs
- `bunx vitest run` — 265 files / 1686 tests
- `bun run build`
- `bunx wrangler deploy --dry-run`

Focused tests cover concurrent coalescing, locale/entity isolation, auth/dynamic/shape bypass, null/error races, JSON symbol removal, Date conversion, related-data placement, and the no-second-roundtrip Section merge. No endpoint, database schema, public API, whole-document TTL, or authorization behavior changes. Realized reuse remains isolate/PoP/locale dependent and will be measured after deployment.