### PR TITLE
perf(catalog): share anonymous detail core across isolates

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -63,7 +63,10 @@ high-cardinality resource IDs.
 - Public runtime cache datapoints use explicit, low-cardinality resource
   namespaces. Full cache keys, including search and filter values, never enter
   the Analytics Engine writer. Catalog detail cache namespaces likewise omit
-  entity IDs.
+  entity IDs. Detail L2 outcomes use fixed `colo_hit`, `colo_miss`,
+  `colo_read_error`, `colo_write_complete`, and `colo_write_error` events; the
+  synthetic Cache API key is never recorded. A completed write only confirms
+  that Cache API processing finished; a later `colo_hit` proves admission.
 
 ## Endpoints
 

--- a/docs/rendering-and-cache.md
+++ b/docs/rendering-and-cache.md
@@ -54,12 +54,20 @@ normalization bounds database input and runtime cache keys.
    cache. Unknown routes instead return a small script-free, private/no-store
    response directly, so scanners do not render or hydrate the full application
    shell and cannot populate attacker-controlled high-cardinality cache keys.
-   Inside this trusted anonymous entrypoint, catalog detail loaders also coalesce
-   public entity core reads for 60 seconds per entity and locale. Course and
-   teacher section-list shapes, section calendar/exam shapes, nulls, and failures
-   are not retained. Section overview related-course queries stay outside the
-   core cache, as do all viewer, description, comment, homework, and subscription
+   Inside this trusted anonymous entrypoint, catalog detail loaders first
+   coalesce public entity core reads in the current isolate, then use a
+   versioned named Cache API entry to share the same result with other isolates
+   in the handling Cloudflare data center. Both layers use the same absolute
+   60-second expiry, so refilling the isolate cache cannot extend stale data.
+   The synthetic key includes entity kind, reviewed data shape, locale, ID, and
+   schema version, but is never fetched as an application endpoint. Cache API
+   failures fall through to the database. Course and teacher section-list
+   shapes, section calendar/exam/related shapes, nulls, and failures are not
+   retained. Section overview related-course queries stay outside the core
+   cache, as do all viewer, description, comment, homework, and subscription
    reads. Dynamic and authenticated SSR never use this runtime detail cache.
+   Named Cache API entries are data-center-local and do not replicate across
+   locations or participate in Tiered Cache.
 4. The default entrypoint rewrites the cached CSP nonce placeholder and request
    ID for every browser response, then marks that outer response private and
    no-store so zone rules cannot bypass the gateway. Raw session headers never

--- a/src/features/catalog/server/catalog-detail-page-server.ts
+++ b/src/features/catalog/server/catalog-detail-page-server.ts
@@ -8,7 +8,10 @@ import {
 import { getCoursePage } from "@/features/catalog/server/course-page-data";
 import { getTeacherPage } from "@/features/catalog/server/teacher-page-data";
 import { getViewerContext } from "@/lib/auth/viewer-context";
-import { cachedPublicRuntimeData } from "@/lib/public-runtime-cache";
+import {
+  cachedPublicRuntimeData,
+  publicDetailColoCacheKey,
+} from "@/lib/public-runtime-cache";
 import {
   buildSocialMetadata,
   formatSocialMetadataMessage,
@@ -38,6 +41,34 @@ const catalogDetailRouteSections = new Set([
 ]);
 
 const PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS = 60_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function isPublicCourseCore(value: unknown, jwId: number) {
+  return (
+    isRecord(value) &&
+    typeof value.id === "number" &&
+    value.jwId === jwId &&
+    typeof value.code === "string" &&
+    typeof value.namePrimary === "string" &&
+    typeof value.sectionCount === "number" &&
+    Array.isArray(value.sections) &&
+    value.sections.length === 0
+  );
+}
+
+function isPublicTeacherCore(value: unknown, id: number) {
+  return (
+    isRecord(value) &&
+    value.id === id &&
+    typeof value.namePrimary === "string" &&
+    typeof value.sectionCount === "number" &&
+    Array.isArray(value.sections) &&
+    value.sections.length === 0
+  );
+}
 
 function resolveCatalogDetailRouteSection(
   section: string | undefined,
@@ -73,7 +104,17 @@ export async function loadCourseDetailPage({
           `catalog-detail:course:${locals.locale}:${jwId}`,
           PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS,
           loadCourse,
-          { shouldCacheResult: (result) => result !== null },
+          {
+            coloCacheKey: publicDetailColoCacheKey(
+              url.origin,
+              "course",
+              locals.locale,
+              jwId,
+            ),
+            shouldCacheResult: (result) => result !== null,
+            validateColoCacheResult: (result) =>
+              isPublicCourseCore(result, jwId),
+          },
         )
       : loadCourse(),
     getViewerContext({ userId: locals.authUser?.id ?? null }),
@@ -152,7 +193,17 @@ export async function loadTeacherDetailPage({
           `catalog-detail:teacher:${locals.locale}:${id}`,
           PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS,
           loadTeacher,
-          { shouldCacheResult: (result) => result !== null },
+          {
+            coloCacheKey: publicDetailColoCacheKey(
+              url.origin,
+              "teacher",
+              locals.locale,
+              id,
+            ),
+            shouldCacheResult: (result) => result !== null,
+            validateColoCacheResult: (result) =>
+              isPublicTeacherCore(result, id),
+          },
         )
       : loadTeacher(),
     getViewerContext({ userId: locals.authUser?.id ?? null }),

--- a/src/features/section-detail/server/section-detail-page-server.ts
+++ b/src/features/section-detail/server/section-detail-page-server.ts
@@ -11,7 +11,10 @@ import {
   getSectionPage,
   withSectionPageRelatedData,
 } from "@/features/section-detail/server/section-page-data";
-import { cachedPublicRuntimeData } from "@/lib/public-runtime-cache";
+import {
+  cachedPublicRuntimeData,
+  publicDetailColoCacheKey,
+} from "@/lib/public-runtime-cache";
 import {
   buildSocialMetadata,
   formatSocialMetadataMessage,
@@ -46,6 +49,40 @@ const sectionDetailRouteSections = new Set([
 ]);
 
 const PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS = 60_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function isEmptyArray(value: unknown) {
+  return Array.isArray(value) && value.length === 0;
+}
+
+function isPublicSectionCore(value: unknown, jwId: number) {
+  return (
+    isRecord(value) &&
+    typeof value.id === "number" &&
+    value.jwId === jwId &&
+    typeof value.code === "string" &&
+    typeof value.courseId === "number" &&
+    (value.semesterId === null || typeof value.semesterId === "number") &&
+    isRecord(value.course) &&
+    typeof value.course.id === "number" &&
+    typeof value.course.jwId === "number" &&
+    typeof value.course.namePrimary === "string" &&
+    Array.isArray(value.adminClasses) &&
+    Array.isArray(value.teachers) &&
+    value.teachers.every(
+      (teacher) => isRecord(teacher) && typeof teacher.id === "number",
+    ) &&
+    typeof value.examCount === "number" &&
+    typeof value.scheduleCount === "number" &&
+    isEmptyArray(value.exams) &&
+    isEmptyArray(value.schedules) &&
+    isEmptyArray(value.sameSemesterOtherTeachers) &&
+    isEmptyArray(value.sameTeacherOtherSemesters)
+  );
+}
 
 function resolveSectionDetailRouteSection(
   section: string | undefined,
@@ -89,7 +126,17 @@ export async function loadSectionDetailPage({
         `catalog-detail:section:${locals.locale}:${jwId}`,
         PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS,
         loadSection,
-        { shouldCacheResult: (result) => result !== null },
+        {
+          coloCacheKey: publicDetailColoCacheKey(
+            url.origin,
+            "section",
+            locals.locale,
+            jwId,
+          ),
+          shouldCacheResult: (result) => result !== null,
+          validateColoCacheResult: (result) =>
+            isPublicSectionCore(result, jwId),
+        },
       )
     : await loadSection();
   if (!sectionCore) error(404, "Section not found");

--- a/src/lib/adapters/cloudflare-runtime.ts
+++ b/src/lib/adapters/cloudflare-runtime.ts
@@ -49,6 +49,17 @@ type CloudflareExecutionContext = {
   waitUntil(promise: Promise<unknown>): void;
 };
 
+export type CloudflareCache = {
+  match(request: Request): Promise<Response | undefined>;
+  put(request: Request, response: Response): Promise<void>;
+};
+
+type CloudflareCacheStorage = {
+  open(name: string): Promise<CloudflareCache>;
+};
+
+type CloudflareTaskScheduler = (promise: Promise<unknown>) => void;
+
 type CloudflareSpan = {
   setAttribute(key: string, value?: boolean | number | string): void;
 };
@@ -83,8 +94,10 @@ type CloudflareRuntimeEnv = Record<string, unknown> & {
 
 type CloudflareRuntimeContext = {
   cache: Map<symbol, unknown>;
+  cacheStorage?: CloudflareCacheStorage;
   env?: CloudflareRuntimeEnv;
   request?: CloudflareRequestContext;
+  scheduleTask?: CloudflareTaskScheduler;
   tracing?: CloudflareTracing;
 };
 
@@ -105,6 +118,35 @@ function normalizeCloudflareRuntimeEnv(env: unknown) {
   return env && typeof env === "object"
     ? (env as CloudflareRuntimeEnv)
     : undefined;
+}
+
+function normalizeCloudflareCacheStorage() {
+  const value = (globalThis as typeof globalThis & { caches?: unknown }).caches;
+  if (!value || typeof value !== "object" || !("open" in value)) {
+    return undefined;
+  }
+  const cacheStorage = value as Partial<CloudflareCacheStorage>;
+  return typeof cacheStorage.open === "function"
+    ? (cacheStorage as CloudflareCacheStorage)
+    : undefined;
+}
+
+function normalizeCloudflareTaskScheduler(
+  executionContext: unknown,
+): CloudflareTaskScheduler | undefined {
+  if (
+    !executionContext ||
+    typeof executionContext !== "object" ||
+    !("waitUntil" in executionContext)
+  ) {
+    return undefined;
+  }
+  const context = executionContext as Partial<CloudflareExecutionContext>;
+  if (typeof context.waitUntil !== "function") return undefined;
+
+  return (promise) => {
+    context.waitUntil?.(promise);
+  };
 }
 
 function getCurrentCloudflareRuntimeEnv() {
@@ -130,7 +172,9 @@ export function runWithCloudflareRuntimeEnv<T>(
       : undefined;
   const context: CloudflareRuntimeContext = {
     cache: new Map(),
+    cacheStorage: normalizeCloudflareCacheStorage(),
     env: normalizeCloudflareRuntimeEnv(env),
+    scheduleTask: normalizeCloudflareTaskScheduler(executionContext),
     tracing,
   };
 
@@ -218,19 +262,19 @@ export function getCloudflareCalendarExportsNamespace() {
   return getCurrentCloudflareRuntimeEnv()?.CALENDAR_EXPORTS;
 }
 
+export function getCloudflareNamedCache(name: string) {
+  return cloudflareRuntimeStorage.getStore()?.cacheStorage?.open(name);
+}
+
+export function getCloudflareRuntimeTaskScheduler() {
+  return cloudflareRuntimeStorage.getStore()?.scheduleTask;
+}
+
 export function getCloudflareTaskScheduler(platform: unknown) {
   if (!platform || typeof platform !== "object") return undefined;
   const value = platform as { context?: unknown; ctx?: unknown };
   const context = value.ctx ?? value.context;
-  if (!context || typeof context !== "object" || !("waitUntil" in context)) {
-    return undefined;
-  }
-  const executionContext = context as Partial<CloudflareExecutionContext>;
-  if (typeof executionContext.waitUntil !== "function") return undefined;
-
-  return (promise: Promise<unknown>) => {
-    executionContext.waitUntil?.(promise);
-  };
+  return normalizeCloudflareTaskScheduler(context);
 }
 
 export function getCloudflareUserMutationRateLimiter(tier: "batch" | "write") {

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -82,7 +82,16 @@ export type PublicRuntimeCacheAnalyticsNamespace =
       | "page:teacher-list"}:${AppLocale}`;
 
 type CacheEventAnalyticsInput = {
-  event: "hit" | "load_error" | "load_success" | "miss";
+  event:
+    | "colo_hit"
+    | "colo_miss"
+    | "colo_read_error"
+    | "colo_write_complete"
+    | "colo_write_error"
+    | "hit"
+    | "load_error"
+    | "load_success"
+    | "miss";
   ioObservedDurationMs: number;
   namespace: PublicRuntimeCacheAnalyticsNamespace;
   storeSize: number;

--- a/src/lib/public-runtime-cache.ts
+++ b/src/lib/public-runtime-cache.ts
@@ -1,3 +1,9 @@
+import type { AppLocale } from "@/i18n/config";
+import {
+  type CloudflareCache,
+  getCloudflareNamedCache,
+  getCloudflareRuntimeTaskScheduler,
+} from "@/lib/adapters/cloudflare-runtime";
 import {
   type PublicRuntimeCacheAnalyticsNamespace,
   writeCacheEventAnalytics,
@@ -9,10 +15,41 @@ type CacheEntry<T> = {
 };
 
 type PublicRuntimeCacheOptions<T> = {
+  coloCacheKey?: string;
   shouldCacheResult?: (result: T) => boolean;
+  validateColoCacheResult?: (result: unknown) => boolean;
 };
 
+type ColoCacheEnvelope = {
+  expiresAt: number;
+  schema: string;
+  value: unknown;
+};
+
+type ColoCacheRead<T> =
+  | { expiresAt: number; hit: true; value: T }
+  | { cache?: CloudflareCache; hit: false; request?: Request };
+
+type ColoCacheEvent =
+  | "colo_hit"
+  | "colo_miss"
+  | "colo_read_error"
+  | "colo_write_error"
+  | "colo_write_complete";
+
 const MAX_ENTRIES = 100;
+const PUBLIC_DETAIL_COLO_CACHE_NAME = "life-ustc-public-detail-core-v1";
+const PUBLIC_DETAIL_COLO_CACHE_SCHEMA = "catalog-detail-core-v1";
+const PUBLIC_DETAIL_COLO_CACHE_PATH =
+  "/_life-ustc-internal-cache/catalog-detail-core/v1";
+const publicDetailColoCacheShapes = {
+  course: "core-without-sections",
+  section: "core-without-exams-schedules-related",
+  teacher: "core-without-sections",
+} as const;
+
+export type PublicDetailColoCacheKind =
+  keyof typeof publicDetailColoCacheShapes;
 
 const globalForPublicRuntimeCache = globalThis as typeof globalThis & {
   __lifeUstcPublicRuntimeCache?: Map<string, CacheEntry<unknown>>;
@@ -49,6 +86,185 @@ function deleteCurrentEntry(
   }
 }
 
+function shortenCurrentEntryExpiry(
+  store: Map<string, CacheEntry<unknown>>,
+  key: string,
+  value: Promise<unknown>,
+  expiresAt: number,
+) {
+  const entry = store.get(key);
+  if (entry?.value === value) {
+    entry.expiresAt = Math.min(entry.expiresAt, expiresAt);
+  }
+}
+
+function writeColoCacheEvent(
+  event: ColoCacheEvent,
+  namespace: PublicRuntimeCacheAnalyticsNamespace,
+  start: number,
+  storeSize: number,
+  ttlMs: number,
+) {
+  writeCacheEventAnalytics({
+    event,
+    ioObservedDurationMs: Date.now() - start,
+    namespace,
+    storeSize,
+    ttlMs,
+  });
+}
+
+function validColoCacheEnvelope(
+  value: unknown,
+  now: number,
+  ttlMs: number,
+): value is ColoCacheEnvelope {
+  if (!value || typeof value !== "object") return false;
+  const envelope = value as Partial<ColoCacheEnvelope>;
+  return (
+    envelope.schema === PUBLIC_DETAIL_COLO_CACHE_SCHEMA &&
+    typeof envelope.expiresAt === "number" &&
+    Number.isSafeInteger(envelope.expiresAt) &&
+    envelope.expiresAt > now &&
+    envelope.expiresAt <= now + ttlMs &&
+    Object.hasOwn(envelope, "value")
+  );
+}
+
+function validColoCacheResult(
+  value: unknown,
+  validate: ((result: unknown) => boolean) | undefined,
+) {
+  try {
+    return validate?.(value) ?? false;
+  } catch {
+    return false;
+  }
+}
+
+async function readColoCache<T>(
+  cacheKey: string,
+  ttlMs: number,
+  namespace: PublicRuntimeCacheAnalyticsNamespace,
+  start: number,
+  storeSize: number,
+  validateColoCacheResult?: (result: unknown) => boolean,
+): Promise<ColoCacheRead<T>> {
+  let cache: CloudflareCache | undefined;
+  let request: Request | undefined;
+  try {
+    request = new Request(cacheKey, { method: "GET" });
+    const cachePromise = getCloudflareNamedCache(PUBLIC_DETAIL_COLO_CACHE_NAME);
+    if (!cachePromise) throw new TypeError("Cache API unavailable");
+    cache = await cachePromise;
+    const response = await cache.match(request);
+    if (!response) {
+      writeColoCacheEvent("colo_miss", namespace, start, storeSize, ttlMs);
+      return { cache, hit: false, request };
+    }
+
+    const parsed: unknown = await response.json();
+    const now = Date.now();
+    if (
+      response.status !== 200 ||
+      !validColoCacheEnvelope(parsed, now, ttlMs)
+    ) {
+      throw new TypeError("Invalid cache envelope");
+    }
+    if (!validColoCacheResult(parsed.value, validateColoCacheResult)) {
+      throw new TypeError("Invalid cached result");
+    }
+    const value = parsed.value as T;
+    writeColoCacheEvent("colo_hit", namespace, start, storeSize, ttlMs);
+    return { expiresAt: parsed.expiresAt, hit: true, value };
+  } catch {
+    writeColoCacheEvent("colo_read_error", namespace, start, storeSize, ttlMs);
+    return { cache, hit: false, request };
+  }
+}
+
+function scheduleColoCacheWrite<T>(
+  cache: CloudflareCache,
+  request: Request,
+  value: T,
+  expiresAt: number,
+  ttlMs: number,
+  namespace: PublicRuntimeCacheAnalyticsNamespace,
+  start: number,
+  storeSize: number,
+) {
+  const scheduleTask = getCloudflareRuntimeTaskScheduler();
+  const remainingTtlMs = expiresAt - Date.now();
+  if (!scheduleTask || remainingTtlMs <= 0) {
+    if (!scheduleTask) {
+      writeColoCacheEvent(
+        "colo_write_error",
+        namespace,
+        start,
+        storeSize,
+        ttlMs,
+      );
+    }
+    return;
+  }
+
+  try {
+    const response = new Response(
+      JSON.stringify({
+        expiresAt,
+        schema: PUBLIC_DETAIL_COLO_CACHE_SCHEMA,
+        value,
+      } satisfies ColoCacheEnvelope),
+      {
+        headers: {
+          "Cache-Control": `public, max-age=${Math.ceil(remainingTtlMs / 1_000)}`,
+          "Content-Type": "application/json; charset=utf-8",
+        },
+      },
+    );
+    let scheduled = false;
+    const write = cache.put(request, response).then(
+      () => {
+        if (scheduled) {
+          writeColoCacheEvent(
+            "colo_write_complete",
+            namespace,
+            start,
+            storeSize,
+            ttlMs,
+          );
+        }
+      },
+      () => {
+        if (scheduled) {
+          writeColoCacheEvent(
+            "colo_write_error",
+            namespace,
+            start,
+            storeSize,
+            ttlMs,
+          );
+        }
+      },
+    );
+    try {
+      scheduleTask(write);
+      scheduled = true;
+    } catch {
+      void write;
+      writeColoCacheEvent(
+        "colo_write_error",
+        namespace,
+        start,
+        storeSize,
+        ttlMs,
+      );
+    }
+  } catch {
+    writeColoCacheEvent("colo_write_error", namespace, start, storeSize, ttlMs);
+  }
+}
+
 export function publicRuntimeCacheKey(
   prefix: string,
   searchParams: URLSearchParams,
@@ -56,6 +272,19 @@ export function publicRuntimeCacheKey(
   const normalized = new URLSearchParams(searchParams);
   normalized.sort();
   return `${prefix}:${normalized.toString()}`;
+}
+
+export function publicDetailColoCacheKey(
+  origin: string,
+  kind: PublicDetailColoCacheKind,
+  locale: AppLocale,
+  id: number,
+) {
+  const shape = publicDetailColoCacheShapes[kind];
+  return new URL(
+    `${PUBLIC_DETAIL_COLO_CACHE_PATH}/${kind}/${shape}/${locale}/${encodeURIComponent(String(id))}`,
+    origin,
+  ).toString();
 }
 
 export function cachedPublicRuntimeData<T>(
@@ -89,33 +318,73 @@ export function cachedPublicRuntimeData<T>(
     storeSize: store.size,
     ttlMs,
   });
-  let value: Promise<T>;
-  value = load()
-    .then((result) => {
-      if (options.shouldCacheResult && !options.shouldCacheResult(result)) {
-        deleteCurrentEntry(store, key, value);
+  const expiresAt = now + ttlMs;
+  const initialStoreSize = store.size;
+  let value: Promise<T> | undefined;
+  value = (async () => {
+    const coloRead = options.coloCacheKey
+      ? await readColoCache<T>(
+          options.coloCacheKey,
+          ttlMs,
+          analyticsNamespace,
+          start,
+          initialStoreSize,
+          options.validateColoCacheResult,
+        )
+      : undefined;
+    if (coloRead?.hit) {
+      if (value) {
+        shortenCurrentEntryExpiry(store, key, value, coloRead.expiresAt);
       }
-      writeCacheEventAnalytics({
-        event: "load_success",
-        ioObservedDurationMs: Date.now() - start,
-        namespace: analyticsNamespace,
-        storeSize: store.size,
-        ttlMs,
-      });
-      return result;
-    })
-    .catch((error) => {
-      deleteCurrentEntry(store, key, value);
-      writeCacheEventAnalytics({
-        event: "load_error",
-        ioObservedDurationMs: Date.now() - start,
-        namespace: analyticsNamespace,
-        storeSize: store.size,
-        ttlMs,
-      });
-      throw error;
+      return coloRead.value;
+    }
+
+    const result = await load();
+    const retain = options.shouldCacheResult?.(result) ?? true;
+    if (!retain) {
+      if (value) deleteCurrentEntry(store, key, value);
+    } else if (coloRead?.cache && coloRead.request) {
+      if (validColoCacheResult(result, options.validateColoCacheResult)) {
+        scheduleColoCacheWrite(
+          coloRead.cache,
+          coloRead.request,
+          result,
+          expiresAt,
+          ttlMs,
+          analyticsNamespace,
+          start,
+          initialStoreSize,
+        );
+      } else {
+        writeColoCacheEvent(
+          "colo_write_error",
+          analyticsNamespace,
+          start,
+          initialStoreSize,
+          ttlMs,
+        );
+      }
+    }
+    writeCacheEventAnalytics({
+      event: "load_success",
+      ioObservedDurationMs: Date.now() - start,
+      namespace: analyticsNamespace,
+      storeSize: store.size,
+      ttlMs,
     });
-  store.set(key, { expiresAt: now + ttlMs, value });
+    return result;
+  })().catch((error) => {
+    if (value) deleteCurrentEntry(store, key, value);
+    writeCacheEventAnalytics({
+      event: "load_error",
+      ioObservedDurationMs: Date.now() - start,
+      namespace: analyticsNamespace,
+      storeSize: store.size,
+      ttlMs,
+    });
+    throw error;
+  });
+  store.set(key, { expiresAt, value });
   pruneOldest(store);
   return value;
 }

--- a/tests/unit/analytics-engine-runtime-events.test.ts
+++ b/tests/unit/analytics-engine-runtime-events.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { setCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
+import {
+  runWithCloudflareRuntimeEnv,
+  setCloudflareRuntimeEnv,
+} from "@/lib/adapters/cloudflare-runtime";
 import { recordAndLogMcpResponse } from "@/lib/api/routes/mcp-response-bookkeeping";
 import { writeAuditLog } from "@/lib/audit/write-audit-log";
 import { withBetterAuthOAuthDebug } from "@/lib/log/oauth-debug";
 import { writeOAuthEventAnalytics } from "@/lib/metrics/analytics-engine";
-import { cachedPublicRuntimeData } from "@/lib/public-runtime-cache";
+import {
+  cachedPublicRuntimeData,
+  publicDetailColoCacheKey,
+} from "@/lib/public-runtime-cache";
 import {
   getStorageObjectResponse,
   headStorageObject,
@@ -25,12 +31,22 @@ function clearPublicRuntimeCache() {
   ).__lifeUstcPublicRuntimeCache;
 }
 
+function validatesSource(value: unknown) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "source" in value &&
+    typeof value.source === "string"
+  );
+}
+
 describe("Cloudflare Analytics Engine runtime events", () => {
   afterEach(() => {
     setCloudflareRuntimeEnv(undefined);
     clearPublicRuntimeCache();
     vi.useRealTimers();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("writes MCP transport datapoints without tool argument values", () => {
@@ -278,6 +294,78 @@ describe("Cloudflare Analytics Engine runtime events", () => {
     });
     expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain(
       "sensitive-marker-679",
+    );
+  });
+
+  it("writes fixed colo-cache outcomes without entity IDs or synthetic keys", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const writeDataPoint = vi.fn();
+    const cachedValue = { source: "colo" };
+    const match = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            expiresAt: 60_000,
+            schema: "catalog-detail-core-v1",
+            value: cachedValue,
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(undefined);
+    const put = vi.fn(async () => undefined);
+    vi.stubGlobal("caches", {
+      open: vi.fn(async () => ({ match, put })),
+    });
+    const scheduled: Promise<unknown>[] = [];
+    const executionContext = {
+      waitUntil(promise: Promise<unknown>) {
+        scheduled.push(promise);
+      },
+    };
+    const sensitiveId = 683999;
+    const coloCacheKey = publicDetailColoCacheKey(
+      "https://example.test",
+      "course",
+      "en-us",
+      sensitiveId,
+    );
+
+    await runWithCloudflareRuntimeEnv(
+      { ANALYTICS: { writeDataPoint } },
+      async () => {
+        await cachedPublicRuntimeData(
+          "page:course-detail:en-us",
+          "l2-hit",
+          60_000,
+          vi.fn(async () => ({ source: "unexpected" })),
+          { coloCacheKey, validateColoCacheResult: validatesSource },
+        );
+        await cachedPublicRuntimeData(
+          "page:course-detail:en-us",
+          "l2-miss",
+          60_000,
+          async () => ({ source: "database" }),
+          { coloCacheKey, validateColoCacheResult: validatesSource },
+        );
+        await Promise.all(scheduled);
+      },
+      executionContext,
+    );
+
+    for (const event of ["colo_hit", "colo_miss", "colo_write_complete"]) {
+      expect(writeDataPoint).toHaveBeenCalledWith({
+        indexes: ["cache:page:course-detail:en-us"],
+        blobs: ["public_runtime_cache_v2", event, "page:course-detail:en-us"],
+        doubles: [expect.any(Number), 60_000, expect.any(Number)],
+      });
+    }
+    expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain(
+      String(sensitiveId),
+    );
+    expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain(
+      "_life-ustc-internal-cache",
     );
   });
 });

--- a/tests/unit/cloudflare-runtime-tracing.test.ts
+++ b/tests/unit/cloudflare-runtime-tracing.test.ts
@@ -1,10 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  getCloudflareNamedCache,
+  getCloudflareRuntimeTaskScheduler,
   runCloudflareTraceSpan,
   runWithCloudflareRuntimeEnv,
 } from "@/lib/adapters/cloudflare-runtime";
 
 describe("Cloudflare runtime tracing", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("creates a custom span and attaches bounded semantic attributes", async () => {
     const setAttribute = vi.fn();
     const enterSpan = vi.fn(
@@ -41,5 +47,36 @@ describe("Cloudflare runtime tracing", () => {
 
   it("runs callbacks unchanged outside the Workers runtime", () => {
     expect(runCloudflareTraceSpan("app.test", {}, () => 42)).toBe(42);
+  });
+
+  it("keeps named caches request-scoped and preserves the waitUntil receiver", async () => {
+    const cache = { match: vi.fn(), put: vi.fn() };
+    const open = vi.fn(async () => cache);
+    vi.stubGlobal("caches", { open });
+    const scheduled: Promise<unknown>[] = [];
+    const executionContext = {
+      waitUntil(this: unknown, promise: Promise<unknown>) {
+        expect(this).toBe(executionContext);
+        scheduled.push(promise);
+      },
+    };
+
+    const selectedCache = await runWithCloudflareRuntimeEnv(
+      {},
+      async () => {
+        const scheduleTask = getCloudflareRuntimeTaskScheduler();
+        expect(scheduleTask).toBeTypeOf("function");
+        scheduleTask?.(Promise.resolve("done"));
+        return await getCloudflareNamedCache("detail-core-v1");
+      },
+      executionContext,
+    );
+
+    expect(selectedCache).toBe(cache);
+    expect(open).toHaveBeenCalledWith("detail-core-v1");
+    expect(scheduled).toHaveLength(1);
+    await expect(scheduled[0]).resolves.toBe("done");
+    expect(getCloudflareNamedCache("outside-request")).toBeUndefined();
+    expect(getCloudflareRuntimeTaskScheduler()).toBeUndefined();
   });
 });

--- a/tests/unit/detail-page-loader-critical-path.test.ts
+++ b/tests/unit/detail-page-loader-critical-path.test.ts
@@ -1,6 +1,7 @@
 /// <reference path="../../src/app.d.ts" />
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runWithCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
 
 const {
   getCommentsPayloadMock,
@@ -100,25 +101,36 @@ const course = {
   id: 11,
   jwId: 101,
   namePrimary: "Calculus",
+  sectionCount: 0,
   sections: [],
 };
 
 const teacher = {
   id: 21,
   namePrimary: "Ada",
+  sectionCount: 0,
   sections: [],
 };
 
 const section = {
+  adminClasses: [],
   code: "001",
   course: {
     id: course.id,
     jwId: course.jwId,
     namePrimary: course.namePrimary,
   },
+  courseId: course.id,
+  examCount: 0,
+  exams: [],
   id: 31,
   jwId: 301,
   retiredAt: null,
+  sameSemesterOtherTeachers: [],
+  sameTeacherOtherSemesters: [],
+  scheduleCount: 0,
+  schedules: [],
+  semesterId: 1,
   teachers: [{ id: teacher.id, namePrimary: teacher.namePrimary }],
 };
 
@@ -180,6 +192,10 @@ beforeEach(() => {
   withSectionPageRelatedDataMock.mockImplementation(
     async (value: typeof section) => value,
   );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe("catalog detail loader critical path", () => {
@@ -376,6 +392,91 @@ describe("catalog detail loader critical path", () => {
     expect(getCoursePageMock).toHaveBeenCalledTimes(4);
   });
 
+  it("uses the colo cache only for reviewed anonymous PublicSsr detail shapes", async () => {
+    const match = vi.fn(async (_request: Request) => undefined);
+    const put = vi.fn(
+      async (_request: Request, _response: Response) => undefined,
+    );
+    const open = vi.fn(async () => ({ match, put }));
+    vi.stubGlobal("caches", { open });
+    const scheduled: Promise<unknown>[] = [];
+    const executionContext = {
+      waitUntil(promise: Promise<unknown>) {
+        scheduled.push(promise);
+      },
+    };
+    const { loadCourseDetailPage, loadTeacherDetailPage } = await import(
+      "@/features/catalog/server/catalog-detail-page-server"
+    );
+    const { loadSectionDetailPage } = await import(
+      "@/features/section-detail/server/section-detail-page-server"
+    );
+
+    await runWithCloudflareRuntimeEnv(
+      {},
+      async () => {
+        await loadCourseDetailPage({
+          locals: locals(null, true),
+          params: { jwId: String(course.jwId) },
+          request: request(`/catalog/courses/${course.jwId}`),
+          url: new URL(`https://example.test/catalog/courses/${course.jwId}`),
+        });
+        await Promise.all(scheduled);
+      },
+      executionContext,
+    );
+
+    expect(open).toHaveBeenCalledWith("life-ustc-public-detail-core-v1");
+    expect(match).toHaveBeenCalledOnce();
+    const matchedRequest = match.mock.calls[0]?.[0];
+    expect(matchedRequest?.url).toBe(
+      `https://example.test/_life-ustc-internal-cache/catalog-detail-core/v1/course/core-without-sections/en-us/${course.jwId}`,
+    );
+    expect(put).toHaveBeenCalledOnce();
+
+    open.mockClear();
+    match.mockClear();
+    put.mockClear();
+    await runWithCloudflareRuntimeEnv(
+      {},
+      async () => {
+        await loadCourseDetailPage({
+          locals: locals(),
+          params: { jwId: String(course.jwId) },
+          request: request(`/catalog/courses/${course.jwId}`),
+          url: new URL(`https://example.test/catalog/courses/${course.jwId}`),
+        });
+        await loadCourseDetailPage({
+          locals: locals(signedInUser, true),
+          params: { jwId: String(course.jwId) },
+          request: request(`/catalog/courses/${course.jwId}`),
+          url: new URL(`https://example.test/catalog/courses/${course.jwId}`),
+        });
+        await loadTeacherDetailPage({
+          locals: locals(null, true),
+          params: { id: String(teacher.id), section: "sections" },
+          request: request(`/catalog/teachers/${teacher.id}/sections`),
+          url: new URL(
+            `https://example.test/catalog/teachers/${teacher.id}/sections`,
+          ),
+        });
+        await loadSectionDetailPage({
+          locals: locals(null, true),
+          params: { jwId: String(section.jwId), section: "calendar" },
+          request: request(`/catalog/sections/${section.jwId}/calendar`),
+          url: new URL(
+            `https://example.test/catalog/sections/${section.jwId}/calendar`,
+          ),
+        });
+      },
+      executionContext,
+    );
+
+    expect(open).not.toHaveBeenCalled();
+    expect(match).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
+  });
+
   it("skips comments outside the teacher comments section", async () => {
     const { loadTeacherDetailPage } = await import(
       "@/features/catalog/server/catalog-detail-page-server"
@@ -486,6 +587,50 @@ describe("detail request session resolution", () => {
 });
 
 describe("section detail loader critical path", () => {
+  it("fails open when a versioned colo entry omits a required section field", async () => {
+    const match = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            expiresAt: Date.now() + 30_000,
+            schema: "catalog-detail-core-v1",
+            value: { ...section, adminClasses: undefined },
+          }),
+        ),
+    );
+    const put = vi.fn(async () => undefined);
+    vi.stubGlobal("caches", {
+      open: vi.fn(async () => ({ match, put })),
+    });
+    const scheduled: Promise<unknown>[] = [];
+    const executionContext = {
+      waitUntil(promise: Promise<unknown>) {
+        scheduled.push(promise);
+      },
+    };
+    const { loadSectionDetailPage } = await import(
+      "@/features/section-detail/server/section-detail-page-server"
+    );
+
+    const result = await runWithCloudflareRuntimeEnv(
+      {},
+      () =>
+        loadSectionDetailPage({
+          locals: locals(null, true),
+          params: { jwId: String(section.jwId) },
+          request: request(`/catalog/sections/${section.jwId}`),
+          url: new URL(`https://example.test/catalog/sections/${section.jwId}`),
+        }),
+      executionContext,
+    );
+    await Promise.all(scheduled);
+
+    expect(match).toHaveBeenCalledOnce();
+    expect(getSectionPageMock).toHaveBeenCalledOnce();
+    expect(put).toHaveBeenCalledOnce();
+    expect(result.section).toBe(section);
+  });
+
   it("loads the section while reusing hook auth and skips comments and homework on overview", async () => {
     let resolveSection: ((value: typeof section) => void) | undefined;
     getSectionPageMock.mockReturnValue(

--- a/tests/unit/public-runtime-cache.test.ts
+++ b/tests/unit/public-runtime-cache.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cachedPublicRuntimeData } from "@/lib/public-runtime-cache";
+import { runWithCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
+import {
+  cachedPublicRuntimeData,
+  publicDetailColoCacheKey,
+} from "@/lib/public-runtime-cache";
 
 function clearPublicRuntimeCache() {
   delete (
@@ -19,6 +23,49 @@ function deferred<T>() {
   return { promise, reject, resolve };
 }
 
+function coloResponse(value: unknown, expiresAt: number, schema?: string) {
+  return new Response(
+    JSON.stringify({
+      expiresAt,
+      schema: schema ?? "catalog-detail-core-v1",
+      value,
+    }),
+    { headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function validatesSource(value: unknown) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "source" in value &&
+    typeof value.source === "string"
+  );
+}
+
+function installNamedCache(options?: {
+  match?: (request: Request) => Promise<Response | undefined>;
+  put?: (request: Request, response: Response) => Promise<void>;
+}) {
+  const match = vi.fn(options?.match ?? (async () => undefined));
+  const put = vi.fn(options?.put ?? (async () => undefined));
+  const cache = { match, put };
+  const open = vi.fn(async () => cache);
+  vi.stubGlobal("caches", { open });
+  return { cache, match, open, put };
+}
+
+function runtimeExecutionContext() {
+  const scheduled: Promise<unknown>[] = [];
+  const context = {
+    waitUntil(this: unknown, promise: Promise<unknown>) {
+      expect(this).toBe(context);
+      scheduled.push(promise);
+    },
+  };
+  return { context, scheduled };
+}
+
 describe("public runtime cache", () => {
   beforeEach(() => {
     clearPublicRuntimeCache();
@@ -28,6 +75,40 @@ describe("public runtime cache", () => {
   afterEach(() => {
     clearPublicRuntimeCache();
     vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("builds same-origin versioned detail keys isolated by kind, shape, locale, and ID", () => {
+    const course = publicDetailColoCacheKey(
+      "https://example.test",
+      "course",
+      "en-us",
+      683001,
+    );
+    const teacher = publicDetailColoCacheKey(
+      "https://example.test",
+      "teacher",
+      "en-us",
+      683001,
+    );
+    const section = publicDetailColoCacheKey(
+      "https://example.test",
+      "section",
+      "zh-cn",
+      683002,
+    );
+
+    expect(new URL(course).origin).toBe("https://example.test");
+    expect(new URL(course).pathname).toBe(
+      "/_life-ustc-internal-cache/catalog-detail-core/v1/course/core-without-sections/en-us/683001",
+    );
+    expect(new URL(teacher).pathname).toContain(
+      "/v1/teacher/core-without-sections/en-us/683001",
+    );
+    expect(new URL(section).pathname).toContain(
+      "/v1/section/core-without-exams-schedules-related/zh-cn/683002",
+    );
+    expect(new Set([course, teacher, section]).size).toBe(3);
   });
 
   it("returns one in-flight promise for concurrent callers of the same key", async () => {
@@ -75,6 +156,36 @@ describe("public runtime cache", () => {
       load,
       options,
     );
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates cache predicate errors and removes the entry", async () => {
+    const load = vi.fn(async () => ({ source: "database" }));
+    const options = {
+      shouldCacheResult: () => {
+        throw new Error("predicate failed");
+      },
+    };
+
+    await expect(
+      cachedPublicRuntimeData(
+        "api:metadata",
+        "predicate-error",
+        60_000,
+        load,
+        options,
+      ),
+    ).rejects.toThrow("predicate failed");
+    await expect(
+      cachedPublicRuntimeData(
+        "api:metadata",
+        "predicate-error",
+        60_000,
+        load,
+        options,
+      ),
+    ).rejects.toThrow("predicate failed");
 
     expect(load).toHaveBeenCalledTimes(2);
   });
@@ -156,5 +267,309 @@ describe("public runtime cache", () => {
         vi.fn(async () => ({ source: "unexpected" })),
       ),
     ).resolves.toEqual({ source: "successor" });
+  });
+
+  it("uses a named colo hit without loading and then serves it from L1", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const cached = { source: "colo" };
+    const { match, open, put } = installNamedCache({
+      match: async () => coloResponse(cached, 20_000),
+    });
+    const load = vi.fn(async () => ({ source: "database" }));
+    const { context } = runtimeExecutionContext();
+
+    await runWithCloudflareRuntimeEnv(
+      {},
+      async () => {
+        const first = await cachedPublicRuntimeData(
+          "page:course-detail:en-us",
+          "course:683001",
+          60_000,
+          load,
+          {
+            coloCacheKey: publicDetailColoCacheKey(
+              "https://example.test",
+              "course",
+              "en-us",
+              683001,
+            ),
+            shouldCacheResult: (result) => result !== null,
+            validateColoCacheResult: validatesSource,
+          },
+        );
+        const second = await cachedPublicRuntimeData(
+          "page:course-detail:en-us",
+          "course:683001",
+          60_000,
+          load,
+          {
+            coloCacheKey: publicDetailColoCacheKey(
+              "https://example.test",
+              "course",
+              "en-us",
+              683001,
+            ),
+            validateColoCacheResult: validatesSource,
+          },
+        );
+
+        expect(first).toEqual(cached);
+        expect(second).toBe(first);
+      },
+      context,
+    );
+
+    expect(open).toHaveBeenCalledOnce();
+    expect(open).toHaveBeenCalledWith("life-ustc-public-detail-core-v1");
+    expect(match).toHaveBeenCalledOnce();
+    expect(load).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it("coalesces one colo miss and schedules one JSON-clean write", async () => {
+    const pending = deferred<{ source: string }>();
+    const { match, put } = installNamedCache();
+    const load = vi.fn(() => pending.promise);
+    const { context, scheduled } = runtimeExecutionContext();
+    const coloCacheKey = publicDetailColoCacheKey(
+      "https://example.test",
+      "section",
+      "en-us",
+      683002,
+    );
+
+    await runWithCloudflareRuntimeEnv(
+      {},
+      async () => {
+        const options = {
+          coloCacheKey,
+          shouldCacheResult: (result: { source: string }) => result !== null,
+          validateColoCacheResult: validatesSource,
+        };
+        const first = cachedPublicRuntimeData(
+          "page:section-detail:en-us",
+          "section:683002",
+          60_000,
+          load,
+          options,
+        );
+        const second = cachedPublicRuntimeData(
+          "page:section-detail:en-us",
+          "section:683002",
+          60_000,
+          load,
+          options,
+        );
+
+        expect(first).toBe(second);
+        await vi.waitFor(() => expect(load).toHaveBeenCalledOnce());
+        pending.resolve({ source: "database" });
+        await expect(Promise.all([first, second])).resolves.toEqual([
+          { source: "database" },
+          { source: "database" },
+        ]);
+        expect(scheduled).toHaveLength(1);
+        await scheduled[0];
+      },
+      context,
+    );
+
+    expect(match).toHaveBeenCalledOnce();
+    expect(put).toHaveBeenCalledOnce();
+    const [writtenRequest, writtenResponse] = put.mock.calls[0] ?? [];
+    expect(writtenRequest?.url).toBe(coloCacheKey);
+    expect(writtenResponse?.headers.get("cache-control")).toBe(
+      "public, max-age=60",
+    );
+    await expect(writtenResponse?.clone().json()).resolves.toMatchObject({
+      expiresAt: expect.any(Number),
+      schema: "catalog-detail-core-v1",
+      value: { source: "database" },
+    });
+  });
+
+  it("does not extend an absolute colo expiry when refilling L1", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { match } = installNamedCache({
+      match: vi
+        .fn()
+        .mockResolvedValueOnce(coloResponse({ source: "colo" }, 1_000))
+        .mockResolvedValueOnce(undefined),
+    });
+    const load = vi.fn(async () => ({ source: "database" }));
+    const { context } = runtimeExecutionContext();
+    const options = {
+      coloCacheKey: publicDetailColoCacheKey(
+        "https://example.test",
+        "teacher",
+        "en-us",
+        683003,
+      ),
+      validateColoCacheResult: validatesSource,
+    };
+
+    await runWithCloudflareRuntimeEnv(
+      {},
+      async () => {
+        await expect(
+          cachedPublicRuntimeData(
+            "page:teacher-detail:en-us",
+            "teacher:683003",
+            60_000,
+            load,
+            options,
+          ),
+        ).resolves.toEqual({ source: "colo" });
+        vi.setSystemTime(1_001);
+        await expect(
+          cachedPublicRuntimeData(
+            "page:teacher-detail:en-us",
+            "teacher:683003",
+            60_000,
+            load,
+            options,
+          ),
+        ).resolves.toEqual({ source: "database" });
+      },
+      context,
+    );
+
+    expect(match).toHaveBeenCalledTimes(2);
+    expect(load).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["malformed JSON", () => new Response("not-json")],
+    [
+      "wrong schema",
+      () => coloResponse({ source: "wrong-schema" }, 30_000, "other-v1"),
+    ],
+    ["expired envelope", () => coloResponse({ source: "expired" }, 1)],
+    ["null value", () => coloResponse(null, 30_000)],
+    ["wrong payload", () => coloResponse({ unexpected: true }, 30_000)],
+  ])("never serves a %s colo entry", async (_case, response) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const { put } = installNamedCache({ match: async () => response() });
+    const load = vi.fn(async () => ({ source: "database" }));
+    const { context, scheduled } = runtimeExecutionContext();
+
+    await runWithCloudflareRuntimeEnv(
+      {},
+      async () => {
+        await expect(
+          cachedPublicRuntimeData(
+            "page:course-detail:en-us",
+            `invalid:${_case}`,
+            60_000,
+            load,
+            {
+              coloCacheKey: publicDetailColoCacheKey(
+                "https://example.test",
+                "course",
+                "en-us",
+                683004,
+              ),
+              shouldCacheResult: (result) => result !== null,
+              validateColoCacheResult: validatesSource,
+            },
+          ),
+        ).resolves.toEqual({ source: "database" });
+        await Promise.all(scheduled);
+      },
+      context,
+    );
+
+    expect(load).toHaveBeenCalledOnce();
+    expect(put).toHaveBeenCalledOnce();
+  });
+
+  it("never writes nulls or loader failures to the colo cache", async () => {
+    const { put } = installNamedCache();
+    const { context, scheduled } = runtimeExecutionContext();
+    const options = {
+      coloCacheKey: publicDetailColoCacheKey(
+        "https://example.test",
+        "section",
+        "zh-cn",
+        683005,
+      ),
+      shouldCacheResult: (result: { source: string } | null) => result !== null,
+      validateColoCacheResult: validatesSource,
+    };
+
+    await runWithCloudflareRuntimeEnv(
+      {},
+      async () => {
+        await expect(
+          cachedPublicRuntimeData(
+            "page:section-detail:zh-cn",
+            "null-colo",
+            60_000,
+            async () => null,
+            options,
+          ),
+        ).resolves.toBeNull();
+        await expect(
+          cachedPublicRuntimeData(
+            "page:section-detail:zh-cn",
+            "error-colo",
+            60_000,
+            async () => {
+              throw new Error("load failed");
+            },
+            options,
+          ),
+        ).rejects.toThrow("load failed");
+      },
+      context,
+    );
+
+    expect(put).not.toHaveBeenCalled();
+    expect(scheduled).toHaveLength(0);
+  });
+
+  it("fails open when colo reads and writes reject", async () => {
+    const { put } = installNamedCache({
+      match: async () => {
+        throw new Error("read failed");
+      },
+      put: async () => {
+        throw new Error("write failed");
+      },
+    });
+    const load = vi.fn(async () => ({ source: "database" }));
+    const { context, scheduled } = runtimeExecutionContext();
+
+    await runWithCloudflareRuntimeEnv(
+      {},
+      async () => {
+        await expect(
+          cachedPublicRuntimeData(
+            "page:course-detail:en-us",
+            "fail-open",
+            60_000,
+            load,
+            {
+              coloCacheKey: publicDetailColoCacheKey(
+                "https://example.test",
+                "course",
+                "en-us",
+                683006,
+              ),
+              validateColoCacheResult: validatesSource,
+            },
+          ),
+        ).resolves.toEqual({ source: "database" });
+        await Promise.all(scheduled);
+      },
+      context,
+    );
+
+    expect(load).toHaveBeenCalledOnce();
+    expect(put).toHaveBeenCalledOnce();
+    expect(scheduled).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

- add a named Cloudflare Cache API L2 behind the existing isolate-local L1 for eligible anonymous Public SSR catalog detail core reads
- use a versioned, same-origin synthetic key partitioned by entity kind, reviewed data shape, locale, and ID
- preserve one absolute 60-second expiry across L2 and L1, validate cached payloads at runtime, and fail open to the database on every Cache API failure
- schedule best-effort writes with `waitUntil`; keep authenticated/dynamic SSR and viewer/comments/descriptions/homework/subscription/section-related data outside both shared-cache payloads
- document the boundary and add low-cardinality cache outcome telemetry; `colo_write_complete` means API processing completed, while only a later `colo_hit` proves admission

## Production evidence

The first production sample after #682 recorded 84 detail-core L1 misses and 3 hits (3.45%). The cache logic was correct, but reuse was limited by isolate/PoP partitioning. Cloudflare documents that named Cache API entries are shared within the handling data center, but are not replicated across data centers and do not participate in Tiered Cache, which matches the required next layer without adding an API endpoint.

## Safety

- anonymous Public SSR only
- no session/viewer-specific data in keys or values
- no new application endpoint; the synthetic path is only a Cache API key
- course/teacher section-list shapes and section exam/calendar/related shapes bypass L2
- nulls, failures, invalid envelopes, and invalid payloads are never served from L2
- metrics omit entity IDs and full cache keys

## Verification

- `DATABASE_URL=... bun run app:prepare`
- `bunx biome check` (only the existing unrelated warning in `src/static-loader/import.ts`)
- `bunx svelte-check --tsconfig ./tsconfig.json` (0 errors, 0 warnings)
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` (265 files, 1702 tests)
- `bun run build`
- `bunx wrangler deploy --dry-run`
- independent review: no remaining blockers

Closes #683