### PR TITLE
perf(dashboard): reuse calendar feed token in subscription tabs

### DIFF
--- a/src/features/dashboard/server/dashboard-page-tab-data.ts
+++ b/src/features/dashboard/server/dashboard-page-tab-data.ts
@@ -108,6 +108,7 @@ export async function loadSignedDashboardTabData(input: {
     input.tab === "subscriptions" || input.tab === "exams"
       ? timeDashboardTabStage("subscriptions", stageContext, () =>
           dashboardTabs.getSubscriptionsTabData(input.userId, input.locale, {
+            calendarFeedToken: input.context.user.calendarFeedToken,
             includeExams: input.tab === "exams",
             sectionIds: input.context.sectionIds,
           }),

--- a/src/features/subscriptions/server/subscription-tab-read-model.ts
+++ b/src/features/subscriptions/server/subscription-tab-read-model.ts
@@ -11,7 +11,11 @@ import {
 export async function getSubscriptionsTabData(
   userId: string,
   locale = DEFAULT_LOCALE,
-  options: { includeExams?: boolean; sectionIds?: readonly number[] } = {},
+  options: {
+    calendarFeedToken?: string | null;
+    includeExams?: boolean;
+    sectionIds?: readonly number[];
+  } = {},
 ) {
   const localizedPrisma = getPrisma(locale);
   const [sections, semesters, calendarSubscriptionUrl] = await Promise.all([
@@ -23,7 +27,7 @@ export async function getSubscriptionsTabData(
       select: { id: true, nameCn: true, startDate: true, endDate: true },
       orderBy: { startDate: "asc" },
     }),
-    getCalendarSubscriptionUrl(userId),
+    getCalendarSubscriptionUrl(userId, options.calendarFeedToken),
   ]);
 
   return {

--- a/tests/unit/calendar-feed-token.test.ts
+++ b/tests/unit/calendar-feed-token.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ensureUserCalendarFeedToken } from "@/features/subscriptions/server/calendar-feed-token";
+import { getCalendarSubscriptionUrl } from "@/features/subscriptions/server/subscription-calendar-read-model";
 import { randomBytesBase64Url } from "@/lib/crypto/web-crypto";
 import { prisma } from "@/lib/db/prisma";
 
@@ -77,5 +78,44 @@ describe("ensureUserCalendarFeedToken 日历订阅令牌", () => {
       data: { calendarFeedToken: "discarded-token" },
     });
     expect(updateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("getCalendarSubscriptionUrl 日历订阅地址", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("已有可信令牌时不重复查询用户", async () => {
+    await expect(
+      getCalendarSubscriptionUrl("user-1", "existing-token"),
+    ).resolves.toBe("/api/calendar-feeds/user-1:existing-token.ics");
+
+    expect(findUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("显式 null 仍初始化令牌且不增加前置查询", async () => {
+    findUniqueMock.mockResolvedValueOnce(userWithToken(null));
+    randomBytesBase64UrlMock.mockReturnValue("generated-token");
+    updateManyMock.mockResolvedValueOnce({ count: 1 });
+
+    await expect(getCalendarSubscriptionUrl("user-1", null)).resolves.toBe(
+      "/api/calendar-feeds/user-1:generated-token.ics",
+    );
+
+    expect(findUniqueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("省略令牌时保留用户查询回退", async () => {
+    findUniqueMock.mockResolvedValueOnce(userWithToken("stored-token"));
+
+    await expect(getCalendarSubscriptionUrl("user-1")).resolves.toBe(
+      "/api/calendar-feeds/user-1:stored-token.ics",
+    );
+
+    expect(findUniqueMock).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      select: { id: true, calendarFeedToken: true },
+    });
   });
 });

--- a/tests/unit/dashboard-subscription-calendar-token.test.ts
+++ b/tests/unit/dashboard-subscription-calendar-token.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  dashboardSubscriptionsMock,
+  getCalendarSubscriptionUrlMock,
+  getDashboardNavStatsMock,
+  listSubscribedSectionsMock,
+  semesterFindManyMock,
+} = vi.hoisted(() => ({
+  dashboardSubscriptionsMock: vi.fn(),
+  getCalendarSubscriptionUrlMock: vi.fn(),
+  getDashboardNavStatsMock: vi.fn(),
+  listSubscribedSectionsMock: vi.fn(),
+  semesterFindManyMock: vi.fn(),
+}));
+
+vi.mock(
+  "@/features/subscriptions/server/subscription-calendar-read-model",
+  () => ({
+    getCalendarSubscriptionUrl: getCalendarSubscriptionUrlMock,
+  }),
+);
+
+vi.mock("@/features/subscriptions/server/subscription-tab-sections", () => ({
+  listSubscribedSectionsForSubscriptionsTab: listSubscribedSectionsMock,
+  subscriptionSectionFromRow: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  getPrisma: () => ({ semester: { findMany: semesterFindManyMock } }),
+}));
+
+vi.mock("@/features/dashboard/server/dashboard-overview-data", () => ({
+  getDashboardNavStats: getDashboardNavStatsMock,
+  getDashboardOverviewData: vi.fn(),
+}));
+
+vi.mock("@/features/dashboard/server/dashboard-tab-data", () => ({
+  getBusTabData: vi.fn(),
+  getCalendarSubscriptionUrl: vi.fn(),
+  getHomeworksTabData: vi.fn(),
+  getSubscriptionsTabData: dashboardSubscriptionsMock,
+  getTodosTabData: vi.fn(),
+}));
+
+vi.mock("@/features/dashboard-links/server/dashboard-link-data", () => ({
+  getLinksTabData: vi.fn(),
+}));
+
+vi.mock("@/lib/log/app-logger", () => ({
+  logAppEvent: vi.fn(),
+}));
+
+import { loadSignedDashboardTabData } from "@/features/dashboard/server/dashboard-page-tab-data";
+import { getSubscriptionsTabData } from "@/features/subscriptions/server/subscription-tab-read-model";
+
+describe("dashboard subscription calendar token reuse", () => {
+  beforeEach(() => {
+    dashboardSubscriptionsMock.mockReset().mockResolvedValue({});
+    getCalendarSubscriptionUrlMock.mockReset().mockResolvedValue("/feed.ics");
+    getDashboardNavStatsMock.mockReset().mockResolvedValue({});
+    listSubscribedSectionsMock.mockReset().mockResolvedValue([]);
+    semesterFindManyMock.mockReset().mockResolvedValue([]);
+  });
+
+  it.each([
+    [
+      "existing token",
+      { calendarFeedToken: "existing-token" },
+      "existing-token",
+    ],
+    ["known null token", { calendarFeedToken: null }, null],
+    ["unspecified token", undefined, undefined],
+  ])("forwards %s without changing its semantics", async (_label, options, token) => {
+    await getSubscriptionsTabData("user-1", "en-us", options);
+
+    expect(getCalendarSubscriptionUrlMock).toHaveBeenCalledWith(
+      "user-1",
+      token,
+    );
+  });
+
+  it.each([
+    ["subscriptions", false],
+    ["exams", true],
+  ])("forwards the dashboard context token for the %s tab", async (tab, includeExams) => {
+    await loadSignedDashboardTabData({
+      calendarSemesterId: undefined,
+      context: {
+        sectionIds: [12],
+        subscribedSections: [{ id: 12, semesterId: 1 }],
+        user: {
+          calendarFeedToken: "context-token",
+          id: "user-1",
+          name: "User",
+          username: "user",
+        },
+      },
+      locale: "en-us",
+      referenceNow: undefined,
+      requestId: "request-1",
+      tab,
+      userId: "user-1",
+    });
+
+    expect(dashboardSubscriptionsMock).toHaveBeenCalledWith("user-1", "en-us", {
+      calendarFeedToken: "context-token",
+      includeExams,
+      sectionIds: [12],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- reuse the authenticated dashboard context's calendar feed token for subscriptions and exams
- preserve the undefined lookup fallback and null-token initialization behavior
- remove one deterministic User.findUnique round trip from those dashboard tab loads
- keep all API endpoints and response shapes unchanged

## Verification

- focused unit tests: 10 passed, including zero lookup for an existing token, null initialization, and undefined fallback
- full Vitest: 266 files / 1707 tests
- Svelte check: 0 errors / 0 warnings
- all three TypeScript projects passed
- Biome passed (one pre-existing unrelated warning in src/static-loader/import.ts)
- production build passed
- Wrangler production dry-run passed

Closes #685
Related: #530, #672