### PR TITLE
perf(workspace): streamline compact overview reads

### DIFF
--- a/src/features/dashboard/server/compact-overview-read-model.ts
+++ b/src/features/dashboard/server/compact-overview-read-model.ts
@@ -1,7 +1,6 @@
 import { withHomeworkItemState } from "@/features/homeworks/server/homework-item-state";
 import {
   countUpcomingSubscribedExams,
-  getActiveSubscribedSectionIds,
   listSubscribedHomeworks,
   listSubscribedSchedules,
   listUpcomingSubscribedExams,
@@ -12,7 +11,12 @@ import {
   listTodoSummary,
 } from "@/features/todos/server/todo-service";
 import { type AppLocale, DEFAULT_LOCALE } from "@/i18n/config";
+import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import { prisma } from "@/lib/db/prisma";
+import {
+  type WorkspaceOverviewStage,
+  writeWorkspaceOverviewStageAnalytics,
+} from "@/lib/metrics/analytics-engine";
 import { parseDateInput } from "@/lib/time/parse-date-input";
 import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
 import { formatShanghaiDate } from "@/lib/time/shanghai-format";
@@ -28,6 +32,33 @@ function requiredDate(value: Date | null | undefined, label: string) {
 
 function shanghaiDateOnlyStart(input: Date) {
   return requiredDate(parseDateInput(formatShanghaiDate(input)), "day start");
+}
+
+async function runOverviewStage<T>(
+  stage: WorkspaceOverviewStage,
+  work: () => Promise<T>,
+) {
+  const startMs = Date.now();
+  try {
+    const result = await runCloudflareTraceSpan(
+      `workspace.overview.${stage}`,
+      {},
+      work,
+    );
+    writeWorkspaceOverviewStageAnalytics({
+      ioObservedDurationMs: Date.now() - startMs,
+      stage,
+      status: "success",
+    });
+    return result;
+  } catch (error) {
+    writeWorkspaceOverviewStageAnalytics({
+      ioObservedDurationMs: Date.now() - startMs,
+      stage,
+      status: "error",
+    });
+    throw error;
+  }
 }
 
 export async function getCompactOverview(
@@ -51,98 +82,127 @@ export async function getCompactOverview(
     .add(homeworkWindowDays, "day")
     .toDate();
 
-  const [user, sectionIds, todos, dueTodosCount, dueTodos] = await Promise.all([
-    prisma.user.findUnique({
-      where: { id: userId },
-      select: { id: true, image: true, isAdmin: true, name: true },
-    }),
-    getActiveSubscribedSectionIds(userId),
-    listTodoSummary({
-      filters: { completed: false },
-      now,
-      take: limit,
-      userId,
-    }),
-    countDueTodos({
-      completed: false,
-      dueAtFrom: now,
-      dueAtTo: homeworkWindowEnd,
-      includeDueAtTo: true,
-      userId,
-    }),
-    listDueTodoSamples({
-      completed: false,
-      dueAtFrom: now,
-      dueAtTo: homeworkWindowEnd,
-      includeDueAtTo: true,
-      take: limit,
-      userId,
-    }),
+  const [user, todos, dueTodosCount, dueTodos] = await Promise.all([
+    runOverviewStage("user_sections", () =>
+      prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          id: true,
+          image: true,
+          isAdmin: true,
+          name: true,
+          subscribedSections: {
+            where: { retiredAt: null },
+            select: { id: true },
+          },
+        },
+      }),
+    ),
+    runOverviewStage("todo_summary", () =>
+      listTodoSummary({
+        filters: { completed: false },
+        now,
+        take: limit,
+        userId,
+      }),
+    ),
+    runOverviewStage("due_todo_count", () =>
+      countDueTodos({
+        completed: false,
+        dueAtFrom: now,
+        dueAtTo: homeworkWindowEnd,
+        includeDueAtTo: true,
+        userId,
+      }),
+    ),
+    runOverviewStage("due_todo_sample", () =>
+      listDueTodoSamples({
+        completed: false,
+        dueAtFrom: now,
+        dueAtTo: homeworkWindowEnd,
+        includeDueAtTo: true,
+        take: limit,
+        userId,
+      }),
+    ),
   ]);
+  const sectionIds =
+    user?.subscribedSections.map((section) => section.id) ?? [];
 
   const [
-    pendingHomeworksCount,
-    todaySchedulesCount,
-    upcomingExamsCount,
-    dueSoonHomeworksCount,
-    schedules,
-    dueSoonHomeworksRaw,
-    upcomingExams,
-  ] =
-    sectionIds.length > 0
-      ? await Promise.all([
-          prisma.homework.count({
-            where: {
-              deletedAt: null,
-              homeworkCompletions: { none: { userId } },
-              sectionId: { in: sectionIds },
-            },
-          }),
-          prisma.schedule.count({
-            where: {
-              date: { gte: todayStart, lt: tomorrowStart },
-              sectionId: { in: sectionIds },
-            },
-          }),
-          countUpcomingSubscribedExams({
-            atTime: now,
-            sectionIds,
-          }),
-          prisma.homework.count({
-            where: {
-              deletedAt: null,
-              homeworkCompletions: { none: { userId } },
-              sectionId: { in: sectionIds },
-              submissionDueAt: { gte: now, lte: homeworkWindowEnd },
-            },
-          }),
-          listSubscribedSchedules(userId, {
-            dateFrom: todayStart,
-            dateTo: todayStart,
-            limit,
-            locale,
-            sectionIds,
-          }),
-          listSubscribedHomeworks(userId, {
-            completed: false,
-            dueAtFrom: now,
-            dueAtTo: homeworkWindowEnd,
-            includeEditors: true,
-            limit,
-            locale,
-            requireDueDate: true,
-            sectionIds,
-          }),
-          listUpcomingSubscribedExams(userId, {
-            atTime: now,
-            limit,
-            locale,
-            sectionIds,
-          }),
-        ])
-      : [0, 0, 0, 0, [], [], []];
+    [
+      pendingHomeworksCount,
+      todaySchedulesCount,
+      upcomingExamsCount,
+      dueSoonHomeworksCount,
+    ],
+    [schedules, dueSoonHomeworksRaw, upcomingExams],
+  ] = await Promise.all([
+    runOverviewStage("counts", () =>
+      sectionIds.length > 0
+        ? Promise.all([
+            prisma.homework.count({
+              where: {
+                deletedAt: null,
+                homeworkCompletions: { none: { userId } },
+                sectionId: { in: sectionIds },
+              },
+            }),
+            prisma.schedule.count({
+              where: {
+                date: { gte: todayStart, lt: tomorrowStart },
+                sectionId: { in: sectionIds },
+              },
+            }),
+            countUpcomingSubscribedExams({
+              atTime: now,
+              sectionIds,
+            }),
+            prisma.homework.count({
+              where: {
+                deletedAt: null,
+                homeworkCompletions: { none: { userId } },
+                sectionId: { in: sectionIds },
+                submissionDueAt: { gte: now, lte: homeworkWindowEnd },
+              },
+            }),
+          ])
+        : Promise.resolve<[number, number, number, number]>([0, 0, 0, 0]),
+    ),
+    runOverviewStage("lists", () =>
+      sectionIds.length > 0
+        ? Promise.all([
+            listSubscribedSchedules(userId, {
+              dateFrom: todayStart,
+              dateTo: todayStart,
+              limit,
+              locale,
+              sectionIds,
+            }),
+            listSubscribedHomeworks(userId, {
+              completed: false,
+              dueAtFrom: now,
+              dueAtTo: homeworkWindowEnd,
+              includeEditors: true,
+              limit,
+              locale,
+              requireDueDate: true,
+              sectionIds,
+            }),
+            listUpcomingSubscribedExams(userId, {
+              atTime: now,
+              limit,
+              locale,
+              sectionIds,
+            }),
+          ])
+        : Promise.resolve<[never[], never[], never[]]>([[], [], []]),
+    ),
+  ]);
 
-  const dueSoonHomeworks = await withHomeworkItemState(dueSoonHomeworksRaw);
+  const dueSoonHomeworks = await runOverviewStage("item_state", () =>
+    withHomeworkItemState(dueSoonHomeworksRaw),
+  );
 
   return {
     user: {

--- a/src/lib/api/routes/me-overview-route.ts
+++ b/src/lib/api/routes/me-overview-route.ts
@@ -1,3 +1,4 @@
+import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import {
   handleRouteError,
   jsonResponse,
@@ -8,9 +9,11 @@ import { compactOverviewQuerySchema } from "@/lib/api/schemas/request-schemas";
 import { requireAuth } from "@/lib/auth/api-auth";
 
 export async function getMyCompactOverviewRoute(request: Request) {
-  const auth = await requireAuth(request, {
-    bearerScope: { feature: "workspace.overview", action: "read" },
-  });
+  const auth = await runCloudflareTraceSpan("workspace.overview.auth", {}, () =>
+    requireAuth(request, {
+      bearerScope: { feature: "workspace.overview", action: "read" },
+    }),
+  );
   if (auth instanceof Response) return auth;
   const { userId } = auth;
 
@@ -26,12 +29,17 @@ export async function getMyCompactOverviewRoute(request: Request) {
     const { getCompactOverview } = await import(
       "@/features/dashboard/server/compact-overview-read-model"
     );
-    const overview = await getCompactOverview(userId, {
-      atTime: parsedQuery.atTime,
-      homeworkWindowDays: parsedQuery.homeworkWindowDays ?? 7,
-      limit: parsedQuery.limit ?? 3,
-      locale: parsedQuery.locale ?? getRequestLocale(request),
-    });
+    const overview = await runCloudflareTraceSpan(
+      "workspace.overview.read",
+      {},
+      () =>
+        getCompactOverview(userId, {
+          atTime: parsedQuery.atTime,
+          homeworkWindowDays: parsedQuery.homeworkWindowDays ?? 7,
+          limit: parsedQuery.limit ?? 3,
+          locale: parsedQuery.locale ?? getRequestLocale(request),
+        }),
+    );
 
     return jsonResponse(overview);
   } catch (error) {

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -128,6 +128,21 @@ type DatabaseEventAnalyticsInput = {
   event: "connection_error" | "pool_error";
 };
 
+export type WorkspaceOverviewStage =
+  | "counts"
+  | "due_todo_count"
+  | "due_todo_sample"
+  | "item_state"
+  | "lists"
+  | "todo_summary"
+  | "user_sections";
+
+type WorkspaceOverviewStageAnalyticsInput = {
+  ioObservedDurationMs: number;
+  stage: WorkspaceOverviewStage;
+  status: "error" | "success";
+};
+
 function statusClass(status: number) {
   if (!Number.isFinite(status)) return "unknown";
   return `${Math.floor(status / 100)}xx`;
@@ -302,6 +317,16 @@ export function writeCalendarFeedCacheAnalytics(
     indexes: [`cache:calendar:${boundedValue(input.feed)}`],
     blobs: ["calendar_feed_cache", input.feed, input.status],
     doubles: [input.ttlMs, input.storeSize],
+  });
+}
+
+export function writeWorkspaceOverviewStageAnalytics(
+  input: WorkspaceOverviewStageAnalyticsInput,
+) {
+  writeAnalyticsDataPoint({
+    indexes: [`workspace:overview:${input.stage}`],
+    blobs: ["workspace_overview_stage_v1", input.stage, input.status],
+    doubles: [input.ioObservedDurationMs],
   });
 }
 

--- a/tests/unit/analytics-engine-runtime-events.test.ts
+++ b/tests/unit/analytics-engine-runtime-events.test.ts
@@ -6,7 +6,10 @@ import {
 import { recordAndLogMcpResponse } from "@/lib/api/routes/mcp-response-bookkeeping";
 import { writeAuditLog } from "@/lib/audit/write-audit-log";
 import { withBetterAuthOAuthDebug } from "@/lib/log/oauth-debug";
-import { writeOAuthEventAnalytics } from "@/lib/metrics/analytics-engine";
+import {
+  writeOAuthEventAnalytics,
+  writeWorkspaceOverviewStageAnalytics,
+} from "@/lib/metrics/analytics-engine";
 import {
   cachedPublicRuntimeData,
   publicDetailColoCacheKey,
@@ -47,6 +50,58 @@ describe("Cloudflare Analytics Engine runtime events", () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+  });
+
+  it("writes fixed low-cardinality workspace overview stage datapoints", () => {
+    const writeDataPoint = installAnalyticsBinding();
+    const stages = [
+      "user_sections",
+      "todo_summary",
+      "due_todo_count",
+      "due_todo_sample",
+      "counts",
+      "lists",
+      "item_state",
+    ] as const;
+
+    stages.forEach((stage, index) => {
+      writeWorkspaceOverviewStageAnalytics({
+        ioObservedDurationMs: index + 1,
+        stage,
+        status: index === stages.length - 1 ? "error" : "success",
+      });
+    });
+
+    expect(writeDataPoint).toHaveBeenCalledTimes(stages.length);
+    stages.forEach((stage, index) => {
+      expect(writeDataPoint).toHaveBeenNthCalledWith(index + 1, {
+        indexes: [`workspace:overview:${stage}`],
+        blobs: [
+          "workspace_overview_stage_v1",
+          stage,
+          index === stages.length - 1 ? "error" : "success",
+        ],
+        doubles: [index + 1],
+      });
+    });
+  });
+
+  it("keeps workspace overview stages available when Analytics Engine fails", () => {
+    setCloudflareRuntimeEnv({
+      ANALYTICS: {
+        writeDataPoint: vi.fn(() => {
+          throw new Error("analytics unavailable");
+        }),
+      },
+    });
+
+    expect(() =>
+      writeWorkspaceOverviewStageAnalytics({
+        ioObservedDurationMs: 5,
+        stage: "todo_summary",
+        status: "success",
+      }),
+    ).not.toThrow();
   });
 
   it("writes MCP transport datapoints without tool argument values", () => {

--- a/tests/unit/compact-overview-read-model.test.ts
+++ b/tests/unit/compact-overview-read-model.test.ts
@@ -1,0 +1,294 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  analyticsMock,
+  countDueTodosMock,
+  countUpcomingSubscribedExamsMock,
+  homeworkCountMock,
+  listDueTodoSamplesMock,
+  listSubscribedHomeworksMock,
+  listSubscribedSchedulesMock,
+  listTodoSummaryMock,
+  listUpcomingSubscribedExamsMock,
+  runCloudflareTraceSpanMock,
+  scheduleCountMock,
+  userFindUniqueMock,
+  withHomeworkItemStateMock,
+} = vi.hoisted(() => ({
+  analyticsMock: vi.fn(),
+  countDueTodosMock: vi.fn(),
+  countUpcomingSubscribedExamsMock: vi.fn(),
+  homeworkCountMock: vi.fn(),
+  listDueTodoSamplesMock: vi.fn(),
+  listSubscribedHomeworksMock: vi.fn(),
+  listSubscribedSchedulesMock: vi.fn(),
+  listTodoSummaryMock: vi.fn(),
+  listUpcomingSubscribedExamsMock: vi.fn(),
+  runCloudflareTraceSpanMock: vi.fn(),
+  scheduleCountMock: vi.fn(),
+  userFindUniqueMock: vi.fn(),
+  withHomeworkItemStateMock: vi.fn(),
+}));
+
+vi.mock("@/lib/adapters/cloudflare-runtime", () => ({
+  runCloudflareTraceSpan: runCloudflareTraceSpanMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    homework: { count: homeworkCountMock },
+    schedule: { count: scheduleCountMock },
+    user: { findUnique: userFindUniqueMock },
+  },
+}));
+
+vi.mock("@/lib/metrics/analytics-engine", () => ({
+  writeWorkspaceOverviewStageAnalytics: analyticsMock,
+}));
+
+vi.mock("@/features/homeworks/server/homework-item-state", () => ({
+  withHomeworkItemState: withHomeworkItemStateMock,
+}));
+
+vi.mock("@/features/subscriptions/server/subscription-read-model", () => ({
+  countUpcomingSubscribedExams: countUpcomingSubscribedExamsMock,
+  listSubscribedHomeworks: listSubscribedHomeworksMock,
+  listSubscribedSchedules: listSubscribedSchedulesMock,
+  listUpcomingSubscribedExams: listUpcomingSubscribedExamsMock,
+}));
+
+vi.mock("@/features/todos/server/todo-service", () => ({
+  countDueTodos: countDueTodosMock,
+  listDueTodoSamples: listDueTodoSamplesMock,
+  listTodoSummary: listTodoSummaryMock,
+}));
+
+const AT_TIME = new Date("2026-07-29T08:00:00.000Z");
+const TODO_COUNTS = { completed: 2, incomplete: 3, overdue: 1 };
+
+describe("compact workspace overview read model", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    runCloudflareTraceSpanMock.mockImplementation(
+      (_name: string, _attributes: object, callback: () => unknown) =>
+        callback(),
+    );
+    userFindUniqueMock.mockResolvedValue({
+      id: "user-1",
+      image: "avatar.png",
+      isAdmin: true,
+      name: "User One",
+      subscribedSections: [{ id: 11 }],
+    });
+    listTodoSummaryMock.mockResolvedValue({
+      counts: TODO_COUNTS,
+      todos: [{ id: "todo-1" }],
+    });
+    countDueTodosMock.mockResolvedValue(2);
+    listDueTodoSamplesMock.mockResolvedValue([{ id: "due-todo-1" }]);
+    homeworkCountMock.mockResolvedValueOnce(4).mockResolvedValueOnce(2);
+    scheduleCountMock.mockResolvedValue(1);
+    countUpcomingSubscribedExamsMock.mockResolvedValue(3);
+    listSubscribedSchedulesMock.mockResolvedValue([]);
+    listSubscribedHomeworksMock.mockResolvedValue([]);
+    listUpcomingSubscribedExamsMock.mockResolvedValue([]);
+    withHomeworkItemStateMock.mockImplementation(async (items) => items);
+  });
+
+  it("reads user fields and active sections once with fixed overview stages", async () => {
+    const { getCompactOverview } = await import(
+      "@/features/dashboard/server/compact-overview-read-model"
+    );
+
+    const overview = await getCompactOverview("user-1", { atTime: AT_TIME });
+
+    expect(userFindUniqueMock).toHaveBeenCalledOnce();
+    expect(userFindUniqueMock).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      select: {
+        id: true,
+        image: true,
+        isAdmin: true,
+        name: true,
+        subscribedSections: {
+          where: { retiredAt: null },
+          select: { id: true },
+        },
+      },
+    });
+    expect(listTodoSummaryMock).toHaveBeenCalledOnce();
+    expect(countDueTodosMock).toHaveBeenCalledOnce();
+    expect(listDueTodoSamplesMock).toHaveBeenCalledOnce();
+    expect(countUpcomingSubscribedExamsMock).toHaveBeenCalledWith({
+      atTime: AT_TIME,
+      sectionIds: [11],
+    });
+    expect(listSubscribedSchedulesMock).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ sectionIds: [11] }),
+    );
+    expect(overview.user).toEqual({
+      image: "avatar.png",
+      isAdmin: true,
+      name: "User One",
+      userId: "user-1",
+    });
+    expect(overview.counts).toEqual({
+      dueSoonHomeworks: 2,
+      pendingHomeworks: 4,
+      todaySchedules: 1,
+      todos: TODO_COUNTS,
+      upcomingExams: 3,
+    });
+    expect(
+      runCloudflareTraceSpanMock.mock.calls.map(([name, attributes]) => [
+        name,
+        attributes,
+      ]),
+    ).toEqual([
+      ["workspace.overview.user_sections", {}],
+      ["workspace.overview.todo_summary", {}],
+      ["workspace.overview.due_todo_count", {}],
+      ["workspace.overview.due_todo_sample", {}],
+      ["workspace.overview.counts", {}],
+      ["workspace.overview.lists", {}],
+      ["workspace.overview.item_state", {}],
+    ]);
+    expect(
+      analyticsMock.mock.calls.map(([input]) => [input.stage, input.status]),
+    ).toEqual([
+      ["user_sections", "success"],
+      ["todo_summary", "success"],
+      ["due_todo_count", "success"],
+      ["due_todo_sample", "success"],
+      ["counts", "success"],
+      ["lists", "success"],
+      ["item_state", "success"],
+    ]);
+  });
+
+  it("starts all three Todo reads independently without waiting for the summary", async () => {
+    let resolveSummary:
+      | ((value: {
+          counts: typeof TODO_COUNTS;
+          todos: { id: string }[];
+        }) => void)
+      | undefined;
+    listTodoSummaryMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSummary = resolve;
+      }),
+    );
+    const { getCompactOverview } = await import(
+      "@/features/dashboard/server/compact-overview-read-model"
+    );
+
+    const overviewPromise = getCompactOverview("user-1", { atTime: AT_TIME });
+
+    expect(listTodoSummaryMock).toHaveBeenCalledOnce();
+    expect(countDueTodosMock).toHaveBeenCalledOnce();
+    expect(listDueTodoSamplesMock).toHaveBeenCalledOnce();
+    resolveSummary?.({ counts: TODO_COUNTS, todos: [{ id: "todo-1" }] });
+    await overviewPromise;
+  });
+
+  it.each([
+    {
+      label: "only retired sections remain after the active-section filter",
+      user: {
+        id: "user-1",
+        image: null,
+        isAdmin: false,
+        name: "User One",
+        subscribedSections: [],
+      },
+      expectedUser: {
+        image: null,
+        isAdmin: false,
+        name: "User One",
+        userId: "user-1",
+      },
+    },
+    {
+      label: "the user row is missing",
+      user: null,
+      expectedUser: {
+        image: null,
+        isAdmin: false,
+        name: null,
+        userId: "user-1",
+      },
+    },
+  ])("uses empty section semantics when $label", async ({
+    user,
+    expectedUser,
+  }) => {
+    userFindUniqueMock.mockResolvedValue(user);
+    const { getCompactOverview } = await import(
+      "@/features/dashboard/server/compact-overview-read-model"
+    );
+
+    const overview = await getCompactOverview("user-1", { atTime: AT_TIME });
+
+    expect(userFindUniqueMock).toHaveBeenCalledOnce();
+    expect(homeworkCountMock).not.toHaveBeenCalled();
+    expect(scheduleCountMock).not.toHaveBeenCalled();
+    expect(countUpcomingSubscribedExamsMock).not.toHaveBeenCalled();
+    expect(listSubscribedSchedulesMock).not.toHaveBeenCalled();
+    expect(listSubscribedHomeworksMock).not.toHaveBeenCalled();
+    expect(listUpcomingSubscribedExamsMock).not.toHaveBeenCalled();
+    expect(withHomeworkItemStateMock).toHaveBeenCalledWith([]);
+    expect(overview.user).toEqual(expectedUser);
+    expect(overview.counts).toEqual({
+      dueSoonHomeworks: 0,
+      pendingHomeworks: 0,
+      todaySchedules: 0,
+      todos: TODO_COUNTS,
+      upcomingExams: 0,
+    });
+  });
+
+  it("starts count and list groups together while preserving each group fan-out", async () => {
+    let resolveFirstCount: ((value: number) => void) | undefined;
+    homeworkCountMock.mockReset();
+    homeworkCountMock
+      .mockReturnValueOnce(
+        new Promise<number>((resolve) => {
+          resolveFirstCount = resolve;
+        }),
+      )
+      .mockResolvedValueOnce(2);
+    const { getCompactOverview } = await import(
+      "@/features/dashboard/server/compact-overview-read-model"
+    );
+
+    const overviewPromise = getCompactOverview("user-1", { atTime: AT_TIME });
+
+    await vi.waitFor(() => {
+      expect(homeworkCountMock).toHaveBeenCalledTimes(2);
+      expect(scheduleCountMock).toHaveBeenCalledOnce();
+      expect(countUpcomingSubscribedExamsMock).toHaveBeenCalledOnce();
+      expect(listSubscribedSchedulesMock).toHaveBeenCalledOnce();
+      expect(listSubscribedHomeworksMock).toHaveBeenCalledOnce();
+      expect(listUpcomingSubscribedExamsMock).toHaveBeenCalledOnce();
+    });
+    resolveFirstCount?.(4);
+    await overviewPromise;
+  });
+
+  it("records an error status and rethrows a failed overview stage", async () => {
+    withHomeworkItemStateMock.mockRejectedValue(new Error("item state failed"));
+    const { getCompactOverview } = await import(
+      "@/features/dashboard/server/compact-overview-read-model"
+    );
+
+    await expect(
+      getCompactOverview("user-1", { atTime: AT_TIME }),
+    ).rejects.toThrow("item state failed");
+    expect(analyticsMock).toHaveBeenCalledWith({
+      ioObservedDurationMs: expect.any(Number),
+      stage: "item_state",
+      status: "error",
+    });
+  });
+});

--- a/tests/unit/workspace-route-tracing.test.ts
+++ b/tests/unit/workspace-route-tracing.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  getCompactOverviewMock,
   getSubscribedSectionIdsMock,
   getUserCalendarSubscriptionMock,
   getViewerContextMock,
@@ -10,6 +11,7 @@ const {
   runCloudflareTraceSpanMock,
   withHomeworkItemStateMock,
 } = vi.hoisted(() => ({
+  getCompactOverviewMock: vi.fn(),
   getSubscribedSectionIdsMock: vi.fn(),
   getUserCalendarSubscriptionMock: vi.fn(),
   getViewerContextMock: vi.fn(),
@@ -41,6 +43,10 @@ vi.mock("@/features/subscriptions/server/subscription-read-model", () => ({
 
 vi.mock("@/features/homeworks/server/homework-item-state", () => ({
   withHomeworkItemState: withHomeworkItemStateMock,
+}));
+
+vi.mock("@/features/dashboard/server/compact-overview-read-model", () => ({
+  getCompactOverview: getCompactOverviewMock,
 }));
 
 describe("workspace route tracing", () => {
@@ -110,6 +116,30 @@ describe("workspace route tracing", () => {
     ).toEqual([
       ["workspace.subscriptions.current.auth", {}],
       ["workspace.subscriptions.current.read", {}],
+    ]);
+  });
+
+  it("separates overview auth from its read without trace attributes", async () => {
+    const overview = { user: { userId: "user-1" } };
+    getCompactOverviewMock.mockResolvedValue(overview);
+    const { getMyCompactOverviewRoute } = await import(
+      "@/lib/api/routes/me-overview-route"
+    );
+
+    const response = await getMyCompactOverviewRoute(
+      new Request("https://example.test/api/workspace/overview"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(overview);
+    expect(
+      runCloudflareTraceSpanMock.mock.calls.map(([name, attributes]) => [
+        name,
+        attributes,
+      ]),
+    ).toEqual([
+      ["workspace.overview.auth", {}],
+      ["workspace.overview.read", {}],
     ]);
   });
 });


### PR DESCRIPTION
## What changed

- merge the compact overview's user/profile lookup and active-section lookup into one Prisma `User.findUnique` selection;
- preserve the three parallel Todo RLS reads and the parallel count/list fan-out instead of wrapping them in one serial interactive transaction;
- add fixed, privacy-safe Cloudflare trace spans for auth/read and seven read-model stages;
- record non-blocking `workspace_overview_stage_v1` Analytics Engine datapoints with only fixed stage/status values.

No endpoint, response shape, filter, authorization rule, RLS boundary, or fallback changes.

## Why

Production evidence in #672 showed temporary 5.4–6.6 s wall-time tails on `/api/workspace/overview`, but the affected requests were not selected by the 5% trace sample. Later requests on the same version were 105–198 ms, with 0 ms Hyperdrive connect spans. That supports removing the deterministic duplicate user read and adding full-sample low-cardinality stage attribution, while avoiding an unproven transaction change that would serialize currently parallel SQL.

Prisma relation loading is implementation-dependent, so this PR claims one fewer duplicate Prisma parent lookup—not a guaranteed one-SQL query.

## Verification

- independent semantic/concurrency review: no blockers;
- focused Vitest: 3 files, 20 tests;
- full Vitest: 267 files, 1719 tests;
- Biome: pass (one pre-existing static-loader warning);
- Svelte: 0 errors, 0 warnings;
- all three TypeScript projects: pass;
- Wrangler generated types check: pass;
- production build: pass;
- Wrangler deploy dry-run: pass;
- retry regression script: pass.

Refs #672.