### PR TITLE
fix(observability): classify colo cache write outcomes

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -64,9 +64,14 @@ high-cardinality resource IDs.
   namespaces. Full cache keys, including search and filter values, never enter
   the Analytics Engine writer. Catalog detail cache namespaces likewise omit
   entity IDs. Detail L2 outcomes use fixed `colo_hit`, `colo_miss`,
-  `colo_read_error`, `colo_write_complete`, and `colo_write_error` events; the
-  synthetic Cache API key is never recorded. A completed write only confirms
-  that Cache API processing finished; a later `colo_hit` proves admission.
+  `colo_read_error`, `colo_write_complete`, `colo_write_skip`, and
+  `colo_write_error` events; the synthetic Cache API key is never recorded.
+  Cache event `blob4` is a fixed low-cardinality reason: `none`,
+  `result_invalid`, `scheduler_unavailable`, `response_build_failed`,
+  `task_scheduling_failed`, or `cache_put_rejected`. A validator-rejected
+  loaded result is an expected write skip, including a course alias result that
+  must redirect to its canonical ID. A completed write only confirms that Cache
+  API processing finished; a later `colo_hit` proves admission.
 
 ## Endpoints
 

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -81,6 +81,14 @@ export type PublicRuntimeCacheAnalyticsNamespace =
       | "page:teacher-detail"
       | "page:teacher-list"}:${AppLocale}`;
 
+export type PublicRuntimeCacheAnalyticsReason =
+  | "cache_put_rejected"
+  | "none"
+  | "response_build_failed"
+  | "result_invalid"
+  | "scheduler_unavailable"
+  | "task_scheduling_failed";
+
 type CacheEventAnalyticsInput = {
   event:
     | "colo_hit"
@@ -88,12 +96,14 @@ type CacheEventAnalyticsInput = {
     | "colo_read_error"
     | "colo_write_complete"
     | "colo_write_error"
+    | "colo_write_skip"
     | "hit"
     | "load_error"
     | "load_success"
     | "miss";
   ioObservedDurationMs: number;
   namespace: PublicRuntimeCacheAnalyticsNamespace;
+  reason?: PublicRuntimeCacheAnalyticsReason;
   storeSize: number;
   ttlMs: number;
 };
@@ -305,7 +315,12 @@ export function writeStorageOperationAnalytics(
 export function writeCacheEventAnalytics(input: CacheEventAnalyticsInput) {
   writeAnalyticsDataPoint({
     indexes: [`cache:${boundedValue(input.namespace)}`],
-    blobs: ["public_runtime_cache_v2", input.event, input.namespace],
+    blobs: [
+      "public_runtime_cache_v2",
+      input.event,
+      input.namespace,
+      input.reason ?? "none",
+    ],
     doubles: [input.ioObservedDurationMs, input.ttlMs, input.storeSize],
   });
 }

--- a/src/lib/public-runtime-cache.ts
+++ b/src/lib/public-runtime-cache.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/adapters/cloudflare-runtime";
 import {
   type PublicRuntimeCacheAnalyticsNamespace,
+  type PublicRuntimeCacheAnalyticsReason,
   writeCacheEventAnalytics,
 } from "@/lib/metrics/analytics-engine";
 
@@ -35,7 +36,8 @@ type ColoCacheEvent =
   | "colo_miss"
   | "colo_read_error"
   | "colo_write_error"
-  | "colo_write_complete";
+  | "colo_write_complete"
+  | "colo_write_skip";
 
 const MAX_ENTRIES = 100;
 const PUBLIC_DETAIL_COLO_CACHE_NAME = "life-ustc-public-detail-core-v1";
@@ -104,11 +106,13 @@ function writeColoCacheEvent(
   start: number,
   storeSize: number,
   ttlMs: number,
+  reason: PublicRuntimeCacheAnalyticsReason = "none",
 ) {
   writeCacheEventAnalytics({
     event,
     ioObservedDurationMs: Date.now() - start,
     namespace,
+    reason,
     storeSize,
     ttlMs,
   });
@@ -203,13 +207,15 @@ function scheduleColoCacheWrite<T>(
         start,
         storeSize,
         ttlMs,
+        "scheduler_unavailable",
       );
     }
     return;
   }
 
+  let response: Response;
   try {
-    const response = new Response(
+    response = new Response(
       JSON.stringify({
         expiresAt,
         schema: PUBLIC_DETAIL_COLO_CACHE_SCHEMA,
@@ -222,46 +228,72 @@ function scheduleColoCacheWrite<T>(
         },
       },
     );
-    let scheduled = false;
-    const write = cache.put(request, response).then(
-      () => {
-        if (scheduled) {
-          writeColoCacheEvent(
-            "colo_write_complete",
-            namespace,
-            start,
-            storeSize,
-            ttlMs,
-          );
-        }
-      },
-      () => {
-        if (scheduled) {
-          writeColoCacheEvent(
-            "colo_write_error",
-            namespace,
-            start,
-            storeSize,
-            ttlMs,
-          );
-        }
-      },
-    );
-    try {
-      scheduleTask(write);
-      scheduled = true;
-    } catch {
-      void write;
-      writeColoCacheEvent(
-        "colo_write_error",
-        namespace,
-        start,
-        storeSize,
-        ttlMs,
-      );
-    }
   } catch {
-    writeColoCacheEvent("colo_write_error", namespace, start, storeSize, ttlMs);
+    writeColoCacheEvent(
+      "colo_write_error",
+      namespace,
+      start,
+      storeSize,
+      ttlMs,
+      "response_build_failed",
+    );
+    return;
+  }
+
+  let cacheWrite: Promise<void>;
+  try {
+    cacheWrite = cache.put(request, response);
+  } catch {
+    writeColoCacheEvent(
+      "colo_write_error",
+      namespace,
+      start,
+      storeSize,
+      ttlMs,
+      "cache_put_rejected",
+    );
+    return;
+  }
+
+  let scheduled = false;
+  const write = cacheWrite.then(
+    () => {
+      if (scheduled) {
+        writeColoCacheEvent(
+          "colo_write_complete",
+          namespace,
+          start,
+          storeSize,
+          ttlMs,
+        );
+      }
+    },
+    () => {
+      if (scheduled) {
+        writeColoCacheEvent(
+          "colo_write_error",
+          namespace,
+          start,
+          storeSize,
+          ttlMs,
+          "cache_put_rejected",
+        );
+      }
+    },
+  );
+  try {
+    scheduleTask(write);
+    scheduled = true;
+  } catch {
+    void write;
+    writeColoCacheEvent(
+      "colo_write_error",
+      namespace,
+      start,
+      storeSize,
+      ttlMs,
+      "task_scheduling_failed",
+    );
   }
 }
 
@@ -357,11 +389,12 @@ export function cachedPublicRuntimeData<T>(
         );
       } else {
         writeColoCacheEvent(
-          "colo_write_error",
+          "colo_write_skip",
           analyticsNamespace,
           start,
           initialStoreSize,
           ttlMs,
+          "result_invalid",
         );
       }
     }

--- a/tests/unit/analytics-engine-runtime-events.test.ts
+++ b/tests/unit/analytics-engine-runtime-events.test.ts
@@ -339,12 +339,12 @@ describe("Cloudflare Analytics Engine runtime events", () => {
     expect(load).toHaveBeenCalledTimes(1);
     expect(writeDataPoint).toHaveBeenCalledWith({
       indexes: [`cache:${namespace}`],
-      blobs: ["public_runtime_cache_v2", "miss", namespace],
+      blobs: ["public_runtime_cache_v2", "miss", namespace, "none"],
       doubles: [expect.any(Number), 60_000, 0],
     });
     expect(writeDataPoint).toHaveBeenCalledWith({
       indexes: [`cache:${namespace}`],
-      blobs: ["public_runtime_cache_v2", "hit", namespace],
+      blobs: ["public_runtime_cache_v2", "hit", namespace, "none"],
       doubles: [expect.any(Number), 60_000, 1],
     });
     expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain(
@@ -412,7 +412,12 @@ describe("Cloudflare Analytics Engine runtime events", () => {
     for (const event of ["colo_hit", "colo_miss", "colo_write_complete"]) {
       expect(writeDataPoint).toHaveBeenCalledWith({
         indexes: ["cache:page:course-detail:en-us"],
-        blobs: ["public_runtime_cache_v2", event, "page:course-detail:en-us"],
+        blobs: [
+          "public_runtime_cache_v2",
+          event,
+          "page:course-detail:en-us",
+          "none",
+        ],
         doubles: [expect.any(Number), 60_000, expect.any(Number)],
       });
     }

--- a/tests/unit/public-runtime-cache.test.ts
+++ b/tests/unit/public-runtime-cache.test.ts
@@ -66,6 +66,85 @@ function runtimeExecutionContext() {
   return { context, scheduled };
 }
 
+function expectColoCacheEvent(
+  writeDataPoint: ReturnType<typeof vi.fn>,
+  event: string,
+  reason: string,
+) {
+  expect(
+    writeDataPoint.mock.calls.filter(
+      ([dataPoint]) =>
+        dataPoint.blobs?.[1] === event && dataPoint.blobs?.[3] === reason,
+    ),
+  ).toHaveLength(1);
+  expect(writeDataPoint).toHaveBeenCalledWith({
+    indexes: ["cache:page:course-detail:en-us"],
+    blobs: [
+      "public_runtime_cache_v2",
+      event,
+      "page:course-detail:en-us",
+      reason,
+    ],
+    doubles: [expect.any(Number), 60_000, expect.any(Number)],
+  });
+}
+
+type ObservedColoMissOptions = {
+  loadResult?: unknown;
+  put?: (request: Request, response: Response) => Promise<void>;
+  scheduler?: "available" | "missing" | "throws";
+  validate?: (value: unknown) => boolean;
+  writeDataPoint?: ReturnType<typeof vi.fn>;
+};
+
+async function observeColoMiss(options: ObservedColoMissOptions = {}) {
+  const writeDataPoint = options.writeDataPoint ?? vi.fn();
+  const { put } = installNamedCache(
+    options.put ? { put: options.put } : undefined,
+  );
+  const scheduled: Promise<unknown>[] = [];
+  const context =
+    options.scheduler === "missing"
+      ? undefined
+      : {
+          waitUntil(promise: Promise<unknown>) {
+            if (options.scheduler === "throws") {
+              throw new Error("scheduler failed");
+            }
+            scheduled.push(promise);
+          },
+        };
+  const loadResult = Object.hasOwn(options, "loadResult")
+    ? options.loadResult
+    : { source: "database" };
+
+  const result = await runWithCloudflareRuntimeEnv(
+    { ANALYTICS: { writeDataPoint } },
+    async () => {
+      const value = await cachedPublicRuntimeData(
+        "page:course-detail:en-us",
+        "observed-colo-miss",
+        60_000,
+        async () => loadResult,
+        {
+          coloCacheKey: publicDetailColoCacheKey(
+            "https://example.test",
+            "course",
+            "en-us",
+            683009,
+          ),
+          validateColoCacheResult: options.validate ?? validatesSource,
+        },
+      );
+      await Promise.all(scheduled);
+      return value;
+    },
+    context,
+  );
+
+  return { put, result, scheduled, writeDataPoint };
+}
+
 describe("public runtime cache", () => {
   beforeEach(() => {
     clearPublicRuntimeCache();
@@ -571,5 +650,110 @@ describe("public runtime cache", () => {
     expect(load).toHaveBeenCalledOnce();
     expect(put).toHaveBeenCalledOnce();
     expect(scheduled).toHaveLength(1);
+  });
+
+  it("reports a validator-rejected canonical result as a write skip", async () => {
+    const canonical = { jwId: 683010, source: "database" };
+    const { put, result, scheduled, writeDataPoint } = await observeColoMiss({
+      loadResult: canonical,
+      validate: () => false,
+    });
+
+    expect(result).toBe(canonical);
+    expect(put).not.toHaveBeenCalled();
+    expect(scheduled).toHaveLength(0);
+    expectColoCacheEvent(writeDataPoint, "colo_write_skip", "result_invalid");
+    expect(writeDataPoint).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        blobs: expect.arrayContaining(["colo_write_error"]),
+      }),
+    );
+  });
+
+  it("reports response serialization failures and returns the loaded result", async () => {
+    const circular: { self?: unknown; source: string } = {
+      source: "database",
+    };
+    circular.self = circular;
+    const { put, result, scheduled, writeDataPoint } = await observeColoMiss({
+      loadResult: circular,
+      validate: () => true,
+    });
+
+    expect(result).toBe(circular);
+    expect(put).not.toHaveBeenCalled();
+    expect(scheduled).toHaveLength(0);
+    expectColoCacheEvent(
+      writeDataPoint,
+      "colo_write_error",
+      "response_build_failed",
+    );
+  });
+
+  it.each([
+    {
+      expectedPutCalls: 0,
+      expectedScheduled: 0,
+      name: "an unavailable runtime scheduler",
+      options: { scheduler: "missing" as const },
+      reason: "scheduler_unavailable",
+    },
+    {
+      expectedPutCalls: 1,
+      expectedScheduled: 0,
+      name: "a task scheduling failure",
+      options: { scheduler: "throws" as const },
+      reason: "task_scheduling_failed",
+    },
+    {
+      expectedPutCalls: 1,
+      expectedScheduled: 1,
+      name: "an asynchronous Cache API rejection",
+      options: {
+        put: async () => {
+          throw new Error("write failed");
+        },
+      },
+      reason: "cache_put_rejected",
+    },
+    {
+      expectedPutCalls: 1,
+      expectedScheduled: 0,
+      name: "a synchronous Cache API rejection",
+      options: {
+        put: () => {
+          throw new Error("write failed");
+        },
+      },
+      reason: "cache_put_rejected",
+    },
+  ])("reports $name without failing the loaded result", async ({
+    expectedPutCalls,
+    expectedScheduled,
+    options,
+    reason,
+  }) => {
+    const { put, result, scheduled, writeDataPoint } =
+      await observeColoMiss(options);
+
+    expect(result).toEqual({ source: "database" });
+    expect(put).toHaveBeenCalledTimes(expectedPutCalls);
+    expect(scheduled).toHaveLength(expectedScheduled);
+    expectColoCacheEvent(writeDataPoint, "colo_write_error", reason);
+  });
+
+  it("keeps a validator-rejected result available when Analytics Engine fails", async () => {
+    const writeDataPoint = vi.fn(() => {
+      throw new Error("analytics unavailable");
+    });
+    const { put, result } = await observeColoMiss({
+      loadResult: { source: "canonical" },
+      validate: () => false,
+      writeDataPoint,
+    });
+
+    expect(result).toEqual({ source: "canonical" });
+    expect(writeDataPoint).toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- classify validator-rejected public detail results as `colo_write_skip` / `result_invalid` instead of cache write failures
- attach one fixed low-cardinality reason to every public runtime cache event while preserving the existing event, namespace, duration, TTL, and store-size positions
- distinguish scheduler absence, response construction, task scheduling, and `cache.put` failures
- keep all cache writes fail-open, off the response critical path, and unchanged in TTL/data/admission behavior

## Production evidence

All three apparent `colo_write_error` events in the inspected production window matched anonymous zh-cn course alias 308 responses and had the exact same duration as the successful loader event. They were expected requested-ID validator rejections, not Cache API or platform failures.

## Verification

- focused cache/Analytics Engine tests: 2 files / 34 tests
- full Vitest: 269 files / 1732 tests
- Svelte check: 0 errors / 0 warnings
- all three TypeScript projects passed
- Biome passed with the same pre-existing static-loader warning
- production build and Wrangler deploy dry-run passed
- independent review found no blockers and verified exact-once terminal events

Closes #688
