### PR TITLE
perf(profile): aggregate public contributions in database

### DIFF
--- a/src/features/profile/server/user-profile-contributions.ts
+++ b/src/features/profile/server/user-profile-contributions.ts
@@ -3,7 +3,6 @@ import {
   campusDateKeyRange,
   campusWeekStartKey,
   requireCampusDateKeyForValue,
-  toCampusDateKey,
 } from "@/lib/time/campus-date";
 import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
 
@@ -12,28 +11,65 @@ export type ContributionCell = {
   count: number;
 };
 
-type ContributionEvent = {
-  createdAt: Date;
-};
-
-type CompletionEvent = {
-  completedAt: Date;
+type ContributionDayRow = {
+  date: string;
+  count: bigint;
 };
 
 type ContributionPrisma = {
-  comment: {
-    findMany(input: unknown): Promise<ContributionEvent[]>;
-  };
-  homework: {
-    findMany(input: unknown): Promise<ContributionEvent[]>;
-  };
-  homeworkCompletion: {
-    findMany(input: unknown): Promise<CompletionEvent[]>;
-  };
-  upload: {
-    findMany(input: unknown): Promise<ContributionEvent[]>;
-  };
+  $queryRaw<T = unknown>(
+    query: TemplateStringsArray,
+    ...values: unknown[]
+  ): PromiseLike<T>;
 };
+
+export async function loadUserProfileContributionDays(
+  prisma: ContributionPrisma,
+  userId: string,
+  startAt: Date,
+) {
+  const rows = await prisma.$queryRaw<ContributionDayRow[]>`
+    SELECT
+      to_char(
+        (events."eventAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Shanghai',
+        'YYYY-MM-DD'
+      ) AS "date",
+      COUNT(*) AS "count"
+    FROM (
+      SELECT "createdAt" AS "eventAt"
+      FROM "Comment"
+      WHERE "userId" = ${userId}
+        AND "createdAt" >= ${startAt}
+        AND "status" IN ('active', 'softbanned')
+
+      UNION ALL
+
+      SELECT "createdAt" AS "eventAt"
+      FROM "Upload"
+      WHERE "userId" = ${userId}
+        AND "createdAt" >= ${startAt}
+
+      UNION ALL
+
+      SELECT "completedAt" AS "eventAt"
+      FROM "HomeworkCompletion"
+      WHERE "userId" = ${userId}
+        AND "completedAt" >= ${startAt}
+
+      UNION ALL
+
+      SELECT "createdAt" AS "eventAt"
+      FROM "Homework"
+      WHERE "createdById" = ${userId}
+        AND "createdAt" >= ${startAt}
+        AND "deletedAt" IS NULL
+    ) AS events
+    GROUP BY 1
+    ORDER BY 1
+  `;
+
+  return rows.map(({ count, date }) => ({ count: Number(count), date }));
+}
 
 export async function buildUserProfileContributions(
   prisma: ContributionPrisma,
@@ -42,45 +78,14 @@ export async function buildUserProfileContributions(
 ) {
   const today = shanghaiDayjs(referenceNow).startOf("day");
   const startDate = today.subtract(364, "day").startOf("day");
-  const [commentEvents, uploadEvents, completionEvents, homeworkEvents] =
-    await Promise.all([
-      prisma.comment.findMany({
-        where: {
-          userId,
-          createdAt: { gte: startDate.toDate() },
-          status: { in: ["active", "softbanned"] },
-        },
-        select: { createdAt: true },
-      }),
-      prisma.upload.findMany({
-        where: { userId, createdAt: { gte: startDate.toDate() } },
-        select: { createdAt: true },
-      }),
-      prisma.homeworkCompletion.findMany({
-        where: { userId, completedAt: { gte: startDate.toDate() } },
-        select: { completedAt: true },
-      }),
-      prisma.homework.findMany({
-        where: {
-          createdById: userId,
-          createdAt: { gte: startDate.toDate() },
-          deletedAt: null,
-        },
-        select: { createdAt: true },
-      }),
-    ]);
-
-  const contributionMap = new Map<string, number>();
-  const addContribution = (date: Date) => {
-    const key = toCampusDateKey(date);
-    if (!key) return;
-    contributionMap.set(key, (contributionMap.get(key) ?? 0) + 1);
-  };
-
-  for (const item of commentEvents) addContribution(item.createdAt);
-  for (const item of uploadEvents) addContribution(item.createdAt);
-  for (const item of completionEvents) addContribution(item.completedAt);
-  for (const item of homeworkEvents) addContribution(item.createdAt);
+  const contributionDays = await loadUserProfileContributionDays(
+    prisma,
+    userId,
+    startDate.toDate(),
+  );
+  const contributionMap = new Map(
+    contributionDays.map(({ count, date }) => [date, count]),
+  );
 
   const startDateKey = requireCampusDateKeyForValue(startDate.toDate());
   const todayKey = requireCampusDateKeyForValue(today.toDate());

--- a/src/features/profile/server/user-profile-page-data.ts
+++ b/src/features/profile/server/user-profile-page-data.ts
@@ -3,16 +3,20 @@ import type { Prisma } from "@/generated/prisma/client";
 import { getPrisma } from "@/lib/db/prisma";
 import { toLoadData } from "@/lib/load-data-utils";
 
+const publicUserIdentitySelect = {
+  id: true,
+  username: true,
+  name: true,
+  image: true,
+  createdAt: true,
+} satisfies Prisma.UserSelect;
+
 async function getUserProfileData(where: Prisma.UserWhereUniqueInput) {
   const prisma = getPrisma("zh-cn");
   const user = await prisma.user.findUnique({
     where,
     select: {
-      id: true,
-      username: true,
-      name: true,
-      image: true,
-      createdAt: true,
+      ...publicUserIdentitySelect,
       _count: {
         select: {
           comments: true,
@@ -45,4 +49,22 @@ export async function getUserProfileByUsername(username: string) {
 
 export async function getUserProfileById(id: string) {
   return getUserProfileData({ id });
+}
+
+export async function getPublicUserIdentityByIdentifier(identifier: string) {
+  const normalized = identifier.trim();
+  if (!normalized) return null;
+
+  const prisma = getPrisma("zh-cn");
+  const user =
+    (await prisma.user.findUnique({
+      where: { username: normalized.toLowerCase() },
+      select: publicUserIdentitySelect,
+    })) ??
+    (await prisma.user.findUnique({
+      where: { id: normalized },
+      select: publicUserIdentitySelect,
+    }));
+
+  return user ? toLoadData(user) : null;
 }

--- a/src/lib/graphql/schema.ts
+++ b/src/lib/graphql/schema.ts
@@ -15,10 +15,7 @@ import {
   searchQueryToTokens,
 } from "@/features/dashboard-links/lib/dashboard-link-search";
 import { getPublicDashboardLinksData } from "@/features/dashboard-links/server/dashboard-link-data";
-import {
-  getUserProfileById,
-  getUserProfileByUsername,
-} from "@/features/profile/server/user-profile-page-data";
+import { getPublicUserIdentityByIdentifier } from "@/features/profile/server/user-profile-page-data";
 import {
   capGraphqlAlternateRoutes,
   capGraphqlBusCampuses,
@@ -325,12 +322,7 @@ export const graphqlSchema = createSchema<
     },
     Community: {
       async user(_parent, args: { identifier: string }) {
-        const identifier = args.identifier.trim();
-        if (!identifier) return null;
-        const profile =
-          (await getUserProfileByUsername(identifier.toLowerCase())) ??
-          (await getUserProfileById(identifier));
-        return profile?.user ?? null;
+        return getPublicUserIdentityByIdentifier(args.identifier);
       },
     },
     Catalog: {

--- a/tests/integration/user-profile-contributions.test.ts
+++ b/tests/integration/user-profile-contributions.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  buildUserProfileContributions,
+  loadUserProfileContributionDays,
+} from "@/features/profile/server/user-profile-contributions";
+import { createTestPrisma, disconnectTestPrisma } from "../shared/prisma";
+
+const prisma = createTestPrisma();
+const referenceNow = new Date("2026-03-02T01:30:00+08:00");
+const startAt = new Date("2025-03-02T16:00:00.000Z");
+
+describe.sequential("public profile contribution aggregation", () => {
+  let userId = "";
+
+  beforeAll(async () => {
+    const section = await prisma.section.findFirst({
+      orderBy: { id: "asc" },
+      select: { id: true },
+    });
+    if (!section) {
+      throw new Error(
+        "Expected the canonical integration seed to include a section",
+      );
+    }
+
+    const marker = crypto.randomUUID();
+    const user = await prisma.user.create({
+      data: {
+        email: `profile-contributions-${marker}@example.test`,
+        name: "Profile contribution integration",
+        username: `profile-contributions-${marker}`,
+      },
+      select: { id: true },
+    });
+    userId = user.id;
+
+    await prisma.comment.createMany({
+      data: [
+        {
+          body: "included active comment",
+          createdAt: new Date("2026-03-01T15:59:00.000Z"),
+          sectionId: section.id,
+          status: "active",
+          userId,
+        },
+        {
+          body: "included softbanned comment",
+          createdAt: new Date("2026-03-01T16:00:00.000Z"),
+          sectionId: section.id,
+          status: "softbanned",
+          userId,
+        },
+        {
+          body: "excluded deleted comment",
+          createdAt: new Date("2026-03-01T17:00:00.000Z"),
+          sectionId: section.id,
+          status: "deleted",
+          userId,
+        },
+        {
+          body: "excluded before lower bound",
+          createdAt: new Date("2025-03-02T15:59:59.999Z"),
+          sectionId: section.id,
+          status: "active",
+          userId,
+        },
+      ],
+    });
+
+    await prisma.upload.createMany({
+      data: [
+        {
+          createdAt: startAt,
+          filename: "lower-bound.txt",
+          key: `profile-contributions/${marker}/lower-bound`,
+          size: 1,
+          userId,
+        },
+        ...Array.from({ length: 20 }, (_, index) => ({
+          createdAt: new Date("2026-03-01T16:15:00.000Z"),
+          filename: `same-day-${index}.txt`,
+          key: `profile-contributions/${marker}/same-day-${index}`,
+          size: 1,
+          userId,
+        })),
+        {
+          createdAt: new Date("2026-03-10T00:00:00.000Z"),
+          filename: "future.txt",
+          key: `profile-contributions/${marker}/future`,
+          size: 1,
+          userId,
+        },
+      ],
+    });
+
+    const includedHomework = await prisma.homework.create({
+      data: {
+        createdAt: new Date("2026-03-01T18:00:00.000Z"),
+        createdById: userId,
+        sectionId: section.id,
+        title: "included authored homework",
+      },
+      select: { id: true },
+    });
+    await Promise.all([
+      prisma.homework.create({
+        data: {
+          createdAt: new Date("2026-03-01T19:00:00.000Z"),
+          createdById: userId,
+          deletedAt: new Date("2026-03-01T19:30:00.000Z"),
+          sectionId: section.id,
+          title: "excluded deleted homework",
+        },
+      }),
+      prisma.homeworkCompletion.create({
+        data: {
+          completedAt: new Date("2026-03-01T20:00:00.000Z"),
+          homeworkId: includedHomework.id,
+          userId,
+        },
+      }),
+    ]);
+  });
+
+  afterAll(async () => {
+    if (userId) {
+      await prisma.homeworkCompletion.deleteMany({ where: { userId } });
+      await prisma.comment.deleteMany({ where: { userId } });
+      await prisma.upload.deleteMany({ where: { userId } });
+      await prisma.homework.deleteMany({ where: { createdById: userId } });
+      await prisma.user.deleteMany({ where: { id: userId } });
+    }
+    await disconnectTestPrisma(prisma);
+  });
+
+  it("returns one aggregate row per Shanghai day across all four sources", async () => {
+    await expect(
+      loadUserProfileContributionDays(prisma, userId, startAt),
+    ).resolves.toEqual([
+      { count: 1, date: "2025-03-03" },
+      { count: 1, date: "2026-03-01" },
+      { count: 23, date: "2026-03-02" },
+      { count: 1, date: "2026-03-10" },
+    ]);
+  });
+
+  it("preserves the week grid and totals events beyond its visible end", async () => {
+    const result = await buildUserProfileContributions(
+      prisma,
+      userId,
+      referenceNow,
+    );
+    const cells = new Map(
+      result.weeks.flat().map((cell) => [cell.date, cell.count]),
+    );
+
+    expect(result.totalContributions).toBe(26);
+    expect(result.weeks[0]?.[0]?.date).toBe("2025-03-02");
+    expect(result.weeks.at(-1)?.at(-1)?.date).toBe("2026-03-07");
+    expect(cells.get("2025-03-03")).toBe(1);
+    expect(cells.get("2026-03-01")).toBe(1);
+    expect(cells.get("2026-03-02")).toBe(23);
+    expect(cells.has("2026-03-10")).toBe(false);
+  });
+});

--- a/tests/unit/user-profile-contributions.test.ts
+++ b/tests/unit/user-profile-contributions.test.ts
@@ -1,28 +1,33 @@
 import { describe, expect, it, vi } from "vitest";
-import { buildUserProfileContributions } from "@/features/profile/server/user-profile-contributions";
+import {
+  buildUserProfileContributions,
+  loadUserProfileContributionDays,
+} from "@/features/profile/server/user-profile-contributions";
+
+function buildPrismaMock(
+  queryRaw: (
+    query: TemplateStringsArray,
+    ...values: unknown[]
+  ) => Promise<unknown>,
+) {
+  return {
+    async $queryRaw<T>(query: TemplateStringsArray, ...values: unknown[]) {
+      return (await queryRaw(query, ...values)) as T;
+    },
+  };
+}
 
 describe("用户主页贡献", () => {
   it("以上海午夜为界按校区日期聚合贡献事件", async () => {
-    const commentFindMany = vi.fn(async (_input: unknown) => [
-      { createdAt: new Date("2026-03-01T15:59:00.000Z") },
-    ]);
-    const uploadFindMany = vi.fn(async (_input: unknown) => [
-      { createdAt: new Date("2026-03-01T16:00:00.000Z") },
-    ]);
-    const completionFindMany = vi.fn(async (_input: unknown) => [
-      { completedAt: new Date("2026-03-01T16:30:00.000Z") },
-    ]);
-    const homeworkFindMany = vi.fn(async (_input: unknown) => [
-      { createdAt: new Date("2026-03-02T04:00:00.000Z") },
-    ]);
+    const queryRaw = vi.fn(
+      async (_query: TemplateStringsArray, ..._values: unknown[]) => [
+        { count: 1n, date: "2026-03-01" },
+        { count: 3n, date: "2026-03-02" },
+      ],
+    );
 
     const result = await buildUserProfileContributions(
-      {
-        comment: { findMany: commentFindMany },
-        homework: { findMany: homeworkFindMany },
-        homeworkCompletion: { findMany: completionFindMany },
-        upload: { findMany: uploadFindMany },
-      },
+      buildPrismaMock(queryRaw),
       "user-1",
       new Date("2026-03-02T01:30:00+08:00"),
     );
@@ -30,17 +35,48 @@ describe("用户主页贡献", () => {
     const cells = new Map(
       result.weeks.flat().map((cell) => [cell.date, cell.count]),
     );
-    const commentQuery = commentFindMany.mock.calls[0]?.[0] as {
-      where: { createdAt: { gte: Date } };
-    };
+    const queryValues = queryRaw.mock.calls[0]?.slice(1) ?? [];
 
-    expect(commentQuery.where.createdAt.gte.toISOString()).toBe(
-      "2025-03-02T16:00:00.000Z",
-    );
+    expect(queryRaw).toHaveBeenCalledOnce();
+    expect(queryValues.filter((value) => value === "user-1")).toHaveLength(4);
+    expect(
+      queryValues
+        .filter((value): value is Date => value instanceof Date)
+        .map((value) => value.toISOString()),
+    ).toEqual(Array.from({ length: 4 }, () => "2025-03-02T16:00:00.000Z"));
     expect(result.totalContributions).toBe(4);
     expect(result.weeks[0]?.[0]?.date).toBe("2025-03-02");
     expect(result.weeks.at(-1)?.at(-1)?.date).toBe("2026-03-07");
     expect(cells.get("2026-03-01")).toBe(1);
     expect(cells.get("2026-03-02")).toBe(3);
+  });
+
+  it("在单条参数化 SQL 中聚合四类贡献并保留原过滤条件", async () => {
+    const queryRaw = vi.fn(
+      async (_query: TemplateStringsArray, ..._values: unknown[]) => [],
+    );
+
+    await loadUserProfileContributionDays(
+      buildPrismaMock(queryRaw),
+      "user-2",
+      new Date("2025-03-02T16:00:00.000Z"),
+    );
+
+    const queryParts = queryRaw.mock.calls[0]?.[0] as
+      | TemplateStringsArray
+      | undefined;
+    const sql = queryParts ? Array.from(queryParts).join("?") : "";
+
+    expect(queryRaw).toHaveBeenCalledOnce();
+    expect(sql).toContain('FROM "Comment"');
+    expect(sql).toContain('FROM "Upload"');
+    expect(sql).toContain('FROM "HomeworkCompletion"');
+    expect(sql).toContain('FROM "Homework"');
+    expect(sql).toContain("AT TIME ZONE 'UTC'");
+    expect(sql).toContain("AT TIME ZONE 'Asia/Shanghai'");
+    expect(sql).toContain("\"status\" IN ('active', 'softbanned')");
+    expect(sql).toContain('"deletedAt" IS NULL');
+    expect(sql).not.toContain('"createdAt" <=');
+    expect(sql).not.toContain('"completedAt" <=');
   });
 });

--- a/tests/unit/user-profile-page-data.test.ts
+++ b/tests/unit/user-profile-page-data.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  buildUserProfileContributions: vi.fn(),
+  findUnique: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  getPrisma: () => ({ user: { findUnique: mocks.findUnique } }),
+}));
+
+vi.mock("@/features/profile/server/user-profile-contributions", () => ({
+  buildUserProfileContributions: mocks.buildUserProfileContributions,
+}));
+
+import { getPublicUserIdentityByIdentifier } from "@/features/profile/server/user-profile-page-data";
+
+const identitySelect = {
+  createdAt: true,
+  id: true,
+  image: true,
+  name: true,
+  username: true,
+};
+
+describe("公开用户身份读取", () => {
+  beforeEach(() => {
+    mocks.buildUserProfileContributions.mockReset();
+    mocks.findUnique.mockReset();
+  });
+
+  it("用户名命中时只读取公开身份字段", async () => {
+    mocks.findUnique.mockResolvedValueOnce({
+      createdAt: new Date("2026-01-02T03:04:05.000Z"),
+      id: "user-id",
+      image: null,
+      name: "User",
+      username: "mixedcase",
+    });
+
+    await expect(
+      getPublicUserIdentityByIdentifier(" MixedCase "),
+    ).resolves.toEqual({
+      createdAt: "2026-01-02T03:04:05.000Z",
+      id: "user-id",
+      image: null,
+      name: "User",
+      username: "mixedcase",
+    });
+    expect(mocks.findUnique).toHaveBeenCalledOnce();
+    expect(mocks.findUnique).toHaveBeenCalledWith({
+      select: identitySelect,
+      where: { username: "mixedcase" },
+    });
+    expect(mocks.buildUserProfileContributions).not.toHaveBeenCalled();
+  });
+
+  it("用户名未命中后才按原始 ID 回退", async () => {
+    mocks.findUnique.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      createdAt: new Date("2026-01-02T03:04:05.000Z"),
+      id: "CaseSensitiveId",
+      image: null,
+      name: "User",
+      username: null,
+    });
+
+    await expect(
+      getPublicUserIdentityByIdentifier(" CaseSensitiveId "),
+    ).resolves.toMatchObject({ id: "CaseSensitiveId" });
+    expect(mocks.findUnique).toHaveBeenNthCalledWith(1, {
+      select: identitySelect,
+      where: { username: "casesensitiveid" },
+    });
+    expect(mocks.findUnique).toHaveBeenNthCalledWith(2, {
+      select: identitySelect,
+      where: { id: "CaseSensitiveId" },
+    });
+    expect(mocks.buildUserProfileContributions).not.toHaveBeenCalled();
+  });
+
+  it("空白或两种查找均未命中时返回 null", async () => {
+    await expect(getPublicUserIdentityByIdentifier("   ")).resolves.toBeNull();
+    expect(mocks.findUnique).not.toHaveBeenCalled();
+
+    mocks.findUnique.mockResolvedValue(null);
+    await expect(
+      getPublicUserIdentityByIdentifier("missing"),
+    ).resolves.toBeNull();
+    expect(mocks.findUnique).toHaveBeenCalledTimes(2);
+    expect(mocks.buildUserProfileContributions).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- make GraphQL `Community.user` use a compact five-field public identity read instead of the full profile/count/contribution loader
- aggregate comment, upload, homework-completion, and authored-homework contributions in one tagged Prisma raw query
- group UTC-backed timestamps by explicit `Asia/Shanghai` calendar day in PostgreSQL
- preserve username-before-ID fallback, the 365-day lower bound, filters, future-total behavior, week grid, and all public response shapes

## Scope and priority

This is a code-proven defensive optimization, not a currently observed production hotspot: the inspected 12-hour window had no profile page/API/GraphQL traffic. No endpoint, migration, speculative index, cache, or cross-request Prisma client is added.

## Verification

- real PostgreSQL regression: 26 source events become 4 daily aggregate rows across the Shanghai midnight boundary
- focused unit and DB-backed contribution/identity tests passed
- full Vitest after integration with #692: 270 files / 1736 tests
- full isolated integration suite passed before the final unrelated rebase
- Svelte check: 0 errors / 0 warnings
- all three TypeScript projects passed
- Biome passed with the same pre-existing static-loader warning
- production build and Wrangler deploy dry-run passed
- independent review found no blockers

Closes #690
