### PR TITLE
perf(bus): bound and coalesce timetable cache

### DIFF
--- a/docs/contracts/bus.json
+++ b/docs/contracts/bus.json
@@ -18,6 +18,7 @@
     "merged-table-grouped-by-route": "The signed-in dashboard and the public /catalog/bus default timetable use a single merged large table to display all applicable routes, grouped into table sections by route; each section shows the visible trips for that route.",
     "raw-data-returned": "/api/catalog/bus and catalog_bus_timetable_get return raw route/stop/trip data within the selected timetable version; the preferences field is null for anonymous callers and returns the authenticated caller's saved preferences; the server does not pre-apply recommendations, filtering, or sorting.",
     "version-topology-self-contained": "When versionKey selects a historical timetable version, routes, stops, campuses, and trips are derived from that same imported schedule version rather than the latest global route topology.",
+    "version-key-boundary": "REST, GraphQL, and MCP normalize surrounding whitespace in versionKey and then require 1-120 ASCII characters matching ^[A-Za-z0-9][A-Za-z0-9._-]*$.",
     "current-version-only": "catalog_bus_route_list only lists routes actually present in the current active timetable version; it does not expose historical route IDs outside the current version.",
     "dashboard-vs-map": "The dashboard prioritizes answering 'how to get the next trip'; the map page handles spatial understanding.",
     "public-version-metadata-omitted": "Public bus dashboard pages omit timetable version metadata rather than showing an unlabeled or unlocalized imported value; the raw title remains available to admin, REST, and MCP consumers.",

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -1261,7 +1261,9 @@
             "name": "versionKey",
             "schema": {
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "maxLength": 120,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
             }
           }
         ],
@@ -4830,7 +4832,9 @@
             "name": "versionKey",
             "schema": {
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "maxLength": 120,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
             }
           },
           {
@@ -4910,7 +4914,9 @@
             "name": "versionKey",
             "schema": {
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "maxLength": 120,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$"
             }
           },
           {

--- a/src/features/bus/lib/bus-version-key.ts
+++ b/src/features/bus/lib/bus-version-key.ts
@@ -1,0 +1,11 @@
+import * as z from "zod";
+
+export const BUS_VERSION_KEY_MAX_LENGTH = 120;
+export const BUS_VERSION_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export const busVersionKeySchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(BUS_VERSION_KEY_MAX_LENGTH)
+  .regex(BUS_VERSION_KEY_PATTERN);

--- a/src/features/bus/server/bus-timetable-data.ts
+++ b/src/features/bus/server/bus-timetable-data.ts
@@ -19,11 +19,17 @@ import {
 } from "./bus-version";
 
 type StaticBusTimetableData = Omit<BusTimetableData, "preferences">;
+type CachedStaticBusTimetableData = Omit<StaticBusTimetableData, "fetchedAt">;
 
 const STATIC_BUS_TIMETABLE_CACHE_TTL_MS = 60_000;
+const STATIC_BUS_TIMETABLE_CACHE_MAX_ENTRIES = 100;
 const staticBusTimetableCache = new Map<
   string,
-  { data: StaticBusTimetableData | null; expiresAt: number }
+  { data: CachedStaticBusTimetableData; expiresAt: number }
+>();
+const staticBusTimetableLoads = new Map<
+  string,
+  Promise<CachedStaticBusTimetableData | null>
 >();
 
 function busVersionNotice(version: {
@@ -43,54 +49,72 @@ function getStaticBusTimetableCacheKey(input: {
   locale: string;
   versionKey?: string | null;
 }) {
-  return [input.locale, input.dateKey, input.versionKey ?? "auto"].join(":");
+  return JSON.stringify([
+    input.locale,
+    input.dateKey,
+    input.versionKey == null
+      ? { type: "auto" }
+      : { key: input.versionKey, type: "explicit" },
+  ]);
 }
 
-export async function getStaticBusTimetableData(
-  input: BusTimetableInput,
-): Promise<StaticBusTimetableData | null> {
-  const locale = input.locale ?? "zh-cn";
-  const now = input.now ? shanghaiDayjs(input.now) : shanghaiDayjs();
-  const dateKey = now.format("YYYY-MM-DD");
-  const cacheKey = getStaticBusTimetableCacheKey({
-    dateKey,
-    locale,
-    versionKey: input.versionKey,
-  });
-  const cached = staticBusTimetableCache.get(cacheKey);
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.data
-      ? { ...cached.data, fetchedAt: now.toISOString() }
-      : null;
+function pruneExpiredStaticBusTimetableEntries(now: number) {
+  for (const [key, entry] of staticBusTimetableCache) {
+    if (entry.expiresAt <= now) staticBusTimetableCache.delete(key);
   }
+}
 
-  const versionRecords = await listEnabledBusVersionRecords();
-  const version = input.versionKey
-    ? await findEffectiveBusVersion(dateKey, input.versionKey)
-    : findEffectiveBusVersionFromRecords(versionRecords, dateKey);
-  if (!version) {
-    staticBusTimetableCache.set(cacheKey, {
-      data: null,
-      expiresAt: Date.now() + STATIC_BUS_TIMETABLE_CACHE_TTL_MS,
-    });
-    return null;
+function setBoundedStaticBusTimetableCacheEntry(
+  key: string,
+  value: { data: CachedStaticBusTimetableData; expiresAt: number },
+) {
+  staticBusTimetableCache.delete(key);
+  while (
+    staticBusTimetableCache.size >= STATIC_BUS_TIMETABLE_CACHE_MAX_ENTRIES
+  ) {
+    const oldestKey = staticBusTimetableCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    staticBusTimetableCache.delete(oldestKey);
   }
+  staticBusTimetableCache.set(key, value);
+}
+
+export function deleteBusTimetableLoadIfCurrent<T>(
+  loads: Map<string, T>,
+  key: string,
+  load: T,
+) {
+  if (loads.get(key) === load) loads.delete(key);
+}
+
+async function loadStaticBusTimetableData(input: {
+  dateKey: string;
+  locale: BusTimetableInput["locale"];
+  versionKey?: string | null;
+}): Promise<CachedStaticBusTimetableData | null> {
+  const versionRecordsPromise = listEnabledBusVersionRecords();
+  const explicitVersionPromise = input.versionKey
+    ? findEffectiveBusVersion(input.dateKey, input.versionKey)
+    : Promise.resolve(null);
+  const [versionRecords, explicitVersion] = await Promise.all([
+    versionRecordsPromise,
+    explicitVersionPromise,
+  ]);
+  const version = input.versionKey
+    ? explicitVersion
+    : findEffectiveBusVersionFromRecords(versionRecords, input.dateKey);
+  if (!version) return null;
 
   const [topology, tripRows] = await Promise.all([
-    getBusVersionTopology(locale, version.id),
+    getBusVersionTopology(input.locale ?? "zh-cn", version.id),
     prisma.busTrip.findMany({
       where: { versionId: version.id },
       orderBy: [{ dayType: "asc" }, { routeId: "asc" }, { position: "asc" }],
     }),
   ]);
-  if (!topology) {
-    staticBusTimetableCache.set(cacheKey, {
-      data: null,
-      expiresAt: Date.now() + STATIC_BUS_TIMETABLE_CACHE_TTL_MS,
-    });
-    return null;
-  }
+  if (!topology) return null;
 
+  const locale = input.locale ?? "zh-cn";
   const versionRouteIds = new Set(tripRows.map((trip) => trip.routeId));
   const routes = topology.routes
     .filter((record) => versionRouteIds.has(record.id))
@@ -106,9 +130,8 @@ export async function getStaticBusTimetableData(
     })
     .filter((trip): trip is BusTripSummary => trip != null);
 
-  const data = {
+  return {
     locale,
-    fetchedAt: now.toISOString(),
     version: {
       id: version.id,
       key: version.key,
@@ -124,11 +147,47 @@ export async function getStaticBusTimetableData(
     availableVersions: summarizeBusVersions(versionRecords),
     notice: busVersionNotice(version),
   };
-  staticBusTimetableCache.set(cacheKey, {
-    data,
-    expiresAt: Date.now() + STATIC_BUS_TIMETABLE_CACHE_TTL_MS,
+}
+
+export async function getStaticBusTimetableData(
+  input: BusTimetableInput,
+): Promise<StaticBusTimetableData | null> {
+  const locale = input.locale ?? "zh-cn";
+  const now = input.now ? shanghaiDayjs(input.now) : shanghaiDayjs();
+  const dateKey = now.format("YYYY-MM-DD");
+  const cacheKey = getStaticBusTimetableCacheKey({
+    dateKey,
+    locale,
+    versionKey: input.versionKey,
   });
-  return data;
+  pruneExpiredStaticBusTimetableEntries(Date.now());
+  const cached = staticBusTimetableCache.get(cacheKey);
+  if (cached) {
+    return { ...cached.data, fetchedAt: now.toISOString() };
+  }
+
+  let load = staticBusTimetableLoads.get(cacheKey);
+  if (!load) {
+    load = loadStaticBusTimetableData({
+      dateKey,
+      locale,
+      versionKey: input.versionKey,
+    });
+    staticBusTimetableLoads.set(cacheKey, load);
+  }
+
+  try {
+    const data = await load;
+    if (data && staticBusTimetableLoads.get(cacheKey) === load) {
+      setBoundedStaticBusTimetableCacheEntry(cacheKey, {
+        data,
+        expiresAt: Date.now() + STATIC_BUS_TIMETABLE_CACHE_TTL_MS,
+      });
+    }
+    return data ? { ...data, fetchedAt: now.toISOString() } : null;
+  } finally {
+    deleteBusTimetableLoadIfCurrent(staticBusTimetableLoads, cacheKey, load);
+  }
 }
 
 export async function getBusTimetableData(

--- a/src/lib/api/schemas/misc-query-schemas.ts
+++ b/src/lib/api/schemas/misc-query-schemas.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import { busVersionKeySchema } from "@/features/bus/lib/bus-version-key";
 import { APP_LOCALES } from "@/i18n/config";
 import {
   booleanQuerySchema,
@@ -59,13 +60,13 @@ const compactOverviewLimitSchema = integerQueryRangeSchema({
 });
 
 export const busQuerySchema = z.object({
-  versionKey: z.string().trim().min(1).optional(),
+  versionKey: busVersionKeySchema.optional(),
 });
 
 export const busRouteSearchQuerySchema = z.object({
   originCampusId: positiveCampusIdQuerySchema.optional(),
   destinationCampusId: positiveCampusIdQuerySchema.optional(),
-  versionKey: z.string().trim().min(1).optional(),
+  versionKey: busVersionKeySchema.optional(),
   locale: z.enum(APP_LOCALES).optional(),
 });
 
@@ -76,7 +77,7 @@ export const busNextDeparturesQuerySchema = z.object({
   dayType: z.enum(["auto", "weekday", "weekend"]).optional(),
   includeDeparted: booleanQuerySchema.optional(),
   limit: busNextDeparturesLimitSchema.optional(),
-  versionKey: z.string().trim().min(1).optional(),
+  versionKey: busVersionKeySchema.optional(),
   locale: z.enum(APP_LOCALES).optional(),
 });
 

--- a/src/lib/graphql/constants.ts
+++ b/src/lib/graphql/constants.ts
@@ -1,3 +1,5 @@
+import { BUS_VERSION_KEY_MAX_LENGTH } from "@/features/bus/lib/bus-version-key";
+
 export const GRAPHQL_ENDPOINT = "/api/graphql";
 
 export const GRAPHQL_LIMITS = {
@@ -20,7 +22,7 @@ export const GRAPHQL_LIMITS = {
   timeoutMs: 5000,
   tokens: 1000,
   topLevelFields: 10,
-  versionKeyChars: 120,
+  versionKeyChars: BUS_VERSION_KEY_MAX_LENGTH,
 } as const;
 
 export const GRAPHQL_SCHEMA_RESOURCE_URI = "life-ustc://graphql/schema";

--- a/src/lib/graphql/input-boundaries.ts
+++ b/src/lib/graphql/input-boundaries.ts
@@ -1,4 +1,5 @@
 import { GraphQLError } from "graphql";
+import { BUS_VERSION_KEY_PATTERN } from "@/features/bus/lib/bus-version-key";
 import { GRAPHQL_LIMITS } from "./constants";
 
 function badUserInput(message: string): never {
@@ -70,15 +71,13 @@ export function validateGraphqlWeekday(value: number | null | undefined) {
 }
 
 export function validateGraphqlVersionKey(value: string | null | undefined) {
+  value = value?.trim();
   const versionKey = validateOptionalText(
     value,
     "versionKey",
     GRAPHQL_LIMITS.versionKeyChars,
   );
-  if (
-    versionKey !== undefined &&
-    !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(versionKey)
-  ) {
+  if (versionKey !== undefined && !BUS_VERSION_KEY_PATTERN.test(versionKey)) {
     badUserInput("versionKey has an invalid format.");
   }
   return versionKey;

--- a/src/lib/mcp/tools/bus-tools.ts
+++ b/src/lib/mcp/tools/bus-tools.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod";
+import { busVersionKeySchema } from "@/features/bus/lib/bus-version-key";
 import {
   flexDateInputSchema,
   mcpLocaleInputSchema,
@@ -30,7 +31,7 @@ export function registerBusTools(server: McpServer) {
       description:
         "Full USTC shuttle bus dataset for clients that need local filtering. Prefer catalog_bus_departure_next for departures or catalog_bus_route_list for discovery.",
       inputSchema: {
-        versionKey: z.string().trim().min(1).optional(),
+        versionKey: busVersionKeySchema.optional(),
         locale: mcpLocaleInputSchema,
         mode: mcpModeInputSchema,
       },
@@ -57,7 +58,7 @@ export function registerBusTools(server: McpServer) {
         "Full weekday/weekend timetable for one route ID. Use catalog_bus_route_list first to find route IDs.",
       inputSchema: {
         routeId: z.number().int().positive(),
-        versionKey: z.string().trim().min(1).optional(),
+        versionKey: busVersionKeySchema.optional(),
         locale: mcpLocaleInputSchema,
         mode: mcpModeInputSchema,
       },
@@ -100,7 +101,7 @@ export function registerBusTools(server: McpServer) {
       inputSchema: {
         originCampusId: z.number().int().positive().optional(),
         destinationCampusId: z.number().int().positive().optional(),
-        versionKey: z.string().trim().min(1).optional(),
+        versionKey: busVersionKeySchema.optional(),
         locale: mcpLocaleInputSchema,
         mode: mcpModeInputSchema,
       },
@@ -124,7 +125,7 @@ export function registerBusTools(server: McpServer) {
         dayType: busDayTypeSchema,
         includeDeparted: z.boolean().default(false),
         limit: z.number().int().min(1).max(50).default(5),
-        versionKey: z.string().trim().min(1).optional(),
+        versionKey: busVersionKeySchema.optional(),
         locale: mcpLocaleInputSchema,
         mode: mcpModeInputSchema,
       },

--- a/tests/unit/api-schemas.test.ts
+++ b/tests/unit/api-schemas.test.ts
@@ -11,6 +11,7 @@ import {
   adminHomeworksQuerySchema,
   adminUsersQuerySchema,
   busNextDeparturesQuerySchema,
+  busQuerySchema,
   busRouteSearchQuerySchema,
   calendarSubscriptionAppendRequestSchema,
   calendarSubscriptionBatchRequestSchema,
@@ -613,6 +614,42 @@ describe("其他请求 schema", () => {
     expect(homeworksQuerySchema.parse({ includeDeleted: "true" })).toEqual({
       includeDeleted: true,
     });
+  });
+
+  it("在所有 REST bus 查询中统一 versionKey 边界", () => {
+    const validVersionKey = `v${"a".repeat(119)}`;
+    const schemas = [
+      { base: {}, schema: busQuerySchema },
+      { base: {}, schema: busRouteSearchQuerySchema },
+      {
+        base: { destinationCampusId: "2", originCampusId: "1" },
+        schema: busNextDeparturesQuerySchema,
+      },
+    ];
+
+    for (const { base, schema } of schemas) {
+      expect(
+        schema.safeParse({ ...base, versionKey: validVersionKey }).success,
+      ).toBe(true);
+      expect(
+        schema.safeParse({ ...base, versionKey: ` ${validVersionKey} ` })
+          .success,
+      ).toBe(true);
+      expect(
+        schema.safeParse({ ...base, versionKey: `v${"a".repeat(120)}` })
+          .success,
+      ).toBe(false);
+      expect(
+        schema.safeParse({ ...base, versionKey: "../unsafe" }).success,
+      ).toBe(false);
+      expect(
+        schema.safeParse({ ...base, versionKey: "-leading-dash" }).success,
+      ).toBe(false);
+    }
+
+    expect(
+      busQuerySchema.parse({ versionKey: ` ${validVersionKey} ` }).versionKey,
+    ).toBe(validVersionKey);
   });
 
   it("校验分页 pageSize 与废弃 limit 别名的边界", () => {

--- a/tests/unit/bus-timetable-data.test.ts
+++ b/tests/unit/bus-timetable-data.test.ts
@@ -1,7 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BusStaticPayload } from "@/features/bus/lib/bus-types";
-import { getNextBusDepartures } from "@/features/bus/server/bus-query-service";
-import { getBusTimetableData } from "@/features/bus/server/bus-timetable-data";
 
 const db = vi.hoisted(() => {
   const east = { id: 1, name: "东区", latitude: 31.1, longitude: 117.1 };
@@ -73,35 +71,16 @@ const db = vi.hoisted(() => {
   ];
 
   return {
-    busCampusFindMany: vi.fn(async () => latestCampuses),
-    busRouteFindMany: vi.fn(async () => [
-      {
-        id: 8,
-        nameCn: "东区 -> 西区 -> 高新",
-        nameEn: null,
-        stops: latestCampuses.map((campus, index) => ({
-          stopOrder: index,
-          campus,
-        })),
-      },
-    ]),
-    busScheduleVersionFindMany: vi.fn(async () => [latestVersion, oldVersion]),
-    busScheduleVersionFindUnique: vi.fn(async (args: unknown) => {
-      const where = (args as { where: { id?: number; key?: string } }).where;
-      if (where.key === oldVersion.key) return oldVersion;
-      if (where.id === oldVersion.id) return { rawJson: oldPayload };
-      return null;
-    }),
-    busTripFindMany: vi.fn(async () => [
-      {
-        id: 101,
-        versionId: oldVersion.id,
-        routeId: 8,
-        dayType: "weekday" as const,
-        position: 0,
-        stopTimes: ["08:00", "08:20"],
-      },
-    ]),
+    busCampusFindMany: vi.fn(),
+    busPreferenceFindUnique: vi.fn(),
+    busRouteFindMany: vi.fn(),
+    busScheduleVersionFindMany: vi.fn(),
+    busScheduleVersionFindUnique: vi.fn(),
+    busTripFindMany: vi.fn(),
+    latestCampuses,
+    latestVersion,
+    oldPayload,
+    oldVersion,
   };
 });
 
@@ -117,15 +96,96 @@ vi.mock("@/lib/db/prisma", () => ({
     },
     busTrip: { findMany: db.busTripFindMany },
   },
+  withUserDbContext: async (
+    _userId: string,
+    run: (tx: {
+      busUserPreference: { findUnique: typeof db.busPreferenceFindUnique };
+    }) => Promise<unknown>,
+  ) =>
+    run({
+      busUserPreference: { findUnique: db.busPreferenceFindUnique },
+    }),
 }));
 
-beforeEach(() => {
-  vi.clearAllMocks();
+type TimetableModule =
+  typeof import("@/features/bus/server/bus-timetable-data");
+type QueryServiceModule =
+  typeof import("@/features/bus/server/bus-query-service");
+
+let timetable: TimetableModule;
+let queryService: QueryServiceModule;
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+function versionLookupCount(key: string) {
+  return db.busScheduleVersionFindUnique.mock.calls.filter(([args]) => {
+    const where = (args as { where?: { key?: string } }).where;
+    return where?.key === key;
+  }).length;
+}
+
+function resetDbMocks() {
+  db.busCampusFindMany.mockReset().mockResolvedValue(db.latestCampuses);
+  db.busPreferenceFindUnique.mockReset().mockResolvedValue(null);
+  db.busRouteFindMany.mockReset().mockResolvedValue([
+    {
+      id: 8,
+      nameCn: "东区 -> 西区 -> 高新",
+      nameEn: null,
+      stops: db.latestCampuses.map((campus, index) => ({
+        stopOrder: index,
+        campus,
+      })),
+    },
+  ]);
+  db.busScheduleVersionFindMany
+    .mockReset()
+    .mockResolvedValue([db.latestVersion, db.oldVersion]);
+  db.busScheduleVersionFindUnique
+    .mockReset()
+    .mockImplementation(async (args: unknown) => {
+      const where = (args as { where: { id?: number; key?: string } }).where;
+      if (where.id === db.oldVersion.id) return { rawJson: db.oldPayload };
+      if (where.key === "missing-bus") return null;
+      if (where.key) return { ...db.oldVersion, key: where.key };
+      return null;
+    });
+  db.busTripFindMany.mockReset().mockResolvedValue([
+    {
+      id: 101,
+      versionId: db.oldVersion.id,
+      routeId: 8,
+      dayType: "weekday" as const,
+      position: 0,
+      stopTimes: ["08:00", "08:20"],
+    },
+  ]);
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime("2026-07-30T00:00:00.000Z");
+  vi.resetModules();
+  resetDbMocks();
+  timetable = await import("@/features/bus/server/bus-timetable-data");
+  queryService = await import("@/features/bus/server/bus-query-service");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("getBusTimetableData 班车时刻表数据", () => {
   it("使用请求历史版本的拓扑结构", async () => {
-    const data = await getBusTimetableData({
+    const data = await timetable.getBusTimetableData({
       locale: "zh-cn",
       now: "2026-02-01T00:00:00.000Z",
       versionKey: "old-bus",
@@ -145,14 +205,14 @@ describe("getBusTimetableData 班车时刻表数据", () => {
   });
 
   it("catalog_bus_departure_next 复用静态时刻表缓存", async () => {
-    await getBusTimetableData({
+    await timetable.getBusTimetableData({
       locale: "zh-cn",
       now: "2026-02-01T00:00:00.000Z",
       versionKey: "old-bus",
     });
     vi.clearAllMocks();
 
-    const data = await getNextBusDepartures({
+    const data = await queryService.getNextBusDepartures({
       locale: "zh-cn",
       originCampusId: 1,
       destinationCampusId: 2,
@@ -167,5 +227,335 @@ describe("getBusTimetableData 班车时刻表数据", () => {
     expect(db.busScheduleVersionFindUnique).not.toHaveBeenCalled();
     expect(db.busCampusFindMany).not.toHaveBeenCalled();
     expect(db.busRouteFindMany).not.toHaveBeenCalled();
+  });
+
+  it("为每次调用刷新 fetchedAt 而不重新加载静态数据", async () => {
+    const first = await timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+      versionKey: "old-bus",
+    });
+    const second = await timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T01:00:00.000Z",
+      versionKey: "old-bus",
+    });
+
+    expect(first?.fetchedAt).toBe("2026-02-01T00:00:00.000Z");
+    expect(second?.fetchedAt).toBe("2026-02-01T01:00:00.000Z");
+    expect(versionLookupCount("old-bus")).toBe(1);
+    expect(db.busTripFindMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("不把调用者偏好放进静态缓存", async () => {
+    db.busPreferenceFindUnique.mockImplementation(async (args: unknown) => {
+      const userId = (args as { where: { userId: string } }).where.userId;
+      return {
+        preferredOriginCampusId: userId === "user-a" ? 1 : 2,
+        preferredDestinationCampusId: null,
+        showDepartedTrips: userId === "user-b",
+      };
+    });
+
+    const first = await timetable.getBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+      userId: "user-a",
+      versionKey: "old-bus",
+    });
+    const second = await timetable.getBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+      userId: "user-b",
+      versionKey: "old-bus",
+    });
+
+    expect(first?.preferences?.preferredOriginCampusId).toBe(1);
+    expect(second?.preferences).toMatchObject({
+      preferredOriginCampusId: 2,
+      showDepartedTrips: true,
+    });
+    expect(versionLookupCount("old-bus")).toBe(1);
+    expect(db.busPreferenceFindUnique).toHaveBeenCalledTimes(2);
+  });
+
+  it("按 locale、日期和显式版本隔离静态数据", async () => {
+    await timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "1998-01-01T00:00:00.000Z",
+      versionKey: "old-bus",
+    });
+    await timetable.getStaticBusTimetableData({
+      locale: "en-us",
+      now: "1998-01-01T00:00:00.000Z",
+      versionKey: "old-bus",
+    });
+    await timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "1998-01-02T00:00:00.000Z",
+      versionKey: "old-bus",
+    });
+    await timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "1998-01-01T00:00:00.000Z",
+      versionKey: "another-bus",
+    });
+
+    expect(db.busTripFindMany).toHaveBeenCalledTimes(4);
+    expect(versionLookupCount("old-bus")).toBe(3);
+    expect(versionLookupCount("another-bus")).toBe(1);
+  });
+
+  it("区分自动选择与合法的显式 auto 版本", async () => {
+    const automatic = await timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+    });
+    const explicit = await timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+      versionKey: "auto",
+    });
+    const automaticAgain = await timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+    });
+
+    expect(automatic?.version?.key).toBe("old-bus");
+    expect(explicit?.version?.key).toBe("auto");
+    expect(automaticAgain?.version?.key).toBe("old-bus");
+    expect(versionLookupCount("auto")).toBe(1);
+    expect(db.busTripFindMany).toHaveBeenCalledTimes(2);
+  });
+
+  it("并发启动 enabled versions 与显式版本读取", async () => {
+    const versions = deferred<unknown>();
+    const explicitVersion = deferred<unknown>();
+    db.busScheduleVersionFindMany.mockReturnValueOnce(versions.promise);
+    db.busScheduleVersionFindUnique.mockReturnValueOnce(
+      explicitVersion.promise,
+    );
+
+    const result = timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+      versionKey: "old-bus",
+    });
+
+    expect(db.busScheduleVersionFindMany).toHaveBeenCalledTimes(1);
+    expect(versionLookupCount("old-bus")).toBe(1);
+
+    versions.resolve([db.latestVersion, db.oldVersion]);
+    explicitVersion.resolve(db.oldVersion);
+    await expect(result).resolves.toMatchObject({
+      version: { key: "old-bus" },
+    });
+  });
+
+  it("合并同 key 并发加载，并从成功时刻开始 60 秒 TTL", async () => {
+    const explicitVersion = deferred<unknown>();
+    db.busScheduleVersionFindUnique.mockReturnValueOnce(
+      explicitVersion.promise,
+    );
+
+    const first = timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+      versionKey: "old-bus",
+    });
+    const second = timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T01:00:00.000Z",
+      versionKey: "old-bus",
+    });
+
+    expect(versionLookupCount("old-bus")).toBe(1);
+    vi.setSystemTime("2026-07-30T00:01:01.000Z");
+    explicitVersion.resolve(db.oldVersion);
+
+    const [firstData, secondData] = await Promise.all([first, second]);
+    const third = await timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T02:00:00.000Z",
+      versionKey: "old-bus",
+    });
+
+    expect(firstData?.fetchedAt).toBe("2026-02-01T00:00:00.000Z");
+    expect(secondData?.fetchedAt).toBe("2026-02-01T01:00:00.000Z");
+    expect(third?.fetchedAt).toBe("2026-02-01T02:00:00.000Z");
+    expect(versionLookupCount("old-bus")).toBe(1);
+  });
+
+  it("不缓存最终 null", async () => {
+    const input = {
+      locale: "zh-cn" as const,
+      now: "2026-02-01T00:00:00.000Z",
+      versionKey: "missing-bus",
+    };
+
+    await expect(
+      timetable.getStaticBusTimetableData(input),
+    ).resolves.toBeNull();
+    await expect(
+      timetable.getStaticBusTimetableData(input),
+    ).resolves.toBeNull();
+
+    expect(versionLookupCount("missing-bus")).toBe(2);
+    expect(db.busTripFindMany).not.toHaveBeenCalled();
+  });
+
+  it("加载失败后允许下一次调用重试", async () => {
+    db.busScheduleVersionFindUnique.mockRejectedValueOnce(
+      new Error("version read failed"),
+    );
+    const input = {
+      locale: "zh-cn" as const,
+      now: "2026-02-01T00:00:00.000Z",
+      versionKey: "old-bus",
+    };
+
+    await expect(timetable.getStaticBusTimetableData(input)).rejects.toThrow(
+      "version read failed",
+    );
+    await expect(
+      timetable.getStaticBusTimetableData(input),
+    ).resolves.toMatchObject({ version: { key: "old-bus" } });
+
+    expect(versionLookupCount("old-bus")).toBe(2);
+  });
+
+  it("超过 100 个其他并发 key 时仍合并同 key 加载", async () => {
+    const raceVersion = deferred<unknown>();
+    const blockedVersions = deferred<unknown>();
+    let raceLookups = 0;
+    db.busScheduleVersionFindUnique.mockImplementation(
+      async (args: unknown) => {
+        const where = (args as { where: { id?: number; key?: string } }).where;
+        if (where.id === db.oldVersion.id) return { rawJson: db.oldPayload };
+        if (where.key === "race-bus") {
+          raceLookups += 1;
+          return raceVersion.promise;
+        }
+        if (where.key?.startsWith("blocked-")) {
+          return blockedVersions.promise;
+        }
+        return null;
+      },
+    );
+
+    const first = timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+      versionKey: "race-bus",
+    });
+    const blocked = Array.from({ length: 101 }, (_, index) =>
+      timetable.getStaticBusTimetableData({
+        locale: "zh-cn",
+        now: "2026-02-01T00:00:00.000Z",
+        versionKey: `blocked-${index}`,
+      }),
+    );
+    const second = timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+      versionKey: "race-bus",
+    });
+
+    expect(raceLookups).toBe(1);
+    raceVersion.resolve({ ...db.oldVersion, key: "race-bus" });
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({
+        version: expect.objectContaining({ key: "race-bus" }),
+      }),
+      expect.objectContaining({
+        version: expect.objectContaining({ key: "race-bus" }),
+      }),
+    ]);
+
+    blockedVersions.resolve(null);
+    await expect(Promise.all(blocked)).resolves.toEqual(
+      Array.from({ length: 101 }, () => null),
+    );
+  });
+
+  it("旧 promise 的清理不会删除同 key 的新 entry", () => {
+    const stale = Promise.resolve(null);
+    const current = Promise.resolve(null);
+    const loads = new Map([["same-key", current]]);
+
+    timetable.deleteBusTimetableLoadIfCurrent(loads, "same-key", stale);
+    expect(loads.get("same-key")).toBe(current);
+
+    timetable.deleteBusTimetableLoadIfCurrent(loads, "same-key", current);
+    expect(loads.has("same-key")).toBe(false);
+  });
+
+  it("把成功静态缓存限制为 100 项", async () => {
+    for (let index = 0; index < 101; index += 1) {
+      await timetable.getStaticBusTimetableData({
+        locale: "zh-cn",
+        now: "2026-02-01T00:00:00.000Z",
+        versionKey: `bounded-${index}`,
+      });
+    }
+
+    await timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+      versionKey: "bounded-0",
+    });
+
+    expect(versionLookupCount("bounded-0")).toBe(2);
+  });
+
+  it("未知版本解析为 null 后不淘汰已有成功项", async () => {
+    for (let index = 0; index < 100; index += 1) {
+      await timetable.getStaticBusTimetableData({
+        locale: "zh-cn",
+        now: "2026-02-01T00:00:00.000Z",
+        versionKey: `valid-${index}`,
+      });
+    }
+
+    await expect(
+      timetable.getStaticBusTimetableData({
+        locale: "zh-cn",
+        now: "2026-02-01T00:00:00.000Z",
+        versionKey: "missing-bus",
+      }),
+    ).resolves.toBeNull();
+    await timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+      versionKey: "valid-0",
+    });
+
+    expect(versionLookupCount("valid-0")).toBe(1);
+  });
+
+  it("每次访问都会清理所有过期成功项", async () => {
+    for (const versionKey of ["expiry-a", "expiry-b"]) {
+      await timetable.getStaticBusTimetableData({
+        locale: "zh-cn",
+        now: "2026-02-01T00:00:00.000Z",
+        versionKey,
+      });
+    }
+
+    vi.setSystemTime("2026-07-30T00:01:01.000Z");
+    await timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+      versionKey: "expiry-c",
+    });
+
+    vi.setSystemTime("2026-07-30T00:00:30.000Z");
+    await timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-01T00:00:00.000Z",
+      versionKey: "expiry-a",
+    });
+
+    expect(versionLookupCount("expiry-a")).toBe(2);
   });
 });

--- a/tests/unit/graphql-input-boundaries.test.ts
+++ b/tests/unit/graphql-input-boundaries.test.ts
@@ -65,6 +65,15 @@ describe("GraphQL protocol input boundaries", () => {
     expect(validateGraphqlVersionKey("static-bus-structured")).toBe(
       "static-bus-structured",
     );
+    expect(validateGraphqlVersionKey(" static-bus-structured ")).toBe(
+      "static-bus-structured",
+    );
+    expect(validateGraphqlVersionKey(`v${"a".repeat(119)}`)).toHaveLength(
+      GRAPHQL_LIMITS.versionKeyChars,
+    );
+    expect(() => validateGraphqlVersionKey(`v${"a".repeat(120)}`)).toThrow(
+      "versionKey must not exceed",
+    );
     expect(() => validateGraphqlVersionKey("../unsafe")).toThrow(
       "versionKey has an invalid format",
     );

--- a/tests/unit/mcp-tool-descriptors.test.ts
+++ b/tests/unit/mcp-tool-descriptors.test.ts
@@ -69,6 +69,8 @@ type JsonSchemaObject = {
   additionalProperties?: boolean;
   anyOf?: JsonSchemaObject[];
   items?: JsonSchemaObject;
+  maxLength?: number;
+  pattern?: string;
   properties?: Record<string, JsonSchemaObject>;
   required?: string[];
   type?: string;
@@ -83,6 +85,13 @@ function outputSchema(result: ToolListResult, name: string) {
 
 function outputSchemaKeys(result: ToolListResult, name: string) {
   return Object.keys(outputSchema(result, name)?.properties ?? {});
+}
+
+function inputSchema(result: ToolListResult, name: string) {
+  const tool = result.tools.find((item) => item.name === name);
+  expect(tool).toBeDefined();
+
+  return tool?.inputSchema as JsonSchemaObject | undefined;
 }
 
 describe("MCP tool descriptors", () => {
@@ -305,6 +314,22 @@ describe("MCP tool descriptors", () => {
         "routes",
       ]),
     );
+  });
+
+  it("advertises the shared bus versionKey boundary", async () => {
+    const result = await listTools();
+
+    for (const name of [
+      "catalog_bus_timetable_get",
+      "catalog_bus_route_get",
+      "catalog_bus_route_search",
+      "catalog_bus_departure_next",
+    ]) {
+      expect(inputSchema(result, name)?.properties?.versionKey).toMatchObject({
+        maxLength: 120,
+        pattern: "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+      });
+    }
   });
 
   it("advertises how to recover past-term personal data", async () => {


### PR DESCRIPTION
## Summary

- bound the isolate-local settled timetable cache to 100 entries and prune every expired entry on access
- coalesce all concurrent loads for the same locale/date/version key; keep live promises tracked until settlement
- retain only successful timetable data, with TTL starting after successful completion; null/error results do not occupy or evict settled cache entries
- use a structured key so automatic selection cannot collide with a legal explicit version named `auto`
- start enabled-version and explicit-version reads concurrently
- apply one trimmed 1–120 character version-key boundary across REST, MCP, and GraphQL, and update generated OpenAPI/contracts
- preserve per-call `fetchedAt`, locale/date/version isolation, user preference separation, TTL, historical dates, and response shapes

## Scope and priority

This is a code-proven resource-boundary fix, not a current production hotspot. The inspected 12-hour window had only 8 bus page and 3 bus API requests, zero 5xx, and no sampled CPU trace. No endpoint, database-client reuse, or speculative cache layer is added.

## Verification

- focused bus/cache/protocol tests: 124 passed in the implementation run; root recheck 5 files / 84 tests
- full Vitest: 270 files / 1751 tests
- OpenAPI generation/parity check passed
- Svelte check: 0 errors / 0 warnings
- all three TypeScript projects passed
- Biome passed with the same pre-existing static-loader warning
- production build and Wrangler deploy dry-run passed
- independent review found and then verified fixes for key collision, live-promise eviction, and stale OpenAPI; final review found no blockers

Closes #691
