### PR TITLE
fix(oauth): seed oauthResource rows before resource-bound token refresh

### DIFF
--- a/src/features/oauth/server/ensure-oauth-resources.server.ts
+++ b/src/features/oauth/server/ensure-oauth-resources.server.ts
@@ -1,0 +1,69 @@
+import { prisma as defaultPrisma } from "@/lib/db/prisma";
+import { getOAuthProviderValidAudiences } from "@/lib/oauth/resource-urls";
+import { OAUTH_PROVIDER_SCOPES } from "@/lib/oauth/scope-registry";
+
+type EnsureOAuthResourcesPrisma = {
+  oauthResource: {
+    findUnique: (input: {
+      where: { identifier: string };
+      select: { id: true };
+    }) => Promise<{ id: string } | null>;
+    create: (input: {
+      data: {
+        identifier: string;
+        name: string;
+        allowedScopes: string[];
+        dpopBoundAccessTokensRequired: boolean;
+        disabled: boolean;
+        policyVersion: number;
+      };
+    }) => Promise<unknown>;
+  };
+};
+
+let seedPromise: Promise<void> | null = null;
+
+async function seedOAuthProviderResources(prisma: EnsureOAuthResourcesPrisma) {
+  const allowedScopes = [...OAUTH_PROVIDER_SCOPES];
+
+  for (const identifier of getOAuthProviderValidAudiences()) {
+    const existing = await prisma.oauthResource.findUnique({
+      where: { identifier },
+      select: { id: true },
+    });
+    if (existing) continue;
+
+    try {
+      await prisma.oauthResource.create({
+        data: {
+          identifier,
+          name: identifier,
+          allowedScopes,
+          dpopBoundAccessTokensRequired: false,
+          disabled: false,
+          policyVersion: 1,
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (/unique|duplicate|UNIQUE/i.test(message)) continue;
+      throw error;
+    }
+  }
+}
+
+export async function ensureOAuthProviderResourcesSeeded(
+  prisma: EnsureOAuthResourcesPrisma = defaultPrisma,
+) {
+  if (!seedPromise) {
+    seedPromise = seedOAuthProviderResources(prisma).catch((error) => {
+      seedPromise = null;
+      throw error;
+    });
+  }
+  return seedPromise;
+}
+
+export function resetOAuthProviderResourceSeedForTests() {
+  seedPromise = null;
+}

--- a/src/lib/api/routes/auth-token.ts
+++ b/src/lib/api/routes/auth-token.ts
@@ -1,3 +1,4 @@
+import { ensureOAuthProviderResourcesSeeded } from "@/features/oauth/server/ensure-oauth-resources.server";
 import { jsonResponse } from "@/lib/api/helpers";
 import { observedApiRoute } from "@/lib/log/api-observability";
 import { withBetterAuthOAuthDebug } from "@/lib/log/oauth-debug";
@@ -212,6 +213,9 @@ async function postRoute(request: Request) {
       ),
       params,
     );
+    if (params.has("resource")) {
+      await ensureOAuthProviderResourcesSeeded();
+    }
     const delegatedResponse = await withBetterAuthOAuthDebug(
       "POST",
       delegatedRequest,

--- a/tests/unit/ensure-oauth-resources.test.ts
+++ b/tests/unit/ensure-oauth-resources.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resetOAuthProviderResourceSeedForTests } from "@/features/oauth/server/ensure-oauth-resources.server";
+
+const { findUniqueMock, createMock } = vi.hoisted(() => ({
+  findUniqueMock: vi.fn(),
+  createMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    oauthResource: {
+      findUnique: findUniqueMock,
+      create: createMock,
+    },
+  },
+}));
+
+vi.mock("@/lib/oauth/resource-urls", () => ({
+  getOAuthProviderValidAudiences: () => [
+    "https://life.example/api/auth",
+    "https://life.example/api/mcp",
+  ],
+}));
+
+vi.mock("@/lib/oauth/scope-registry", () => ({
+  OAUTH_PROVIDER_SCOPES: ["workspace.todo:read", "mcp:tools"],
+}));
+
+describe("ensureOAuthProviderResourcesSeeded", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetOAuthProviderResourceSeedForTests();
+    findUniqueMock.mockReset();
+    createMock.mockReset();
+  });
+
+  it("inserts missing oauthResource rows once per process", async () => {
+    findUniqueMock.mockResolvedValue(null);
+    createMock.mockResolvedValue({ id: "resource-1" });
+
+    const { ensureOAuthProviderResourcesSeeded } = await import(
+      "@/features/oauth/server/ensure-oauth-resources.server"
+    );
+
+    await ensureOAuthProviderResourcesSeeded();
+    await ensureOAuthProviderResourcesSeeded();
+
+    expect(createMock).toHaveBeenCalledTimes(2);
+    expect(createMock).toHaveBeenNthCalledWith(1, {
+      data: expect.objectContaining({
+        identifier: "https://life.example/api/auth",
+        allowedScopes: ["workspace.todo:read", "mcp:tools"],
+      }),
+    });
+    expect(createMock).toHaveBeenNthCalledWith(2, {
+      data: expect.objectContaining({
+        identifier: "https://life.example/api/mcp",
+      }),
+    });
+  });
+
+  it("skips identifiers that already exist", async () => {
+    findUniqueMock.mockImplementation(async ({ where }) =>
+      where.identifier === "https://life.example/api/auth"
+        ? { id: "existing" }
+        : null,
+    );
+    createMock.mockResolvedValue({ id: "resource-2" });
+
+    const { ensureOAuthProviderResourcesSeeded } = await import(
+      "@/features/oauth/server/ensure-oauth-resources.server"
+    );
+
+    await ensureOAuthProviderResourcesSeeded();
+
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(createMock).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        identifier: "https://life.example/api/mcp",
+      }),
+    });
+  });
+});

--- a/tests/unit/oauth-token-route.test.ts
+++ b/tests/unit/oauth-token-route.test.ts
@@ -10,6 +10,7 @@ import {
 
 const {
   betterAuthHandlerMock,
+  ensureOAuthProviderResourcesSeededMock,
   findRefreshTokenMock,
   isOAuthRefreshGrantActiveMock,
   logAppEventMock,
@@ -22,6 +23,7 @@ const {
   verifyAccessTokenJwtPayloadMock,
 } = vi.hoisted(() => ({
   betterAuthHandlerMock: vi.fn(),
+  ensureOAuthProviderResourcesSeededMock: vi.fn().mockResolvedValue(undefined),
   findRefreshTokenMock: vi.fn(),
   isOAuthRefreshGrantActiveMock: vi.fn(),
   logAppEventMock: vi.fn(),
@@ -32,6 +34,10 @@ const {
   signJwtMock: vi.fn(),
   updateRefreshTokenMock: vi.fn(),
   verifyAccessTokenJwtPayloadMock: vi.fn(),
+}));
+
+vi.mock("@/features/oauth/server/ensure-oauth-resources.server", () => ({
+  ensureOAuthProviderResourcesSeeded: ensureOAuthProviderResourcesSeededMock,
 }));
 
 vi.mock("@/lib/log/app-logger", async (importOriginal) => ({


### PR DESCRIPTION
## Summary
- Seeds `oauthResource` rows from `getOAuthProviderValidAudiences()` before Better Auth processes token requests that include RFC 8707 `resource` parameters.
- Maps Better Auth oauthResource/oauthClientResource/oauthClientAssertion schema models to the Prisma `OauthResource*` models.

## Context
After Better Auth 1.7 migration, the `oauthResource` table was created but never populated. Bot refresh requests that include both `/api/auth` and `/api/mcp` failed with:
`invalid_target: requested resource https://life-ustc.tiankaima.dev/api/auth is not configured`

## Test plan
- [x] `vitest run tests/unit/ensure-oauth-resources.test.ts tests/unit/oauth-provider-plugin.test.ts tests/unit/oauth-token-route.test.ts`
- [ ] CI green
- [ ] After deploy: bot agent MCP run succeeds without re-login
- [ ] Production probes: CIMD/DCR/MCP discovery still pass


Made with [Cursor](https://cursor.com)