### PR TITLE
perf(cache): revision-scoped KV TTL and calendar invalidation

### DIFF
--- a/src/features/calendar/server/calendar-export-cache.ts
+++ b/src/features/calendar/server/calendar-export-cache.ts
@@ -1,4 +1,7 @@
-import { getCloudflareCalendarExportsNamespace } from "@/lib/adapters/cloudflare-runtime";
+import {
+  getCloudflareCalendarExportsNamespace,
+  getCloudflareRuntimeTaskScheduler,
+} from "@/lib/adapters/cloudflare-runtime";
 import { sha256Base64Url } from "@/lib/crypto/web-crypto";
 import { writeCalendarFeedCacheAnalytics } from "@/lib/metrics/analytics-engine";
 
@@ -261,4 +264,28 @@ export async function getCachedUserCalendarExport(
 export function resetUserCalendarExportCacheForTest() {
   userCalendarExportCache.clear();
   userCalendarExportRefreshes.clear();
+}
+
+export async function invalidateUserCalendarExportCache(userId: string) {
+  userCalendarExportCache.delete(userId);
+  userCalendarExportRefreshes.delete(userId);
+
+  const namespace = getCloudflareCalendarExportsNamespace();
+  if (!namespace) return;
+
+  try {
+    await namespace.delete(cacheKey(userId));
+  } catch {
+    recordCalendarFeedCacheStatus("store_error");
+  }
+}
+
+export function scheduleInvalidateUserCalendarExportCache(userId: string) {
+  const scheduleTask = getCloudflareRuntimeTaskScheduler();
+  const work = invalidateUserCalendarExportCache(userId);
+  if (scheduleTask) {
+    scheduleTask(work);
+    return;
+  }
+  void work;
 }

--- a/src/features/calendar/server/calendar-export-invalidation.ts
+++ b/src/features/calendar/server/calendar-export-invalidation.ts
@@ -1,0 +1,33 @@
+import {
+  invalidateUserCalendarExportCache,
+  scheduleInvalidateUserCalendarExportCache,
+} from "@/features/calendar/server/calendar-export-cache";
+import { getCloudflareRuntimeTaskScheduler } from "@/lib/adapters/cloudflare-runtime";
+import { prisma } from "@/lib/db/prisma";
+
+export {
+  invalidateUserCalendarExportCache,
+  scheduleInvalidateUserCalendarExportCache,
+};
+
+export async function invalidateCalendarExportsForSection(sectionId: number) {
+  const subscribers = await prisma.user.findMany({
+    where: { subscribedSections: { some: { id: sectionId } } },
+    select: { id: true },
+  });
+  await Promise.all(
+    subscribers.map((subscriber) =>
+      invalidateUserCalendarExportCache(subscriber.id),
+    ),
+  );
+}
+
+export function scheduleInvalidateCalendarExportsForSection(sectionId: number) {
+  const scheduleTask = getCloudflareRuntimeTaskScheduler();
+  const work = invalidateCalendarExportsForSection(sectionId);
+  if (scheduleTask) {
+    scheduleTask(work);
+    return;
+  }
+  void work;
+}

--- a/src/features/calendar/server/calendar-export-invalidation.ts
+++ b/src/features/calendar/server/calendar-export-invalidation.ts
@@ -11,13 +11,13 @@ export {
 };
 
 export async function invalidateCalendarExportsForSection(sectionId: number) {
-  const subscribers = await prisma.user.findMany({
-    where: { subscribedSections: { some: { id: sectionId } } },
-    select: { id: true },
+  const subscribers = await prisma.userSectionSubscription.findMany({
+    where: { sectionId },
+    select: { userId: true },
   });
   await Promise.all(
     subscribers.map((subscriber) =>
-      invalidateUserCalendarExportCache(subscriber.id),
+      invalidateUserCalendarExportCache(subscriber.userId),
     ),
   );
 }

--- a/src/features/catalog/server/catalog-detail-page-server.ts
+++ b/src/features/catalog/server/catalog-detail-page-server.ts
@@ -9,6 +9,10 @@ import { getCoursePage } from "@/features/catalog/server/course-page-data";
 import { getTeacherPage } from "@/features/catalog/server/teacher-page-data";
 import { getViewerContext } from "@/lib/auth/viewer-context";
 import {
+  buildPublicDetailRuntimeCacheOptions,
+  PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS,
+} from "@/lib/catalog-detail-runtime-cache";
+import {
   cachedPublicRuntimeData,
   publicDetailColoCacheKey,
 } from "@/lib/public-runtime-cache";
@@ -39,8 +43,6 @@ const catalogDetailRouteSections = new Set([
   "sections",
   "comments",
 ]);
-
-const PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS = 60_000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object";
@@ -97,24 +99,31 @@ export async function loadCourseDetailPage({
   const includeSections = detailSection === "sections";
   const loadCourse = () =>
     getCoursePage(jwId, locals.locale, { includeSections });
-  const [course, viewer] = await Promise.all([
+  const courseCacheOptions =
     locals.publicSsr && !locals.authUser && !includeSections
+      ? await buildPublicDetailRuntimeCacheOptions({
+          coloCacheKey: publicDetailColoCacheKey(
+            url.origin,
+            "course",
+            locals.locale,
+            jwId,
+          ),
+          id: jwId,
+          kind: "course",
+          kvShape: "core-without-sections",
+          locale: locals.locale,
+          shouldCacheResult: (result) => result !== null,
+          validateColoCacheResult: (result) => isPublicCourseCore(result, jwId),
+        })
+      : null;
+  const [course, viewer] = await Promise.all([
+    courseCacheOptions
       ? cachedPublicRuntimeData(
           `page:course-detail:${locals.locale}`,
           `catalog-detail:course:${locals.locale}:${jwId}`,
           PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS,
           loadCourse,
-          {
-            coloCacheKey: publicDetailColoCacheKey(
-              url.origin,
-              "course",
-              locals.locale,
-              jwId,
-            ),
-            shouldCacheResult: (result) => result !== null,
-            validateColoCacheResult: (result) =>
-              isPublicCourseCore(result, jwId),
-          },
+          courseCacheOptions,
         )
       : loadCourse(),
     getViewerContext({ userId: locals.authUser?.id ?? null }),
@@ -196,24 +205,31 @@ export async function loadTeacherDetailPage({
   const includeSections = detailSection === "sections";
   const loadTeacher = () =>
     getTeacherPage(id, locals.locale, { includeSections });
-  const [teacher, viewer] = await Promise.all([
+  const teacherCacheOptions =
     locals.publicSsr && !locals.authUser && !includeSections
+      ? await buildPublicDetailRuntimeCacheOptions({
+          coloCacheKey: publicDetailColoCacheKey(
+            url.origin,
+            "teacher",
+            locals.locale,
+            id,
+          ),
+          id,
+          kind: "teacher",
+          kvShape: "core-without-sections",
+          locale: locals.locale,
+          shouldCacheResult: (result) => result !== null,
+          validateColoCacheResult: (result) => isPublicTeacherCore(result, id),
+        })
+      : null;
+  const [teacher, viewer] = await Promise.all([
+    teacherCacheOptions
       ? cachedPublicRuntimeData(
           `page:teacher-detail:${locals.locale}`,
           `catalog-detail:teacher:${locals.locale}:${id}`,
           PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS,
           loadTeacher,
-          {
-            coloCacheKey: publicDetailColoCacheKey(
-              url.origin,
-              "teacher",
-              locals.locale,
-              id,
-            ),
-            shouldCacheResult: (result) => result !== null,
-            validateColoCacheResult: (result) =>
-              isPublicTeacherCore(result, id),
-          },
+          teacherCacheOptions,
         )
       : loadTeacher(),
     getViewerContext({ userId: locals.authUser?.id ?? null }),

--- a/src/features/dashboard/server/compact-overview-read-model.ts
+++ b/src/features/dashboard/server/compact-overview-read-model.ts
@@ -172,7 +172,6 @@ export async function getCompactOverview(
               completed: false,
               dueAtFrom: now,
               dueAtTo: homeworkWindowEnd,
-              includeEditors: true,
               limit,
               locale,
               requireDueDate: true,

--- a/src/features/homeworks/server/homework-completion.ts
+++ b/src/features/homeworks/server/homework-completion.ts
@@ -1,3 +1,4 @@
+import { scheduleInvalidateUserCalendarExportCache } from "@/features/calendar/server/calendar-export-invalidation";
 import { withUserDbContext } from "@/lib/db/prisma";
 
 type HomeworkCompletionTransaction = Parameters<
@@ -28,7 +29,7 @@ export async function setHomeworkCompletion(input: {
   homeworkId: string;
   userId: string;
 }): Promise<HomeworkCompletionResult> {
-  return withUserDbContext(input.userId, async (tx) => {
+  const result = await withUserDbContext(input.userId, async (tx) => {
     const homework = await tx.homework.findUnique({
       where: { id: input.homeworkId },
       select: { id: true, deletedAt: true },
@@ -43,13 +44,17 @@ export async function setHomeworkCompletion(input: {
 
     return writeHomeworkCompletion(tx, input);
   });
+  if (result.success) {
+    scheduleInvalidateUserCalendarExportCache(input.userId);
+  }
+  return result;
 }
 
 export async function setHomeworkCompletions(input: {
   items: Array<{ completed: boolean; homeworkId: string }>;
   userId: string;
 }) {
-  return withUserDbContext(input.userId, async (tx) => {
+  const result = await withUserDbContext(input.userId, async (tx) => {
     const homeworkIds = [
       ...new Set(input.items.map((item) => item.homeworkId)),
     ];
@@ -81,6 +86,10 @@ export async function setHomeworkCompletions(input: {
     }
     return { results };
   });
+  if (result.results.some((item) => item.success)) {
+    scheduleInvalidateUserCalendarExportCache(input.userId);
+  }
+  return result;
 }
 
 async function writeHomeworkCompletion(

--- a/src/features/homeworks/server/homework-create.ts
+++ b/src/features/homeworks/server/homework-create.ts
@@ -1,3 +1,4 @@
+import { scheduleInvalidateCalendarExportsForSection } from "@/features/calendar/server/calendar-export-invalidation";
 import { prisma } from "@/lib/db/prisma";
 import {
   type HomeworkWriteAuthError,
@@ -110,6 +111,8 @@ export async function createHomeworkForSection(
 
     return homework;
   });
+
+  scheduleInvalidateCalendarExportsForSection(sectionId);
 
   return { ok: true as const, homework };
 }

--- a/src/features/homeworks/server/homework-mutations.ts
+++ b/src/features/homeworks/server/homework-mutations.ts
@@ -1,3 +1,4 @@
+import { scheduleInvalidateCalendarExportsForSection } from "@/features/calendar/server/calendar-export-invalidation";
 import { prisma } from "@/lib/db/prisma";
 import { isPrismaUniqueConstraintError } from "@/lib/db/prisma-errors";
 import { updateHomeworkDescription } from "./homework-description";
@@ -27,7 +28,7 @@ export async function updateHomework(input: {
 
   const homework = await prisma.homework.findUnique({
     where: { id: input.homeworkId },
-    select: { id: true, deletedAt: true },
+    select: { id: true, deletedAt: true, sectionId: true },
   });
 
   if (!homework) {
@@ -64,6 +65,8 @@ export async function updateHomework(input: {
     if (!isPrismaUniqueConstraintError(error)) throw error;
     await writeHomeworkUpdate();
   }
+
+  scheduleInvalidateCalendarExportsForSection(homework.sectionId);
 
   return { ok: true as const };
 }
@@ -119,6 +122,8 @@ export async function deleteHomework(input: {
       },
     });
   });
+
+  scheduleInvalidateCalendarExportsForSection(homework.sectionId);
 
   return { ok: true as const, alreadyDeleted: false };
 }

--- a/src/features/section-detail/server/section-detail-page-server.ts
+++ b/src/features/section-detail/server/section-detail-page-server.ts
@@ -10,6 +10,10 @@ import {
 import { getSectionPage } from "@/features/section-detail/server/section-page-data";
 import type { AppLocale } from "@/i18n/config";
 import {
+  buildPublicDetailRuntimeCacheOptions,
+  PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS,
+} from "@/lib/catalog-detail-runtime-cache";
+import {
   cachedPublicRuntimeData,
   publicDetailColoCacheKey,
 } from "@/lib/public-runtime-cache";
@@ -46,7 +50,6 @@ const sectionDetailRouteSections = new Set([
   "comments",
 ]);
 
-const PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS = 60_000;
 const PUBLIC_DETAIL_COLO_CACHE_PATH =
   "/_life-ustc-internal-cache/catalog-detail-core/v1";
 
@@ -171,7 +174,7 @@ export async function loadSectionDetailPage({
           : `catalog-detail:section:${locals.locale}:${jwId}`,
         PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS,
         loadSection,
-        {
+        await buildPublicDetailRuntimeCacheOptions({
           coloCacheKey: cachePublicOverviewCore
             ? publicSectionOverviewColoCacheKey(url.origin, locals.locale, jwId)
             : publicDetailColoCacheKey(
@@ -180,12 +183,18 @@ export async function loadSectionDetailPage({
                 locals.locale,
                 jwId,
               ),
+          id: jwId,
+          kind: "section",
+          kvShape: cachePublicOverviewCore
+            ? "core-with-related-overview"
+            : "core-without-exams-schedules-related",
+          locale: locals.locale,
           shouldCacheResult: (result) => result !== null,
           validateColoCacheResult: (result) =>
             cachePublicOverviewCore
               ? isPublicSectionOverviewCore(result, jwId)
               : isPublicSectionCore(result, jwId),
-        },
+        }),
       )
     : await loadSection();
   if (!section) error(404, "Section not found");

--- a/src/features/subscriptions/server/subscription-write-model.ts
+++ b/src/features/subscriptions/server/subscription-write-model.ts
@@ -1,3 +1,4 @@
+import { scheduleInvalidateUserCalendarExportCache } from "@/features/calendar/server/calendar-export-invalidation";
 import type { Prisma } from "@/generated/prisma/client";
 import type { AppLocale } from "@/i18n/config";
 import { DEFAULT_LOCALE } from "@/i18n/config";
@@ -280,9 +281,13 @@ export async function mutateUserSectionSubscriptionsInTransaction(
 async function mutateUserSectionSubscriptions(
   input: LockedSectionSubscriptionMutationInput,
 ) {
-  return withUserDbContext(input.userId, (tx) =>
+  const result = await withUserDbContext(input.userId, (tx) =>
     mutateUserSectionSubscriptionsInTransaction(tx, input),
   );
+  if (result) {
+    scheduleInvalidateUserCalendarExportCache(input.userId);
+  }
+  return result;
 }
 
 type ResolvedCalendarSubscriptionSections = NonNullable<

--- a/src/lib/adapters/cloudflare-runtime.ts
+++ b/src/lib/adapters/cloudflare-runtime.ts
@@ -69,6 +69,7 @@ type CloudflareTracing = {
 };
 
 export type CloudflareKVNamespace = {
+  delete(key: string): Promise<void>;
   get<T = unknown>(
     key: string,
     options: { cacheTtl?: number; type: "json" },

--- a/src/lib/catalog-detail-cache-revision.ts
+++ b/src/lib/catalog-detail-cache-revision.ts
@@ -1,0 +1,25 @@
+import { prisma } from "@/lib/db/prisma";
+
+const REVISION_CACHE_TTL_MS = 60_000;
+const BOOTSTRAP_REVISION = "bootstrap";
+
+let cachedRevision: { expiresAt: number; value: string } | null = null;
+
+export function resetCatalogDetailCacheRevisionForTest() {
+  cachedRevision = null;
+}
+
+export async function getCatalogDetailCacheRevision() {
+  const now = Date.now();
+  if (cachedRevision && cachedRevision.expiresAt > now) {
+    return cachedRevision.value;
+  }
+
+  const state = await prisma.staticImportState.findUnique({
+    where: { id: "global" },
+    select: { snapshotSha256: true },
+  });
+  const value = state?.snapshotSha256?.slice(0, 16) ?? BOOTSTRAP_REVISION;
+  cachedRevision = { expiresAt: now + REVISION_CACHE_TTL_MS, value };
+  return value;
+}

--- a/src/lib/catalog-detail-runtime-cache.ts
+++ b/src/lib/catalog-detail-runtime-cache.ts
@@ -1,0 +1,34 @@
+import type { AppLocale } from "@/i18n/config";
+import { getCatalogDetailCacheRevision } from "@/lib/catalog-detail-cache-revision";
+import {
+  type PublicDetailColoCacheKind,
+  publicDetailKvCacheKey,
+} from "@/lib/public-runtime-cache";
+
+export const PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS = 60_000;
+export const PUBLIC_DETAIL_KV_CACHE_TTL_MS = 3_600_000;
+
+export async function buildPublicDetailRuntimeCacheOptions<T>(input: {
+  coloCacheKey?: string;
+  id: number;
+  kind: PublicDetailColoCacheKind;
+  kvShape: string;
+  locale: AppLocale;
+  shouldCacheResult?: (result: T) => boolean;
+  validateColoCacheResult?: (result: unknown) => boolean;
+}) {
+  const revision = await getCatalogDetailCacheRevision();
+  return {
+    coloCacheKey: input.coloCacheKey,
+    kvCacheKey: publicDetailKvCacheKey(
+      revision,
+      input.kind,
+      input.locale,
+      input.id,
+      input.kvShape,
+    ),
+    kvTtlMs: PUBLIC_DETAIL_KV_CACHE_TTL_MS,
+    shouldCacheResult: input.shouldCacheResult,
+    validateColoCacheResult: input.validateColoCacheResult,
+  };
+}

--- a/src/lib/public-runtime-cache.ts
+++ b/src/lib/public-runtime-cache.ts
@@ -19,6 +19,7 @@ type CacheEntry<T> = {
 type PublicRuntimeCacheOptions<T> = {
   coloCacheKey?: string;
   kvCacheKey?: string;
+  kvTtlMs?: number;
   shouldCacheResult?: (result: T) => boolean;
   validateColoCacheResult?: (result: unknown) => boolean;
 };
@@ -477,12 +478,13 @@ export function publicRuntimeCacheKey(
 }
 
 export function publicDetailKvCacheKey(
+  revision: string,
   kind: PublicDetailColoCacheKind,
   locale: AppLocale,
   id: number,
-  shape: (typeof publicDetailColoCacheShapes)[PublicDetailColoCacheKind],
+  shape: string,
 ) {
-  return `v1:${kind}:${locale}:${id}:${shape}`;
+  return `v1:${revision}:${kind}:${locale}:${id}:${shape}`;
 }
 
 function resolvePublicDetailKvCacheKey(options: {
@@ -558,11 +560,13 @@ export function cachedPublicRuntimeData<T>(
   const initialStoreSize = store.size;
   let value: Promise<T> | undefined;
   value = (async () => {
-    const kvCacheKey = resolvePublicDetailKvCacheKey(options);
+    const kvCacheKey =
+      options.kvCacheKey ?? resolvePublicDetailKvCacheKey(options);
+    const kvTtlMs = options.kvTtlMs ?? ttlMs;
     const kvRead = kvCacheKey
       ? await readKvCache<T>(
           kvCacheKey,
-          ttlMs,
+          kvTtlMs,
           analyticsNamespace,
           start,
           initialStoreSize,
@@ -603,12 +607,13 @@ export function cachedPublicRuntimeData<T>(
         options.validateColoCacheResult,
       );
       if (resultValid) {
+        const kvTtlMs = options.kvTtlMs ?? ttlMs;
         if (kvCacheKey) {
           scheduleKvCacheWrite(
             kvCacheKey,
             result,
-            expiresAt,
-            ttlMs,
+            Date.now() + kvTtlMs,
+            kvTtlMs,
             analyticsNamespace,
             start,
             initialStoreSize,

--- a/tests/unit/calendar-export-cache.test.ts
+++ b/tests/unit/calendar-export-cache.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getCachedUserCalendarExport,
+  invalidateUserCalendarExportCache,
   requestMatchesEtag,
   resetUserCalendarExportCacheForTest,
   USER_CALENDAR_EXPORT_FRESH_TTL_MS,
@@ -16,6 +17,9 @@ const calendarExport = {
 function kvNamespace() {
   const values = new Map<string, string>();
   return {
+    delete: vi.fn(async (key: string) => {
+      values.delete(key);
+    }),
     get: vi.fn(async (key: string) => {
       const value = values.get(key);
       return value ? JSON.parse(value) : null;
@@ -215,5 +219,20 @@ describe("用户 iCal 导出缓存", () => {
         etag,
       ),
     ).toBe(false);
+  });
+
+  it("deletes cached exports from memory and KV", async () => {
+    const namespace = kvNamespace();
+    setCloudflareRuntimeEnv({ CALENDAR_EXPORTS: namespace });
+
+    const buildExport = vi.fn(async () => calendarExport);
+    await getCachedUserCalendarExport("user-1", buildExport);
+    expect(buildExport).toHaveBeenCalledOnce();
+
+    await invalidateUserCalendarExportCache("user-1");
+    await getCachedUserCalendarExport("user-1", buildExport);
+
+    expect(buildExport).toHaveBeenCalledTimes(2);
+    expect(namespace.delete).toHaveBeenCalledWith("user-calendar:v1:user-1");
   });
 });

--- a/tests/unit/catalog-detail-cache-revision.test.ts
+++ b/tests/unit/catalog-detail-cache-revision.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getCatalogDetailCacheRevision,
+  resetCatalogDetailCacheRevisionForTest,
+} from "@/lib/catalog-detail-cache-revision";
+
+const { findUniqueMock } = vi.hoisted(() => ({
+  findUniqueMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    staticImportState: {
+      findUnique: findUniqueMock,
+    },
+  },
+}));
+
+describe("catalog detail cache revision", () => {
+  afterEach(() => {
+    resetCatalogDetailCacheRevisionForTest();
+    findUniqueMock.mockReset();
+  });
+
+  it("uses the static import snapshot SHA prefix as the revision", async () => {
+    findUniqueMock.mockResolvedValue({
+      snapshotSha256:
+        "abcdef0123456789abcdef0123456789abcdef0123456789abcdef01",
+    });
+
+    await expect(getCatalogDetailCacheRevision()).resolves.toBe(
+      "abcdef0123456789",
+    );
+    await expect(getCatalogDetailCacheRevision()).resolves.toBe(
+      "abcdef0123456789",
+    );
+    expect(findUniqueMock).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to bootstrap when static import state is missing", async () => {
+    findUniqueMock.mockResolvedValue(null);
+
+    await expect(getCatalogDetailCacheRevision()).resolves.toBe("bootstrap");
+  });
+});

--- a/tests/unit/detail-page-loader-critical-path.test.ts
+++ b/tests/unit/detail-page-loader-critical-path.test.ts
@@ -74,6 +74,11 @@ vi.mock("@/lib/auth/viewer-context", () => ({
   getViewerContext: getViewerContextMock,
 }));
 
+vi.mock("@/lib/catalog-detail-cache-revision", () => ({
+  getCatalogDetailCacheRevision: vi.fn(async () => "test-revision"),
+  resetCatalogDetailCacheRevisionForTest: vi.fn(),
+}));
+
 const anonymousViewer = {
   image: null,
   isAdmin: false,

--- a/tests/unit/public-runtime-cache.test.ts
+++ b/tests/unit/public-runtime-cache.test.ts
@@ -225,23 +225,27 @@ describe("public runtime cache", () => {
     expect(new Set([course, teacher, section]).size).toBe(3);
   });
 
-  it("builds versioned KV keys isolated by kind, shape, locale, and ID", () => {
+  it("builds versioned KV keys isolated by revision, kind, shape, locale, and ID", () => {
     expect(
       publicDetailKvCacheKey(
+        "abc123def4567890",
         "section",
         "zh-cn",
         12345,
         "core-without-exams-schedules-related",
       ),
-    ).toBe("v1:section:zh-cn:12345:core-without-exams-schedules-related");
+    ).toBe(
+      "v1:abc123def4567890:section:zh-cn:12345:core-without-exams-schedules-related",
+    );
     expect(
       publicDetailKvCacheKey(
+        "abc123def4567890",
         "course",
         "en-us",
         683001,
         "core-without-sections",
       ),
-    ).toBe("v1:course:en-us:683001:core-without-sections");
+    ).toBe("v1:abc123def4567890:course:en-us:683001:core-without-sections");
   });
 
   it("uses a KV hit without loading or colo reads and then serves it from L1", async () => {
@@ -249,19 +253,18 @@ describe("public runtime cache", () => {
     vi.setSystemTime(10_000);
     const cached = { source: "kv" };
     const namespace = kvNamespace();
-    namespace.seed(
-      publicDetailKvCacheKey(
-        "course",
-        "en-us",
-        683001,
-        "core-without-sections",
-      ),
-      {
-        expiresAt: 20_000,
-        schema: "catalog-detail-core-v1",
-        value: cached,
-      },
+    const kvCacheKey = publicDetailKvCacheKey(
+      "rev",
+      "course",
+      "en-us",
+      683001,
+      "core-without-sections",
     );
+    namespace.seed(kvCacheKey, {
+      expiresAt: 20_000,
+      schema: "catalog-detail-core-v1",
+      value: cached,
+    });
     const { match, open, put } = installNamedCache();
     const load = vi.fn(async () => ({ source: "database" }));
     const { context } = runtimeExecutionContext();
@@ -281,6 +284,7 @@ describe("public runtime cache", () => {
               "en-us",
               683001,
             ),
+            kvCacheKey,
             validateColoCacheResult: validatesSource,
           },
         );
@@ -296,6 +300,7 @@ describe("public runtime cache", () => {
               "en-us",
               683001,
             ),
+            kvCacheKey,
             validateColoCacheResult: validatesSource,
           },
         );
@@ -307,10 +312,10 @@ describe("public runtime cache", () => {
     );
 
     expect(namespace.get).toHaveBeenCalledOnce();
-    expect(namespace.get).toHaveBeenCalledWith(
-      "v1:course:en-us:683001:core-without-sections",
-      { cacheTtl: 60, type: "json" },
-    );
+    expect(namespace.get).toHaveBeenCalledWith(kvCacheKey, {
+      cacheTtl: 60,
+      type: "json",
+    });
     expect(open).not.toHaveBeenCalled();
     expect(match).not.toHaveBeenCalled();
     expect(load).not.toHaveBeenCalled();
@@ -330,6 +335,7 @@ describe("public runtime cache", () => {
       683002,
     );
     const kvCacheKey = publicDetailKvCacheKey(
+      "rev",
       "section",
       "en-us",
       683002,
@@ -341,6 +347,7 @@ describe("public runtime cache", () => {
       async () => {
         const options = {
           coloCacheKey,
+          kvCacheKey,
           shouldCacheResult: (result: { source: string }) => result !== null,
           validateColoCacheResult: validatesSource,
         };


### PR DESCRIPTION
## Summary
- Scope catalog detail KV keys by static-import revision (`snapshotSha256` prefix) and raise KV TTL to 1h while keeping L1 at 60s.
- Invalidate user calendar exports on subscription and homework mutations (section subscribers for homework CRUD; per-user for completion).
- Trim dashboard overview homework list by dropping `includeEditors` from the lists stage.

## Test plan
- [x] `vitest run tests/unit/catalog-detail-cache-revision.test.ts`
- [x] `vitest run tests/unit/public-runtime-cache.test.ts`
- [x] `vitest run tests/unit/calendar-export-cache.test.ts`
- [ ] CI Check / run + E2E

## Notes
- Independent of #703 (section-detail client tabs); safe to merge in either order.
- Revision auto-updates on each static import via new `snapshotSha256`; no manual KV purge needed.


Made with [Cursor](https://cursor.com)