### PR TITLE
fix(ui): polish copy, tables, and duplicate titles

### DIFF
--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -500,19 +500,6 @@
     "invalidUsername": "Invalid username",
     "usernameTaken": "Username already taken"
   },
-  "myComments": {
-    "title": "My Comments",
-    "description": "Review all comments you posted.",
-    "content": "Content",
-    "postedIn": "Posted in",
-    "status": "Status",
-    "createdAt": "Created",
-    "viewThread": "View thread",
-    "noResults": "No comments yet",
-    "statusActive": "Active",
-    "statusSoftbanned": "Private",
-    "statusDeleted": "Deleted"
-  },
   "myHomeworks": {
     "title": "My Homework",
     "description": "Track homework for your subscribed sections.",
@@ -932,31 +919,10 @@
         "title": "Authorized apps",
         "description": "Review and revoke third-party access"
       },
-      "content": {
-        "title": "Content",
-        "description": "Uploads and my comments"
-      },
       "danger": {
         "title": "Danger zone",
         "description": "Irreversible actions like deleting account"
       }
-    },
-    "content": {
-      "title": "Content",
-      "description": "Uploads and comments stay with the course, section, or homework where they belong.",
-      "emptyTitle": "No standalone content settings",
-      "emptyDescription": "Manage uploads and comments from the course, section, or homework where they belong. Use the links below to continue from the right context.",
-      "browseSections": {
-        "title": "Browse sections",
-        "description": "Open a section page to review comments, homework, and attached uploads."
-      },
-      "commentGuide": {
-        "title": "Comment guide",
-        "description": "Review visibility, anonymous posting, and formatting rules before joining a discussion."
-      },
-      "comments": "Comments",
-      "uploads": "Uploads",
-      "subscriptions": "Subscriptions"
     },
     "preferences": {
       "title": "Preferences",
@@ -1069,7 +1035,7 @@
       },
       {
         "syntax": "sectioncode:code",
-        "description": "Search by section code (alias: lecturecode:code)",
+        "description": "Search by section code",
         "example": "sectioncode:01"
       },
       {
@@ -1079,12 +1045,12 @@
       },
       {
         "syntax": "credits:number",
-        "description": "Search by exact credit value (alias: credit:number)",
+        "description": "Search by exact credit value",
         "example": "credits:3"
       },
       {
         "syntax": "department:name",
-        "description": "Search by department name (alias: dept:name)",
+        "description": "Search by department name",
         "example": "department:计算机"
       },
       {
@@ -1099,17 +1065,17 @@
       },
       {
         "syntax": "level:name",
-        "description": "Search by education level (alias: edulevel:name)",
+        "description": "Search by education level",
         "example": "level:本科"
       },
       {
         "syntax": "type:name",
-        "description": "Search by class type (alias: classtype:name)",
+        "description": "Search by class type",
         "example": "type:必修"
       },
       {
         "syntax": "sort:field",
-        "description": "Sort results by field (alias: sortby:field). capacity uses current enrollment; teacher uses teacher count",
+        "description": "Sort results by field. credits sorts by credit value; capacity uses enrollment; teacher uses teacher count",
         "example": "sort:credits"
       },
       {

--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -1798,7 +1798,6 @@
     "descriptionsTab": "Descriptions",
     "suspensionsTab": "Suspensions",
     "pageDescription": "Review comments, descriptions, homework, and account suspensions.",
-    "currentView": "Current view",
     "refreshQueue": "Refresh queue",
     "refreshingQueue": "Refreshing...",
     "activeCountMeta": "{count} active",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -500,19 +500,6 @@
     "invalidUsername": "用户名无效",
     "usernameTaken": "用户名已被占用"
   },
-  "myComments": {
-    "title": "我的评论",
-    "description": "查看你发布的所有评论。",
-    "content": "内容",
-    "postedIn": "发布于",
-    "status": "状态",
-    "createdAt": "创建时间",
-    "viewThread": "查看讨论",
-    "noResults": "暂无评论",
-    "statusActive": "正常",
-    "statusSoftbanned": "仅自己可见",
-    "statusDeleted": "已删除"
-  },
   "myHomeworks": {
     "title": "我的作业",
     "description": "查看你订阅的教学班的作业信息。",
@@ -898,31 +885,10 @@
         "title": "已授权应用",
         "description": "查看并撤销第三方访问"
       },
-      "content": {
-        "title": "内容管理",
-        "description": "上传资料与我的评论"
-      },
       "danger": {
         "title": "危险操作",
         "description": "删除账户等不可恢复操作"
       }
-    },
-    "content": {
-      "title": "内容管理",
-      "description": "上传与评论会保留在所属课程、班级或作业对象中管理。",
-      "emptyTitle": "没有独立的内容设置页",
-      "emptyDescription": "请在对应课程、班级或作业页面中管理上传与评论。下面提供继续操作的入口。",
-      "browseSections": {
-        "title": "浏览班级",
-        "description": "打开班级详情页，查看相关评论、作业与附加上传。"
-      },
-      "commentGuide": {
-        "title": "评论指南",
-        "description": "参与讨论前，先了解可见性、匿名发布与格式支持规则。"
-      },
-      "comments": "评论",
-      "uploads": "上传",
-      "subscriptions": "订阅"
     },
     "preferences": {
       "title": "偏好设置",
@@ -1035,7 +1001,7 @@
       },
       {
         "syntax": "sectioncode:班级代码",
-        "description": "按班级代码搜索（别名：lecturecode:班级代码）",
+        "description": "按班级代码搜索",
         "example": "sectioncode:01"
       },
       {
@@ -1045,12 +1011,12 @@
       },
       {
         "syntax": "credits:学分数",
-        "description": "按精确学分值搜索（别名：credit:学分数）",
+        "description": "按精确学分值搜索",
         "example": "credits:3"
       },
       {
         "syntax": "department:院系名",
-        "description": "按院系名称搜索（别名：dept:院系名）",
+        "description": "按院系名称搜索",
         "example": "department:计算机"
       },
       {
@@ -1065,17 +1031,17 @@
       },
       {
         "syntax": "level:教育层次",
-        "description": "按教育层次搜索（别名：edulevel:教育层次）",
+        "description": "按教育层次搜索",
         "example": "level:本科"
       },
       {
         "syntax": "type:课程类型",
-        "description": "按课程类型搜索（别名：classtype:课程类型）",
+        "description": "按课程类型搜索",
         "example": "type:必修"
       },
       {
         "syntax": "sort:字段",
-        "description": "按字段排序结果（别名：sortby:字段）。capacity 按当前人数排序，teacher 按教师数量排序",
+        "description": "按字段排序结果。credits 按学分，capacity 按当前人数，teacher 按教师数量",
         "example": "sort:credits"
       },
       {

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -1764,7 +1764,6 @@
     "descriptionsTab": "课程简介",
     "suspensionsTab": "封禁",
     "pageDescription": "处理评论、课程简介、作业和账号封禁。",
-    "currentView": "当前视图",
     "refreshQueue": "刷新队列",
     "refreshingQueue": "刷新中...",
     "activeCountMeta": "{count} 个生效中",

--- a/src/features/admin/components/AdminModerationHeader.svelte
+++ b/src/features/admin/components/AdminModerationHeader.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import PageHeader from "$lib/components/PageHeader.svelte";
-import PageHeaderMeta from "$lib/components/PageHeaderMeta.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
 import type {
@@ -17,8 +16,6 @@ export let isRefreshing: boolean;
 export let moderationHref: (tab: AdminModerationTab) => string;
 export let refreshQueue: () => void | Promise<void>;
 export let tabs: AdminModerationHeaderTab[];
-
-$: currentTabLabel = tabs.find(([id]) => id === currentTab)?.[1] ?? currentTab;
 </script>
 
 <PageHeader title={copy.title} description={copy.pageDescription} eyebrow={adminCopy.title}>
@@ -32,9 +29,6 @@ $: currentTabLabel = tabs.find(([id]) => id === currentTab)?.[1] ?? currentTab;
     >
       {isRefreshing ? copy.refreshingQueue : copy.refreshQueue}
     </Button>
-  {/snippet}
-  {#snippet meta()}
-    <PageHeaderMeta label={copy.currentView} value={currentTabLabel} />
   {/snippet}
 </PageHeader>
 

--- a/src/features/admin/components/admin-moderation-page-types.ts
+++ b/src/features/admin/components/admin-moderation-page-types.ts
@@ -22,7 +22,6 @@ export type AdminModerationCopy = AdminModerationCommentsCopy &
     calendarButtonLabel: string;
     close: string;
     confirmButton: string;
-    currentView: string;
     defaultBanReason: string;
     deleteHomeworkAction: string;
     deleteHomeworkAuditDescription: string;

--- a/src/features/dashboard/components/ExamsListView.svelte
+++ b/src/features/dashboard/components/ExamsListView.svelte
@@ -9,7 +9,6 @@ import type {
   ExamTimeLabel,
 } from "./dashboard-exam-component-types";
 
-export let dashboardCopy: ExamsCopyProps["dashboardCopy"];
 export let dashboardTabHref: DashboardTabHref;
 export let exams: DashboardExamRow[];
 export let examTimeLabel: ExamTimeLabel;
@@ -17,10 +16,10 @@ export let sectionCopy: ExamsCopyProps["sectionCopy"];
 export let subscriptionsCopy: ExamsCopyProps["subscriptionsCopy"];
 </script>
 
-<Table.Root>
+<Table.Root class="min-w-0">
   <Table.Header>
     <Table.Row>
-      <Table.Head>{dashboardCopy.nav.exams.title}</Table.Head>
+      <Table.Head>{subscriptionsCopy.courseName}</Table.Head>
       <Table.Head>{subscriptionsCopy.section}</Table.Head>
       <Table.Head class="text-center">{sectionCopy.examDate}</Table.Head>
       <Table.Head class="text-center">{sectionCopy.examTime}</Table.Head>

--- a/src/features/dashboard/components/ExamsTab.svelte
+++ b/src/features/dashboard/components/ExamsTab.svelte
@@ -102,9 +102,8 @@ export let filteredExamRows: DashboardExamRow[];
           {subscriptionsCopy}
         />
       </div>
-      <div class="hidden md:block">
+      <div class="hidden min-w-0 overflow-x-auto md:block">
         <ExamsListView
-          {dashboardCopy}
           {dashboardTabHref}
           {examTimeLabel}
           exams={filteredExamRows}

--- a/src/features/dashboard/components/HomeworksListView.svelte
+++ b/src/features/dashboard/components/HomeworksListView.svelte
@@ -28,7 +28,7 @@ export let toggleHomeworkCompletion: (
 ) => void | Promise<void>;
 </script>
 
-<Table.Root data-testid="dashboard-homeworks-list">
+<Table.Root class="min-w-0" data-testid="dashboard-homeworks-list">
   <Table.Header>
     <Table.Row>
       <Table.Head>{homeworksCopy.titleLabel}</Table.Head>

--- a/src/features/dashboard/components/HomeworksTab.svelte
+++ b/src/features/dashboard/components/HomeworksTab.svelte
@@ -150,7 +150,7 @@ $: ({
           {toggleHomeworkCompletion}
         />
       </div>
-      <div class="hidden md:block">
+      <div class="hidden min-w-0 overflow-x-auto md:block">
         <HomeworksListView
           {filteredHomeworkItems}
           {fmtDate}

--- a/src/features/oauth/components/OAuthAuthorizeErrorPanel.svelte
+++ b/src/features/oauth/components/OAuthAuthorizeErrorPanel.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 import * as Alert from "$lib/components/ui/alert/index.js";
 
+export let hint: string | null | undefined = undefined;
 export let message: string;
-export let title: string;
 </script>
 
 <Alert.Root variant="destructive">
-  <Alert.Title role="heading" aria-level={2}>{title}</Alert.Title>
   <Alert.Description>{message}</Alert.Description>
+  {#if hint}
+    <Alert.Description class="text-destructive/90">{hint}</Alert.Description>
+  {/if}
 </Alert.Root>

--- a/src/features/oauth/components/OAuthAuthorizePage.svelte
+++ b/src/features/oauth/components/OAuthAuthorizePage.svelte
@@ -27,6 +27,7 @@ type PageData = {
   scopes?: Array<{ label: string; value: string }>;
   state: string;
   title?: string;
+  hint?: string;
 };
 
 export let data: PageData;
@@ -37,9 +38,7 @@ $: pageTitle =
     ? (data.title ?? "OAuth")
     : (data.copy?.title ?? "OAuth");
 $: pageDescription =
-  data.state === "error"
-    ? (data.message ?? "")
-    : (data.copy?.description ?? "");
+  data.state === "error" ? "" : (data.copy?.description ?? "");
 </script>
 
 <svelte:head><title>{pageTitle} - Life@USTC</title></svelte:head>
@@ -67,8 +66,8 @@ $: pageDescription =
     <Card.Content class="grid gap-5 p-6">
       {#if data.state === "error"}
         <OAuthAuthorizeErrorPanel
+          hint={data.hint}
           message={data.message ?? ""}
-          title={data.title ?? "OAuth"}
         />
       {:else if data.copy}
         <OAuthAuthorizeConsentPanel

--- a/src/features/oauth/server/oauth-authorize-page-server.ts
+++ b/src/features/oauth/server/oauth-authorize-page-server.ts
@@ -52,6 +52,7 @@ export const loadOAuthAuthorizePage = async ({
       state: "error",
       title: copy.errorPageTitle,
       message: copy.errorMissingClientId,
+      hint: copy.errorPageHint,
     };
   }
 
@@ -93,6 +94,7 @@ export const loadOAuthAuthorizePage = async ({
       state: "error",
       title: copy.errorPageTitle,
       message: copy.errorInvalidClient,
+      hint: copy.errorPageHint,
     };
   }
 };

--- a/src/features/settings/components/settings-component-types.ts
+++ b/src/features/settings/components/settings-component-types.ts
@@ -76,20 +76,6 @@ export type SettingsCopy = {
       unnamedClient: string;
       updatedAt: string;
     };
-    content: {
-      browseSections: {
-        description: string;
-        title: string;
-      };
-      commentGuide: {
-        description: string;
-        title: string;
-      };
-      description: string;
-      emptyDescription: string;
-      emptyTitle: string;
-      title: string;
-    };
     description: string;
     preferences: {
       appearance: {


### PR DESCRIPTION
## Summary
- Remove parser-alias wording from section search help examples (zh/en)
- Delete unused locale keys: `settings.content`, `settings.nav.content`, `myComments`, `moderation.currentView`
- Drop admin moderation `currentView` meta badge (tab nav already shows selection)
- Fix OAuth authorize error page duplicate title (PageHeader title + alert title)
- Improve dashboard homework/exam list tables: `min-w-0`, horizontal scroll wrapper, correct exam column header

## Test plan
- [x] `bunx biome check .`
- [x] `bun run build`
- [ ] CI e2e shards