### PR TITLE
feat(search): add global search and fix calendar export freshness

### DIFF
--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -77,6 +77,24 @@
     "userNotFound": "User not found",
     "unknown": "Unknown"
   },
+  "globalSearch": {
+    "title": "Search",
+    "placeholder": "Search courses, sections, teachers…",
+    "placeholderSignedIn": "Search courses, sections, homework, todos…",
+    "shortcut": "Ctrl K",
+    "shortcutMac": "⌘ K",
+    "noResults": "No results found",
+    "searching": "Searching…",
+    "hint": "Type at least 2 characters to search",
+    "openSearch": "Open search",
+    "groups": {
+      "courses": "Courses",
+      "sections": "Sections",
+      "teachers": "Teachers",
+      "homeworks": "Homework",
+      "todos": "Todos"
+    }
+  },
   "CalendarEventCard": {
     "session": "Class",
     "exam": "Exam",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -77,6 +77,24 @@
     "userNotFound": "未找到用户",
     "unknown": "未知"
   },
+  "globalSearch": {
+    "title": "搜索",
+    "placeholder": "搜索课程、班级、教师…",
+    "placeholderSignedIn": "搜索课程、班级、作业、待办…",
+    "shortcut": "Ctrl K",
+    "shortcutMac": "⌘ K",
+    "noResults": "未找到相关结果",
+    "searching": "搜索中…",
+    "hint": "输入至少 2 个字符开始搜索",
+    "openSearch": "打开搜索",
+    "groups": {
+      "courses": "课程",
+      "sections": "班级",
+      "teachers": "教师",
+      "homeworks": "作业",
+      "todos": "待办"
+    }
+  },
   "CalendarEventCard": {
     "session": "课程",
     "exam": "考试",

--- a/src/features/dashboard/server/dashboard-overview-data.ts
+++ b/src/features/dashboard/server/dashboard-overview-data.ts
@@ -78,7 +78,9 @@ export async function getDashboardOverviewData(
     (homework) => homework.homeworkCompletions.length === 0,
   );
   const calendarHomeworks = overviewHomeworks.filter(
-    (homework) => homework.submissionDueAt !== null,
+    (homework) =>
+      homework.submissionDueAt !== null &&
+      homework.homeworkCompletions.length === 0,
   );
   const schedule = buildDashboardOverviewSchedule({
     dashboardSections,

--- a/src/features/search/server/global-search-service.ts
+++ b/src/features/search/server/global-search-service.ts
@@ -1,0 +1,236 @@
+import {
+  listCourseSummaries,
+  listSectionSummaries,
+  listTeacherSummaries,
+} from "@/features/catalog/server/course-section-queries";
+import type {
+  GlobalSearchResponse,
+  GlobalSearchResultGroup,
+  GlobalSearchResultItem,
+} from "@/features/search/server/global-search-types";
+import type { AppLocale } from "@/i18n/config";
+import { withUserDbContext } from "@/lib/db/prisma";
+import { ilike } from "@/lib/query-filter-helpers";
+import { formatSemesterName } from "@/lib/text/format-semester-name";
+
+const DEFAULT_LIMIT = 5;
+const MIN_QUERY_LENGTH = 2;
+
+function catalogPrimaryName(item: {
+  nameCn?: string | null;
+  namePrimary?: string | null;
+}) {
+  return item.namePrimary ?? item.nameCn ?? "";
+}
+
+function toCourseItem(course: {
+  code: string;
+  jwId: number;
+  nameCn: string | null;
+  namePrimary: string | null;
+}): GlobalSearchResultItem {
+  return {
+    id: `course:${course.jwId}`,
+    title: catalogPrimaryName(course),
+    description: course.code,
+    href: `/catalog/courses/${course.jwId}`,
+  };
+}
+
+function toSectionItem(
+  section: {
+    code: string;
+    course: {
+      code: string;
+      nameCn: string | null;
+      namePrimary: string | null;
+    };
+    jwId: number;
+    semester: { nameCn: string | null } | null;
+  },
+  locale: AppLocale,
+): GlobalSearchResultItem {
+  const courseName = catalogPrimaryName(section.course);
+  const semesterName = section.semester
+    ? formatSemesterName(locale, section.semester.nameCn)
+    : null;
+  return {
+    id: `section:${section.jwId}`,
+    title: `${courseName} · ${section.code}`,
+    description: semesterName,
+    href: `/catalog/sections/${section.jwId}`,
+  };
+}
+
+function toTeacherItem(teacher: {
+  code: string;
+  department: { nameCn: string | null } | null;
+  id: number;
+  nameCn: string;
+}): GlobalSearchResultItem {
+  return {
+    id: `teacher:${teacher.id}`,
+    title: teacher.nameCn,
+    description: teacher.department?.nameCn ?? teacher.code,
+    href: `/catalog/teachers/${teacher.id}`,
+  };
+}
+
+async function searchCatalogGroups(
+  query: string,
+  locale: AppLocale,
+  limit: number,
+): Promise<GlobalSearchResultGroup[]> {
+  const [courses, sections, teachers] = await Promise.all([
+    listCourseSummaries({
+      filters: { search: query },
+      locale,
+      pagination: { page: 1, pageSize: limit },
+    }),
+    listSectionSummaries({
+      filters: { search: query },
+      locale,
+      pagination: { page: 1, pageSize: limit },
+    }),
+    listTeacherSummaries({
+      filters: { search: query },
+      locale,
+      pagination: { page: 1, pageSize: limit },
+    }),
+  ]);
+
+  const groups: GlobalSearchResultGroup[] = [];
+  if (courses.data.length > 0) {
+    groups.push({
+      type: "courses",
+      items: courses.data.map(toCourseItem),
+    });
+  }
+  if (sections.data.length > 0) {
+    groups.push({
+      type: "sections",
+      items: sections.data.map((section) => toSectionItem(section, locale)),
+    });
+  }
+  if (teachers.data.length > 0) {
+    groups.push({
+      type: "teachers",
+      items: teachers.data.map(toTeacherItem),
+    });
+  }
+  return groups;
+}
+
+async function searchWorkspaceGroups(
+  query: string,
+  userId: string,
+  limit: number,
+): Promise<GlobalSearchResultGroup[]> {
+  return withUserDbContext(userId, async (tx) => {
+    const [homeworks, todos] = await Promise.all([
+      tx.homework.findMany({
+        where: {
+          deletedAt: null,
+          title: ilike(query),
+          section: {
+            retiredAt: null,
+            subscriptions: { some: { userId } },
+          },
+        },
+        select: {
+          id: true,
+          title: true,
+          section: {
+            select: {
+              jwId: true,
+              course: {
+                select: {
+                  namePrimary: true,
+                  nameCn: true,
+                },
+              },
+            },
+          },
+        },
+        orderBy: [{ submissionDueAt: "asc" }, { createdAt: "desc" }],
+        take: limit,
+      }),
+      tx.todo.findMany({
+        where: {
+          userId,
+          OR: [{ title: ilike(query) }, { content: ilike(query) }],
+        },
+        select: {
+          id: true,
+          title: true,
+          dueAt: true,
+          completed: true,
+        },
+        orderBy: [{ dueAt: "asc" }, { createdAt: "desc" }],
+        take: limit,
+      }),
+    ]);
+
+    const groups: GlobalSearchResultGroup[] = [];
+    if (homeworks.length > 0) {
+      groups.push({
+        type: "homeworks",
+        items: homeworks.map((homework) => ({
+          id: `homework:${homework.id}`,
+          title: homework.title,
+          description: homework.section
+            ? catalogPrimaryName(homework.section.course)
+            : null,
+          href: homework.section?.jwId
+            ? `/catalog/sections/${homework.section.jwId}?tab=homework&homeworkId=${encodeURIComponent(homework.id)}`
+            : "/workspace/homeworks",
+        })),
+      });
+    }
+    if (todos.length > 0) {
+      groups.push({
+        type: "todos",
+        items: todos.map((todo) => ({
+          id: `todo:${todo.id}`,
+          title: todo.title,
+          description: todo.dueAt
+            ? todo.dueAt.toISOString().slice(0, 10)
+            : todo.completed
+              ? "completed"
+              : null,
+          href: "/workspace/todos",
+        })),
+      });
+    }
+    return groups;
+  });
+}
+
+export async function searchGlobally(input: {
+  limit?: number;
+  locale: AppLocale;
+  query: string;
+  userId?: string | null;
+}): Promise<GlobalSearchResponse> {
+  const query = input.query.trim();
+  const limit = input.limit ?? DEFAULT_LIMIT;
+  if (query.length < MIN_QUERY_LENGTH) {
+    return { query, groups: [] };
+  }
+
+  const [catalogGroups, workspaceGroups] = await Promise.all([
+    searchCatalogGroups(query, input.locale, limit),
+    input.userId
+      ? searchWorkspaceGroups(query, input.userId, limit)
+      : Promise.resolve([]),
+  ]);
+
+  return {
+    query,
+    groups: [...catalogGroups, ...workspaceGroups],
+  };
+}
+
+export function hasGlobalSearchQuery(query: string) {
+  return query.trim().length >= MIN_QUERY_LENGTH;
+}

--- a/src/features/search/server/global-search-types.ts
+++ b/src/features/search/server/global-search-types.ts
@@ -1,0 +1,16 @@
+export type GlobalSearchResultItem = {
+  description: string | null;
+  href: string;
+  id: string;
+  title: string;
+};
+
+export type GlobalSearchResultGroup = {
+  items: GlobalSearchResultItem[];
+  type: "courses" | "homeworks" | "sections" | "teachers" | "todos";
+};
+
+export type GlobalSearchResponse = {
+  groups: GlobalSearchResultGroup[];
+  query: string;
+};

--- a/src/features/todos/server/todo-service.ts
+++ b/src/features/todos/server/todo-service.ts
@@ -1,3 +1,4 @@
+import { scheduleInvalidateUserCalendarExportCache } from "@/features/calendar/server/calendar-export-invalidation";
 import type { Prisma, TodoPriority } from "@/generated/prisma/client";
 import { buildPaginatedResponse, normalizePagination } from "@/lib/api/helpers";
 import { withUserDbContext } from "@/lib/db/prisma";
@@ -92,7 +93,7 @@ function normalizeTodoUserId(userId: string) {
 
 export async function createTodo(input: TodoCreateInput) {
   const userId = normalizeTodoUserId(input.userId);
-  return withUserDbContext(userId, (tx) =>
+  const todo = await withUserDbContext(userId, (tx) =>
     tx.todo.create({
       select: { id: true },
       data: {
@@ -104,6 +105,8 @@ export async function createTodo(input: TodoCreateInput) {
       },
     }),
   );
+  scheduleInvalidateUserCalendarExportCache(userId);
+  return todo;
 }
 
 export async function listTodos(where: Prisma.TodoWhereInput) {
@@ -451,13 +454,14 @@ export async function updateOwnedTodo(input: {
       data: updates,
       select: todoSnapshotSelect,
     });
+    scheduleInvalidateUserCalendarExportCache(userId);
     return { ok: true as const, todo };
   });
 }
 
 export async function deleteOwnedTodo(id: string, userId: string) {
   userId = normalizeTodoUserId(userId);
-  return withUserDbContext(userId, async (tx) => {
+  const result = await withUserDbContext(userId, async (tx) => {
     const deleted = await tx.todo.deleteMany({ where: { id, userId } });
     if (deleted.count > 0) return { ok: true as const };
 
@@ -471,4 +475,6 @@ export async function deleteOwnedTodo(id: string, userId: string) {
     }
     return { ok: false as const, error: "not_found" as const };
   });
+  if (result.ok) scheduleInvalidateUserCalendarExportCache(userId);
+  return result;
 }

--- a/src/lib/api/routes/global-search.ts
+++ b/src/lib/api/routes/global-search.ts
@@ -1,0 +1,40 @@
+import { searchGlobally } from "@/features/search/server/global-search-service";
+import { handleRouteError, jsonResponse } from "@/lib/api/helpers";
+import { getRequestLocale } from "@/lib/api/routes/request-locale";
+import { resolveApiUserId } from "@/lib/auth/api-auth";
+
+const MAX_LIMIT = 10;
+
+function parseSearchQuery(request: Request) {
+  const searchParams = new URL(request.url).searchParams;
+  const query = searchParams.get("q") ?? searchParams.get("query") ?? "";
+  const limitParam = searchParams.get("limit");
+  const limit = limitParam ? Number(limitParam) : undefined;
+  if (
+    limit !== undefined &&
+    (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT)
+  ) {
+    return jsonResponse({ error: "Invalid limit" }, { status: 400 });
+  }
+  return { query, limit };
+}
+
+export async function getGlobalSearchRoute(request: Request) {
+  const parsed = parseSearchQuery(request);
+  if (parsed instanceof Response) return parsed;
+
+  const locale = getRequestLocale(request);
+  const userId = await resolveApiUserId(request);
+
+  try {
+    const result = await searchGlobally({
+      query: parsed.query,
+      limit: parsed.limit,
+      locale,
+      userId,
+    });
+    return jsonResponse(result);
+  } catch (error) {
+    return handleRouteError("Failed to search", error);
+  }
+}

--- a/src/lib/components/shell/AppShell.svelte
+++ b/src/lib/components/shell/AppShell.svelte
@@ -26,6 +26,7 @@ import {
   SHELL_THEME_CHANGE_EVENT,
   setStoredThemeMode,
 } from "$lib/components/shell/app-shell-actions";
+import GlobalSearchDialog from "$lib/components/shell/GlobalSearchDialog.svelte";
 import {
   applyShellTheme,
   buildFooterLinks,
@@ -58,6 +59,7 @@ export let data: AppShellData;
 
 let themeMode: ThemeMode = "system";
 let sidebarOpen = true;
+let globalSearchOpen = false;
 let userMenuOpen = false;
 let localeMenuOpen = false;
 let themeMenuOpen = false;
@@ -96,6 +98,23 @@ $: detailWorkspace = isDetailWorkspacePath($page.url.pathname);
 $: showFooter = shouldShowAppFooter($page.url.pathname, Boolean(viewerUser));
 $: mainContentLabel = resolveMainContentLabel($page.data);
 const footerLinks = buildFooterLinks(data.copy.footer);
+
+$: globalSearchShortcutLabel =
+  typeof navigator !== "undefined" &&
+  /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+    ? data.copy.globalSearch.shortcutMac
+    : data.copy.globalSearch.shortcut;
+
+function openGlobalSearch() {
+  globalSearchOpen = true;
+}
+
+function handleGlobalSearchKeydown(event: KeyboardEvent) {
+  if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+    event.preventDefault();
+    openGlobalSearch();
+  }
+}
 
 function resolveMainContentLabel(pageData: Record<string, unknown>) {
   const label = pageData.mainContentLabel;
@@ -520,6 +539,7 @@ onMount(() => {
   themeMode = loadStoredThemeMode(themeMode);
   applyShellTheme(themeMode);
   document.documentElement.dataset.lifeUstcHydrated = "true";
+  window.addEventListener("keydown", handleGlobalSearchKeydown);
 
   const syncThemeMode = (event: Event) => {
     const nextThemeMode = (event as CustomEvent<ThemeMode>).detail;
@@ -539,6 +559,7 @@ onMount(() => {
   systemTheme.addEventListener("change", applySystemTheme);
 
   return () => {
+    window.removeEventListener("keydown", handleGlobalSearchKeydown);
     window.removeEventListener(SHELL_THEME_CHANGE_EVENT, syncThemeMode);
     systemTheme.removeEventListener("change", applySystemTheme);
   };
@@ -613,14 +634,17 @@ afterNavigate(({ from, to }) => {
       <AppTopbar
         {closeMenus}
         copy={data.copy}
+        globalSearchShortcutLabel={globalSearchShortcutLabel}
         locale={data.locale}
         {localeMenuOpen}
+        onOpenGlobalSearch={openGlobalSearch}
         {setLocale}
         {setLocaleMenuOpen}
         {setThemeMenuOpen}
         {setThemeMode}
         {themeMenuOpen}
         {themeMode}
+        signedIn={Boolean(viewerUser)}
         user={viewerUser}
         {viewerLoading}
       />
@@ -664,3 +688,12 @@ afterNavigate(({ from, to }) => {
       />
     {/if}
 </Sidebar.Provider>
+
+<GlobalSearchDialog
+  copy={data.copy.globalSearch}
+  bind:open={globalSearchOpen}
+  signedIn={Boolean(viewerUser)}
+  on:openChange={(event) => {
+    globalSearchOpen = event.detail;
+  }}
+/>

--- a/src/lib/components/shell/AppTopbar.svelte
+++ b/src/lib/components/shell/AppTopbar.svelte
@@ -8,11 +8,14 @@ import type {
   LayoutUserSummary,
 } from "$lib/shell/layout-server-data";
 import AppPreferencesMenu from "./AppPreferencesMenu.svelte";
+import GlobalSearchTrigger from "./GlobalSearchTrigger.svelte";
 
 export let closeMenus: () => void;
 export let copy: LayoutCopy;
 export let locale: "en-us" | "zh-cn";
 export let localeMenuOpen: boolean;
+export let onOpenGlobalSearch: () => void;
+export let globalSearchShortcutLabel: string;
 export let setLocale: (locale: "en-us" | "zh-cn") => void;
 export let setLocaleMenuOpen: (open: boolean) => void;
 export let setThemeMenuOpen: (open: boolean) => void;
@@ -21,6 +24,7 @@ export let themeMenuOpen: boolean;
 export let themeMode: ThemeMode;
 export let user: LayoutUserSummary;
 export let viewerLoading = false;
+export let signedIn = false;
 </script>
 
 <header
@@ -47,7 +51,27 @@ export let viewerLoading = false;
       <span class="truncate">Life@USTC</span>
     </a>
 
+    <div class="hidden min-w-0 flex-1 justify-center px-4 md:flex">
+      <GlobalSearchTrigger
+        copy={copy.globalSearch}
+        onOpen={onOpenGlobalSearch}
+        shortcutLabel={globalSearchShortcutLabel}
+        {signedIn}
+        variant="desktop"
+      />
+    </div>
+
     <div class="ml-auto flex items-center gap-1">
+      <div class="md:hidden">
+        <GlobalSearchTrigger
+          copy={copy.globalSearch}
+          onOpen={onOpenGlobalSearch}
+          shortcutLabel={globalSearchShortcutLabel}
+          {signedIn}
+          variant="mobile"
+        />
+      </div>
+
       <AppPreferencesMenu
         {copy}
         {locale}

--- a/src/lib/components/shell/GlobalSearchDialog.svelte
+++ b/src/lib/components/shell/GlobalSearchDialog.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+import BookOpenIcon from "@lucide/svelte/icons/book-open";
+import ClipboardCheckIcon from "@lucide/svelte/icons/clipboard-check";
+import ListTodoIcon from "@lucide/svelte/icons/list-todo";
+import RouteIcon from "@lucide/svelte/icons/route";
+import SearchIcon from "@lucide/svelte/icons/search";
+import SearchXIcon from "@lucide/svelte/icons/search-x";
+import UsersIcon from "@lucide/svelte/icons/users";
+import { createEventDispatcher } from "svelte";
+import { goto } from "$app/navigation";
+import { Button } from "$lib/components/ui/button/index.js";
+import * as Dialog from "$lib/components/ui/dialog/index.js";
+import * as Empty from "$lib/components/ui/empty/index.js";
+import { Input } from "$lib/components/ui/input/index.js";
+import * as Kbd from "$lib/components/ui/kbd/index.js";
+import { ScrollArea } from "$lib/components/ui/scroll-area/index.js";
+import { Separator } from "$lib/components/ui/separator/index.js";
+import { Spinner } from "$lib/components/ui/spinner/index.js";
+import type { LayoutCopy } from "$lib/shell/layout-server-data";
+
+type SearchGroupType =
+  | "courses"
+  | "homeworks"
+  | "sections"
+  | "teachers"
+  | "todos";
+
+type SearchResultItem = {
+  description: string | null;
+  href: string;
+  id: string;
+  title: string;
+};
+
+type SearchResultGroup = {
+  items: SearchResultItem[];
+  type: SearchGroupType;
+};
+
+type SearchResponse = {
+  groups: SearchResultGroup[];
+  query: string;
+};
+
+export let copy: LayoutCopy["globalSearch"];
+export let open = false;
+export let signedIn = false;
+
+const dispatch = createEventDispatcher<{
+  openChange: boolean;
+}>();
+
+let query = "";
+let groups: SearchResultGroup[] = [];
+let isSearching = false;
+let hasSearched = false;
+let searchGeneration = 0;
+let inputElement: HTMLInputElement | undefined;
+
+const groupIcons: Record<SearchGroupType, typeof BookOpenIcon> = {
+  courses: BookOpenIcon,
+  homeworks: ClipboardCheckIcon,
+  sections: RouteIcon,
+  teachers: UsersIcon,
+  todos: ListTodoIcon,
+};
+
+$: placeholder = signedIn ? copy.placeholderSignedIn : copy.placeholder;
+$: showHint = query.trim().length > 0 && query.trim().length < 2;
+$: showEmpty = hasSearched && !isSearching && groups.length === 0 && !showHint;
+
+function resetSearchState() {
+  searchGeneration += 1;
+  query = "";
+  groups = [];
+  hasSearched = false;
+  isSearching = false;
+}
+
+function handleOpenChange(nextOpen: boolean) {
+  dispatch("openChange", nextOpen);
+  if (!nextOpen) resetSearchState();
+}
+
+async function runSearch() {
+  const trimmed = query.trim();
+  if (trimmed.length < 2) {
+    groups = [];
+    hasSearched = false;
+    return;
+  }
+
+  const generation = ++searchGeneration;
+  isSearching = true;
+  hasSearched = true;
+
+  try {
+    const response = await fetch(
+      `/api/search?q=${encodeURIComponent(trimmed)}&limit=5`,
+    );
+    if (!response.ok || generation !== searchGeneration) return;
+    const body = (await response.json()) as SearchResponse;
+    if (generation !== searchGeneration) return;
+    groups = body.groups ?? [];
+  } catch {
+    if (generation !== searchGeneration) return;
+    groups = [];
+  } finally {
+    if (generation === searchGeneration) {
+      isSearching = false;
+    }
+  }
+}
+
+function handleInput() {
+  void runSearch();
+}
+
+function navigateTo(href: string) {
+  dispatch("openChange", false);
+  void goto(href);
+}
+
+$: if (open) {
+  queueMicrotask(() => inputElement?.focus());
+}
+</script>
+
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+  <Dialog.Content class="gap-0 overflow-hidden p-0 sm:max-w-xl">
+    <Dialog.Header class="space-y-0 border-b px-4 py-3">
+      <Dialog.Title class="sr-only">{copy.title}</Dialog.Title>
+      <div class="flex items-center gap-2">
+        <SearchIcon class="size-4 shrink-0 text-muted-foreground" />
+        <Input
+          bind:this={inputElement}
+          bind:value={query}
+          class="h-10 border-0 bg-transparent px-0 shadow-none focus-visible:ring-0"
+          oninput={handleInput}
+          placeholder={placeholder}
+        />
+        {#if isSearching}
+          <Spinner class="size-4 shrink-0" />
+        {/if}
+      </div>
+    </Dialog.Header>
+
+    <ScrollArea class="max-h-[min(60vh,28rem)]">
+      <div class="p-2">
+        {#if showHint}
+          <p class="px-2 py-6 text-center text-muted-foreground text-sm">
+            {copy.hint}
+          </p>
+        {:else if showEmpty}
+          <Empty.Root class="py-8">
+            <Empty.Media variant="icon">
+              <SearchXIcon />
+            </Empty.Media>
+            <Empty.Title>{copy.noResults}</Empty.Title>
+          </Empty.Root>
+        {:else}
+          {#each groups as group, groupIndex (group.type)}
+            {@const Icon = groupIcons[group.type]}
+            {#if groupIndex > 0}
+              <Separator class="my-2" />
+            {/if}
+            <div class="px-2 py-1">
+              <p class="px-2 py-1 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+                {copy.groups[group.type]}
+              </p>
+              <ul class="grid gap-1">
+                {#each group.items as item (item.id)}
+                  <li>
+                    <button
+                      class="hover:bg-muted flex w-full min-w-0 items-start gap-3 rounded-md px-2 py-2 text-left transition-colors"
+                      onclick={() => navigateTo(item.href)}
+                      type="button"
+                    >
+                      <Icon class="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                      <span class="min-w-0">
+                        <span class="block truncate font-medium">{item.title}</span>
+                        {#if item.description}
+                          <span class="block truncate text-muted-foreground text-sm">
+                            {item.description}
+                          </span>
+                        {/if}
+                      </span>
+                    </button>
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {/each}
+        {/if}
+      </div>
+    </ScrollArea>
+  </Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/shell/GlobalSearchTrigger.svelte
+++ b/src/lib/components/shell/GlobalSearchTrigger.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+import SearchIcon from "@lucide/svelte/icons/search";
+import { Button } from "$lib/components/ui/button/index.js";
+import * as Kbd from "$lib/components/ui/kbd/index.js";
+import type { LayoutCopy } from "$lib/shell/layout-server-data";
+
+export let copy: LayoutCopy["globalSearch"];
+export let onOpen: () => void;
+export let shortcutLabel: string;
+export let signedIn = false;
+export let variant: "desktop" | "mobile" = "desktop";
+
+$: placeholder = signedIn ? copy.placeholderSignedIn : copy.placeholder;
+</script>
+
+{#if variant === "desktop"}
+  <Button
+    aria-label={copy.openSearch}
+    class="h-9 w-full max-w-sm justify-start gap-2 px-3 text-muted-foreground lg:max-w-md"
+    onclick={onOpen}
+    type="button"
+    variant="outline"
+  >
+    <SearchIcon class="size-4 shrink-0" />
+    <span class="truncate">{placeholder}</span>
+    <span class="ml-auto hidden items-center gap-1 sm:inline-flex">
+      <Kbd.Root>{shortcutLabel}</Kbd.Root>
+    </span>
+  </Button>
+{:else}
+  <Button
+    aria-label={copy.openSearch}
+    class="size-11"
+    onclick={onOpen}
+    type="button"
+    variant="ghost"
+  >
+    <SearchIcon class="size-5" />
+  </Button>
+{/if}

--- a/src/lib/shell/layout-server-data.ts
+++ b/src/lib/shell/layout-server-data.ts
@@ -6,6 +6,7 @@ const layoutMessages = {
     accessibility: enUsMessages.accessibility,
     admin: enUsMessages.admin,
     common: enUsMessages.common,
+    globalSearch: enUsMessages.globalSearch,
     homepage: enUsMessages.homepage,
     language: enUsMessages.language,
     meDashboard: enUsMessages.meDashboard,
@@ -19,6 +20,7 @@ const layoutMessages = {
     accessibility: zhCnMessages.accessibility,
     admin: zhCnMessages.admin,
     common: zhCnMessages.common,
+    globalSearch: zhCnMessages.globalSearch,
     homepage: zhCnMessages.homepage,
     language: zhCnMessages.language,
     meDashboard: zhCnMessages.meDashboard,
@@ -121,6 +123,7 @@ export function buildLayoutCopy(locale: LayoutLocale) {
     },
     language: messages.language,
     theme: messages.theme,
+    globalSearch: messages.globalSearch,
   };
 }
 

--- a/src/routes/api/search/+server.ts
+++ b/src/routes/api/search/+server.ts
@@ -1,0 +1,11 @@
+import { getGlobalSearchRoute } from "@/lib/api/routes/global-search";
+import { svelteRequestHandler } from "@/lib/api/svelte-route";
+import { observedApiRoute } from "@/lib/log/api-observability";
+
+/**
+ * Global search across catalog and workspace entities.
+ * @params q, limit
+ * @response globalSearchResponse
+ * @response 400:openApiErrorSchema
+ */
+export const GET = svelteRequestHandler(observedApiRoute(getGlobalSearchRoute));

--- a/tests/unit/global-search-service.test.ts
+++ b/tests/unit/global-search-service.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  listCourseSummariesMock,
+  listSectionSummariesMock,
+  listTeacherSummariesMock,
+  withUserDbContextMock,
+} = vi.hoisted(() => ({
+  listCourseSummariesMock: vi.fn(),
+  listSectionSummariesMock: vi.fn(),
+  listTeacherSummariesMock: vi.fn(),
+  withUserDbContextMock: vi.fn(),
+}));
+
+vi.mock("@/features/catalog/server/course-section-queries", () => ({
+  listCourseSummaries: listCourseSummariesMock,
+  listSectionSummaries: listSectionSummariesMock,
+  listTeacherSummaries: listTeacherSummariesMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  withUserDbContext: withUserDbContextMock,
+}));
+
+import {
+  hasGlobalSearchQuery,
+  searchGlobally,
+} from "@/features/search/server/global-search-service";
+
+describe("global search service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listCourseSummariesMock.mockResolvedValue({ data: [] });
+    listSectionSummariesMock.mockResolvedValue({ data: [] });
+    listTeacherSummariesMock.mockResolvedValue({ data: [] });
+    withUserDbContextMock.mockImplementation(
+      async (_userId: string, work: (tx: unknown) => Promise<unknown>) =>
+        work({
+          homework: { findMany: vi.fn().mockResolvedValue([]) },
+          todo: { findMany: vi.fn().mockResolvedValue([]) },
+        }),
+    );
+  });
+
+  it("returns empty groups for short queries", async () => {
+    const result = await searchGlobally({
+      locale: "zh-cn",
+      query: "a",
+    });
+
+    expect(result.groups).toEqual([]);
+    expect(listCourseSummariesMock).not.toHaveBeenCalled();
+  });
+
+  it("searches catalog entities for public users", async () => {
+    listCourseSummariesMock.mockResolvedValue({
+      data: [
+        {
+          jwId: 101,
+          code: "CS101",
+          nameCn: "数据结构",
+          namePrimary: "数据结构",
+        },
+      ],
+    });
+
+    const result = await searchGlobally({
+      locale: "zh-cn",
+      query: "数据",
+    });
+
+    expect(listCourseSummariesMock).toHaveBeenCalledWith({
+      filters: { search: "数据" },
+      locale: "zh-cn",
+      pagination: { page: 1, pageSize: 5 },
+    });
+    expect(result.groups).toEqual([
+      {
+        type: "courses",
+        items: [
+          {
+            id: "course:101",
+            title: "数据结构",
+            description: "CS101",
+            href: "/catalog/courses/101",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("includes workspace groups for signed-in users", async () => {
+    const homeworkFindMany = vi.fn().mockResolvedValue([
+      {
+        id: "hw-1",
+        title: "Lab 1",
+        section: {
+          jwId: 42,
+          course: { nameCn: "操作系统", namePrimary: "操作系统" },
+        },
+      },
+    ]);
+    const todoFindMany = vi.fn().mockResolvedValue([
+      {
+        id: "todo-1",
+        title: "Buy textbook",
+        dueAt: new Date("2026-08-01T00:00:00.000Z"),
+        completed: false,
+      },
+    ]);
+    withUserDbContextMock.mockImplementation(
+      async (_userId: string, work: (tx: unknown) => Promise<unknown>) =>
+        work({
+          homework: { findMany: homeworkFindMany },
+          todo: { findMany: todoFindMany },
+        }),
+    );
+
+    const result = await searchGlobally({
+      locale: "en-us",
+      query: "lab",
+      userId: "user-1",
+    });
+
+    expect(homeworkFindMany).toHaveBeenCalled();
+    expect(todoFindMany).toHaveBeenCalled();
+    expect(result.groups.map((group) => group.type)).toEqual([
+      "homeworks",
+      "todos",
+    ]);
+    expect(result.groups[0]?.items[0]?.href).toContain("homeworkId=hw-1");
+  });
+
+  it("detects minimum query length", () => {
+    expect(hasGlobalSearchQuery("a")).toBe(false);
+    expect(hasGlobalSearchQuery("ab")).toBe(true);
+  });
+});

--- a/tests/unit/todo-calendar-invalidation.test.ts
+++ b/tests/unit/todo-calendar-invalidation.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invalidateMock, withUserDbContextMock } = vi.hoisted(() => ({
+  invalidateMock: vi.fn(),
+  withUserDbContextMock: vi.fn(),
+}));
+
+vi.mock("@/features/calendar/server/calendar-export-invalidation", () => ({
+  scheduleInvalidateUserCalendarExportCache: invalidateMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  withUserDbContext: withUserDbContextMock,
+}));
+
+import {
+  createTodo,
+  deleteOwnedTodo,
+  updateOwnedTodo,
+} from "@/features/todos/server/todo-service";
+
+describe("todo calendar export invalidation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("invalidates calendar cache after creating a todo", async () => {
+    withUserDbContextMock.mockImplementation(
+      async (_userId: string, work: (tx: unknown) => Promise<unknown>) =>
+        work({
+          todo: {
+            create: vi.fn().mockResolvedValue({ id: "todo-1" }),
+          },
+        }),
+    );
+
+    await createTodo({
+      userId: "user-1",
+      title: "Read chapter 1",
+    });
+
+    expect(invalidateMock).toHaveBeenCalledWith("user-1");
+  });
+
+  it("invalidates calendar cache after updating a todo", async () => {
+    withUserDbContextMock.mockImplementation(
+      async (_userId: string, work: (tx: unknown) => Promise<unknown>) =>
+        work({
+          todo: {
+            findUnique: vi
+              .fn()
+              .mockResolvedValue({ id: "todo-1", userId: "user-1" }),
+            update: vi.fn().mockResolvedValue({
+              id: "todo-1",
+              title: "Updated",
+              content: null,
+              priority: "medium",
+              dueAt: new Date(),
+              completed: false,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            }),
+          },
+        }),
+    );
+
+    const result = await updateOwnedTodo({
+      id: "todo-1",
+      userId: "user-1",
+      data: {
+        title: "Updated",
+        hasDueAt: false,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(invalidateMock).toHaveBeenCalledWith("user-1");
+  });
+
+  it("invalidates calendar cache after deleting a todo", async () => {
+    withUserDbContextMock.mockImplementation(
+      async (_userId: string, work: (tx: unknown) => Promise<unknown>) =>
+        work({
+          todo: {
+            deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+          },
+        }),
+    );
+
+    const result = await deleteOwnedTodo("todo-1", "user-1");
+
+    expect(result.ok).toBe(true);
+    expect(invalidateMock).toHaveBeenCalledWith("user-1");
+  });
+});


### PR DESCRIPTION
## Summary
- Add site-wide search in the top bar (`Ctrl+K` / `⌘+K`) across courses, sections, teachers, and signed-in homework/todos via `GET /api/search`
- Invalidate user iCal feed cache when todos are created, updated, or deleted so exports stay in sync
- Align web calendar homework display with iCal by excluding completed items without due dates

## Test plan
- [x] `npx vitest run tests/unit/global-search-service.test.ts tests/unit/todo-calendar-invalidation.test.ts`
- [ ] Verify top-bar search opens and returns catalog results while signed out
- [ ] Verify signed-in search includes homework/todos
- [ ] Create or complete a todo and confirm subscription `.ics` updates without waiting for cache TTL