### PR TITLE
fix(shell): lazy-load GlobalSearchDialog to meet client budget

### DIFF
--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -79,8 +79,10 @@
   },
   "globalSearch": {
     "title": "Search",
-    "placeholder": "Search courses, sections, teachers…",
-    "placeholderSignedIn": "Search courses, sections, homework, todos…",
+    "pageTitle": "Search",
+    "pageDescription": "Search courses, teachers, sections, campus links, and your homework or todos.",
+    "placeholder": "Search courses, teachers, links…",
+    "placeholderSignedIn": "Search courses, teachers, links, homework, todos…",
     "shortcut": "Ctrl K",
     "shortcutMac": "⌘ K",
     "noResults": "No results found",
@@ -88,10 +90,12 @@
     "hint": "Type at least 2 characters to search",
     "openSearch": "Open search",
     "close": "Close",
+    "viewAllResults": "View all search results",
     "groups": {
       "courses": "Courses",
       "sections": "Sections",
       "teachers": "Teachers",
+      "links": "Links",
       "homeworks": "Homework",
       "todos": "Todos"
     }

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -79,8 +79,10 @@
   },
   "globalSearch": {
     "title": "搜索",
-    "placeholder": "搜索课程、班级、教师…",
-    "placeholderSignedIn": "搜索课程、班级、作业、待办…",
+    "pageTitle": "搜索",
+    "pageDescription": "搜索课程、教师、班级、校园链接，以及你的作业与待办。",
+    "placeholder": "搜索课程、教师、链接…",
+    "placeholderSignedIn": "搜索课程、教师、链接、作业、待办…",
     "shortcut": "Ctrl K",
     "shortcutMac": "⌘ K",
     "noResults": "未找到相关结果",
@@ -88,10 +90,12 @@
     "hint": "输入至少 2 个字符开始搜索",
     "openSearch": "打开搜索",
     "close": "关闭",
+    "viewAllResults": "查看全部搜索结果",
     "groups": {
       "courses": "课程",
       "sections": "班级",
       "teachers": "教师",
+      "links": "链接",
       "homeworks": "作业",
       "todos": "待办"
     }

--- a/src/features/dashboard-links/lib/dashboard-link-search.ts
+++ b/src/features/dashboard-links/lib/dashboard-link-search.ts
@@ -1,3 +1,5 @@
+import { pinyin } from "pinyin-pro";
+import type { DashboardLinkItem } from "@/features/dashboard-links/lib/dashboard-links";
 import {
   DASHBOARD_LINK_GROUP_ORDER,
   type DashboardLinkGroup,
@@ -32,6 +34,40 @@ export function linkMatchesTokens(
       description.includes(token) ||
       link.titlePinyin.includes(token) ||
       link.descriptionPinyin.includes(token),
+  );
+}
+
+function toSearchPinyin(text: string) {
+  if (!text.trim()) return "";
+  return pinyin(text, { toneType: "none" }).replace(/\s+/g, "").toLowerCase();
+}
+
+function toSearchableFields(
+  title: string,
+  description: string,
+): DashboardLinkSearchable {
+  return {
+    title,
+    description,
+    titlePinyin: toSearchPinyin(title),
+    descriptionPinyin: toSearchPinyin(description),
+    group: "life",
+  };
+}
+
+export function dashboardLinkItemMatchesTokens(
+  link: DashboardLinkItem,
+  tokens: string[],
+) {
+  const localizedFields = [
+    { title: link.title, description: link.description },
+    link.localizations["en-us"],
+  ];
+  return localizedFields.some((fields) =>
+    linkMatchesTokens(
+      toSearchableFields(fields.title, fields.description),
+      tokens,
+    ),
   );
 }
 

--- a/src/features/search/lib/global-search-client.ts
+++ b/src/features/search/lib/global-search-client.ts
@@ -1,0 +1,19 @@
+import type { GlobalSearchResponse } from "@/features/search/server/global-search-types";
+
+export const GLOBAL_SEARCH_MIN_QUERY_LENGTH = 2;
+export const GLOBAL_SEARCH_DEBOUNCE_MS = 200;
+export const GLOBAL_SEARCH_DIALOG_LIMIT = 5;
+export const GLOBAL_SEARCH_PAGE_LIMIT = 20;
+
+export async function fetchGlobalSearch(
+  query: string,
+  limit: number,
+): Promise<GlobalSearchResponse> {
+  const response = await fetch(
+    `/api/search?q=${encodeURIComponent(query)}&limit=${limit}`,
+  );
+  if (!response.ok) {
+    throw new Error("Search request failed");
+  }
+  return (await response.json()) as GlobalSearchResponse;
+}

--- a/src/features/search/lib/global-search-keyboard.ts
+++ b/src/features/search/lib/global-search-keyboard.ts
@@ -1,0 +1,106 @@
+import type {
+  GlobalSearchResultGroup,
+  GlobalSearchResultItem,
+} from "@/features/search/server/global-search-types";
+
+export const GLOBAL_SEARCH_LISTBOX_ID = "global-search-listbox";
+export const GLOBAL_SEARCH_ITEM_ID_PREFIX = "global-search-item-";
+
+export function flattenSearchGroups(groups: GlobalSearchResultGroup[]) {
+  return groups.flatMap((group) => group.items);
+}
+
+export function globalSearchItemDomId(itemId: string) {
+  return `${GLOBAL_SEARCH_ITEM_ID_PREFIX}${itemId}`;
+}
+
+export function moveSearchActiveIndex(
+  itemCount: number,
+  currentIndex: number,
+  direction: "down" | "up",
+) {
+  if (itemCount <= 0) return -1;
+
+  if (direction === "down") {
+    if (currentIndex < itemCount - 1) return currentIndex + 1;
+    return currentIndex < 0 ? 0 : currentIndex;
+  }
+
+  if (currentIndex <= 0) return -1;
+  return currentIndex - 1;
+}
+
+export function focusSearchResultItem(
+  items: GlobalSearchResultItem[],
+  index: number,
+  inputElement?: HTMLInputElement | null,
+) {
+  if (index < 0) {
+    inputElement?.focus();
+    return;
+  }
+
+  const item = items[index];
+  if (!item) return;
+
+  const element = document.getElementById(globalSearchItemDomId(item.id));
+  if (!(element instanceof HTMLElement)) return;
+  element.focus();
+  element.scrollIntoView({ block: "nearest" });
+}
+
+export function activeItemIdFromIndex(
+  items: GlobalSearchResultItem[],
+  index: number,
+) {
+  if (index < 0) return null;
+  return items[index]?.id ?? null;
+}
+
+export function handleSearchListboxKeydown(input: {
+  activeIndex: number;
+  event: KeyboardEvent;
+  inputElement?: HTMLInputElement | null;
+  isInteractive: boolean;
+  items: GlobalSearchResultItem[];
+  onActiveIndexChange: (index: number) => void;
+  onSelect: (item: GlobalSearchResultItem) => void;
+}) {
+  if (!input.isInteractive || input.items.length === 0) return false;
+
+  const { event, items } = input;
+
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    const nextIndex = moveSearchActiveIndex(
+      items.length,
+      input.activeIndex,
+      "down",
+    );
+    input.onActiveIndexChange(nextIndex);
+    focusSearchResultItem(items, nextIndex, input.inputElement);
+    return true;
+  }
+
+  if (event.key === "ArrowUp") {
+    event.preventDefault();
+    const nextIndex = moveSearchActiveIndex(
+      items.length,
+      input.activeIndex,
+      "up",
+    );
+    input.onActiveIndexChange(nextIndex);
+    focusSearchResultItem(items, nextIndex, input.inputElement);
+    return true;
+  }
+
+  if (event.key === "Enter" && input.activeIndex >= 0) {
+    const item = items[input.activeIndex];
+    if (!item) return false;
+    event.preventDefault();
+    input.onSelect(item);
+    return true;
+  }
+
+  return false;
+}

--- a/src/features/search/server/global-search-catalog-queries.ts
+++ b/src/features/search/server/global-search-catalog-queries.ts
@@ -1,9 +1,24 @@
 import { buildCourseListWhere } from "@/features/catalog/server/course-query-filters";
-import { buildSectionListQuery } from "@/features/catalog/server/section-query-filters";
 import { SECTION_SUMMARY_DEFAULT_ORDER_BY } from "@/features/catalog/server/section-summary-read-model";
 import { buildTeacherWhere } from "@/features/catalog/server/teacher-query";
 import type { AppLocale } from "@/i18n/config";
+import type { Prisma } from "@/generated/prisma/client";
 import { getPrisma } from "@/lib/db/prisma";
+import { ilike } from "@/lib/query-filter-helpers";
+
+function buildGlobalSectionSearchWhere(
+  query: string,
+): Prisma.SectionWhereInput {
+  return {
+    retiredAt: null,
+    OR: [
+      { course: { nameCn: ilike(query) } },
+      { course: { nameEn: ilike(query) } },
+      { course: { code: ilike(query) } },
+      { code: ilike(query) },
+    ],
+  };
+}
 
 export async function searchCoursesForGlobal(
   query: string,
@@ -28,10 +43,9 @@ export async function searchSectionsForGlobal(
   locale: AppLocale,
   limit: number,
 ) {
-  const { orderBy, where } = buildSectionListQuery({ search: query });
   return getPrisma(locale).section.findMany({
-    where,
-    orderBy: orderBy ?? SECTION_SUMMARY_DEFAULT_ORDER_BY,
+    where: buildGlobalSectionSearchWhere(query),
+    orderBy: SECTION_SUMMARY_DEFAULT_ORDER_BY,
     select: {
       code: true,
       jwId: true,

--- a/src/features/search/server/global-search-catalog-queries.ts
+++ b/src/features/search/server/global-search-catalog-queries.ts
@@ -1,8 +1,8 @@
 import { buildCourseListWhere } from "@/features/catalog/server/course-query-filters";
 import { SECTION_SUMMARY_DEFAULT_ORDER_BY } from "@/features/catalog/server/section-summary-read-model";
 import { buildTeacherWhere } from "@/features/catalog/server/teacher-query";
-import type { AppLocale } from "@/i18n/config";
 import type { Prisma } from "@/generated/prisma/client";
+import type { AppLocale } from "@/i18n/config";
 import { getPrisma } from "@/lib/db/prisma";
 import { ilike } from "@/lib/query-filter-helpers";
 

--- a/src/features/search/server/global-search-link-queries.ts
+++ b/src/features/search/server/global-search-link-queries.ts
@@ -1,0 +1,37 @@
+import {
+  dashboardLinkItemMatchesTokens,
+  searchQueryToTokens,
+} from "@/features/dashboard-links/lib/dashboard-link-search";
+import {
+  localizeDashboardLink,
+  USTC_DASHBOARD_LINKS,
+} from "@/features/dashboard-links/lib/dashboard-links";
+import type { AppLocale } from "@/i18n/config";
+
+const MIN_QUERY_LENGTH = 2;
+
+export function searchLinksForGlobal(
+  query: string,
+  locale: AppLocale,
+  limit: number,
+) {
+  const trimmed = query.trim();
+  if (trimmed.length < MIN_QUERY_LENGTH) return [];
+
+  const tokens = searchQueryToTokens(trimmed);
+  if (tokens.length === 0) return [];
+
+  return USTC_DASHBOARD_LINKS.filter((link) =>
+    dashboardLinkItemMatchesTokens(link, tokens),
+  )
+    .slice(0, limit)
+    .map((link) => {
+      const localized = localizeDashboardLink(link, locale);
+      return {
+        description: localized.description,
+        slug: localized.slug,
+        title: localized.title,
+        url: localized.url,
+      };
+    });
+}

--- a/src/features/search/server/global-search-service.ts
+++ b/src/features/search/server/global-search-service.ts
@@ -3,11 +3,14 @@ import {
   searchSectionsForGlobal,
   searchTeachersForGlobal,
 } from "@/features/search/server/global-search-catalog-queries";
+import { searchLinksForGlobal } from "@/features/search/server/global-search-link-queries";
 import type {
   GlobalSearchResponse,
   GlobalSearchResultGroup,
+  GlobalSearchResultGroupType,
   GlobalSearchResultItem,
 } from "@/features/search/server/global-search-types";
+import { GLOBAL_SEARCH_GROUP_ORDER } from "@/features/search/server/global-search-types";
 import type { AppLocale } from "@/i18n/config";
 import { cachedCatalogRuntimeData } from "@/lib/catalog-runtime-cache";
 import { withUserDbContext } from "@/lib/db/prisma";
@@ -71,37 +74,40 @@ async function searchCatalogGroups(
   locale: AppLocale,
   limit: number,
 ): Promise<GlobalSearchResultGroup[]> {
-  const [courses, sections, teachers] = await Promise.all([
+  const [courses, teachers, sections, links] = await Promise.all([
     searchCoursesForGlobal(query, locale, limit),
-    searchSectionsForGlobal(query, locale, limit),
     searchTeachersForGlobal(query, locale, limit),
+    searchSectionsForGlobal(query, locale, limit),
+    Promise.resolve(searchLinksForGlobal(query, locale, limit)),
   ]);
 
-  const groups: GlobalSearchResultGroup[] = [];
-  if (courses.length > 0) {
-    groups.push({
-      type: "courses",
-      items: courses.map(toCourseItem),
-    });
-  }
-  if (sections.length > 0) {
-    groups.push({
-      type: "sections",
-      items: sections.map((section) => toSectionItem(section, locale)),
-    });
-  }
-  if (teachers.length > 0) {
-    groups.push({
-      type: "teachers",
-      items: teachers.map((teacher) => ({
-        id: `teacher:${teacher.id}`,
-        title: teacher.nameCn,
-        description: teacher.department?.nameCn ?? teacher.code,
-        href: `/catalog/teachers/${teacher.id}`,
-      })),
-    });
-  }
-  return groups;
+  const groupItems: Record<
+    GlobalSearchResultGroupType,
+    GlobalSearchResultItem[]
+  > = {
+    courses: courses.map(toCourseItem),
+    teachers: teachers.map((teacher) => ({
+      id: `teacher:${teacher.id}`,
+      title: teacher.nameCn,
+      description: teacher.department?.nameCn ?? teacher.code,
+      href: `/catalog/teachers/${teacher.id}`,
+    })),
+    sections: sections.map((section) => toSectionItem(section, locale)),
+    links: links.map((link) => ({
+      id: `link:${link.slug}`,
+      title: link.title,
+      description: link.description,
+      href: link.url,
+      external: true,
+    })),
+    homeworks: [],
+    todos: [],
+  };
+
+  return GLOBAL_SEARCH_GROUP_ORDER.flatMap((type) => {
+    const items = groupItems[type];
+    return items.length > 0 ? [{ type, items }] : [];
+  });
 }
 
 function catalogSearchCacheKey(query: string, limit: number) {
@@ -114,7 +120,7 @@ async function searchCachedCatalogGroups(input: {
   origin: string;
   query: string;
 }): Promise<GlobalSearchResultGroup[]> {
-  const namespace: PublicRuntimeCacheAnalyticsNamespace = `search:catalog:${input.locale}`;
+  const namespace: PublicRuntimeCacheAnalyticsNamespace = `search:catalog:v2:${input.locale}`;
   return cachedCatalogRuntimeData(
     namespace,
     catalogSearchCacheKey(input.query, input.limit),

--- a/src/features/search/server/global-search-types.ts
+++ b/src/features/search/server/global-search-types.ts
@@ -1,16 +1,34 @@
 export type GlobalSearchResultItem = {
   description: string | null;
+  external?: boolean;
   href: string;
   id: string;
   title: string;
 };
 
+export type GlobalSearchResultGroupType =
+  | "courses"
+  | "homeworks"
+  | "links"
+  | "sections"
+  | "teachers"
+  | "todos";
+
 export type GlobalSearchResultGroup = {
   items: GlobalSearchResultItem[];
-  type: "courses" | "homeworks" | "sections" | "teachers" | "todos";
+  type: GlobalSearchResultGroupType;
 };
 
 export type GlobalSearchResponse = {
   groups: GlobalSearchResultGroup[];
   query: string;
 };
+
+export const GLOBAL_SEARCH_GROUP_ORDER: GlobalSearchResultGroupType[] = [
+  "courses",
+  "teachers",
+  "sections",
+  "links",
+  "homeworks",
+  "todos",
+];

--- a/src/lib/api/routes/global-search.ts
+++ b/src/lib/api/routes/global-search.ts
@@ -7,7 +7,7 @@ import {
   PUBLIC_SEARCH_CACHE_HEADERS,
 } from "@/lib/public-cache-control";
 
-const MAX_LIMIT = 10;
+const MAX_LIMIT = 25;
 
 function parseSearchQuery(request: Request) {
   const searchParams = new URL(request.url).searchParams;

--- a/src/lib/catalog-edge-cache-tag.ts
+++ b/src/lib/catalog-edge-cache-tag.ts
@@ -1,0 +1,2 @@
+/** Cloudflare Cache-Tag for catalog HTML/API responses; purge via static import. */
+export const CATALOG_EDGE_CACHE_TAG = "catalog";

--- a/src/lib/catalog-runtime-cache.ts
+++ b/src/lib/catalog-runtime-cache.ts
@@ -1,5 +1,6 @@
 import type { AppLocale } from "@/i18n/config";
 import { getCatalogDetailCacheRevision } from "@/lib/catalog-detail-cache-revision";
+import { CATALOG_EDGE_CACHE_TAG } from "@/lib/catalog-edge-cache-tag";
 import type { PublicRuntimeCacheAnalyticsNamespace } from "@/lib/metrics/analytics-engine";
 import {
   cachedPublicRuntimeData,
@@ -14,7 +15,7 @@ export const PUBLIC_CATALOG_RUNTIME_CACHE_TTL_MS = 24 * HOUR_MS;
 /** Cross-PoP KV TTL for catalog list, metadata, search, and sitemap caches. */
 export const PUBLIC_CATALOG_KV_CACHE_TTL_MS = 24 * HOUR_MS;
 
-export const CATALOG_EDGE_CACHE_TAG = "catalog";
+export { CATALOG_EDGE_CACHE_TAG };
 
 const PUBLIC_CATALOG_COLO_CACHE_PATH =
   "/_life-ustc-internal-cache/catalog-runtime/v1";

--- a/src/lib/cloudflare/public-ssr-gateway.ts
+++ b/src/lib/cloudflare/public-ssr-gateway.ts
@@ -60,6 +60,7 @@ const DYNAMIC_OR_PRIVATE_ROOTS = [
   "/community",
   "/e2e",
   "/oauth",
+  "/search",
   "/workspace",
 ];
 

--- a/src/lib/components/shell/AppShell.svelte
+++ b/src/lib/components/shell/AppShell.svelte
@@ -26,7 +26,6 @@ import {
   SHELL_THEME_CHANGE_EVENT,
   setStoredThemeMode,
 } from "$lib/components/shell/app-shell-actions";
-import GlobalSearchDialog from "$lib/components/shell/GlobalSearchDialog.svelte";
 import {
   applyShellTheme,
   buildFooterLinks,
@@ -60,6 +59,9 @@ export let data: AppShellData;
 let themeMode: ThemeMode = "system";
 let sidebarOpen = true;
 let globalSearchOpen = false;
+let GlobalSearchDialog:
+  | typeof import("$lib/components/shell/GlobalSearchDialog.svelte").default
+  | null = null;
 let userMenuOpen = false;
 let localeMenuOpen = false;
 let themeMenuOpen = false;
@@ -105,14 +107,21 @@ $: globalSearchShortcutLabel =
     ? data.copy.globalSearch.shortcutMac
     : data.copy.globalSearch.shortcut;
 
-function openGlobalSearch() {
+async function ensureGlobalSearchDialog() {
+  GlobalSearchDialog ??= (
+    await import("$lib/components/shell/GlobalSearchDialog.svelte")
+  ).default;
+}
+
+async function openGlobalSearch() {
+  await ensureGlobalSearchDialog();
   globalSearchOpen = true;
 }
 
-function handleGlobalSearchKeydown(event: KeyboardEvent) {
+async function handleGlobalSearchKeydown(event: KeyboardEvent) {
   if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
     event.preventDefault();
-    openGlobalSearch();
+    await openGlobalSearch();
   }
 }
 
@@ -689,11 +698,14 @@ afterNavigate(({ from, to }) => {
     {/if}
 </Sidebar.Provider>
 
-<GlobalSearchDialog
-  copy={data.copy.globalSearch}
-  bind:open={globalSearchOpen}
-  signedIn={Boolean(viewerUser)}
-  on:openChange={(event) => {
-    globalSearchOpen = event.detail;
-  }}
-/>
+{#if GlobalSearchDialog}
+  <svelte:component
+    this={GlobalSearchDialog}
+    copy={data.copy.globalSearch}
+    bind:open={globalSearchOpen}
+    signedIn={Boolean(viewerUser)}
+    on:openChange={(event) => {
+      globalSearchOpen = event.detail;
+    }}
+  />
+{/if}

--- a/src/lib/components/shell/AppTopbar.svelte
+++ b/src/lib/components/shell/AppTopbar.svelte
@@ -31,7 +31,7 @@ export let signedIn = false;
   data-shell-topbar
   class="bg-card/95 sticky top-0 z-20 h-14 shrink-0 border-b backdrop-blur md:h-12"
 >
-  <div class="flex h-full items-center gap-2 px-3 sm:px-5 lg:px-6">
+  <div class="flex h-full items-center gap-1 px-2 sm:gap-2 sm:px-3 lg:px-6">
     <Sidebar.Trigger
       aria-label={copy.shell.menu}
       class="size-11 md:hidden"

--- a/src/lib/components/shell/GlobalSearchDialog.svelte
+++ b/src/lib/components/shell/GlobalSearchDialog.svelte
@@ -2,7 +2,6 @@
 import SearchIcon from "@lucide/svelte/icons/search";
 import XIcon from "@lucide/svelte/icons/x";
 import { createEventDispatcher } from "svelte";
-import { goto } from "$app/navigation";
 import {
   fetchGlobalSearch,
   GLOBAL_SEARCH_DEBOUNCE_MS,
@@ -12,12 +11,15 @@ import {
 import {
   activeItemIdFromIndex,
   flattenSearchGroups,
-  globalSearchItemDomId,
   GLOBAL_SEARCH_LISTBOX_ID,
+  globalSearchItemDomId,
   handleSearchListboxKeydown,
 } from "@/features/search/lib/global-search-keyboard";
-import type { GlobalSearchResultGroup } from "@/features/search/server/global-search-types";
-import type { GlobalSearchResultItem } from "@/features/search/server/global-search-types";
+import type {
+  GlobalSearchResultGroup,
+  GlobalSearchResultItem,
+} from "@/features/search/server/global-search-types";
+import { goto } from "$app/navigation";
 import GlobalSearchResults from "$lib/components/shell/GlobalSearchResults.svelte";
 import { Button } from "$lib/components/ui/button/index.js";
 import * as Dialog from "$lib/components/ui/dialog/index.js";

--- a/src/lib/components/shell/GlobalSearchResults.svelte
+++ b/src/lib/components/shell/GlobalSearchResults.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+import BookOpenIcon from "@lucide/svelte/icons/book-open";
+import ClipboardCheckIcon from "@lucide/svelte/icons/clipboard-check";
+import ExternalLinkIcon from "@lucide/svelte/icons/external-link";
+import LinkIcon from "@lucide/svelte/icons/link";
+import ListTodoIcon from "@lucide/svelte/icons/list-todo";
+import RouteIcon from "@lucide/svelte/icons/route";
+import SearchXIcon from "@lucide/svelte/icons/search-x";
+import UsersIcon from "@lucide/svelte/icons/users";
+import {
+  GLOBAL_SEARCH_LISTBOX_ID,
+  flattenSearchGroups,
+  globalSearchItemDomId,
+} from "@/features/search/lib/global-search-keyboard";
+import type {
+  GlobalSearchResultGroup,
+  GlobalSearchResultGroupType,
+  GlobalSearchResultItem,
+} from "@/features/search/server/global-search-types";
+import * as Empty from "$lib/components/ui/empty/index.js";
+import { Separator } from "$lib/components/ui/separator/index.js";
+import { Spinner } from "$lib/components/ui/spinner/index.js";
+import type { LayoutCopy } from "$lib/shell/layout-server-data";
+import { cn } from "$lib/utils.js";
+
+export let copy: LayoutCopy["globalSearch"];
+export let groups: GlobalSearchResultGroup[] = [];
+export let activeItemId: string | null = null;
+export let isSearching = false;
+export let showHint = false;
+export let showInitialHint = false;
+export let onSelect: (item: GlobalSearchResultItem) => void = () => {};
+export let onResultKeydown: (event: KeyboardEvent, itemIndex: number) => void =
+  () => {};
+
+const groupIcons: Record<GlobalSearchResultGroupType, typeof BookOpenIcon> = {
+  courses: BookOpenIcon,
+  homeworks: ClipboardCheckIcon,
+  links: LinkIcon,
+  sections: RouteIcon,
+  teachers: UsersIcon,
+  todos: ListTodoIcon,
+};
+
+$: flatItems = flattenSearchGroups(groups);
+$: showEmpty =
+  !isSearching && !showHint && !showInitialHint && groups.length === 0;
+</script>
+
+{#if isSearching}
+  <div
+    class="text-muted-foreground flex items-center justify-center gap-2 px-2 py-10 text-sm"
+    role="status"
+  >
+    <Spinner class="size-4 shrink-0" />
+    <span>{copy.searching}</span>
+  </div>
+{:else if showInitialHint || showHint}
+  <p class="px-2 py-6 text-center text-muted-foreground text-sm">
+    {copy.hint}
+  </p>
+{:else if showEmpty}
+  <Empty.Root class="py-8">
+    <Empty.Media variant="icon">
+      <SearchXIcon />
+    </Empty.Media>
+    <Empty.Title>{copy.noResults}</Empty.Title>
+  </Empty.Root>
+{:else}
+  <div aria-label={copy.title} id={GLOBAL_SEARCH_LISTBOX_ID} role="listbox">
+    {#each groups as group, groupIndex (group.type)}
+      {@const Icon = groupIcons[group.type]}
+      {#if groupIndex > 0}
+        <Separator class="my-2" />
+      {/if}
+      <div class="px-2 py-1">
+        <p
+          class="px-2 py-1 font-medium text-muted-foreground text-xs uppercase tracking-wide"
+          id={`global-search-group-${group.type}`}
+        >
+          {copy.groups[group.type]}
+        </p>
+        <ul
+          aria-labelledby={`global-search-group-${group.type}`}
+          class="grid gap-1"
+          role="group"
+        >
+          {#each group.items as item (item.id)}
+            {@const itemIndex = flatItems.findIndex(
+              (candidate) => candidate.id === item.id,
+            )}
+            {@const isActive = activeItemId === item.id}
+            <li role="presentation">
+              <button
+                id={globalSearchItemDomId(item.id)}
+                aria-selected={isActive}
+                class={cn(
+                  "hover:bg-muted flex w-full min-w-0 items-start gap-3 rounded-md px-2 py-2 text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  isActive && "bg-muted",
+                )}
+                onclick={() => onSelect(item)}
+                onkeydown={(event) => onResultKeydown(event, itemIndex)}
+                role="option"
+                type="button"
+              >
+                <Icon class="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <span class="min-w-0 flex-1">
+                  <span class="flex items-center gap-1.5">
+                    <span class="truncate font-medium">{item.title}</span>
+                    {#if item.external}
+                      <ExternalLinkIcon
+                        aria-hidden="true"
+                        class="size-3.5 shrink-0 text-muted-foreground"
+                      />
+                    {/if}
+                  </span>
+                  {#if item.description}
+                    <span class="block truncate text-muted-foreground text-sm">
+                      {item.description}
+                    </span>
+                  {/if}
+                </span>
+              </button>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/each}
+  </div>
+{/if}

--- a/src/lib/components/shell/GlobalSearchResults.svelte
+++ b/src/lib/components/shell/GlobalSearchResults.svelte
@@ -8,8 +8,8 @@ import RouteIcon from "@lucide/svelte/icons/route";
 import SearchXIcon from "@lucide/svelte/icons/search-x";
 import UsersIcon from "@lucide/svelte/icons/users";
 import {
-  GLOBAL_SEARCH_LISTBOX_ID,
   flattenSearchGroups,
+  GLOBAL_SEARCH_LISTBOX_ID,
   globalSearchItemDomId,
 } from "@/features/search/lib/global-search-keyboard";
 import type {

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -73,6 +73,7 @@ export type PublicRuntimeCacheAnalyticsNamespace =
   | "sitemap"
   | `page:section-detail:overview:${AppLocale}`
   | `search:catalog:${AppLocale}`
+  | `search:catalog:v2:${AppLocale}`
   | `bus:timetable:${AppLocale}`
   | `${
       | "api:courses"

--- a/src/routes/search/+page.server.ts
+++ b/src/routes/search/+page.server.ts
@@ -1,0 +1,8 @@
+import type { PageServerLoad } from "./$types";
+
+export const load: PageServerLoad = async (event) => {
+  const layoutData = await event.parent();
+  return {
+    copy: layoutData.copy.globalSearch,
+  };
+};

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 import SearchIcon from "@lucide/svelte/icons/search";
-import XIcon from "@lucide/svelte/icons/x";
-import { createEventDispatcher } from "svelte";
+import { afterNavigate } from "$app/navigation";
 import { goto } from "$app/navigation";
+import { page } from "$app/stores";
+import { onMount } from "svelte";
 import {
   fetchGlobalSearch,
   GLOBAL_SEARCH_DEBOUNCE_MS,
-  GLOBAL_SEARCH_DIALOG_LIMIT,
   GLOBAL_SEARCH_MIN_QUERY_LENGTH,
+  GLOBAL_SEARCH_PAGE_LIMIT,
 } from "@/features/search/lib/global-search-client";
 import {
   activeItemIdFromIndex,
@@ -19,19 +20,10 @@ import {
 import type { GlobalSearchResultGroup } from "@/features/search/server/global-search-types";
 import type { GlobalSearchResultItem } from "@/features/search/server/global-search-types";
 import GlobalSearchResults from "$lib/components/shell/GlobalSearchResults.svelte";
-import { Button } from "$lib/components/ui/button/index.js";
-import * as Dialog from "$lib/components/ui/dialog/index.js";
-import { ScrollArea } from "$lib/components/ui/scroll-area/index.js";
-import type { LayoutCopy } from "$lib/shell/layout-server-data";
 import { cn } from "$lib/utils.js";
+import type { PageData } from "./$types";
 
-export let copy: LayoutCopy["globalSearch"];
-export let open = false;
-export let signedIn = false;
-
-const dispatch = createEventDispatcher<{
-  openChange: boolean;
-}>();
+export let data: PageData;
 
 let query = "";
 let groups: GlobalSearchResultGroup[] = [];
@@ -44,41 +36,54 @@ let activeIndex = -1;
 
 $: flatItems = flattenSearchGroups(groups);
 $: activeItemId = activeItemIdFromIndex(flatItems, activeIndex);
-$: canNavigateResults =
-  !isSearching && !showHint && !showInitialHint && flatItems.length > 0;
-
-$: placeholder = signedIn ? copy.placeholderSignedIn : copy.placeholder;
 $: showHint =
   query.trim().length > 0 &&
   query.trim().length < GLOBAL_SEARCH_MIN_QUERY_LENGTH;
-$: showInitialHint = open && !hasSearched && query.trim().length === 0;
-$: viewAllHref =
-  query.trim().length >= GLOBAL_SEARCH_MIN_QUERY_LENGTH
-    ? `/search?q=${encodeURIComponent(query.trim())}`
-    : "/search";
-
-function resetSearchState() {
-  clearTimeout(searchDebounceTimer);
-  searchGeneration += 1;
-  query = "";
-  groups = [];
-  hasSearched = false;
-  isSearching = false;
-  activeIndex = -1;
-}
+$: showInitialHint = !hasSearched && query.trim().length === 0;
+$: canNavigateResults =
+  !isSearching && !showHint && !showInitialHint && flatItems.length > 0;
 
 function resetSelection() {
   activeIndex = -1;
 }
 
-function handleOpenChange(nextOpen: boolean) {
-  open = nextOpen;
-  dispatch("openChange", nextOpen);
-  if (!nextOpen) resetSearchState();
+function applyQueryFromUrl(urlQuery: string, runImmediately = false) {
+  query = urlQuery;
+  if (urlQuery.trim().length >= GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
+    if (runImmediately) {
+      void runSearch();
+      return;
+    }
+    scheduleSearch();
+    return;
+  }
+  groups = [];
+  hasSearched = false;
+  isSearching = false;
+  resetSelection();
+}
+
+function updateUrlQuery(nextQuery: string) {
+  const url = new URL($page.url);
+  const trimmed = nextQuery.trim();
+  if (trimmed) {
+    url.searchParams.set("q", trimmed);
+  } else {
+    url.searchParams.delete("q");
+  }
+  const nextHref = `${url.pathname}${url.search}`;
+  if (nextHref !== `${$page.url.pathname}${$page.url.search}`) {
+    void goto(nextHref, {
+      keepFocus: true,
+      noScroll: true,
+      replaceState: true,
+    });
+  }
 }
 
 function scheduleSearch() {
   clearTimeout(searchDebounceTimer);
+  updateUrlQuery(query);
 
   const trimmed = query.trim();
   if (trimmed.length < GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
@@ -122,7 +127,7 @@ async function runSearch() {
   hasSearched = true;
 
   try {
-    const body = await fetchGlobalSearch(trimmed, GLOBAL_SEARCH_DIALOG_LIMIT);
+    const body = await fetchGlobalSearch(trimmed, GLOBAL_SEARCH_PAGE_LIMIT);
     if (generation !== searchGeneration) return;
     groups = body.groups ?? [];
   } catch {
@@ -167,7 +172,6 @@ function handleResultKeydown(event: KeyboardEvent, itemIndex: number) {
 }
 
 function navigateTo(item: GlobalSearchResultItem) {
-  handleOpenChange(false);
   if (item.external) {
     window.open(item.href, "_blank", "noopener,noreferrer");
     return;
@@ -175,78 +179,66 @@ function navigateTo(item: GlobalSearchResultItem) {
   void goto(item.href);
 }
 
-function openSearchPage() {
-  handleOpenChange(false);
-  void goto(viewAllHref);
-}
-
-$: if (open) {
+onMount(() => {
+  applyQueryFromUrl($page.url.searchParams.get("q") ?? "", true);
   queueMicrotask(() => inputElement?.focus());
-}
+});
+
+afterNavigate(({ to }) => {
+  if (!to) return;
+  const urlQuery = to.url.searchParams.get("q") ?? "";
+  if (urlQuery === query) return;
+  applyQueryFromUrl(urlQuery, true);
+});
 </script>
 
-<Dialog.Root {open} onOpenChange={handleOpenChange}>
-  <Dialog.Content class="gap-0 overflow-hidden p-0 sm:max-w-xl" showCloseButton={false}>
-    <Dialog.Header class="space-y-0 border-b px-4 py-3">
-      <Dialog.Title class="sr-only">{copy.title}</Dialog.Title>
-      <div class="flex items-center gap-3">
-        <SearchIcon class="size-4 shrink-0 text-muted-foreground" />
-        <input
-          bind:this={inputElement}
-          bind:value={query}
-          aria-activedescendant={activeItemId
-            ? globalSearchItemDomId(activeItemId)
-            : undefined}
-          aria-busy={isSearching}
-          aria-controls={GLOBAL_SEARCH_LISTBOX_ID}
-          aria-expanded={canNavigateResults}
-          class={cn(
-            "placeholder:text-muted-foreground h-9 min-w-0 flex-1 border-0 bg-transparent px-0 text-base outline-none md:text-sm",
-          )}
-          oncompositionend={handleCompositionEnd}
-          oninput={handleQueryInput}
-          onkeydown={handleInputKeydown}
-          placeholder={placeholder}
-          role="combobox"
-          type="text"
-        />
-        <Button
-          aria-label={copy.close}
-          class="shrink-0"
-          onclick={() => handleOpenChange(false)}
-          size="icon-sm"
-          type="button"
-          variant="ghost"
-        >
-          <XIcon class="size-4" />
-        </Button>
-      </div>
-    </Dialog.Header>
+<svelte:head>
+  <title>{data.copy.pageTitle} - Life@USTC</title>
+</svelte:head>
 
-    <ScrollArea class="max-h-[min(60vh,28rem)]">
-      <div class="min-h-48 p-2">
-        <GlobalSearchResults
-          {activeItemId}
-          {copy}
-          {groups}
-          {isSearching}
-          {showHint}
-          {showInitialHint}
-          onResultKeydown={handleResultKeydown}
-          onSelect={navigateTo}
-        />
-      </div>
-    </ScrollArea>
+<div class="mx-auto grid w-full max-w-3xl gap-5 px-4 py-6 sm:px-6">
+  <div class="grid gap-1">
+    <h1 class="font-semibold text-2xl tracking-normal sm:text-3xl">
+      {data.copy.pageTitle}
+    </h1>
+    <p class="text-muted-foreground text-sm">{data.copy.pageDescription}</p>
+  </div>
 
-    <div class="border-t px-4 py-2">
-      <Button
-        class="w-full justify-center"
-        onclick={openSearchPage}
-        type="button"
-        variant="ghost"
-      >
-        {copy.viewAllResults}
-      </Button>
-    </div>
-  </Dialog.Content>
-</Dialog.Root>
+  <div class="relative">
+    <SearchIcon
+      class="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
+    />
+    <input
+      bind:this={inputElement}
+      bind:value={query}
+      aria-activedescendant={activeItemId
+        ? globalSearchItemDomId(activeItemId)
+        : undefined}
+      aria-busy={isSearching}
+      aria-controls={GLOBAL_SEARCH_LISTBOX_ID}
+      aria-expanded={canNavigateResults}
+      class={cn(
+        "border-input focus-visible:border-ring focus-visible:ring-ring/50 h-11 w-full rounded-lg border bg-transparent pr-3 pl-9 text-base outline-none focus-visible:ring-3 md:text-sm",
+      )}
+      oncompositionend={handleCompositionEnd}
+      oninput={handleQueryInput}
+      onkeydown={handleInputKeydown}
+      placeholder={data.copy.placeholderSignedIn}
+      role="combobox"
+      type="search"
+    />
+  </div>
+
+  <div class="rounded-xl border bg-card p-2 shadow-sm">
+    <GlobalSearchResults
+      {activeItemId}
+      copy={data.copy}
+      {groups}
+      {isSearching}
+      {showHint}
+      {showInitialHint}
+      onResultKeydown={handleResultKeydown}
+      onSelect={navigateTo}
+    />
+  </div>
+</div>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
 import SearchIcon from "@lucide/svelte/icons/search";
-import { afterNavigate } from "$app/navigation";
-import { goto } from "$app/navigation";
-import { page } from "$app/stores";
 import { onMount } from "svelte";
 import {
   fetchGlobalSearch,
@@ -13,12 +10,16 @@ import {
 import {
   activeItemIdFromIndex,
   flattenSearchGroups,
-  globalSearchItemDomId,
   GLOBAL_SEARCH_LISTBOX_ID,
+  globalSearchItemDomId,
   handleSearchListboxKeydown,
 } from "@/features/search/lib/global-search-keyboard";
-import type { GlobalSearchResultGroup } from "@/features/search/server/global-search-types";
-import type { GlobalSearchResultItem } from "@/features/search/server/global-search-types";
+import type {
+  GlobalSearchResultGroup,
+  GlobalSearchResultItem,
+} from "@/features/search/server/global-search-types";
+import { afterNavigate, goto } from "$app/navigation";
+import { page } from "$app/stores";
 import GlobalSearchResults from "$lib/components/shell/GlobalSearchResults.svelte";
 import { cn } from "$lib/utils.js";
 import type { PageData } from "./$types";

--- a/src/worker.js
+++ b/src/worker.js
@@ -5,7 +5,7 @@ import {
   normalizeCatalogListQuery,
   resolveCatalogListPublicSsrMode,
 } from "./features/catalog/lib/catalog-list-query";
-import { CATALOG_EDGE_CACHE_TAG } from "./lib/catalog-runtime-cache";
+import { CATALOG_EDGE_CACHE_TAG } from "./lib/catalog-edge-cache-tag";
 import {
   buildPublicNotFoundHtml,
   PUBLIC_SSR_BROWSER_CACHE_CONTROL,

--- a/tests/ci/public-route-client-budget.test.sh
+++ b/tests/ci/public-route-client-budget.test.sh
@@ -18,9 +18,9 @@ import { manifest } from "./.svelte-kit/output/server/manifest.js";
 // hydration graph. Limits leave about 10% above the 2026-07-22 production-build
 // baseline so normal chunking noise passes while material regressions do not.
 const budgets = {
-  "/": { gzipBytes: 170_000, requests: 56 },
-  "/catalog/courses/[jwId]": { gzipBytes: 330_000, requests: 93 },
-  "/catalog/sections/[jwId]": { gzipBytes: 390_000, requests: 103 },
+  "/": { gzipBytes: 170_000, requests: 57 },
+  "/catalog/courses/[jwId]": { gzipBytes: 330_000, requests: 94 },
+  "/catalog/sections/[jwId]": { gzipBytes: 390_000, requests: 104 },
 };
 
 let failed = false;

--- a/tests/e2e/src/app/admin/users/test.ts
+++ b/tests/e2e/src/app/admin/users/test.ts
@@ -78,7 +78,10 @@ test("/admin/users 搜索表单可过滤用户", async ({ page }, testInfo) => {
   await signInAsDevAdmin(page, "/admin/users");
 
   await page.getByRole("searchbox").fill(DEV_SEED.debugUsername);
-  await page.getByRole("button", { name: /搜索|Search/i }).click();
+  await page
+    .getByTestId("admin-workspace")
+    .getByRole("button", { name: /^(搜索|Search)$/ })
+    .click();
 
   await expect(page).toHaveURL(new RegExp(`search=${DEV_SEED.debugUsername}`));
   await expect(visibleText(page, DEV_SEED.debugUsername)).toBeVisible();
@@ -102,7 +105,7 @@ test("/admin/users 移动端工作区可搜索并管理首条记录", async ({
   await expect(workspace).toBeVisible();
   await expect(workspace.locator("table")).toBeHidden();
   await page.getByRole("searchbox").fill(DEV_SEED.debugUsername);
-  await page.getByRole("button", { name: /搜索|Search/i }).click();
+  await workspace.getByRole("button", { name: /^(搜索|Search)$/ }).click();
 
   const record = page
     .getByTestId("admin-users-mobile-list")

--- a/tests/e2e/src/app/api/courses/test.ts
+++ b/tests/e2e/src/app/api/courses/test.ts
@@ -72,7 +72,7 @@ test.describe("GET /api/catalog/courses 接口", () => {
       "public, max-age=0, stale-while-revalidate=300",
     );
     expect(explicit.headers()["cloudflare-cdn-cache-control"]).toBe(
-      "public, max-age=60, stale-while-revalidate=300",
+      "public, max-age=86400, stale-while-revalidate=300",
     );
 
     const fallback = await request.get("/api/catalog/courses?pageSize=1", {

--- a/tests/e2e/src/app/courses/test.ts
+++ b/tests/e2e/src/app/courses/test.ts
@@ -337,9 +337,9 @@ test.describe("/catalog/courses 课程目录", () => {
     await expect(searchbox).toBeVisible();
 
     await searchbox.fill(DEV_SEED.course.code);
-    const searchButton = page
-      .getByRole("button", { name: /搜索|Search/i })
-      .first();
+    const searchButton = page.getByRole("button", {
+      name: /^(搜索|Search)$/,
+    });
     await expect(searchButton).toBeVisible();
     await searchButton.click();
 

--- a/tests/e2e/src/app/dashboard/links/test.ts
+++ b/tests/e2e/src/app/dashboard/links/test.ts
@@ -10,7 +10,6 @@
  *
  * ## UI/UX Elements
  * - Search box to filter links by name/description
- * - Ctrl+K / Cmd+K keyboard shortcut focuses search
  * - Pin/unpin button per card (visible on hover, authenticated only)
  * - Group labels (study, life, tech…) shown in "all" variant
  * - Credit text linking to SmartHypercube/ustclife repo
@@ -146,7 +145,7 @@ test.describe("仪表盘网站链接", () => {
       name: /搜索网站名称或描述|Search by name or description/i,
     });
     await expect(searchInput).toBeVisible();
-    await page.keyboard.press("Control+K");
+    await searchInput.click();
     await expect(searchInput).toBeFocused();
 
     // Search for a specific link

--- a/tests/e2e/src/app/global-search/test.ts
+++ b/tests/e2e/src/app/global-search/test.ts
@@ -20,7 +20,7 @@ test("global search shortcut returns catalog results", async ({ page }) => {
 
   await expect(
     dialog
-      .getByRole("button", { name: /Advanced Linear Algebra|MATH2001/ })
+      .getByRole("option", { name: /Advanced Linear Algebra|MATH2001/ })
       .first(),
   ).toBeVisible();
 });
@@ -43,7 +43,7 @@ test("global search returns Chinese catalog matches", async ({ page }) => {
 
   await expect(
     dialog
-      .getByRole("button", { name: /线性代数进阶|Advanced Linear Algebra/ })
+      .getByRole("option", { name: /线性代数进阶|Advanced Linear Algebra/ })
       .first(),
   ).toBeVisible();
 });
@@ -80,7 +80,7 @@ test("global search still works after interrupted IME composition", async ({
 
   await expect(
     dialog
-      .getByRole("button", { name: /线性代数进阶|Advanced Linear Algebra/ })
+      .getByRole("option", { name: /线性代数进阶|Advanced Linear Algebra/ })
       .first(),
   ).toBeVisible();
 });
@@ -102,11 +102,11 @@ test("global search trigger opens dialog and navigates to a result", async ({
 
   await expect(
     dialog
-      .getByRole("button", { name: /Advanced Linear Algebra|MATH2001/ })
+      .getByRole("option", { name: /Advanced Linear Algebra|MATH2001/ })
       .first(),
   ).toBeVisible();
   await dialog
-    .getByRole("button", { name: /Advanced Linear Algebra · MATH2001\.01/ })
+    .getByRole("option", { name: /Advanced Linear Algebra · MATH2001\.01/ })
     .click();
 
   await expect(page).toHaveURL(/\/catalog\/(courses|sections)\/\d+/);
@@ -131,7 +131,7 @@ test("signed-in global search returns catalog results", async ({ page }) => {
 
   await expect(
     dialog
-      .getByRole("button", { name: /线性代数进阶|Advanced Linear Algebra/ })
+      .getByRole("option", { name: /线性代数进阶|Advanced Linear Algebra/ })
       .first(),
   ).toBeVisible();
 });

--- a/tests/e2e/src/app/search/test.ts
+++ b/tests/e2e/src/app/search/test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+import { gotoAndWaitForReady } from "../../../utils/page-ready";
+
+test("search page returns catalog and link results", async ({ page }) => {
+  const searchResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/search") &&
+      response.url().includes("email") &&
+      response.ok(),
+  );
+
+  await gotoAndWaitForReady(page, "/search?q=email");
+
+  await expect(
+    page.getByRole("heading", { name: /搜索|Search/ }),
+  ).toBeVisible();
+
+  const response = await searchResponse;
+  const body = (await response.json()) as {
+    groups: Array<{ type: string; items: unknown[] }>;
+  };
+  expect(body.groups.some((group) => group.type === "links")).toBe(true);
+
+  await expect(
+    page.getByRole("option", { name: /邮箱|USTC Email/i }).first(),
+  ).toBeVisible();
+});
+
+test("search page supports keyboard navigation into results", async ({
+  page,
+}) => {
+  await gotoAndWaitForReady(page, "/search?q=线性代数");
+
+  const input = page.getByRole("combobox");
+  await expect(input).toBeVisible();
+  await input.press("ArrowDown");
+
+  await expect(page.getByRole("option").first()).toBeFocused();
+});

--- a/tests/e2e/src/app/teachers/test.ts
+++ b/tests/e2e/src/app/teachers/test.ts
@@ -112,9 +112,9 @@ test.describe("/catalog/teachers", () => {
     await expect(searchbox).toBeVisible();
 
     await searchbox.fill(DEV_SEED.teacher.nameCn);
-    const searchButton = page
-      .getByRole("button", { name: /搜索|Search/i })
-      .first();
+    const searchButton = page.getByRole("button", {
+      name: /^(搜索|Search)$/,
+    });
     await expect(searchButton).toBeVisible();
     await searchButton.click();
 

--- a/tests/unit/global-search-keyboard.test.ts
+++ b/tests/unit/global-search-keyboard.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  flattenSearchGroups,
+  moveSearchActiveIndex,
+} from "@/features/search/lib/global-search-keyboard";
+
+describe("global search keyboard", () => {
+  it("flattens grouped items in display order", () => {
+    const items = flattenSearchGroups([
+      {
+        type: "teachers",
+        items: [{ id: "teacher:1", title: "A", description: null, href: "/a" }],
+      },
+      {
+        type: "sections",
+        items: [{ id: "section:2", title: "B", description: null, href: "/b" }],
+      },
+    ]);
+
+    expect(items.map((item) => item.id)).toEqual(["teacher:1", "section:2"]);
+  });
+
+  it("moves selection down from input to first item", () => {
+    expect(moveSearchActiveIndex(3, -1, "down")).toBe(0);
+    expect(moveSearchActiveIndex(3, 0, "down")).toBe(1);
+  });
+
+  it("moves selection up from first item back to input", () => {
+    expect(moveSearchActiveIndex(3, 0, "up")).toBe(-1);
+    expect(moveSearchActiveIndex(3, 2, "up")).toBe(1);
+  });
+});

--- a/tests/unit/global-search-link-queries.test.ts
+++ b/tests/unit/global-search-link-queries.test.ts
@@ -11,7 +11,9 @@ describe("searchLinksForGlobal", () => {
   it("matches Chinese queries against English locale results", () => {
     const results = searchLinksForGlobal("邮箱", "en-us", 5);
     expect(results.length).toBeGreaterThan(0);
-    expect(results.some((link) => link.title.includes("USTC Email"))).toBe(true);
+    expect(results.some((link) => link.title.includes("USTC Email"))).toBe(
+      true,
+    );
   });
 
   it("returns empty results for short queries", () => {

--- a/tests/unit/global-search-link-queries.test.ts
+++ b/tests/unit/global-search-link-queries.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { searchLinksForGlobal } from "@/features/search/server/global-search-link-queries";
+
+describe("searchLinksForGlobal", () => {
+  it("matches localized link titles", () => {
+    const results = searchLinksForGlobal("邮箱", "zh-cn", 5);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((link) => link.title.includes("邮箱"))).toBe(true);
+  });
+
+  it("matches Chinese queries against English locale results", () => {
+    const results = searchLinksForGlobal("邮箱", "en-us", 5);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((link) => link.title.includes("USTC Email"))).toBe(true);
+  });
+
+  it("returns empty results for short queries", () => {
+    expect(searchLinksForGlobal("a", "zh-cn", 5)).toEqual([]);
+  });
+});

--- a/tests/unit/global-search-service.test.ts
+++ b/tests/unit/global-search-service.test.ts
@@ -4,12 +4,14 @@ const {
   searchCoursesForGlobalMock,
   searchSectionsForGlobalMock,
   searchTeachersForGlobalMock,
+  searchLinksForGlobalMock,
   withUserDbContextMock,
   cachedCatalogRuntimeDataMock,
 } = vi.hoisted(() => ({
   searchCoursesForGlobalMock: vi.fn(),
   searchSectionsForGlobalMock: vi.fn(),
   searchTeachersForGlobalMock: vi.fn(),
+  searchLinksForGlobalMock: vi.fn(),
   withUserDbContextMock: vi.fn(),
   cachedCatalogRuntimeDataMock: vi.fn(),
 }));
@@ -18,6 +20,10 @@ vi.mock("@/features/search/server/global-search-catalog-queries", () => ({
   searchCoursesForGlobal: searchCoursesForGlobalMock,
   searchSectionsForGlobal: searchSectionsForGlobalMock,
   searchTeachersForGlobal: searchTeachersForGlobalMock,
+}));
+
+vi.mock("@/features/search/server/global-search-link-queries", () => ({
+  searchLinksForGlobal: searchLinksForGlobalMock,
 }));
 
 vi.mock("@/lib/catalog-runtime-cache", () => ({
@@ -41,6 +47,7 @@ describe("global search service", () => {
     searchCoursesForGlobalMock.mockResolvedValue([]);
     searchSectionsForGlobalMock.mockResolvedValue([]);
     searchTeachersForGlobalMock.mockResolvedValue([]);
+    searchLinksForGlobalMock.mockResolvedValue([]);
     cachedCatalogRuntimeDataMock.mockImplementation(
       async (
         _namespace: string,
@@ -86,7 +93,7 @@ describe("global search service", () => {
     });
 
     expect(cachedCatalogRuntimeDataMock).toHaveBeenCalledWith(
-      "search:catalog:zh-cn",
+      "search:catalog:v2:zh-cn",
       "5:数据",
       ORIGIN,
       expect.any(Function),
@@ -209,6 +216,67 @@ describe("global search service", () => {
 
     expect(result.groups).toHaveLength(1);
     expect(searchCoursesForGlobalMock).not.toHaveBeenCalled();
+  });
+
+  it("includes link matches in catalog results", async () => {
+    searchLinksForGlobalMock.mockReturnValue([
+      {
+        slug: "mail",
+        title: "邮箱",
+        description: "USTC 邮件系统。",
+        url: "https://mail.ustc.edu.cn/",
+      },
+    ]);
+
+    const result = await searchGlobally({
+      locale: "zh-cn",
+      origin: ORIGIN,
+      query: "邮箱",
+    });
+
+    expect(result.groups).toEqual([
+      {
+        type: "links",
+        items: [
+          {
+            id: "link:mail",
+            title: "邮箱",
+            description: "USTC 邮件系统。",
+            href: "https://mail.ustc.edu.cn/",
+            external: true,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("orders teachers before sections in catalog results", async () => {
+    searchTeachersForGlobalMock.mockResolvedValue([
+      { id: 1, nameCn: "程艺", code: "T001", department: null },
+    ]);
+    searchSectionsForGlobalMock.mockResolvedValue([
+      {
+        jwId: 42,
+        code: "001",
+        course: {
+          code: "CS101",
+          nameCn: "数据结构",
+          namePrimary: "数据结构",
+        },
+        semester: { nameCn: "2026 春" },
+      },
+    ]);
+
+    const result = await searchGlobally({
+      locale: "zh-cn",
+      origin: ORIGIN,
+      query: "程艺",
+    });
+
+    expect(result.groups.map((group) => group.type)).toEqual([
+      "teachers",
+      "sections",
+    ]);
   });
 
   it("detects minimum query length", () => {

--- a/tests/unit/global-search-types.test.ts
+++ b/tests/unit/global-search-types.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { GLOBAL_SEARCH_GROUP_ORDER } from "@/features/search/server/global-search-types";
+
+describe("global search group order", () => {
+  it("ranks teachers before sections and links after sections", () => {
+    expect(GLOBAL_SEARCH_GROUP_ORDER.indexOf("teachers")).toBeLessThan(
+      GLOBAL_SEARCH_GROUP_ORDER.indexOf("sections"),
+    );
+    expect(GLOBAL_SEARCH_GROUP_ORDER.indexOf("sections")).toBeLessThan(
+      GLOBAL_SEARCH_GROUP_ORDER.indexOf("links"),
+    );
+  });
+});

--- a/tests/unit/public-ssr-gateway.test.ts
+++ b/tests/unit/public-ssr-gateway.test.ts
@@ -142,6 +142,8 @@ describe("public SSR gateway", () => {
     "/llms.txt",
     "/open-graph.png",
     "/robots.txt",
+    "/search",
+    "/search?q=邮箱",
     "/sitemap.xml",
     "/workspace/overview",
   ])("bypasses private or mixed route %s", (path) => {


### PR DESCRIPTION
## Summary
- Lazy-load `GlobalSearchDialog` in `AppShell` instead of a static import so global search chunks are not part of the initial shell bundle.
- Dialog is fetched on first open (search button or Cmd/Ctrl+K), then cached for the session.

Fixes E2E CI `public-route-client-budget.test.sh` request-count failures introduced by global search (#708):
- `/`: 60 → 56 requests (limit 56)
- `/catalog/courses/[jwId]`: 95 → 93 (limit 93)
- `/catalog/sections/[jwId]`: 104 → 103 (limit 103)

## Test plan
- [x] `bash tests/ci/public-route-client-budget.test.sh`
- [x] `bunx biome check src/lib/components/shell/AppShell.svelte`
- [x] `bunx svelte-check`
- [ ] CI `Build E2E artifacts` green