### PR TITLE
perf(dashboard): parallelize overview independent reads

### DIFF
--- a/src/features/dashboard/server/dashboard-overview-calendar.ts
+++ b/src/features/dashboard/server/dashboard-overview-calendar.ts
@@ -1,2 +1,5 @@
 export { buildRollingCalendarPreview } from "./dashboard-overview-calendar-preview";
-export { buildSemesterCalendarPayload } from "./dashboard-overview-semester-calendar";
+export {
+  buildSemesterCalendarPayload,
+  resolveGridSemesterBounds,
+} from "./dashboard-overview-semester-calendar";

--- a/src/features/dashboard/server/dashboard-overview-data.ts
+++ b/src/features/dashboard/server/dashboard-overview-data.ts
@@ -1,10 +1,14 @@
 import { listSubscribedHomeworks } from "@/features/subscriptions/server/subscription-read-model";
 import { formatSemesterName } from "@/lib/text/format-semester-name";
-import { buildSemesterCalendarPayload } from "./dashboard-overview-calendar";
+import {
+  buildSemesterCalendarPayload,
+  resolveGridSemesterBounds,
+} from "./dashboard-overview-calendar";
 import { resolveDashboardOverviewContext } from "./dashboard-overview-context";
 import { getDashboardOverviewLinksData } from "./dashboard-overview-links";
 import { buildDashboardOverviewSchedule } from "./dashboard-overview-schedule";
 import { resolveDashboardOverviewSectionScope } from "./dashboard-overview-section-scope";
+import { listSemesterCalendarTodos } from "./dashboard-overview-semester-todos";
 import type {
   OverviewData,
   OverviewDataOptions,
@@ -40,21 +44,9 @@ export async function getDashboardOverviewData(
     scheduleDateStart,
   } = semesterContext;
 
-  const linksPromise = getDashboardOverviewLinksData(userId, {
-    locale,
-    skipLinks: options.skipLinks,
-  });
-
-  const {
-    calendarSemesterNavList,
-    calendarSemesterPicker,
-    currentTermName,
-    dashboardSections,
-    hasAnySelection,
-    hasCurrentTermSelection,
-    homeworkSectionIds,
-    sectionsForCalendarGrid,
-  } = await resolveDashboardOverviewSectionScope({
+  const { semesterEnd, semesterStart } =
+    resolveGridSemesterBounds(gridSemesterRow);
+  const sectionScopePromise = resolveDashboardOverviewSectionScope({
     calendarSemesterId: options.calendarSemesterId,
     currentSemester,
     gridSemesterRow,
@@ -66,14 +58,42 @@ export async function getDashboardOverviewData(
     semesters,
     userId,
   });
+  const linksPromise = getDashboardOverviewLinksData(userId, {
+    locale,
+    skipLinks: options.skipLinks,
+  });
+  const semesterTodosPromise = listSemesterCalendarTodos({
+    semesterEnd,
+    semesterStart,
+    userId,
+  });
+
+  const {
+    calendarSemesterNavList,
+    calendarSemesterPicker,
+    currentTermName,
+    dashboardSections,
+    hasAnySelection,
+    hasCurrentTermSelection,
+    homeworkSectionIds,
+    sectionsForCalendarGrid,
+  } = await sectionScopePromise;
 
   const now = referenceNow;
-  const overviewHomeworks = await listSubscribedHomeworks(userId, {
-    incompleteOrHasDueDate: true,
-    locale,
-    sectionIds: homeworkSectionIds,
-    shape: "dashboard",
-  });
+  const [
+    overviewHomeworks,
+    { dashboardLinks, recommendedLinks, pinnedLinks, overviewLinks },
+    semesterTodos,
+  ] = await Promise.all([
+    listSubscribedHomeworks(userId, {
+      incompleteOrHasDueDate: true,
+      locale,
+      sectionIds: homeworkSectionIds,
+      shape: "dashboard",
+    }),
+    linksPromise,
+    semesterTodosPromise,
+  ]);
   const homeworks = overviewHomeworks.filter(
     (homework) => homework.homeworkCompletions.length === 0,
   );
@@ -88,26 +108,19 @@ export async function getDashboardOverviewData(
     locale,
     referenceNow: now,
   });
-  const [
-    {
-      allExams,
-      allSessions,
-      semesterEnd,
-      semesterHomeworks,
-      semesterStart,
-      semesterTodos,
-      semesterWeeks,
-    },
-    { dashboardLinks, recommendedLinks, pinnedLinks, overviewLinks },
-  ] = await Promise.all([
-    buildSemesterCalendarPayload({
-      calendarHomeworks,
-      gridSemesterRow,
-      sectionsForCalendarGrid,
-      userId,
-    }),
-    linksPromise,
-  ]);
+  const {
+    allExams,
+    allSessions,
+    semesterEnd: calendarSemesterEnd,
+    semesterHomeworks,
+    semesterStart: calendarSemesterStart,
+    semesterWeeks,
+  } = buildSemesterCalendarPayload({
+    calendarHomeworks,
+    gridSemesterRow,
+    sectionsForCalendarGrid,
+    semesterTodos,
+  });
 
   const defaultCalendarSemesterId = currentSemester?.id ?? null;
   const activeCalendarSemesterId = gridSemesterRow?.id ?? null;
@@ -138,8 +151,8 @@ export async function getDashboardOverviewData(
     weekDayFormatter: schedule.weekDayFormatter,
     referenceNow: now,
     todayStart: schedule.todayStart,
-    semesterStart,
-    semesterEnd,
+    semesterStart: calendarSemesterStart,
+    semesterEnd: calendarSemesterEnd,
     semesterWeeks,
     allSessions,
     allExams,

--- a/src/features/dashboard/server/dashboard-overview-semester-calendar.ts
+++ b/src/features/dashboard/server/dashboard-overview-semester-calendar.ts
@@ -5,25 +5,17 @@ import {
   getSemesterWeeks,
   sortSessionsByStart,
 } from "./dashboard-helpers";
-import { listSemesterCalendarTodos } from "./dashboard-overview-semester-todos";
+import type { CalendarTodoItem } from "./dashboard-overview-types";
 import type { HomeworkWithSection } from "./dashboard-types";
 
-export async function buildSemesterCalendarPayload({
-  calendarHomeworks,
-  gridSemesterRow,
-  sectionsForCalendarGrid,
-  userId,
-}: {
-  calendarHomeworks: HomeworkWithSection[];
-  gridSemesterRow: {
-    id: number;
-    nameCn: string | null;
-    startDate: Date | null;
-    endDate: Date | null;
-  } | null;
-  sectionsForCalendarGrid: Parameters<typeof buildSessions>[0];
-  userId: string;
-}) {
+type GridSemesterRow = {
+  id: number;
+  nameCn: string | null;
+  startDate: Date | null;
+  endDate: Date | null;
+} | null;
+
+export function resolveGridSemesterBounds(gridSemesterRow: GridSemesterRow) {
   const semesterStart =
     gridSemesterRow?.startDate != null
       ? shanghaiDayjs(gridSemesterRow.startDate).startOf("day")
@@ -32,6 +24,23 @@ export async function buildSemesterCalendarPayload({
     gridSemesterRow?.endDate != null
       ? shanghaiDayjs(gridSemesterRow.endDate).endOf("day")
       : null;
+
+  return { semesterEnd, semesterStart };
+}
+
+export function buildSemesterCalendarPayload({
+  calendarHomeworks,
+  gridSemesterRow,
+  sectionsForCalendarGrid,
+  semesterTodos,
+}: {
+  calendarHomeworks: HomeworkWithSection[];
+  gridSemesterRow: GridSemesterRow;
+  sectionsForCalendarGrid: Parameters<typeof buildSessions>[0];
+  semesterTodos: CalendarTodoItem[];
+}) {
+  const { semesterEnd, semesterStart } =
+    resolveGridSemesterBounds(gridSemesterRow);
   const semesterWeeks =
     semesterStart && semesterEnd && !semesterStart.isAfter(semesterEnd)
       ? getSemesterWeeks(semesterStart, semesterEnd)
@@ -51,11 +60,6 @@ export async function buildSemesterCalendarPayload({
           );
         })
       : [];
-  const semesterTodos = await listSemesterCalendarTodos({
-    semesterEnd,
-    semesterStart,
-    userId,
-  });
 
   return {
     allExams,

--- a/tests/unit/dashboard-overview-homework-read.test.ts
+++ b/tests/unit/dashboard-overview-homework-read.test.ts
@@ -5,6 +5,7 @@ const {
   buildDashboardOverviewScheduleMock,
   buildSemesterCalendarPayloadMock,
   getDashboardOverviewLinksDataMock,
+  listSemesterCalendarTodosMock,
   listSubscribedHomeworksMock,
   resolveDashboardOverviewContextMock,
   resolveDashboardOverviewSectionScopeMock,
@@ -12,6 +13,7 @@ const {
   buildDashboardOverviewScheduleMock: vi.fn(),
   buildSemesterCalendarPayloadMock: vi.fn(),
   getDashboardOverviewLinksDataMock: vi.fn(),
+  listSemesterCalendarTodosMock: vi.fn(),
   listSubscribedHomeworksMock: vi.fn(),
   resolveDashboardOverviewContextMock: vi.fn(),
   resolveDashboardOverviewSectionScopeMock: vi.fn(),
@@ -21,9 +23,22 @@ vi.mock("@/features/subscriptions/server/subscription-read-model", () => ({
   listSubscribedHomeworks: listSubscribedHomeworksMock,
 }));
 
-vi.mock("@/features/dashboard/server/dashboard-overview-calendar", () => ({
-  buildSemesterCalendarPayload: buildSemesterCalendarPayloadMock,
-}));
+vi.mock("@/features/dashboard/server/dashboard-overview-calendar", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/features/dashboard/server/dashboard-overview-calendar")
+  >("@/features/dashboard/server/dashboard-overview-calendar");
+  return {
+    ...actual,
+    buildSemesterCalendarPayload: buildSemesterCalendarPayloadMock,
+  };
+});
+
+vi.mock(
+  "@/features/dashboard/server/dashboard-overview-semester-todos",
+  () => ({
+    listSemesterCalendarTodos: listSemesterCalendarTodosMock,
+  }),
+);
 
 vi.mock("@/features/dashboard/server/dashboard-overview-context", () => ({
   resolveDashboardOverviewContext: resolveDashboardOverviewContextMock,
@@ -92,6 +107,7 @@ describe("dashboard overview homework read", () => {
       pinnedLinks: [],
       recommendedLinks: [],
     });
+    listSemesterCalendarTodosMock.mockResolvedValue([]);
     buildDashboardOverviewScheduleMock.mockImplementation(() => ({
       calendarDays: [],
       calendarHomeworks: [],
@@ -107,13 +123,12 @@ describe("dashboard overview homework read", () => {
       weekDays: [],
       weeklySessions: [],
     }));
-    buildSemesterCalendarPayloadMock.mockResolvedValue({
+    buildSemesterCalendarPayloadMock.mockReturnValue({
       allExams: [],
       allSessions: [],
       semesterEnd: null,
       semesterHomeworks: [],
       semesterStart: null,
-      semesterTodos: [],
       semesterWeeks: [],
     });
   });
@@ -147,8 +162,60 @@ describe("dashboard overview homework read", () => {
     expect(buildSemesterCalendarPayloadMock).toHaveBeenCalledWith(
       expect.objectContaining({
         calendarHomeworks: [incompleteWithDue],
+        semesterTodos: [],
       }),
     );
+  });
+
+  it("starts links and semester todos before section scope completes", async () => {
+    let releaseSectionScope!: () => void;
+    const sectionScopeGate = new Promise<void>((resolve) => {
+      releaseSectionScope = resolve;
+    });
+    let linksStarted = false;
+    let semesterTodosStarted = false;
+
+    resolveDashboardOverviewSectionScopeMock.mockImplementation(async () => {
+      await sectionScopeGate;
+      return {
+        calendarSemesterNavList: [],
+        calendarSemesterPicker: [],
+        currentTermName: "—",
+        dashboardSections: [],
+        hasAnySelection: true,
+        hasCurrentTermSelection: true,
+        homeworkSectionIds: [12],
+        sectionsForCalendarGrid: [],
+      };
+    });
+    getDashboardOverviewLinksDataMock.mockImplementation(() => {
+      linksStarted = true;
+      return Promise.resolve({
+        dashboardLinks: [],
+        overviewLinks: [],
+        pinnedLinks: [],
+        recommendedLinks: [],
+      });
+    });
+    listSemesterCalendarTodosMock.mockImplementation(() => {
+      semesterTodosStarted = true;
+      return Promise.resolve([]);
+    });
+    listSubscribedHomeworksMock.mockResolvedValue([]);
+
+    const pending = getDashboardOverviewData("user-1", { locale: "en-us" });
+
+    await vi.waitFor(() => {
+      expect(linksStarted).toBe(true);
+      expect(semesterTodosStarted).toBe(true);
+    });
+    expect(resolveDashboardOverviewSectionScopeMock).toHaveBeenCalled();
+    expect(listSubscribedHomeworksMock).not.toHaveBeenCalled();
+
+    releaseSectionScope();
+    await pending;
+
+    expect(listSubscribedHomeworksMock).toHaveBeenCalledOnce();
   });
 
   it("builds the exact database union and excludes completed undated rows", () => {


### PR DESCRIPTION
## Summary
- Overlap dashboard overview reads that do not depend on each other: section scope, links, semester todos, and homework
- Hoist semester todo fetching out of `buildSemesterCalendarPayload` so it can run in parallel with section scope and links
- Add a unit test asserting independent reads start before section scope completes

## Test plan
- [x] `bunx biome check`
- [x] `bunx vitest run`
- [ ] CI green