### PR TITLE
perf(observability): attribute page SSR class and catalog detail tab

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -24,7 +24,11 @@ high-cardinality resource IDs.
   diagnosis.
 - Successful page completion logs are deterministically sampled at 10% in
   production while the full Analytics Engine datapoint remains unsampled. Responses
-  taking at least one second and all 4xx/5xx outcomes remain in logs. API
+  taking at least one second and all 4xx/5xx outcomes remain in logs. Page finish
+  and error logs and `page_request_v2` datapoints include low-cardinality route
+  attribution: normalized route id, `public-ssr` vs `dynamic-ssr` class, auth
+  signal presence (`present`/`absent`), and catalog detail tab when the route is a
+  course, section, or teacher detail page (`not_applicable` otherwise). API
   requests emit one finish or error event rather than a redundant start event.
 - Production API request metrics are written to Cloudflare Analytics Engine.
 - API request metrics live in `src/lib/log/api-observability-recording.ts`.

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -34,6 +34,11 @@ import {
   recordPageRequestFinish,
 } from "@/lib/metrics/page-observability";
 import {
+  classifyPageAuthSignalPresence,
+  classifyPageSsrClass,
+  resolvePageCatalogDetailTab,
+} from "@/lib/metrics/page-request-attribution";
+import {
   OAUTH_DEVICE_AUTHORIZATION_ENDPOINT_PATH,
   OAUTH_TOKEN_ENDPOINT_PATH,
 } from "@/lib/oauth/constants";
@@ -211,10 +216,20 @@ const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
     authIoObservedDurationMs,
     totalIoObservedDurationMs: Date.now() - startMs,
   });
+  const pageAttribution = () => ({
+    authSignalPresence: classifyPageAuthSignalPresence(hasAuthSignal),
+    catalogDetailTab: resolvePageCatalogDetailTab(
+      event.route.id,
+      event.url,
+      event.params,
+    ),
+    ssrClass: classifyPageSsrClass(event.locals.publicSsr),
+  });
   const recordPageFinish = (status: number, responseBytes?: number) => {
     if (apiObservability || pageObservationRecorded) return;
     pageObservationRecorded = true;
     recordPageRequestFinish({
+      attribution: pageAttribution(),
       authMode: pageAuthMode,
       locale,
       method: event.request.method,
@@ -229,6 +244,7 @@ const handleWithRuntimeEnv: Handle = async ({ event, resolve }) => {
     if (apiObservability || pageObservationRecorded) return;
     pageObservationRecorded = true;
     recordPageRequestError({
+      attribution: pageAttribution(),
       authMode: pageAuthMode,
       errorName: getSafeErrorName(error),
       locale,

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -18,12 +18,15 @@ type PageRequestAnalyticsInput = {
   appIoObservedDurationMs: number;
   authIoObservedDurationMs: number;
   authMode: "anonymous" | "authenticated";
+  authSignalPresence: "absent" | "present";
+  catalogDetailTab: string;
   event: "finish" | "error";
   ioObservedDurationMs: number;
   locale: string;
   method: string;
   responseBytes?: number;
   route: string;
+  ssrClass: "dynamic-ssr" | "public-ssr";
   status: number;
 };
 
@@ -239,6 +242,9 @@ export function writePageRequestAnalytics(input: PageRequestAnalyticsInput) {
       boundedValue(input.locale),
       input.authMode,
       hasResponseBytes ? "response_bytes_known" : "response_bytes_unknown",
+      input.ssrClass,
+      input.authSignalPresence,
+      boundedValue(input.catalogDetailTab),
     ],
     doubles: [
       input.ioObservedDurationMs,

--- a/src/lib/metrics/page-observability.ts
+++ b/src/lib/metrics/page-observability.ts
@@ -1,8 +1,19 @@
 import { logAppEvent } from "@/lib/log/app-logger";
 import { isProductionEnvironment } from "@/lib/log/app-logger-core";
 import { writePageRequestAnalytics } from "@/lib/metrics/analytics-engine";
+import type {
+  PageAuthSignalPresence,
+  PageCatalogDetailTab,
+  PageSsrClass,
+} from "@/lib/metrics/page-request-attribution";
 
 export type PageAuthMode = "anonymous" | "authenticated";
+
+type PageRequestAttribution = {
+  authSignalPresence: PageAuthSignalPresence;
+  catalogDetailTab: PageCatalogDetailTab;
+  ssrClass: PageSsrClass;
+};
 
 export type PageObservedTimings = {
   appIoObservedDurationMs: number;
@@ -20,6 +31,7 @@ function shouldLogSuccessfulPage(requestId: string) {
 }
 
 export function recordPageRequestFinish(input: {
+  attribution: PageRequestAttribution;
   authMode: PageAuthMode;
   locale: string;
   method: string;
@@ -38,6 +50,8 @@ export function recordPageRequestFinish(input: {
   ) {
     logAppEvent(input.status >= 500 ? "error" : "info", "page.request.finish", {
       authMode: input.authMode,
+      authSignalPresence: input.attribution.authSignalPresence,
+      catalogDetailTab: input.attribution.catalogDetailTab,
       event: "page.request.finish",
       ioObservedDurationMs: input.timings.totalIoObservedDurationMs,
       locale: input.locale,
@@ -46,6 +60,7 @@ export function recordPageRequestFinish(input: {
       responseBytes: input.responseBytes,
       route,
       source: "sveltekit",
+      ssrClass: input.attribution.ssrClass,
       status: input.status,
     });
   }
@@ -54,12 +69,15 @@ export function recordPageRequestFinish(input: {
     appIoObservedDurationMs: input.timings.appIoObservedDurationMs,
     authIoObservedDurationMs: input.timings.authIoObservedDurationMs,
     authMode: input.authMode,
+    authSignalPresence: input.attribution.authSignalPresence,
+    catalogDetailTab: input.attribution.catalogDetailTab,
     event: "finish",
     ioObservedDurationMs: input.timings.totalIoObservedDurationMs,
     locale: input.locale,
     method: input.method,
     responseBytes: input.responseBytes,
     route,
+    ssrClass: input.attribution.ssrClass,
     status: input.status,
   });
 }
@@ -77,6 +95,8 @@ export function recordPageRequestError(
 
   logAppEvent("error", "page.request.error", {
     authMode: input.authMode,
+    authSignalPresence: input.attribution.authSignalPresence,
+    catalogDetailTab: input.attribution.catalogDetailTab,
     errorName: input.errorName,
     event: "page.request.error",
     ioObservedDurationMs: input.timings.totalIoObservedDurationMs,
@@ -85,6 +105,7 @@ export function recordPageRequestError(
     requestId: input.requestId,
     route,
     source: "sveltekit",
+    ssrClass: input.attribution.ssrClass,
     status,
   });
 
@@ -92,11 +113,14 @@ export function recordPageRequestError(
     appIoObservedDurationMs: input.timings.appIoObservedDurationMs,
     authIoObservedDurationMs: input.timings.authIoObservedDurationMs,
     authMode: input.authMode,
+    authSignalPresence: input.attribution.authSignalPresence,
+    catalogDetailTab: input.attribution.catalogDetailTab,
     event: "error",
     ioObservedDurationMs: input.timings.totalIoObservedDurationMs,
     locale: input.locale,
     method: input.method,
     route,
+    ssrClass: input.attribution.ssrClass,
     status,
   });
 }

--- a/src/lib/metrics/page-request-attribution.ts
+++ b/src/lib/metrics/page-request-attribution.ts
@@ -1,0 +1,78 @@
+import {
+  parseSectionDetailTab,
+  SECTION_DETAIL_TAB_QUERY,
+} from "@/features/section-detail/lib/section-detail-tab";
+
+export type PageSsrClass = "dynamic-ssr" | "public-ssr";
+
+export type PageAuthSignalPresence = "absent" | "present";
+
+export type PageCatalogDetailTab =
+  | "calendar"
+  | "comments"
+  | "exams"
+  | "homework"
+  | "introduction"
+  | "not_applicable"
+  | "overview"
+  | "sections"
+  | "teachers";
+
+const COURSE_TEACHER_DETAIL_TABS = new Set([
+  "comments",
+  "introduction",
+  "overview",
+  "sections",
+]);
+
+const SECTION_DETAIL_ROUTE = "/catalog/sections/[jwId]";
+const COURSE_DETAIL_ROUTE = "/catalog/courses/[jwId]";
+const COURSE_DETAIL_SECTION_ROUTE = "/catalog/courses/[jwId]/[section]";
+const TEACHER_DETAIL_ROUTE = "/catalog/teachers/[id]";
+const TEACHER_DETAIL_SECTION_ROUTE = "/catalog/teachers/[id]/[section]";
+
+export function classifyPageSsrClass(publicSsr: boolean): PageSsrClass {
+  return publicSsr ? "public-ssr" : "dynamic-ssr";
+}
+
+export function classifyPageAuthSignalPresence(
+  hasAuthSignal: boolean,
+): PageAuthSignalPresence {
+  return hasAuthSignal ? "present" : "absent";
+}
+
+function resolveCourseTeacherDetailTab(
+  section: string | undefined,
+): PageCatalogDetailTab {
+  if (!section) return "overview";
+  return COURSE_TEACHER_DETAIL_TABS.has(section)
+    ? (section as PageCatalogDetailTab)
+    : "not_applicable";
+}
+
+export function resolvePageCatalogDetailTab(
+  routeId: string | null,
+  url: URL,
+  params: Record<string, string> = {},
+): PageCatalogDetailTab {
+  if (!routeId) return "not_applicable";
+
+  if (routeId === SECTION_DETAIL_ROUTE) {
+    return parseSectionDetailTab(
+      url.searchParams.get(SECTION_DETAIL_TAB_QUERY),
+    );
+  }
+
+  if (routeId === COURSE_DETAIL_ROUTE || routeId === TEACHER_DETAIL_ROUTE) {
+    return "overview";
+  }
+
+  if (
+    routeId === COURSE_DETAIL_SECTION_ROUTE ||
+    routeId === TEACHER_DETAIL_SECTION_ROUTE
+  ) {
+    return resolveCourseTeacherDetailTab(params.section);
+  }
+
+  return "not_applicable";
+}

--- a/tests/unit/page-observability.test.ts
+++ b/tests/unit/page-observability.test.ts
@@ -18,6 +18,11 @@ describe("页面性能可观测性", () => {
     setCloudflareRuntimeEnv({ ANALYTICS: { writeDataPoint } });
 
     recordPageRequestFinish({
+      attribution: {
+        authSignalPresence: "present",
+        catalogDetailTab: "not_applicable",
+        ssrClass: "dynamic-ssr",
+      },
       authMode: "authenticated",
       locale: "zh-cn",
       method: "GET",
@@ -44,6 +49,9 @@ describe("页面性能可观测性", () => {
         "zh-cn",
         "authenticated",
         "response_bytes_known",
+        "dynamic-ssr",
+        "present",
+        "not_applicable",
       ],
       doubles: [95, 200, 12345, 12, 80],
     });
@@ -58,6 +66,11 @@ describe("页面性能可观测性", () => {
     setCloudflareRuntimeEnv({ ANALYTICS: { writeDataPoint } });
 
     recordPageRequestFinish({
+      attribution: {
+        authSignalPresence: "absent",
+        catalogDetailTab: "not_applicable",
+        ssrClass: "dynamic-ssr",
+      },
       authMode: "anonymous",
       locale: "en-us",
       method: "GET",
@@ -83,6 +96,9 @@ describe("页面性能可观测性", () => {
         "en-us",
         "anonymous",
         "response_bytes_unknown",
+        "dynamic-ssr",
+        "absent",
+        "not_applicable",
       ],
       doubles: [6, 404, 0, 0, 5],
     });
@@ -95,6 +111,11 @@ describe("页面性能可观测性", () => {
     setCloudflareRuntimeEnv({ ANALYTICS: { writeDataPoint } });
 
     recordPageRequestFinish({
+      attribution: {
+        authSignalPresence: "absent",
+        catalogDetailTab: "not_applicable",
+        ssrClass: "dynamic-ssr",
+      },
       authMode: "anonymous",
       locale: "zh-cn",
       method: "GET",
@@ -124,6 +145,11 @@ describe("页面性能可观测性", () => {
 
     expect(() =>
       recordPageRequestFinish({
+        attribution: {
+          authSignalPresence: "absent",
+          catalogDetailTab: "not_applicable",
+          ssrClass: "dynamic-ssr",
+        },
         authMode: "anonymous",
         locale: "zh-cn",
         method: "GET",
@@ -143,6 +169,11 @@ describe("页面性能可观测性", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
 
     recordPageRequestFinish({
+      attribution: {
+        authSignalPresence: "absent",
+        catalogDetailTab: "not_applicable",
+        ssrClass: "dynamic-ssr",
+      },
       authMode: "anonymous",
       locale: "zh-cn",
       method: "POST",
@@ -172,6 +203,11 @@ describe("页面性能可观测性", () => {
     setCloudflareRuntimeEnv({ ANALYTICS: { writeDataPoint } });
 
     recordPageRequestError({
+      attribution: {
+        authSignalPresence: "present",
+        catalogDetailTab: "not_applicable",
+        ssrClass: "dynamic-ssr",
+      },
       authMode: "authenticated",
       errorName: "TypeError",
       locale: "en-us",

--- a/tests/unit/page-request-attribution.test.ts
+++ b/tests/unit/page-request-attribution.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyPageAuthSignalPresence,
+  classifyPageSsrClass,
+  resolvePageCatalogDetailTab,
+} from "@/lib/metrics/page-request-attribution";
+
+describe("page request attribution", () => {
+  it("classifies public-ssr vs dynamic-ssr from the hook publicSsr marker", () => {
+    expect(classifyPageSsrClass(true)).toBe("public-ssr");
+    expect(classifyPageSsrClass(false)).toBe("dynamic-ssr");
+  });
+
+  it("classifies auth signal presence without session resolution", () => {
+    expect(classifyPageAuthSignalPresence(true)).toBe("present");
+    expect(classifyPageAuthSignalPresence(false)).toBe("absent");
+  });
+
+  it("resolves section detail tabs from the canonical query param only", () => {
+    const url = new URL(
+      "https://life.example/catalog/sections/12345?tab=calendar",
+    );
+
+    expect(resolvePageCatalogDetailTab("/catalog/sections/[jwId]", url)).toBe(
+      "calendar",
+    );
+    expect(
+      resolvePageCatalogDetailTab("/catalog/sections/[jwId]", url, {
+        section: "introduction",
+      }),
+    ).toBe("calendar");
+  });
+
+  it("defaults section and course detail routes without tabs to overview", () => {
+    expect(
+      resolvePageCatalogDetailTab(
+        "/catalog/sections/[jwId]",
+        new URL("https://life.example/catalog/sections/12345"),
+      ),
+    ).toBe("overview");
+    expect(
+      resolvePageCatalogDetailTab(
+        "/catalog/courses/[jwId]",
+        new URL("https://life.example/catalog/courses/42"),
+      ),
+    ).toBe("overview");
+    expect(
+      resolvePageCatalogDetailTab(
+        "/catalog/teachers/[id]",
+        new URL("https://life.example/catalog/teachers/7"),
+      ),
+    ).toBe("overview");
+  });
+
+  it("resolves course and teacher detail tabs from route params", () => {
+    expect(
+      resolvePageCatalogDetailTab(
+        "/catalog/courses/[jwId]/[section]",
+        new URL("https://life.example/catalog/courses/42/comments"),
+        { section: "comments" },
+      ),
+    ).toBe("comments");
+    expect(
+      resolvePageCatalogDetailTab(
+        "/catalog/teachers/[id]/[section]",
+        new URL("https://life.example/catalog/teachers/7/sections"),
+        { section: "sections" },
+      ),
+    ).toBe("sections");
+  });
+
+  it("returns not_applicable for non-catalog detail routes", () => {
+    expect(
+      resolvePageCatalogDetailTab(
+        "/workspace",
+        new URL("https://life.example/workspace"),
+      ),
+    ).toBe("not_applicable");
+    expect(
+      resolvePageCatalogDetailTab(null, new URL("https://life.example/")),
+    ).toBe("not_applicable");
+  });
+});


### PR DESCRIPTION
## Summary
- Extend `page_request_v2` Analytics Engine datapoints and sampled page logs with low-cardinality route attribution: `ssrClass` (`public-ssr` / `dynamic-ssr`), `authSignalPresence` (`present` / `absent`), and `catalogDetailTab` (fixed tab enum or `not_applicable`).
- Add `page-request-attribution` helpers with unit tests; wire attribution through `hooks.server.ts` without recording entity IDs or query values.
- Document the new fields in `docs/observability.md`.

Closes #530

## Test plan
- [x] `bunx biome check` on changed files
- [x] `bunx vitest run` (1865 tests)
- [ ] Post-merge: correlate Worker `exceededResources` / tail latency with `ssrClass`, route id, and catalog detail tab in Analytics Engine