### PR TITLE
test(e2e): make clean full-suite runs match sharded CI

### DIFF
--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -147,6 +147,7 @@ jobs:
             ci:verify)
               bash tests/ci/retry.test.sh
               bash tests/ci/seed-guard.test.sh
+              bash tests/ci/e2e-full-suite-parity.test.sh
               bun run app:prepare
               bunx wrangler types --include-runtime=false --check
               bunx biome check

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "db:migrate:deploy": "prisma migrate deploy",
     "static:load": "bun run src/static-loader/cli.ts",
     "e2e:server": "wrangler dev --config wrangler.e2e.jsonc --ip 127.0.0.1 --port 3000 --local",
-    "e2e:test": "playwright test",
+    "e2e:test": "bash tests/ci/e2e-full-suite-parity.sh",
     "e2e:test:shard1": "playwright test --shard=1/4",
     "e2e:test:shard2": "playwright test --shard=2/4",
     "e2e:test:shard3": "playwright test --shard=3/4",

--- a/tests/ci/e2e-full-suite-parity.sh
+++ b/tests/ci/e2e-full-suite-parity.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Run the complete E2E suite with the same per-shard database lifecycle as CI.
+#
+# CI runs four independent jobs. Each job migrates, seeds, and executes one
+# Playwright shard against a fresh database. A single unsharded `playwright test`
+# invocation reuses one seed across all files and projects, so shared-state
+# mutations from earlier shards leak into later ones.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+readonly E2E_SHARD_TOTAL=4
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "DATABASE_URL must be set for E2E database lifecycle." >&2
+  exit 1
+fi
+
+if [[ "${ALLOW_DATABASE_SEED:-}" != "true" ]]; then
+  echo "Set ALLOW_DATABASE_SEED=true before reseeding for each shard." >&2
+  exit 1
+fi
+
+bun run app:prepare
+bun run build
+
+failed_shards=()
+
+for shard in $(seq 1 "$E2E_SHARD_TOTAL"); do
+  echo "=== E2E shard ${shard}/${E2E_SHARD_TOTAL} ==="
+  bun run app:prepare
+  bun run db:migrate:deploy
+  bunx prisma db seed
+  if ! bunx playwright test --shard="${shard}/${E2E_SHARD_TOTAL}"; then
+    failed_shards+=("${shard}/${E2E_SHARD_TOTAL}")
+  fi
+done
+
+if ((${#failed_shards[@]} > 0)); then
+  echo "E2E full-suite parity failed for shard(s): ${failed_shards[*]}" >&2
+  exit 1
+fi
+
+echo "E2E full-suite parity passed for all ${E2E_SHARD_TOTAL} shards."

--- a/tests/ci/e2e-full-suite-parity.test.sh
+++ b/tests/ci/e2e-full-suite-parity.test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail() {
+  echo "e2e full-suite parity guard failed: $*" >&2
+  exit 1
+}
+
+orchestration_script="${repo_root}/tests/ci/e2e-full-suite-parity.sh"
+test -x "$orchestration_script" ||
+  fail "missing executable ${orchestration_script}"
+
+grep -q 'readonly E2E_SHARD_TOTAL=4' "$orchestration_script" ||
+  fail "orchestration script must declare E2E_SHARD_TOTAL=4"
+
+ci_shard_count="$(
+  grep -Eo 'shard: [0-9]+/4' "${repo_root}/.github/workflows/ci.yml" | wc -l | tr -d ' '
+)"
+[[ "$ci_shard_count" == "4" ]] ||
+  fail "ci.yml defines ${ci_shard_count} E2E shards, expected 4"
+
+for shard in 1 2 3 4; do
+  grep -q "\"e2e:test:shard${shard}\": \"playwright test --shard=${shard}/4\"" \
+    "${repo_root}/package.json" ||
+    fail "package.json is missing e2e:test:shard${shard}"
+done
+
+grep -q '"e2e:test": "bash tests/ci/e2e-full-suite-parity.sh"' \
+  "${repo_root}/package.json" ||
+  fail 'package.json e2e:test must invoke tests/ci/e2e-full-suite-parity.sh'
+
+grep -q 'bun run db:migrate:deploy' "$orchestration_script" ||
+  fail "orchestration script must migrate before each shard"
+grep -q 'bunx prisma db seed' "$orchestration_script" ||
+  fail "orchestration script must seed before each shard"
+grep -q 'bunx playwright test --shard=' "$orchestration_script" ||
+  fail "orchestration script must run sharded Playwright"
+
+job_phase_script="${repo_root}/.github/workflows/db-backed-bun-job.yml"
+grep -q 'bun run db:migrate:deploy' "$job_phase_script" ||
+  fail "db-backed-bun-job.yml must migrate before E2E shards"
+grep -q 'bunx prisma db seed' "$job_phase_script" ||
+  fail "db-backed-bun-job.yml must seed before E2E shards"
+grep -q 'bunx playwright test --shard="\$E2E_SHARD"' "$job_phase_script" ||
+  fail "db-backed-bun-job.yml must run sharded Playwright"
+
+echo "e2e full-suite parity guard passed"

--- a/tests/ci/e2e-full-suite-parity.test.sh
+++ b/tests/ci/e2e-full-suite-parity.test.sh
@@ -9,14 +9,14 @@ fail() {
 }
 
 orchestration_script="${repo_root}/tests/ci/e2e-full-suite-parity.sh"
-test -x "$orchestration_script" ||
-  fail "missing executable ${orchestration_script}"
+test -f "$orchestration_script" ||
+  fail "missing ${orchestration_script}"
 
 grep -q 'readonly E2E_SHARD_TOTAL=4' "$orchestration_script" ||
   fail "orchestration script must declare E2E_SHARD_TOTAL=4"
 
 ci_shard_count="$(
-  grep -Eo 'shard: [0-9]+/4' "${repo_root}/.github/workflows/ci.yml" | wc -l | tr -d ' '
+  grep -cE 'shard: [0-9]+/4' "${repo_root}/.github/workflows/ci.yml" || true
 )"
 [[ "$ci_shard_count" == "4" ]] ||
   fail "ci.yml defines ${ci_shard_count} E2E shards, expected 4"

--- a/tests/e2e/AGENTS.md
+++ b/tests/e2e/AGENTS.md
@@ -91,7 +91,12 @@ await page.waitForTimeout(1000); // rejected by $life-ustc-dev-loop checks
 
 ## Concurrency
 
-The canonical Playwright run uses one worker because multiple files mutate the
+The canonical full-suite command is `bun run e2e:test`, which runs four CI
+shards sequentially and reseeds the database before each shard. Do not use a
+single unsharded `playwright test` invocation as a release gate; it reuses one
+seed across all files and projects while CI gives each shard a fresh database.
+
+Within a shard, Playwright uses one worker because multiple files mutate the
 same seeded debug user. Files with shared-state mutations also use
 `test.describe.configure({ mode: "serial" })` to make the dependency explicit.
 Current examples:

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -72,7 +72,7 @@ CI sets `DATABASE_URL`, seeds data, and runs migrations before each E2E shard. F
 
 ## Reporting
 
-- Per-shard HTML reports (local full suite): `playwright-report/html/`
+- HTML reporter output (local full suite): `playwright-report/html/` — each shard overwrites the same folder, so only the last shard's HTML remains unless you archive between runs.
 - Per-shard raw results: `playwright-report/e2e-results/`
 - CI uploads blob reports per shard; merge them via the `Publish E2E HTML report` workflow when debugging shard-only failures.
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -4,26 +4,46 @@ Playwright specs live under `tests/e2e/src`. CI runs them in four shards to stay
 
 ## Match CI locally
 
-Start the E2E worker (in a separate terminal):
+Prerequisites:
+
+- PostgreSQL available at `DATABASE_URL` (see root README)
+- Migrations applied at least once
+- `ALLOW_DATABASE_SEED=true` in your environment
+
+Start from a clean database when validating the complete suite:
 
 ```bash
-bun run e2e:server
+bun run app:prepare
+bun run db:migrate:deploy
+ALLOW_DATABASE_SEED=true bunx prisma db seed
+ALLOW_DATABASE_SEED=true bun run build
+ALLOW_DATABASE_SEED=true bun run e2e:test
 ```
 
-Run one shard (same as CI `E2E_SHARD=current/total`):
+`bun run e2e:test` is the canonical full-suite command. It runs the same four shards as GitHub Actions and **reseeds the database before each shard**, which matches CI's per-job lifecycle. A single unsharded `bunx playwright test` reuses one seed across all files and projects; several specs mutate the shared debug user, todos, OAuth clients, and homework fixtures, so that command is not equivalent to CI and may fail even when all shards pass.
+
+Run one shard manually (same as CI `E2E_SHARD=current/total`):
 
 ```bash
+bun run app:prepare
+bun run db:migrate:deploy
+ALLOW_DATABASE_SEED=true bunx prisma db seed
 bunx playwright test --shard=1/4
 bunx playwright test --shard=2/4
 bunx playwright test --shard=3/4
 bunx playwright test --shard=4/4
 ```
 
-Run the full suite sequentially (slower, closer to a release smoke check):
+Or use the package aliases:
 
 ```bash
-bun run e2e:test
+bun run e2e:test:shard1
+bun run e2e:test:shard2
+bun run e2e:test:shard3
+bun run e2e:test:shard4
 ```
+
+For a focused local run after setup, `bunx playwright test <path>` is fine. Playwright starts the E2E server automatically via `bun run e2e:server` unless you start it yourself in another terminal.
 
 ## Visual regression matrix
 
@@ -48,8 +68,12 @@ Deterministic setup uses `NEXT_LOCALE` cookies, `life-ustc-theme=light` in `loca
 
 ## Environment
 
-CI sets `DATABASE_URL`, seeds data, and runs migrations before E2E. For local runs, use the same `.env` values documented in the root README and ensure migrations are applied.
+CI sets `DATABASE_URL`, seeds data, and runs migrations before each E2E shard. For local runs, use the same `.env` values documented in the root README and ensure migrations are applied.
 
 ## Reporting
 
-Failed CI shards upload Playwright HTML reports. Merge them via the `Publish E2E HTML report` workflow when debugging shard-only failures.
+- Per-shard HTML reports (local full suite): `playwright-report/html/`
+- Per-shard raw results: `playwright-report/e2e-results/`
+- CI uploads blob reports per shard; merge them via the `Publish E2E HTML report` workflow when debugging shard-only failures.
+
+Remove local `playwright-report/` output before committing unless you are attaching artifacts for debugging.

--- a/tests/unit/e2e-full-suite-parity.test.ts
+++ b/tests/unit/e2e-full-suite-parity.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+
+describe("E2E full-suite parity orchestration", () => {
+  test("package.json routes e2e:test through the CI-parity script", () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(repoRoot, "package.json"), "utf8"),
+    ) as { scripts: Record<string, string> };
+
+    expect(packageJson.scripts["e2e:test"]).toBe(
+      "bash tests/ci/e2e-full-suite-parity.sh",
+    );
+    expect(packageJson.scripts["e2e:test:shard4"]).toBe(
+      "playwright test --shard=4/4",
+    );
+  });
+
+  test("orchestration script reseeds before each shard", () => {
+    const script = readFileSync(
+      resolve(repoRoot, "tests/ci/e2e-full-suite-parity.sh"),
+      "utf8",
+    );
+
+    expect(script).toContain("readonly E2E_SHARD_TOTAL=4");
+    expect(script).toContain("bun run db:migrate:deploy");
+    expect(script).toContain("bunx prisma db seed");
+    expect(script).toContain("bunx playwright test --shard=");
+    expect(script).toContain("E2E_SHARD_TOTAL");
+  });
+});


### PR DESCRIPTION
## Summary
- Route `bun run e2e:test` through `tests/ci/e2e-full-suite-parity.sh`, which migrates and reseeds the database before each of the four Playwright shards (matching GitHub Actions).
- Add CI drift guards (`tests/ci/e2e-full-suite-parity.test.sh` + unit test) so the orchestration cannot silently diverge from `.github/workflows/ci.yml`.
- Document the reproducible clean-database full-suite command and clarify that unsharded `bunx playwright test` is not CI-equivalent.

## Root cause
CI runs four independent E2E jobs; each job gets a fresh database seed before its shard. A single local `playwright test` invocation reuses one seed across all files and projects, so shared-state mutations (debug user profile, todos, OAuth clients, homework fixtures) from earlier tests leak into later ones. That produced ~53 failures locally while every CI shard passed.

## Test plan
- [x] `bash tests/ci/e2e-full-suite-parity.test.sh`
- [x] `bun run app:prepare`
- [x] `bunx biome check`
- [x] `bunx svelte-check --tsconfig ./tsconfig.json`
- [x] `bunx tsc --noEmit -p tsconfig.typecheck.json`
- [x] `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- [x] `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- [x] `bunx vitest run`
- [ ] `ALLOW_DATABASE_SEED=true bun run e2e:test` (in progress locally)

Fixes #608