### PR TITLE
test(nav): guard hover-only code preload policy

### DIFF
--- a/src/lib/components/AGENTS.md
+++ b/src/lib/components/AGENTS.md
@@ -4,6 +4,12 @@ Shared UI primitives and layout components.
 
 ## Rules
 
+- Client navigation follows `docs/rendering-and-cache.md`: `src/app.html` sets
+  `data-sveltekit-preload-code="hover"` and `data-sveltekit-preload-data="tap"`.
+  Hover may warm route code only; `__data.json` preload waits for tap/click
+  intent. `DetailSectionNav` links use `data-sveltekit-preload-data="off"`
+  because tab switches are handled client-side or should not prefetch sibling
+  tabs on pointer hover.
 - Keep components feature-neutral: no route data loading, mutations, or feature-owned state machines.
 - Feature-specific UI stays under `src/features/<feature>/components`.
 - Prefer the local UI wrapper components here over direct primitive-library usage in feature code.

--- a/tests/e2e/src/app/courses/[jwId]/test.ts
+++ b/tests/e2e/src/app/courses/[jwId]/test.ts
@@ -219,6 +219,9 @@ test.describe("/catalog/courses/[jwId] 课程详情", () => {
     await expect(
       nav.getByRole("link", { name: /评论|Comments/i }),
     ).toBeVisible();
+    await expect(
+      nav.getByRole("link", { name: /简介|Description/i }),
+    ).toHaveAttribute("data-sveltekit-preload-data", "off");
 
     await jumpToCourseSection(page, /评论|Comments/i, "#course-comments");
     await expect(page).toHaveURL(/\/catalog\/courses\/\d+\/comments$/);

--- a/tests/e2e/src/app/courses/[jwId]/test.ts
+++ b/tests/e2e/src/app/courses/[jwId]/test.ts
@@ -219,10 +219,9 @@ test.describe("/catalog/courses/[jwId] 课程详情", () => {
     await expect(
       nav.getByRole("link", { name: /评论|Comments/i }),
     ).toBeVisible();
-    await expect(nav.locator("a[href]")).toHaveAttribute(
-      "data-sveltekit-preload-data",
-      "off",
-    );
+    await expect(
+      nav.getByRole("link", { name: /班级|Sections/i }),
+    ).toHaveAttribute("data-sveltekit-preload-data", "off");
 
     await jumpToCourseSection(page, /评论|Comments/i, "#course-comments");
     await expect(page).toHaveURL(/\/catalog\/courses\/\d+\/comments$/);

--- a/tests/e2e/src/app/courses/[jwId]/test.ts
+++ b/tests/e2e/src/app/courses/[jwId]/test.ts
@@ -219,9 +219,10 @@ test.describe("/catalog/courses/[jwId] 课程详情", () => {
     await expect(
       nav.getByRole("link", { name: /评论|Comments/i }),
     ).toBeVisible();
-    await expect(
-      nav.getByRole("link", { name: /简介|Description/i }),
-    ).toHaveAttribute("data-sveltekit-preload-data", "off");
+    await expect(nav.locator("a[href]")).toHaveAttribute(
+      "data-sveltekit-preload-data",
+      "off",
+    );
 
     await jumpToCourseSection(page, /评论|Comments/i, "#course-comments");
     await expect(page).toHaveURL(/\/catalog\/courses\/\d+\/comments$/);

--- a/tests/e2e/src/app/courses/test.ts
+++ b/tests/e2e/src/app/courses/test.ts
@@ -60,9 +60,14 @@ test.describe("/catalog/courses 课程目录", () => {
   });
 
   test("目录链接悬停时不预取 __data.json", async ({ page }) => {
-    await gotoAndWaitForReady(page, "/catalog/courses");
+    await gotoAndWaitForReady(
+      page,
+      `/catalog/courses?search=${encodeURIComponent(DEV_SEED.course.code)}`,
+    );
     const courseLink = page
-      .locator(`a[href="/catalog/courses/${DEV_SEED.course.jwId}"]`)
+      .locator(
+        `#main-content a[href="/catalog/courses/${DEV_SEED.course.jwId}"]:visible`,
+      )
       .first();
     await expect(courseLink).toBeVisible();
 

--- a/tests/e2e/src/app/courses/test.ts
+++ b/tests/e2e/src/app/courses/test.ts
@@ -59,6 +59,29 @@ test.describe("/catalog/courses 课程目录", () => {
     expect(html).toContain(DEV_SEED.course.code);
   });
 
+  test("目录链接悬停时不预取 __data.json", async ({ page }) => {
+    const dataJsonRequests: string[] = [];
+    page.on("request", (request) => {
+      if (request.url().includes("__data.json")) {
+        dataJsonRequests.push(request.url());
+      }
+    });
+
+    await gotoAndWaitForReady(page, "/catalog/courses");
+    const courseLink = page
+      .locator(`a[href="/catalog/courses/${DEV_SEED.course.jwId}"]`)
+      .first();
+    await expect(courseLink).toBeVisible();
+    await courseLink.hover();
+
+    await expect(
+      page.waitForRequest((request) => request.url().includes("__data.json"), {
+        timeout: 750,
+      }),
+    ).rejects.toThrow();
+    expect(dataJsonRequests).toEqual([]);
+  });
+
   test("语言切换正常工作", async ({ page, baseURL }, testInfo) => {
     await gotoAndWaitForReady(page, "/catalog/courses", {
       testInfo,

--- a/tests/e2e/src/app/courses/test.ts
+++ b/tests/e2e/src/app/courses/test.ts
@@ -60,26 +60,21 @@ test.describe("/catalog/courses 课程目录", () => {
   });
 
   test("目录链接悬停时不预取 __data.json", async ({ page }) => {
-    const dataJsonRequests: string[] = [];
-    page.on("request", (request) => {
-      if (request.url().includes("__data.json")) {
-        dataJsonRequests.push(request.url());
-      }
-    });
-
     await gotoAndWaitForReady(page, "/catalog/courses");
     const courseLink = page
       .locator(`a[href="/catalog/courses/${DEV_SEED.course.jwId}"]`)
       .first();
     await expect(courseLink).toBeVisible();
-    await courseLink.hover();
 
-    await expect(
-      page.waitForRequest((request) => request.url().includes("__data.json"), {
+    const dataJsonDuringHover = page
+      .waitForRequest((request) => request.url().includes("__data.json"), {
         timeout: 750,
-      }),
-    ).rejects.toThrow();
-    expect(dataJsonRequests).toEqual([]);
+      })
+      .then(() => true)
+      .catch(() => false);
+
+    await courseLink.hover();
+    expect(await dataJsonDuringHover).toBe(false);
   });
 
   test("语言切换正常工作", async ({ page, baseURL }, testInfo) => {

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -446,9 +446,10 @@ test.describe("/catalog/sections/[jwId] 班级详情页", () => {
     await expect(
       nav.getByRole("link", { name: /评论|Comments/i }),
     ).toBeVisible();
-    await expect(
-      nav.getByRole("link", { name: /日历|Calendar/i }),
-    ).toHaveAttribute("data-sveltekit-preload-data", "off");
+    await expect(nav.locator("a[href]")).toHaveAttribute(
+      "data-sveltekit-preload-data",
+      "off",
+    );
 
     await jumpToSection(page, /作业|Homework/i, "#tab-homework");
     await expect(page).toHaveURL(/\/catalog\/sections\/\d+\?tab=homework$/);

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -446,10 +446,9 @@ test.describe("/catalog/sections/[jwId] 班级详情页", () => {
     await expect(
       nav.getByRole("link", { name: /评论|Comments/i }),
     ).toBeVisible();
-    await expect(nav.locator("a[href]")).toHaveAttribute(
-      "data-sveltekit-preload-data",
-      "off",
-    );
+    await expect(
+      nav.getByRole("link", { name: /日历|Calendar/i }),
+    ).toHaveAttribute("data-sveltekit-preload-data", "off");
 
     await jumpToSection(page, /作业|Homework/i, "#tab-homework");
     await expect(page).toHaveURL(/\/catalog\/sections\/\d+\?tab=homework$/);

--- a/tests/e2e/src/app/teachers/[id]/test.ts
+++ b/tests/e2e/src/app/teachers/[id]/test.ts
@@ -211,9 +211,10 @@ test.describe("/catalog/teachers/[id] 教师详情页", () => {
     await expect(
       nav.getByRole("link", { name: /评论|Comments/i }),
     ).toBeVisible();
-    await expect(
-      nav.getByRole("link", { name: /简介|Description/i }),
-    ).toHaveAttribute("data-sveltekit-preload-data", "off");
+    await expect(nav.locator("a[href]")).toHaveAttribute(
+      "data-sveltekit-preload-data",
+      "off",
+    );
 
     await jumpToTeacherSection(page, /评论|Comments/i, "#teacher-comments");
     await expect(page).toHaveURL(/\/catalog\/teachers\/\d+\/comments$/);

--- a/tests/e2e/src/app/teachers/[id]/test.ts
+++ b/tests/e2e/src/app/teachers/[id]/test.ts
@@ -211,10 +211,9 @@ test.describe("/catalog/teachers/[id] 教师详情页", () => {
     await expect(
       nav.getByRole("link", { name: /评论|Comments/i }),
     ).toBeVisible();
-    await expect(nav.locator("a[href]")).toHaveAttribute(
-      "data-sveltekit-preload-data",
-      "off",
-    );
+    await expect(
+      nav.getByRole("link", { name: /授课班级|Teaching Sections/i }),
+    ).toHaveAttribute("data-sveltekit-preload-data", "off");
 
     await jumpToTeacherSection(page, /评论|Comments/i, "#teacher-comments");
     await expect(page).toHaveURL(/\/catalog\/teachers\/\d+\/comments$/);

--- a/tests/e2e/src/app/teachers/[id]/test.ts
+++ b/tests/e2e/src/app/teachers/[id]/test.ts
@@ -211,6 +211,9 @@ test.describe("/catalog/teachers/[id] 教师详情页", () => {
     await expect(
       nav.getByRole("link", { name: /评论|Comments/i }),
     ).toBeVisible();
+    await expect(
+      nav.getByRole("link", { name: /简介|Description/i }),
+    ).toHaveAttribute("data-sveltekit-preload-data", "off");
 
     await jumpToTeacherSection(page, /评论|Comments/i, "#teacher-comments");
     await expect(page).toHaveURL(/\/catalog\/teachers\/\d+\/comments$/);

--- a/tests/unit/navigation-preload-policy.test.ts
+++ b/tests/unit/navigation-preload-policy.test.ts
@@ -10,8 +10,16 @@ const repoRoot = path.resolve(
 
 const sourceRoots = ["src"];
 
-const hoverDataPreloadPattern =
-  /data-sveltekit-preload-data\s*=\s*(?:"hover"|'hover'|""|''|{[^}]*hover[^}]*})/;
+const hoverLiteralPattern =
+  /data-sveltekit-preload-data\s*=\s*(?:"hover"|'hover'|\{\s*["']hover["']\s*\})/;
+const hoverBooleanAttributePattern =
+  /data-sveltekit-preload-data(?=[\s/>])(?!\s*=)/;
+
+function hasHoverDataPreload(source: string): boolean {
+  return (
+    hoverLiteralPattern.test(source) || hoverBooleanAttributePattern.test(source)
+  );
+}
 
 async function collectSourceFiles(directory: string): Promise<string[]> {
   const entries = await readdir(directory, { withFileTypes: true });
@@ -37,7 +45,7 @@ describe("navigation preload policy", () => {
 
     expect(appHtml).toMatch(/data-sveltekit-preload-code\s*=\s*["']hover["']/);
     expect(appHtml).toMatch(/data-sveltekit-preload-data\s*=\s*["']tap["']/);
-    expect(appHtml).not.toMatch(hoverDataPreloadPattern);
+    expect(hasHoverDataPreload(appHtml)).toBe(false);
   });
 
   it("disables SvelteKit data preload on detail section nav links", async () => {
@@ -56,7 +64,7 @@ describe("navigation preload policy", () => {
       const files = await collectSourceFiles(path.join(repoRoot, root));
       for (const file of files) {
         const source = await readFile(file, "utf8");
-        if (!hoverDataPreloadPattern.test(source)) continue;
+        if (!hasHoverDataPreload(source)) continue;
         violations.push(path.relative(repoRoot, file));
       }
     }

--- a/tests/unit/navigation-preload-policy.test.ts
+++ b/tests/unit/navigation-preload-policy.test.ts
@@ -17,7 +17,8 @@ const hoverBooleanAttributePattern =
 
 function hasHoverDataPreload(source: string): boolean {
   return (
-    hoverLiteralPattern.test(source) || hoverBooleanAttributePattern.test(source)
+    hoverLiteralPattern.test(source) ||
+    hoverBooleanAttributePattern.test(source)
   );
 }
 

--- a/tests/unit/navigation-preload-policy.test.ts
+++ b/tests/unit/navigation-preload-policy.test.ts
@@ -1,0 +1,66 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+const sourceRoots = ["src"];
+
+const hoverDataPreloadPattern =
+  /data-sveltekit-preload-data\s*=\s*(?:"hover"|'hover'|""|''|{[^}]*hover[^}]*})/;
+
+async function collectSourceFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectSourceFiles(fullPath)));
+      continue;
+    }
+    if (entry.name.endsWith(".svelte") || entry.name.endsWith(".html")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+describe("navigation preload policy", () => {
+  it("sets global code hover and data tap defaults in app.html", async () => {
+    const appHtml = await readFile(path.join(repoRoot, "src/app.html"), "utf8");
+
+    expect(appHtml).toMatch(/data-sveltekit-preload-code\s*=\s*["']hover["']/);
+    expect(appHtml).toMatch(/data-sveltekit-preload-data\s*=\s*["']tap["']/);
+    expect(appHtml).not.toMatch(hoverDataPreloadPattern);
+  });
+
+  it("disables SvelteKit data preload on detail section nav links", async () => {
+    const detailNav = await readFile(
+      path.join(repoRoot, "src/lib/components/DetailSectionNav.svelte"),
+      "utf8",
+    );
+
+    expect(detailNav).toContain('data-sveltekit-preload-data="off"');
+  });
+
+  it("does not opt links back into hover data preload", async () => {
+    const violations: string[] = [];
+
+    for (const root of sourceRoots) {
+      const files = await collectSourceFiles(path.join(repoRoot, root));
+      for (const file of files) {
+        const source = await readFile(file, "utf8");
+        if (!hoverDataPreloadPattern.test(source)) continue;
+        violations.push(path.relative(repoRoot, file));
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Audited preload/prefetch usage across AppShell, catalog links, and detail nav against `docs/rendering-and-cache.md`.
- No runtime violations on `origin/main`: global defaults are `preload-code=hover` + `preload-data=tap`, and `DetailSectionNav` keeps tab links at `preload-data=off`.
- Added unit + e2e guardrails so hover cannot regress to uncached `__data.json` preloads.

## Test plan
- [x] `bunx biome check` on touched files
- [x] `bunx vitest run tests/unit/navigation-preload-policy.test.ts`
- [ ] CI