### PR TITLE
refactor(search): share global search client controller

### DIFF
--- a/src/features/search/lib/global-search-controller.ts
+++ b/src/features/search/lib/global-search-controller.ts
@@ -1,0 +1,331 @@
+import { derived, get, type Readable, writable } from "svelte/store";
+import {
+  fetchGlobalSearch,
+  GLOBAL_SEARCH_DEBOUNCE_MS,
+  GLOBAL_SEARCH_MIN_QUERY_LENGTH,
+} from "@/features/search/lib/global-search-client";
+import {
+  activeItemIdFromIndex,
+  flattenSearchGroups,
+  handleSearchListboxKeydown,
+} from "@/features/search/lib/global-search-keyboard";
+import type {
+  GlobalSearchResultGroup,
+  GlobalSearchResultItem,
+} from "@/features/search/server/global-search-types";
+
+export type GlobalSearchUrlSyncOptions = {
+  getPageUrl: () => URL;
+  goto: (
+    href: string,
+    options?: {
+      keepFocus?: boolean;
+      noScroll?: boolean;
+      replaceState?: boolean;
+    },
+  ) => Promise<void>;
+};
+
+export type GlobalSearchControllerOptions = {
+  limit: number;
+  urlSync?: GlobalSearchUrlSyncOptions;
+  showInitialHintDeps?: Readable<unknown>;
+  getShowInitialHint?: (state: {
+    hasSearched: boolean;
+    query: string;
+  }) => boolean;
+  onNavigate?: (item: GlobalSearchResultItem) => void;
+};
+
+export type GlobalSearchController = {
+  query: ReturnType<typeof writable<string>>;
+  groups: ReturnType<typeof writable<GlobalSearchResultGroup[]>>;
+  isSearching: ReturnType<typeof writable<boolean>>;
+  hasSearched: ReturnType<typeof writable<boolean>>;
+  activeIndex: ReturnType<typeof writable<number>>;
+  flatItems: Readable<GlobalSearchResultItem[]>;
+  activeItemId: Readable<string | null>;
+  showHint: Readable<boolean>;
+  showInitialHint: Readable<boolean>;
+  canNavigateResults: Readable<boolean>;
+  reset: () => void;
+  resetSelection: () => void;
+  applyQueryFromUrl: (urlQuery: string, runImmediately?: boolean) => void;
+  scheduleSearch: () => void;
+  handleQueryInput: (event: Event) => void;
+  handleCompositionEnd: (event: CompositionEvent) => void;
+  handleInputKeydown: (
+    event: KeyboardEvent,
+    inputElement: HTMLInputElement | null,
+  ) => void;
+  handleResultKeydown: (
+    event: KeyboardEvent,
+    itemIndex: number,
+    inputElement: HTMLInputElement | null,
+  ) => void;
+  navigateTo: (item: GlobalSearchResultItem) => void;
+  syncFromUrlNavigation: (url: URL) => void;
+};
+
+export function createGlobalSearchController(
+  options: GlobalSearchControllerOptions,
+): GlobalSearchController {
+  const query = writable("");
+  const groups = writable<GlobalSearchResultGroup[]>([]);
+  const isSearching = writable(false);
+  const hasSearched = writable(false);
+  const activeIndex = writable(-1);
+
+  let searchGeneration = 0;
+  let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const flatItems = derived(groups, ($groups) => flattenSearchGroups($groups));
+
+  const showHint = derived(query, ($query) => {
+    const trimmed = $query.trim();
+    return (
+      trimmed.length > 0 && trimmed.length < GLOBAL_SEARCH_MIN_QUERY_LENGTH
+    );
+  });
+
+  const showInitialHint = derived(
+    [hasSearched, query, options.showInitialHintDeps ?? writable(null)],
+    ([$hasSearched, $query]) => {
+      if (options.getShowInitialHint) {
+        return options.getShowInitialHint({
+          hasSearched: $hasSearched,
+          query: $query,
+        });
+      }
+      return !$hasSearched && $query.trim().length === 0;
+    },
+  );
+
+  const canNavigateResults = derived(
+    [isSearching, showHint, showInitialHint, flatItems],
+    ([$isSearching, $showHint, $showInitialHint, $flatItems]) =>
+      !$isSearching && !$showHint && !$showInitialHint && $flatItems.length > 0,
+  );
+
+  const activeItemId = derived(
+    [flatItems, activeIndex],
+    ([$flatItems, $activeIndex]) =>
+      activeItemIdFromIndex($flatItems, $activeIndex),
+  );
+
+  function resetSelection() {
+    activeIndex.set(-1);
+  }
+
+  function clearSearchDebounce() {
+    clearTimeout(searchDebounceTimer);
+  }
+
+  function reset() {
+    clearSearchDebounce();
+    searchGeneration += 1;
+    query.set("");
+    groups.set([]);
+    hasSearched.set(false);
+    isSearching.set(false);
+    activeIndex.set(-1);
+  }
+
+  function updateUrlQuery(nextQuery: string) {
+    const urlSync = options.urlSync;
+    if (!urlSync) return;
+
+    const url = new URL(urlSync.getPageUrl());
+    const trimmed = nextQuery.trim();
+    if (trimmed) {
+      url.searchParams.set("q", trimmed);
+    } else {
+      url.searchParams.delete("q");
+    }
+    const nextHref = `${url.pathname}${url.search}`;
+    const currentUrl = urlSync.getPageUrl();
+    const currentHref = `${currentUrl.pathname}${currentUrl.search}`;
+    if (nextHref !== currentHref) {
+      void urlSync.goto(nextHref, {
+        keepFocus: true,
+        noScroll: true,
+        replaceState: true,
+      });
+    }
+  }
+
+  async function runSearch() {
+    const trimmed = get(query).trim();
+    if (trimmed.length < GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
+      groups.set([]);
+      hasSearched.set(false);
+      return;
+    }
+
+    const generation = ++searchGeneration;
+    isSearching.set(true);
+    hasSearched.set(true);
+
+    try {
+      const body = await fetchGlobalSearch(trimmed, options.limit);
+      if (generation !== searchGeneration) return;
+      groups.set(body.groups ?? []);
+    } catch {
+      if (generation !== searchGeneration) return;
+      groups.set([]);
+    } finally {
+      if (generation === searchGeneration) {
+        isSearching.set(false);
+      }
+    }
+  }
+
+  function scheduleSearch() {
+    clearSearchDebounce();
+    updateUrlQuery(get(query));
+
+    const trimmed = get(query).trim();
+    if (trimmed.length < GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
+      groups.set([]);
+      hasSearched.set(false);
+      isSearching.set(false);
+      resetSelection();
+      return;
+    }
+
+    resetSelection();
+    searchDebounceTimer = setTimeout(() => {
+      void runSearch();
+    }, GLOBAL_SEARCH_DEBOUNCE_MS);
+  }
+
+  function applyQueryFromUrl(urlQuery: string, runImmediately = false) {
+    query.set(urlQuery);
+    if (urlQuery.trim().length >= GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
+      if (runImmediately) {
+        void runSearch();
+        return;
+      }
+      scheduleSearch();
+      return;
+    }
+    groups.set([]);
+    hasSearched.set(false);
+    isSearching.set(false);
+    resetSelection();
+  }
+
+  function handleQueryInput(event: Event) {
+    const input = event.currentTarget as HTMLInputElement;
+    query.set(input.value);
+    if (event instanceof InputEvent && event.isComposing) {
+      return;
+    }
+    scheduleSearch();
+  }
+
+  function handleCompositionEnd(event: CompositionEvent) {
+    query.set((event.currentTarget as HTMLInputElement).value);
+    scheduleSearch();
+  }
+
+  function navigateTo(item: GlobalSearchResultItem) {
+    if (options.onNavigate) {
+      options.onNavigate(item);
+      return;
+    }
+    if (item.external) {
+      window.open(item.href, "_blank", "noopener,noreferrer");
+      return;
+    }
+    if (options.urlSync) {
+      void options.urlSync.goto(item.href);
+    }
+  }
+
+  function handleInputKeydown(
+    event: KeyboardEvent,
+    inputElement: HTMLInputElement | null,
+  ) {
+    handleSearchListboxKeydown({
+      activeIndex: get(activeIndex),
+      event,
+      inputElement,
+      isInteractive: get(canNavigateResults),
+      items: get(flatItems),
+      onActiveIndexChange: (index) => {
+        activeIndex.set(index);
+      },
+      onSelect: navigateTo,
+    });
+  }
+
+  function handleResultKeydown(
+    event: KeyboardEvent,
+    itemIndex: number,
+    inputElement: HTMLInputElement | null,
+  ) {
+    if (itemIndex >= 0 && itemIndex !== get(activeIndex)) {
+      activeIndex.set(itemIndex);
+    }
+    handleSearchListboxKeydown({
+      activeIndex: itemIndex,
+      event,
+      inputElement,
+      isInteractive: get(canNavigateResults),
+      items: get(flatItems),
+      onActiveIndexChange: (index) => {
+        activeIndex.set(index);
+      },
+      onSelect: navigateTo,
+    });
+  }
+
+  function syncFromUrlNavigation(url: URL) {
+    const urlQuery = url.searchParams.get("q") ?? "";
+    if (urlQuery === get(query)) return;
+    applyQueryFromUrl(urlQuery, true);
+  }
+
+  return {
+    query,
+    groups,
+    isSearching,
+    hasSearched,
+    activeIndex,
+    flatItems,
+    activeItemId,
+    showHint,
+    showInitialHint,
+    canNavigateResults,
+    reset,
+    resetSelection,
+    applyQueryFromUrl,
+    scheduleSearch,
+    handleQueryInput,
+    handleCompositionEnd,
+    handleInputKeydown,
+    handleResultKeydown,
+    navigateTo,
+    syncFromUrlNavigation,
+  };
+}
+
+export function mountGlobalSearchUrlSync(
+  controller: GlobalSearchController,
+  input: {
+    getPageUrl: () => URL;
+  },
+) {
+  controller.applyQueryFromUrl(
+    input.getPageUrl().searchParams.get("q") ?? "",
+    true,
+  );
+
+  return {
+    handleAfterNavigate: (to: URL | undefined) => {
+      if (!to) return;
+      controller.syncFromUrlNavigation(to);
+    },
+  };
+}

--- a/src/lib/components/shell/GlobalSearchDialog.svelte
+++ b/src/lib/components/shell/GlobalSearchDialog.svelte
@@ -2,23 +2,17 @@
 import SearchIcon from "@lucide/svelte/icons/search";
 import XIcon from "@lucide/svelte/icons/x";
 import { createEventDispatcher } from "svelte";
+import { writable } from "svelte/store";
 import {
-  fetchGlobalSearch,
-  GLOBAL_SEARCH_DEBOUNCE_MS,
   GLOBAL_SEARCH_DIALOG_LIMIT,
   GLOBAL_SEARCH_MIN_QUERY_LENGTH,
 } from "@/features/search/lib/global-search-client";
+import { createGlobalSearchController } from "@/features/search/lib/global-search-controller";
 import {
-  activeItemIdFromIndex,
-  flattenSearchGroups,
   GLOBAL_SEARCH_LISTBOX_ID,
   globalSearchItemDomId,
-  handleSearchListboxKeydown,
 } from "@/features/search/lib/global-search-keyboard";
-import type {
-  GlobalSearchResultGroup,
-  GlobalSearchResultItem,
-} from "@/features/search/server/global-search-types";
+import type { GlobalSearchResultItem } from "@/features/search/server/global-search-types";
 import { goto } from "$app/navigation";
 import GlobalSearchResults from "$lib/components/shell/GlobalSearchResults.svelte";
 import { Button } from "$lib/components/ui/button/index.js";
@@ -35,147 +29,56 @@ const dispatch = createEventDispatcher<{
   openChange: boolean;
 }>();
 
-let query = "";
-let groups: GlobalSearchResultGroup[] = [];
-let isSearching = false;
-let hasSearched = false;
-let searchGeneration = 0;
-let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 let inputElement: HTMLInputElement | null = null;
-let activeIndex = -1;
+const dialogOpen = writable(false);
+$: dialogOpen.set(open);
 
-$: flatItems = flattenSearchGroups(groups);
-$: activeItemId = activeItemIdFromIndex(flatItems, activeIndex);
-$: canNavigateResults =
-  !isSearching && !showHint && !showInitialHint && flatItems.length > 0;
+const search = createGlobalSearchController({
+  limit: GLOBAL_SEARCH_DIALOG_LIMIT,
+  showInitialHintDeps: dialogOpen,
+  getShowInitialHint: ({ hasSearched, query }) =>
+    open && !hasSearched && query.trim().length === 0,
+  onNavigate: (item) => {
+    handleOpenChange(false);
+    navigateToItem(item);
+  },
+});
 
-$: placeholder = signedIn ? copy.placeholderSignedIn : copy.placeholder;
-$: showHint =
-  query.trim().length > 0 &&
-  query.trim().length < GLOBAL_SEARCH_MIN_QUERY_LENGTH;
-$: showInitialHint = open && !hasSearched && query.trim().length === 0;
-$: viewAllHref =
-  query.trim().length >= GLOBAL_SEARCH_MIN_QUERY_LENGTH
-    ? `/search?q=${encodeURIComponent(query.trim())}`
-    : "/search";
+const {
+  query,
+  groups,
+  isSearching,
+  activeItemId,
+  showHint,
+  showInitialHint,
+  canNavigateResults,
+  reset,
+  handleCompositionEnd,
+  handleQueryInput,
+  handleInputKeydown,
+  handleResultKeydown,
+  navigateTo,
+} = search;
 
-function resetSearchState() {
-  clearTimeout(searchDebounceTimer);
-  searchGeneration += 1;
-  query = "";
-  groups = [];
-  hasSearched = false;
-  isSearching = false;
-  activeIndex = -1;
-}
-
-function resetSelection() {
-  activeIndex = -1;
-}
-
-function handleOpenChange(nextOpen: boolean) {
-  open = nextOpen;
-  dispatch("openChange", nextOpen);
-  if (!nextOpen) resetSearchState();
-}
-
-function scheduleSearch() {
-  clearTimeout(searchDebounceTimer);
-
-  const trimmed = query.trim();
-  if (trimmed.length < GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
-    groups = [];
-    hasSearched = false;
-    isSearching = false;
-    resetSelection();
-    return;
-  }
-
-  resetSelection();
-  searchDebounceTimer = setTimeout(() => {
-    void runSearch();
-  }, GLOBAL_SEARCH_DEBOUNCE_MS);
-}
-
-function handleQueryInput(event: Event) {
-  const input = event.currentTarget as HTMLInputElement;
-  query = input.value;
-  if (event instanceof InputEvent && event.isComposing) {
-    return;
-  }
-  scheduleSearch();
-}
-
-function handleCompositionEnd(event: CompositionEvent) {
-  query = (event.currentTarget as HTMLInputElement).value;
-  scheduleSearch();
-}
-
-async function runSearch() {
-  const trimmed = query.trim();
-  if (trimmed.length < GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
-    groups = [];
-    hasSearched = false;
-    return;
-  }
-
-  const generation = ++searchGeneration;
-  isSearching = true;
-  hasSearched = true;
-
-  try {
-    const body = await fetchGlobalSearch(trimmed, GLOBAL_SEARCH_DIALOG_LIMIT);
-    if (generation !== searchGeneration) return;
-    groups = body.groups ?? [];
-  } catch {
-    if (generation !== searchGeneration) return;
-    groups = [];
-  } finally {
-    if (generation === searchGeneration) {
-      isSearching = false;
-    }
-  }
-}
-
-function handleInputKeydown(event: KeyboardEvent) {
-  handleSearchListboxKeydown({
-    activeIndex,
-    event,
-    inputElement,
-    isInteractive: canNavigateResults,
-    items: flatItems,
-    onActiveIndexChange: (index) => {
-      activeIndex = index;
-    },
-    onSelect: navigateTo,
-  });
-}
-
-function handleResultKeydown(event: KeyboardEvent, itemIndex: number) {
-  if (itemIndex >= 0 && itemIndex !== activeIndex) {
-    activeIndex = itemIndex;
-  }
-  handleSearchListboxKeydown({
-    activeIndex: itemIndex,
-    event,
-    inputElement,
-    isInteractive: canNavigateResults,
-    items: flatItems,
-    onActiveIndexChange: (index) => {
-      activeIndex = index;
-    },
-    onSelect: navigateTo,
-  });
-}
-
-function navigateTo(item: GlobalSearchResultItem) {
-  handleOpenChange(false);
+function navigateToItem(item: GlobalSearchResultItem) {
   if (item.external) {
     window.open(item.href, "_blank", "noopener,noreferrer");
     return;
   }
   void goto(item.href);
 }
+
+function handleOpenChange(nextOpen: boolean) {
+  open = nextOpen;
+  dispatch("openChange", nextOpen);
+  if (!nextOpen) reset();
+}
+
+$: placeholder = signedIn ? copy.placeholderSignedIn : copy.placeholder;
+$: viewAllHref =
+  $query.trim().length >= GLOBAL_SEARCH_MIN_QUERY_LENGTH
+    ? `/search?q=${encodeURIComponent($query.trim())}`
+    : "/search";
 
 function openSearchPage() {
   handleOpenChange(false);
@@ -195,19 +98,19 @@ $: if (open) {
         <SearchIcon class="size-4 shrink-0 text-muted-foreground" />
         <input
           bind:this={inputElement}
-          bind:value={query}
-          aria-activedescendant={activeItemId
-            ? globalSearchItemDomId(activeItemId)
+          bind:value={$query}
+          aria-activedescendant={$activeItemId
+            ? globalSearchItemDomId($activeItemId)
             : undefined}
-          aria-busy={isSearching}
+          aria-busy={$isSearching}
           aria-controls={GLOBAL_SEARCH_LISTBOX_ID}
-          aria-expanded={canNavigateResults}
+          aria-expanded={$canNavigateResults}
           class={cn(
             "placeholder:text-muted-foreground h-9 min-w-0 flex-1 border-0 bg-transparent px-0 text-base outline-none md:text-sm",
           )}
           oncompositionend={handleCompositionEnd}
           oninput={handleQueryInput}
-          onkeydown={handleInputKeydown}
+          onkeydown={(event) => handleInputKeydown(event, inputElement)}
           placeholder={placeholder}
           role="combobox"
           type="text"
@@ -228,13 +131,14 @@ $: if (open) {
     <ScrollArea class="max-h-[min(60vh,28rem)]">
       <div class="min-h-48 p-2">
         <GlobalSearchResults
-          {activeItemId}
+          activeItemId={$activeItemId}
           {copy}
-          {groups}
-          {isSearching}
-          {showHint}
-          {showInitialHint}
-          onResultKeydown={handleResultKeydown}
+          groups={$groups}
+          isSearching={$isSearching}
+          showHint={$showHint}
+          showInitialHint={$showInitialHint}
+          onResultKeydown={(event, itemIndex) =>
+            handleResultKeydown(event, itemIndex, inputElement)}
           onSelect={navigateTo}
         />
       </div>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -1,23 +1,15 @@
 <script lang="ts">
 import SearchIcon from "@lucide/svelte/icons/search";
 import { onMount } from "svelte";
+import { GLOBAL_SEARCH_PAGE_LIMIT } from "@/features/search/lib/global-search-client";
 import {
-  fetchGlobalSearch,
-  GLOBAL_SEARCH_DEBOUNCE_MS,
-  GLOBAL_SEARCH_MIN_QUERY_LENGTH,
-  GLOBAL_SEARCH_PAGE_LIMIT,
-} from "@/features/search/lib/global-search-client";
+  createGlobalSearchController,
+  mountGlobalSearchUrlSync,
+} from "@/features/search/lib/global-search-controller";
 import {
-  activeItemIdFromIndex,
-  flattenSearchGroups,
   GLOBAL_SEARCH_LISTBOX_ID,
   globalSearchItemDomId,
-  handleSearchListboxKeydown,
 } from "@/features/search/lib/global-search-keyboard";
-import type {
-  GlobalSearchResultGroup,
-  GlobalSearchResultItem,
-} from "@/features/search/server/global-search-types";
 import { afterNavigate, goto } from "$app/navigation";
 import { page } from "$app/stores";
 import GlobalSearchResults from "$lib/components/shell/GlobalSearchResults.svelte";
@@ -26,170 +18,42 @@ import type { PageData } from "./$types";
 
 export let data: PageData;
 
-let query = "";
-let groups: GlobalSearchResultGroup[] = [];
-let isSearching = false;
-let hasSearched = false;
-let searchGeneration = 0;
-let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 let inputElement: HTMLInputElement | null = null;
-let activeIndex = -1;
 
-$: flatItems = flattenSearchGroups(groups);
-$: activeItemId = activeItemIdFromIndex(flatItems, activeIndex);
-$: showHint =
-  query.trim().length > 0 &&
-  query.trim().length < GLOBAL_SEARCH_MIN_QUERY_LENGTH;
-$: showInitialHint = !hasSearched && query.trim().length === 0;
-$: canNavigateResults =
-  !isSearching && !showHint && !showInitialHint && flatItems.length > 0;
+const search = createGlobalSearchController({
+  limit: GLOBAL_SEARCH_PAGE_LIMIT,
+  urlSync: {
+    getPageUrl: () => $page.url,
+    goto,
+  },
+});
 
-function resetSelection() {
-  activeIndex = -1;
-}
+const {
+  query,
+  groups,
+  isSearching,
+  activeItemId,
+  showHint,
+  showInitialHint,
+  canNavigateResults,
+  handleCompositionEnd,
+  handleQueryInput,
+  handleInputKeydown,
+  handleResultKeydown,
+  navigateTo,
+} = search;
 
-function applyQueryFromUrl(urlQuery: string, runImmediately = false) {
-  query = urlQuery;
-  if (urlQuery.trim().length >= GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
-    if (runImmediately) {
-      void runSearch();
-      return;
-    }
-    scheduleSearch();
-    return;
-  }
-  groups = [];
-  hasSearched = false;
-  isSearching = false;
-  resetSelection();
-}
-
-function updateUrlQuery(nextQuery: string) {
-  const url = new URL($page.url);
-  const trimmed = nextQuery.trim();
-  if (trimmed) {
-    url.searchParams.set("q", trimmed);
-  } else {
-    url.searchParams.delete("q");
-  }
-  const nextHref = `${url.pathname}${url.search}`;
-  if (nextHref !== `${$page.url.pathname}${$page.url.search}`) {
-    void goto(nextHref, {
-      keepFocus: true,
-      noScroll: true,
-      replaceState: true,
-    });
-  }
-}
-
-function scheduleSearch() {
-  clearTimeout(searchDebounceTimer);
-  updateUrlQuery(query);
-
-  const trimmed = query.trim();
-  if (trimmed.length < GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
-    groups = [];
-    hasSearched = false;
-    isSearching = false;
-    resetSelection();
-    return;
-  }
-
-  resetSelection();
-  searchDebounceTimer = setTimeout(() => {
-    void runSearch();
-  }, GLOBAL_SEARCH_DEBOUNCE_MS);
-}
-
-function handleQueryInput(event: Event) {
-  const input = event.currentTarget as HTMLInputElement;
-  query = input.value;
-  if (event instanceof InputEvent && event.isComposing) {
-    return;
-  }
-  scheduleSearch();
-}
-
-function handleCompositionEnd(event: CompositionEvent) {
-  query = (event.currentTarget as HTMLInputElement).value;
-  scheduleSearch();
-}
-
-async function runSearch() {
-  const trimmed = query.trim();
-  if (trimmed.length < GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
-    groups = [];
-    hasSearched = false;
-    return;
-  }
-
-  const generation = ++searchGeneration;
-  isSearching = true;
-  hasSearched = true;
-
-  try {
-    const body = await fetchGlobalSearch(trimmed, GLOBAL_SEARCH_PAGE_LIMIT);
-    if (generation !== searchGeneration) return;
-    groups = body.groups ?? [];
-  } catch {
-    if (generation !== searchGeneration) return;
-    groups = [];
-  } finally {
-    if (generation === searchGeneration) {
-      isSearching = false;
-    }
-  }
-}
-
-function handleInputKeydown(event: KeyboardEvent) {
-  handleSearchListboxKeydown({
-    activeIndex,
-    event,
-    inputElement,
-    isInteractive: canNavigateResults,
-    items: flatItems,
-    onActiveIndexChange: (index) => {
-      activeIndex = index;
-    },
-    onSelect: navigateTo,
-  });
-}
-
-function handleResultKeydown(event: KeyboardEvent, itemIndex: number) {
-  if (itemIndex >= 0 && itemIndex !== activeIndex) {
-    activeIndex = itemIndex;
-  }
-  handleSearchListboxKeydown({
-    activeIndex: itemIndex,
-    event,
-    inputElement,
-    isInteractive: canNavigateResults,
-    items: flatItems,
-    onActiveIndexChange: (index) => {
-      activeIndex = index;
-    },
-    onSelect: navigateTo,
-  });
-}
-
-function navigateTo(item: GlobalSearchResultItem) {
-  if (item.external) {
-    window.open(item.href, "_blank", "noopener,noreferrer");
-    return;
-  }
-  void goto(item.href);
-}
+let urlSyncMount: ReturnType<typeof mountGlobalSearchUrlSync>;
 
 onMount(() => {
-  applyQueryFromUrl($page.url.searchParams.get("q") ?? "", true);
+  urlSyncMount = mountGlobalSearchUrlSync(search, {
+    getPageUrl: () => $page.url,
+  });
   queueMicrotask(() => inputElement?.focus());
 });
 
 afterNavigate(({ to }) => {
-  if (!to) return;
-  const urlQuery = to.url.searchParams.get("q") ?? "";
-  if (urlQuery === query) return;
-  applyQueryFromUrl(urlQuery, true);
+  urlSyncMount?.handleAfterNavigate(to?.url);
 });
 </script>
 
@@ -211,19 +75,19 @@ afterNavigate(({ to }) => {
     />
     <input
       bind:this={inputElement}
-      bind:value={query}
-      aria-activedescendant={activeItemId
-        ? globalSearchItemDomId(activeItemId)
+      bind:value={$query}
+      aria-activedescendant={$activeItemId
+        ? globalSearchItemDomId($activeItemId)
         : undefined}
-      aria-busy={isSearching}
+      aria-busy={$isSearching}
       aria-controls={GLOBAL_SEARCH_LISTBOX_ID}
-      aria-expanded={canNavigateResults}
+      aria-expanded={$canNavigateResults}
       class={cn(
         "border-input focus-visible:border-ring focus-visible:ring-ring/50 h-11 w-full rounded-lg border bg-transparent pr-3 pl-9 text-base outline-none focus-visible:ring-3 md:text-sm",
       )}
       oncompositionend={handleCompositionEnd}
       oninput={handleQueryInput}
-      onkeydown={handleInputKeydown}
+      onkeydown={(event) => handleInputKeydown(event, inputElement)}
       placeholder={data.copy.placeholderSignedIn}
       role="combobox"
       type="search"
@@ -232,13 +96,14 @@ afterNavigate(({ to }) => {
 
   <div class="rounded-xl border bg-card p-2 shadow-sm">
     <GlobalSearchResults
-      {activeItemId}
+      activeItemId={$activeItemId}
       copy={data.copy}
-      {groups}
-      {isSearching}
-      {showHint}
-      {showInitialHint}
-      onResultKeydown={handleResultKeydown}
+      groups={$groups}
+      isSearching={$isSearching}
+      showHint={$showHint}
+      showInitialHint={$showInitialHint}
+      onResultKeydown={(event, itemIndex) =>
+        handleResultKeydown(event, itemIndex, inputElement)}
       onSelect={navigateTo}
     />
   </div>

--- a/tests/unit/global-search-controller.test.ts
+++ b/tests/unit/global-search-controller.test.ts
@@ -1,0 +1,307 @@
+import { get } from "svelte/store";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GLOBAL_SEARCH_DEBOUNCE_MS } from "@/features/search/lib/global-search-client";
+import {
+  createGlobalSearchController,
+  mountGlobalSearchUrlSync,
+} from "@/features/search/lib/global-search-controller";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function mockSearchFetch(body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(body),
+  });
+}
+
+describe("createGlobalSearchController", () => {
+  it("debounces search and fetches with the configured limit", async () => {
+    vi.useFakeTimers();
+    const fetchMock = mockSearchFetch({
+      groups: [
+        {
+          type: "courses",
+          items: [
+            {
+              id: "course:1",
+              title: "Math",
+              description: null,
+              href: "/catalog/courses/1",
+            },
+          ],
+        },
+      ],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const controller = createGlobalSearchController({ limit: 5 });
+    controller.query.set("math");
+
+    controller.scheduleSearch();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(GLOBAL_SEARCH_DEBOUNCE_MS);
+    await vi.runAllTimersAsync();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/search?q=${encodeURIComponent("math")}&limit=5`,
+    );
+    expect(get(controller.groups)).toHaveLength(1);
+    expect(get(controller.isSearching)).toBe(false);
+    expect(get(controller.hasSearched)).toBe(true);
+
+    vi.useRealTimers();
+  });
+
+  it("clears results when query is shorter than the minimum length", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn());
+
+    const controller = createGlobalSearchController({ limit: 5 });
+    controller.query.set("ab");
+    controller.scheduleSearch();
+    controller.query.set("a");
+    controller.scheduleSearch();
+
+    expect(get(controller.groups)).toEqual([]);
+    expect(get(controller.hasSearched)).toBe(false);
+    expect(get(controller.isSearching)).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("ignores stale responses when a newer search starts", async () => {
+    vi.useFakeTimers();
+    let resolveFirst: ((response: unknown) => void) | undefined;
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            groups: [
+              {
+                type: "courses",
+                items: [
+                  {
+                    id: "course:new",
+                    title: "New",
+                    description: null,
+                    href: "/catalog/courses/new",
+                  },
+                ],
+              },
+            ],
+          }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const controller = createGlobalSearchController({ limit: 5 });
+    controller.query.set("old query");
+    controller.scheduleSearch();
+    await vi.advanceTimersByTimeAsync(GLOBAL_SEARCH_DEBOUNCE_MS);
+
+    controller.query.set("new query");
+    controller.scheduleSearch();
+    await vi.advanceTimersByTimeAsync(GLOBAL_SEARCH_DEBOUNCE_MS);
+    await vi.runAllTimersAsync();
+
+    resolveFirst?.({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          groups: [
+            {
+              type: "courses",
+              items: [
+                {
+                  id: "course:old",
+                  title: "Old",
+                  description: null,
+                  href: "/catalog/courses/old",
+                },
+              ],
+            },
+          ],
+        }),
+    });
+    await vi.runAllTimersAsync();
+
+    expect(get(controller.groups)[0]?.items[0]?.id).toBe("course:new");
+
+    vi.useRealTimers();
+  });
+
+  it("syncs query to the URL when urlSync is configured", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", mockSearchFetch({ groups: [] }));
+
+    const pageUrl = new URL("https://example.test/search");
+    const goto = vi.fn().mockResolvedValue(undefined);
+    const controller = createGlobalSearchController({
+      limit: 20,
+      urlSync: {
+        getPageUrl: () => pageUrl,
+        goto,
+      },
+    });
+
+    controller.query.set("physics");
+    controller.scheduleSearch();
+
+    expect(goto).toHaveBeenCalledOnce();
+    expect(goto).toHaveBeenCalledWith("/search?q=physics", {
+      keepFocus: true,
+      noScroll: true,
+      replaceState: true,
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("defers search while IME composition is active", async () => {
+    vi.useFakeTimers();
+    const fetchMock = mockSearchFetch({ groups: [] });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal(
+      "InputEvent",
+      class MockInputEvent extends Event {
+        isComposing: boolean;
+        constructor(type: string, init?: { isComposing?: boolean }) {
+          super(type);
+          this.isComposing = init?.isComposing ?? false;
+        }
+      },
+    );
+    vi.stubGlobal(
+      "CompositionEvent",
+      class MockCompositionEvent extends Event {},
+    );
+
+    const controller = createGlobalSearchController({ limit: 5 });
+    const input = { value: "ni" } as HTMLInputElement;
+
+    const composingEvent = new InputEvent("input", {
+      bubbles: true,
+      isComposing: true,
+    });
+    Object.defineProperty(composingEvent, "currentTarget", { value: input });
+    controller.handleQueryInput(composingEvent);
+
+    expect(get(controller.query)).toBe("ni");
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const endEvent = new CompositionEvent("compositionend", { bubbles: true });
+    Object.defineProperty(endEvent, "currentTarget", { value: input });
+    controller.handleCompositionEnd(endEvent);
+
+    await vi.advanceTimersByTimeAsync(GLOBAL_SEARCH_DEBOUNCE_MS);
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    vi.useRealTimers();
+  });
+
+  it("uses onNavigate when provided", () => {
+    const onNavigate = vi.fn();
+    const controller = createGlobalSearchController({
+      limit: 5,
+      onNavigate,
+    });
+    const item = {
+      id: "course:1",
+      title: "Math",
+      description: null,
+      href: "/catalog/courses/1",
+    };
+
+    controller.navigateTo(item);
+    expect(onNavigate).toHaveBeenCalledWith(item);
+  });
+
+  it("resets all state", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      mockSearchFetch({
+        groups: [
+          {
+            type: "courses",
+            items: [
+              {
+                id: "course:1",
+                title: "Math",
+                description: null,
+                href: "/catalog/courses/1",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const controller = createGlobalSearchController({ limit: 5 });
+    controller.query.set("math");
+    controller.scheduleSearch();
+    await vi.advanceTimersByTimeAsync(GLOBAL_SEARCH_DEBOUNCE_MS);
+    await vi.runAllTimersAsync();
+
+    controller.reset();
+
+    expect(get(controller.query)).toBe("");
+    expect(get(controller.groups)).toEqual([]);
+    expect(get(controller.hasSearched)).toBe(false);
+    expect(get(controller.isSearching)).toBe(false);
+    expect(get(controller.activeIndex)).toBe(-1);
+
+    vi.useRealTimers();
+  });
+});
+
+describe("mountGlobalSearchUrlSync", () => {
+  it("applies the initial URL query and handles later navigation", async () => {
+    vi.useFakeTimers();
+    const fetchMock = mockSearchFetch({ groups: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pageUrl = new URL("https://example.test/search?q=algebra");
+    const controller = createGlobalSearchController({
+      limit: 20,
+      urlSync: {
+        getPageUrl: () => pageUrl,
+        goto: vi.fn(),
+      },
+    });
+
+    const mount = mountGlobalSearchUrlSync(controller, {
+      getPageUrl: () => pageUrl,
+    });
+
+    await Promise.resolve();
+    expect(get(controller.query)).toBe("algebra");
+
+    mount.handleAfterNavigate(
+      new URL("https://example.test/search?q=calculus"),
+    );
+    await Promise.resolve();
+    expect(get(controller.query)).toBe("calculus");
+
+    mount.handleAfterNavigate(
+      new URL("https://example.test/search?q=calculus"),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `createGlobalSearchController` for shared query state, debounced fetch, keyboard navigation, and optional URL sync.
- Slim down `GlobalSearchDialog` and `/search` to wire the controller; dialog lazy-load in `AppShell` unchanged.
- Preserve IME composition handling and native input binding; add unit tests for the controller.

## Test plan
- [x] `biome check` on changed files
- [x] `svelte-check` (0 errors)
- [x] `vitest run` global-search-* unit tests (14 passed)