### PR TITLE
feat(observability): workspace route stage attribution for #672

### DIFF
--- a/src/lib/api/routes/calendar-subscriptions.ts
+++ b/src/lib/api/routes/calendar-subscriptions.ts
@@ -1,4 +1,3 @@
-import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import {
   badRequest,
   handleRouteError,
@@ -17,12 +16,17 @@ import {
   calendarSubscriptionRemoveRequestSchema,
 } from "@/lib/api/schemas/request-schemas";
 import { requireAuth } from "@/lib/auth/api-auth";
+import {
+  runWithWorkspaceRouteAttribution,
+  runWorkspaceRouteStage,
+} from "@/lib/log/workspace-route-attribution";
 
 export async function getCurrentCalendarSubscriptionRoute(request: Request) {
   try {
-    const auth = await runCloudflareTraceSpan(
-      "workspace.subscriptions.current.auth",
-      {},
+    const auth = await runWorkspaceRouteStage(
+      "subscriptions_current",
+      "auth",
+      { request },
       () =>
         requireAuth(request, {
           bearerScope: { feature: "workspace.subscription", action: "read" },
@@ -31,20 +35,27 @@ export async function getCurrentCalendarSubscriptionRoute(request: Request) {
     if (auth instanceof Response) return auth;
     const { userId } = auth;
 
-    const { getUserCalendarSubscription } = await import(
-      "@/features/subscriptions/server/subscription-read-model"
-    );
-    const subscription = await runCloudflareTraceSpan(
-      "workspace.subscriptions.current.read",
-      {},
-      () => getUserCalendarSubscription(userId, getRequestLocale(request)),
-    );
+    return runWithWorkspaceRouteAttribution(
+      "subscriptions_current",
+      request,
+      async () => {
+        const { getUserCalendarSubscription } = await import(
+          "@/features/subscriptions/server/subscription-read-model"
+        );
+        const subscription = await runWorkspaceRouteStage(
+          "subscriptions_current",
+          "read",
+          { request },
+          () => getUserCalendarSubscription(userId, getRequestLocale(request)),
+        );
 
-    if (!subscription) {
-      return jsonResponse({ subscription: null });
-    }
+        if (!subscription) {
+          return jsonResponse({ subscription: null });
+        }
 
-    return jsonResponse({ subscription });
+        return jsonResponse({ subscription });
+      },
+    );
   } catch (error) {
     return handleRouteError("Failed to fetch calendar subscription", error);
   }

--- a/src/lib/api/routes/homework-subscribed-read-route.ts
+++ b/src/lib/api/routes/homework-subscribed-read-route.ts
@@ -1,12 +1,16 @@
-import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import { handleRouteError, jsonResponse } from "@/lib/api/helpers";
 import { getRequestLocale } from "@/lib/api/routes/request-locale";
 import { requireAuth } from "@/lib/auth/api-auth";
+import {
+  runWithWorkspaceRouteAttribution,
+  runWorkspaceRouteStage,
+} from "@/lib/log/workspace-route-attribution";
 
 export async function getSubscribedHomeworksRoute(request: Request) {
-  const auth = await runCloudflareTraceSpan(
-    "workspace.homeworks.auth",
-    {},
+  const auth = await runWorkspaceRouteStage(
+    "homeworks",
+    "auth",
+    { request },
     () =>
       requireAuth(request, {
         bearerScope: { feature: "workspace.homework", action: "read" },
@@ -16,67 +20,70 @@ export async function getSubscribedHomeworksRoute(request: Request) {
   const { userId } = auth;
   const locale = getRequestLocale(request);
 
-  try {
-    const [{ getViewerContext }, subscriptionReadModel, homeworkItemState] =
-      await Promise.all([
-        import("@/lib/auth/viewer-context"),
-        import("@/features/subscriptions/server/subscription-read-model"),
-        import("@/features/homeworks/server/homework-item-state"),
+  return runWithWorkspaceRouteAttribution("homeworks", request, async () => {
+    try {
+      const [{ getViewerContext }, subscriptionReadModel, homeworkItemState] =
+        await Promise.all([
+          import("@/lib/auth/viewer-context"),
+          import("@/features/subscriptions/server/subscription-read-model"),
+          import("@/features/homeworks/server/homework-item-state"),
+        ]);
+      const {
+        getSubscribedSectionIds,
+        listSubscribedHomeworkAuditLogs,
+        listSubscribedHomeworks,
+      } = subscriptionReadModel;
+      const { withHomeworkItemState } = homeworkItemState;
+
+      const [viewer, sectionIds] = await Promise.all([
+        runWorkspaceRouteStage("homeworks", "viewer", { request }, () =>
+          getViewerContext({
+            includeAdmin: true,
+            userId,
+          }),
+        ),
+        runWorkspaceRouteStage("homeworks", "section_ids", { request }, () =>
+          getSubscribedSectionIds(userId),
+        ),
       ]);
-    const {
-      getSubscribedSectionIds,
-      listSubscribedHomeworkAuditLogs,
-      listSubscribedHomeworks,
-    } = subscriptionReadModel;
-    const { withHomeworkItemState } = homeworkItemState;
 
-    const [viewer, sectionIds] = await Promise.all([
-      runCloudflareTraceSpan("workspace.homeworks.viewer", {}, () =>
-        getViewerContext({
-          includeAdmin: true,
-          userId,
-        }),
-      ),
-      runCloudflareTraceSpan("workspace.homeworks.section_ids", {}, () =>
-        getSubscribedSectionIds(userId),
-      ),
-    ]);
+      if (sectionIds.length === 0) {
+        return jsonResponse({
+          viewer,
+          homeworks: [],
+          auditLogs: [],
+          sectionIds: [],
+        });
+      }
 
-    if (sectionIds.length === 0) {
+      const [homeworks, auditLogs] = await Promise.all([
+        runWorkspaceRouteStage("homeworks", "read", { request }, () =>
+          listSubscribedHomeworks(userId, {
+            locale,
+            includeEditors: true,
+            sectionIds,
+          }),
+        ),
+        runWorkspaceRouteStage("homeworks", "audit", { request }, () =>
+          listSubscribedHomeworkAuditLogs(userId, 50, sectionIds),
+        ),
+      ]);
+
+      const responseHomeworks = await runWorkspaceRouteStage(
+        "homeworks",
+        "item_state",
+        { request },
+        () => withHomeworkItemState(homeworks, userId),
+      );
+
       return jsonResponse({
         viewer,
-        homeworks: [],
-        auditLogs: [],
-        sectionIds: [],
+        homeworks: responseHomeworks,
+        auditLogs,
+        sectionIds,
       });
+    } catch (error) {
+      return handleRouteError("Failed to fetch subscribed homeworks", error);
     }
-
-    const [homeworks, auditLogs] = await Promise.all([
-      runCloudflareTraceSpan("workspace.homeworks.read", {}, () =>
-        listSubscribedHomeworks(userId, {
-          locale,
-          includeEditors: true,
-          sectionIds,
-        }),
-      ),
-      runCloudflareTraceSpan("workspace.homeworks.audit", {}, () =>
-        listSubscribedHomeworkAuditLogs(userId, 50, sectionIds),
-      ),
-    ]);
-
-    const responseHomeworks = await runCloudflareTraceSpan(
-      "workspace.homeworks.item_state",
-      {},
-      () => withHomeworkItemState(homeworks),
-    );
-
-    return jsonResponse({
-      viewer,
-      homeworks: responseHomeworks,
-      auditLogs,
-      sectionIds,
-    });
-  } catch (error) {
-    return handleRouteError("Failed to fetch subscribed homeworks", error);
-  }
+  });
 }

--- a/src/lib/api/routes/homework-subscribed-read-route.ts
+++ b/src/lib/api/routes/homework-subscribed-read-route.ts
@@ -73,7 +73,7 @@ export async function getSubscribedHomeworksRoute(request: Request) {
         "homeworks",
         "item_state",
         { request },
-        () => withHomeworkItemState(homeworks, userId),
+        () => withHomeworkItemState(homeworks),
       );
 
       return jsonResponse({

--- a/src/lib/db/rls-context.ts
+++ b/src/lib/db/rls-context.ts
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { Prisma } from "@/generated/prisma/client";
+import { recordWorkspaceRouteDbContext } from "@/lib/log/workspace-route-attribution";
 
 type UserRlsContext = {
   tx: Prisma.TransactionClient;
@@ -34,8 +35,10 @@ export async function runWithUserRlsContext<T>(
     return action(active.tx);
   }
 
+  const transactionStartMs = Date.now();
   return client.$transaction(async (tx) => {
     await tx.$queryRaw`SELECT set_config('app.user_id', ${normalizedUserId}, true)`;
+    recordWorkspaceRouteDbContext(Date.now() - transactionStartMs);
     return userRlsStorage.run({ tx, userId: normalizedUserId }, () =>
       action(tx),
     );

--- a/src/lib/log/api-observability.ts
+++ b/src/lib/log/api-observability.ts
@@ -12,3 +12,7 @@ export {
   recordObservedApiError,
   recordObservedApiResponse,
 } from "@/lib/log/api-observability-wrapper";
+export {
+  runWithWorkspaceRouteAttribution,
+  runWorkspaceRouteStage,
+} from "@/lib/log/workspace-route-attribution";

--- a/src/lib/log/workspace-route-attribution.ts
+++ b/src/lib/log/workspace-route-attribution.ts
@@ -1,0 +1,179 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
+import { getApiRequestObservabilityRequestId } from "@/lib/log/api-observability-context";
+import { logAppEvent } from "@/lib/log/app-logger";
+import { isProductionEnvironment } from "@/lib/log/app-logger-core";
+import {
+  type WorkspaceRouteName,
+  type WorkspaceRouteStage,
+  writeWorkspaceRouteStageAnalytics,
+} from "@/lib/metrics/analytics-engine";
+
+type WorkspaceRouteAttributionContext = {
+  requestId: string | undefined;
+  route: WorkspaceRouteName;
+};
+
+const workspaceRouteAttributionStorage =
+  new AsyncLocalStorage<WorkspaceRouteAttributionContext>();
+
+export function getWorkspaceRouteAttribution() {
+  return workspaceRouteAttributionStorage.getStore();
+}
+
+export function runWithWorkspaceRouteAttribution<T>(
+  route: WorkspaceRouteName,
+  request: Request,
+  work: () => Promise<T>,
+): Promise<T> {
+  return workspaceRouteAttributionStorage.run(
+    {
+      route,
+      requestId: getApiRequestObservabilityRequestId(request),
+    },
+    work,
+  );
+}
+
+function shouldLogSuccessfulWorkspaceStage(requestId: string | undefined) {
+  if (!isProductionEnvironment()) return true;
+  if (!requestId) return true;
+
+  let hash = 0;
+  for (let index = 0; index < requestId.length; index += 1) {
+    hash = (hash * 31 + requestId.charCodeAt(index)) >>> 0;
+  }
+  return hash % 4 === 0;
+}
+
+function shouldLogWorkspaceStage(
+  requestId: string | undefined,
+  status: "error" | "success",
+  ioObservedDurationMs: number,
+) {
+  if (status === "error") return true;
+  if (ioObservedDurationMs >= 1_000) return true;
+  return shouldLogSuccessfulWorkspaceStage(requestId);
+}
+
+function workspaceTraceSpanName(
+  route: WorkspaceRouteName,
+  stage: WorkspaceRouteStage,
+) {
+  if (route === "homeworks") {
+    return `workspace.homeworks.${stage}`;
+  }
+
+  if (stage === "auth") {
+    return "workspace.subscriptions.current.auth";
+  }
+  if (stage === "db_context") {
+    return "workspace.subscriptions.current.db_context";
+  }
+  return "workspace.subscriptions.current.read";
+}
+
+function logWorkspaceRouteStage(input: {
+  ioObservedDurationMs: number;
+  requestId: string | undefined;
+  route: WorkspaceRouteName;
+  stage: WorkspaceRouteStage;
+  status: "error" | "success";
+}) {
+  if (
+    !shouldLogWorkspaceStage(
+      input.requestId,
+      input.status,
+      input.ioObservedDurationMs,
+    )
+  ) {
+    return;
+  }
+
+  logAppEvent(
+    input.status === "error" ? "warn" : "info",
+    "workspace.route.stage",
+    {
+      event: "workspace.route.stage",
+      ioObservedDurationMs: input.ioObservedDurationMs,
+      requestId: input.requestId,
+      route: input.route,
+      source: "api",
+      stage: input.stage,
+      status: input.status,
+    },
+  );
+}
+
+export function recordWorkspaceRouteDbContext(ioObservedDurationMs: number) {
+  const attribution = getWorkspaceRouteAttribution();
+  if (!attribution) return;
+
+  writeWorkspaceRouteStageAnalytics({
+    ioObservedDurationMs,
+    route: attribution.route,
+    stage: "db_context",
+    status: "success",
+  });
+  logWorkspaceRouteStage({
+    ioObservedDurationMs,
+    requestId: attribution.requestId,
+    route: attribution.route,
+    stage: "db_context",
+    status: "success",
+  });
+}
+
+export async function runWorkspaceRouteStage<T>(
+  route: WorkspaceRouteName,
+  stage: WorkspaceRouteStage,
+  input: { request?: Request },
+  work: () => Promise<T>,
+): Promise<T> {
+  const attribution = getWorkspaceRouteAttribution();
+  const requestId =
+    attribution?.requestId ??
+    (input.request
+      ? getApiRequestObservabilityRequestId(input.request)
+      : undefined);
+  const startMs = Date.now();
+
+  try {
+    const result = await runCloudflareTraceSpan(
+      workspaceTraceSpanName(route, stage),
+      {},
+      work,
+    );
+    const ioObservedDurationMs = Date.now() - startMs;
+    writeWorkspaceRouteStageAnalytics({
+      ioObservedDurationMs,
+      route,
+      stage,
+      status: "success",
+    });
+    logWorkspaceRouteStage({
+      ioObservedDurationMs,
+      requestId,
+      route,
+      stage,
+      status: "success",
+    });
+    return result;
+  } catch (error) {
+    const ioObservedDurationMs = Date.now() - startMs;
+    writeWorkspaceRouteStageAnalytics({
+      ioObservedDurationMs,
+      route,
+      stage,
+      status: "error",
+    });
+    logWorkspaceRouteStage({
+      ioObservedDurationMs,
+      requestId,
+      route,
+      stage,
+      status: "error",
+    });
+    throw error;
+  }
+}

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -164,9 +164,33 @@ export type WorkspaceOverviewStage =
   | "todo_summary"
   | "user_sections";
 
+export type WorkspaceRouteName = "homeworks" | "subscriptions_current";
+
+export type WorkspaceHomeworksRouteStage =
+  | "audit"
+  | "auth"
+  | "item_state"
+  | "read"
+  | "section_ids"
+  | "viewer";
+
+export type WorkspaceSubscriptionsCurrentRouteStage = "auth" | "read";
+
+export type WorkspaceRouteStage =
+  | "db_context"
+  | WorkspaceHomeworksRouteStage
+  | WorkspaceSubscriptionsCurrentRouteStage;
+
 type WorkspaceOverviewStageAnalyticsInput = {
   ioObservedDurationMs: number;
   stage: WorkspaceOverviewStage;
+  status: "error" | "success";
+};
+
+type WorkspaceRouteStageAnalyticsInput = {
+  ioObservedDurationMs: number;
+  route: WorkspaceRouteName;
+  stage: WorkspaceRouteStage;
   status: "error" | "success";
 };
 
@@ -358,6 +382,16 @@ export function writeWorkspaceOverviewStageAnalytics(
   writeAnalyticsDataPoint({
     indexes: [`workspace:overview:${input.stage}`],
     blobs: ["workspace_overview_stage_v1", input.stage, input.status],
+    doubles: [input.ioObservedDurationMs],
+  });
+}
+
+export function writeWorkspaceRouteStageAnalytics(
+  input: WorkspaceRouteStageAnalyticsInput,
+) {
+  writeAnalyticsDataPoint({
+    indexes: [`workspace:${input.route}:${input.stage}`],
+    blobs: ["workspace_route_stage_v1", input.route, input.stage, input.status],
     doubles: [input.ioObservedDurationMs],
   });
 }

--- a/tests/unit/analytics-engine-runtime-events.test.ts
+++ b/tests/unit/analytics-engine-runtime-events.test.ts
@@ -9,6 +9,7 @@ import { withBetterAuthOAuthDebug } from "@/lib/log/oauth-debug";
 import {
   writeOAuthEventAnalytics,
   writeWorkspaceOverviewStageAnalytics,
+  writeWorkspaceRouteStageAnalytics,
 } from "@/lib/metrics/analytics-engine";
 import {
   cachedPublicRuntimeData,
@@ -82,6 +83,39 @@ describe("Cloudflare Analytics Engine runtime events", () => {
           index === stages.length - 1 ? "error" : "success",
         ],
         doubles: [index + 1],
+      });
+    });
+  });
+
+  it("writes fixed low-cardinality workspace route stage datapoints", () => {
+    const writeDataPoint = installAnalyticsBinding();
+    const stages = [
+      { route: "homeworks", stage: "auth" },
+      { route: "homeworks", stage: "section_ids" },
+      { route: "homeworks", stage: "db_context" },
+      { route: "subscriptions_current", stage: "read" },
+    ] as const;
+
+    stages.forEach((entry, index) => {
+      writeWorkspaceRouteStageAnalytics({
+        ioObservedDurationMs: index + 10,
+        route: entry.route,
+        stage: entry.stage,
+        status: "success",
+      });
+    });
+
+    expect(writeDataPoint).toHaveBeenCalledTimes(stages.length);
+    stages.forEach((entry, index) => {
+      expect(writeDataPoint).toHaveBeenNthCalledWith(index + 1, {
+        indexes: [`workspace:${entry.route}:${entry.stage}`],
+        blobs: [
+          "workspace_route_stage_v1",
+          entry.route,
+          entry.stage,
+          "success",
+        ],
+        doubles: [index + 10],
       });
     });
   });

--- a/tests/unit/workspace-route-attribution.test.ts
+++ b/tests/unit/workspace-route-attribution.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setApiRequestObservabilityContext } from "@/lib/log/api-observability";
+
+const {
+  logAppEventMock,
+  runCloudflareTraceSpanMock,
+  writeWorkspaceRouteStageAnalyticsMock,
+} = vi.hoisted(() => ({
+  logAppEventMock: vi.fn(),
+  runCloudflareTraceSpanMock: vi.fn(),
+  writeWorkspaceRouteStageAnalyticsMock: vi.fn(),
+}));
+
+vi.mock("@/lib/adapters/cloudflare-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/adapters/cloudflare-runtime")>();
+  return {
+    ...actual,
+    runCloudflareTraceSpan: runCloudflareTraceSpanMock,
+  };
+});
+
+vi.mock("@/lib/log/app-logger", () => ({
+  logAppEvent: logAppEventMock,
+}));
+
+vi.mock("@/lib/metrics/analytics-engine", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/metrics/analytics-engine")>();
+  return {
+    ...actual,
+    writeWorkspaceRouteStageAnalytics: writeWorkspaceRouteStageAnalyticsMock,
+  };
+});
+
+describe("workspace route attribution", () => {
+  beforeEach(() => {
+    writeWorkspaceRouteStageAnalyticsMock.mockClear();
+    logAppEventMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("writes unsampled Analytics Engine datapoints for each stage", async () => {
+    runCloudflareTraceSpanMock.mockImplementation(
+      (_name: string, _attributes: object, callback: () => unknown) =>
+        callback(),
+    );
+    const { runWorkspaceRouteStage } = await import(
+      "@/lib/log/workspace-route-attribution"
+    );
+
+    await runWorkspaceRouteStage("homeworks", "auth", {}, async () => "ok");
+
+    expect(writeWorkspaceRouteStageAnalyticsMock).toHaveBeenCalledWith({
+      ioObservedDurationMs: expect.any(Number),
+      route: "homeworks",
+      stage: "auth",
+      status: "success",
+    });
+    expect(runCloudflareTraceSpanMock).toHaveBeenCalledWith(
+      "workspace.homeworks.auth",
+      {},
+      expect.any(Function),
+    );
+  });
+
+  it("uses subscriptions route trace names", async () => {
+    runCloudflareTraceSpanMock.mockImplementation(
+      (_name: string, _attributes: object, callback: () => unknown) =>
+        callback(),
+    );
+    const { runWorkspaceRouteStage } = await import(
+      "@/lib/log/workspace-route-attribution"
+    );
+
+    await runWorkspaceRouteStage(
+      "subscriptions_current",
+      "read",
+      {},
+      async () => null,
+    );
+
+    expect(runCloudflareTraceSpanMock).toHaveBeenCalledWith(
+      "workspace.subscriptions.current.read",
+      {},
+      expect.any(Function),
+    );
+    expect(writeWorkspaceRouteStageAnalyticsMock).toHaveBeenCalledWith({
+      ioObservedDurationMs: expect.any(Number),
+      route: "subscriptions_current",
+      stage: "read",
+      status: "success",
+    });
+  });
+
+  it("samples successful stage logs at 25% in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    runCloudflareTraceSpanMock.mockImplementation(
+      (_name: string, _attributes: object, callback: () => unknown) =>
+        callback(),
+    );
+    const { runWorkspaceRouteStage } = await import(
+      "@/lib/log/workspace-route-attribution"
+    );
+
+    let expectedLogCount = 0;
+    for (let index = 0; index < 8; index += 1) {
+      const requestId = `request-${index}`;
+      let hash = 0;
+      for (let charIndex = 0; charIndex < requestId.length; charIndex += 1) {
+        hash = (hash * 31 + requestId.charCodeAt(charIndex)) >>> 0;
+      }
+      if (hash % 4 === 0) expectedLogCount += 1;
+
+      const request = new Request(
+        "https://example.test/api/workspace/homeworks",
+      );
+      setApiRequestObservabilityContext(request, {
+        requestId,
+        startMs: Date.now(),
+      });
+      await runWorkspaceRouteStage(
+        "homeworks",
+        "viewer",
+        { request },
+        async () => "ok",
+      );
+    }
+
+    expect(
+      logAppEventMock.mock.calls.filter(
+        ([, message]) => message === "workspace.route.stage",
+      ),
+    ).toHaveLength(expectedLogCount);
+    expect(writeWorkspaceRouteStageAnalyticsMock).toHaveBeenCalledTimes(8);
+  });
+
+  it("always logs slow stages in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-07T00:00:00.000Z"));
+    runCloudflareTraceSpanMock.mockImplementation(
+      (_name: string, _attributes: object, callback: () => unknown) => {
+        vi.advanceTimersByTime(1_200);
+        return callback();
+      },
+    );
+    const request = new Request(
+      "https://example.test/api/workspace/subscriptions/current",
+    );
+    setApiRequestObservabilityContext(request, {
+      requestId: "slow-request",
+      startMs: Date.now(),
+    });
+    const { runWorkspaceRouteStage } = await import(
+      "@/lib/log/workspace-route-attribution"
+    );
+
+    await runWorkspaceRouteStage(
+      "subscriptions_current",
+      "auth",
+      { request },
+      async () => "ok",
+    );
+
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "info",
+      "workspace.route.stage",
+      expect.objectContaining({
+        ioObservedDurationMs: 1_200,
+        requestId: "slow-request",
+        route: "subscriptions_current",
+        stage: "auth",
+        status: "success",
+      }),
+    );
+  });
+
+  it("records db_context only while route attribution is active", async () => {
+    writeWorkspaceRouteStageAnalyticsMock.mockClear();
+    const { recordWorkspaceRouteDbContext, runWithWorkspaceRouteAttribution } =
+      await import("@/lib/log/workspace-route-attribution");
+
+    recordWorkspaceRouteDbContext(42);
+    expect(writeWorkspaceRouteStageAnalyticsMock).not.toHaveBeenCalled();
+
+    const request = new Request("https://example.test/api/workspace/homeworks");
+    setApiRequestObservabilityContext(request, {
+      requestId: "db-context-request",
+      startMs: Date.now(),
+    });
+    await runWithWorkspaceRouteAttribution("homeworks", request, async () => {
+      recordWorkspaceRouteDbContext(42);
+    });
+
+    expect(writeWorkspaceRouteStageAnalyticsMock).toHaveBeenCalledWith({
+      ioObservedDurationMs: 42,
+      route: "homeworks",
+      stage: "db_context",
+      status: "success",
+    });
+  });
+});

--- a/tests/unit/workspace-route-tracing.test.ts
+++ b/tests/unit/workspace-route-tracing.test.ts
@@ -22,9 +22,23 @@ const {
   withHomeworkItemStateMock: vi.fn(),
 }));
 
-vi.mock("@/lib/adapters/cloudflare-runtime", () => ({
-  runCloudflareTraceSpan: runCloudflareTraceSpanMock,
-}));
+vi.mock("@/lib/adapters/cloudflare-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/adapters/cloudflare-runtime")>();
+  return {
+    ...actual,
+    runCloudflareTraceSpan: runCloudflareTraceSpanMock,
+  };
+});
+
+vi.mock("@/lib/metrics/analytics-engine", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/metrics/analytics-engine")>();
+  return {
+    ...actual,
+    writeWorkspaceRouteStageAnalytics: vi.fn(),
+  };
+});
 
 vi.mock("@/lib/auth/api-auth", () => ({
   requireAuth: requireAuthMock,


### PR DESCRIPTION
## Summary
- Add `workspace_route_stage_v1` Analytics Engine datapoints and 25% head-sampled `workspace.route.stage` logs for `/api/workspace/homeworks` and `/api/workspace/subscriptions/current`.
- Split attribution into low-cardinality stages: `auth`, `viewer`, `section_ids`, `read`, `audit`, `item_state`, and per-RLS-transaction `db_context` (pool/connect through `set_config`).
- Keep existing Cloudflare trace spans; homework route continues parallel `viewer` + `section_ids` reads from #674.

## Instrumentation
| Layer | Event | Sampling |
|---|---|---|
| Analytics Engine | `workspace_route_stage_v1` indexed by `workspace:{route}:{stage}` | Unsampled |
| Logs | `workspace.route.stage` with `ioObservedDurationMs`, route, stage | 25% success; all ≥1s and errors |
| Traces | `workspace.homeworks.*` / `workspace.subscriptions.current.*` spans | 5% head (Worker default) |

## Fixes
- No duplicate session lookup found (bearer JWT vs cookie session paths are single-pass).
- `db_context` timing records only while route attribution context is active (no global noise).

## Test plan
- [x] `biome check` on changed files
- [x] `vitest run tests/unit/workspace-route-attribution.test.ts`
- [x] `vitest run tests/unit/workspace-route-tracing.test.ts`
- [x] `vitest run tests/unit/analytics-engine-runtime-events.test.ts`

Related to #672 (instrumentation slice; issue remains open for post-deploy trace comparison per acceptance criteria).