### PR TITLE
fix: address unresolved review feedback from merged PR batch

### DIFF
--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -156,9 +156,6 @@ jobs:
               bunx tsc --noEmit -p tsconfig.typecheck.tests.json
               bunx tsc --noEmit -p tsconfig.typecheck.operational.json
               bunx vitest run
-              if [ "${VISUAL_REGRESSION:-}" = "1" ]; then
-                bash tests/ci/visual-regression.test.sh
-              fi
               ;;
             ci:integration)
               bun run app:prepare
@@ -188,6 +185,7 @@ jobs:
               expected_sequence_privileges="$(psql "$runtime_database_url" -X -tA \
                 --file=prisma/roles/export-app-runtime-sequence-privileges.sql)"
               expected_function_privileges='public.comment_attachment_summaries(p_comment_ids text[]):EXECUTE'
+              expected_function_privileges+=',public.comment_hidden_root_count(p_section_id integer, p_course_id integer, p_teacher_id integer, p_homework_id text, p_section_teacher_id integer):EXECUTE'
               expected_function_privileges+=',public.comment_reaction_summaries(comment_ids text[]):EXECUTE'
               expected_function_privileges+=',public.find_downloadable_upload(p_upload_id text):EXECUTE'
               expected_function_privileges+=',public.get_public_profile_homework_completions(p_user_id text, p_since timestamp without time zone):EXECUTE'

--- a/prisma/migrations/20260802120000_comment_hidden_count_definer/migration.sql
+++ b/prisma/migrations/20260802120000_comment_hidden_count_definer/migration.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+-- FORCE RLS applies to the function owner too. This policy is bound to the
+-- migration owner and activated only by the hidden-count helper below.
+CREATE POLICY "Comment_hidden_count_reader" ON "Comment"
+  FOR SELECT
+  TO CURRENT_USER
+  USING (true);
+
+REVOKE ALL
+  ON FUNCTION public.comment_hidden_root_count(
+    integer,
+    integer,
+    integer,
+    text,
+    integer
+  )
+  FROM PUBLIC;
+
+COMMIT;

--- a/prisma/roles/production-runtime-bootstrap.sql
+++ b/prisma/roles/production-runtime-bootstrap.sql
@@ -266,6 +266,13 @@ ALTER FUNCTION public.get_public_profile_upload_stats(
 ) OWNER TO life_ustc_function_owner;
 ALTER FUNCTION public.comment_reaction_summaries(text[])
   OWNER TO life_ustc_function_owner;
+ALTER FUNCTION public.comment_hidden_root_count(
+  integer,
+  integer,
+  integer,
+  text,
+  integer
+) OWNER TO life_ustc_function_owner;
 ALTER FUNCTION public.get_public_profile_homework_completions(
   text,
   timestamp without time zone
@@ -294,6 +301,10 @@ CREATE POLICY "Upload_definer_read" ON "Upload"
 
 DROP POLICY IF EXISTS "CommentReaction_definer_read" ON "CommentReaction";
 ALTER POLICY "CommentReaction_summary_reader" ON "CommentReaction"
+  TO life_ustc_function_owner;
+
+DROP POLICY IF EXISTS "Comment_hidden_count_definer_read" ON "Comment";
+ALTER POLICY "Comment_hidden_count_reader" ON "Comment"
   TO life_ustc_function_owner;
 
 ALTER POLICY "HomeworkCompletion_profile_reader" ON "HomeworkCompletion"

--- a/src/features/admin/server/admin-home-page-data.ts
+++ b/src/features/admin/server/admin-home-page-data.ts
@@ -1,13 +1,9 @@
-import {
-  getPrismaClient,
-  requireAdminPage,
-} from "@/features/admin/server/admin-page-auth";
+import { requireAdminPage } from "@/features/admin/server/admin-page-auth";
 import { authPrisma } from "@/lib/db/auth-prisma";
 import { getPrisma, withUserDbContext } from "@/lib/db/prisma";
 
 export async function getAdminHomeData(request: Request) {
   const admin = await requireAdminPage(request);
-  const prisma = await getPrismaClient();
   const [
     users,
     comments,
@@ -19,14 +15,14 @@ export async function getAdminHomeData(request: Request) {
     busVersions,
   ] = await withUserDbContext(admin.id, (tx) =>
     Promise.all([
-      prisma.user.count(),
+      tx.user.count(),
       tx.comment.count(),
       tx.comment.count({ where: { status: "active" } }),
       tx.comment.count({ where: { status: "deleted" } }),
-      prisma.homework.count({ where: { deletedAt: null } }),
+      tx.homework.count({ where: { deletedAt: null } }),
       authPrisma.oAuthClient.count(),
-      prisma.userSuspension.count({ where: { liftedAt: null } }),
-      prisma.busScheduleVersion.count(),
+      tx.userSuspension.count({ where: { liftedAt: null } }),
+      tx.busScheduleVersion.count(),
     ]),
   );
 

--- a/src/features/search/lib/global-search-controller.ts
+++ b/src/features/search/lib/global-search-controller.ts
@@ -186,6 +186,7 @@ export function createGlobalSearchController(
 
     const trimmed = get(query).trim();
     if (trimmed.length < GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
+      searchGeneration += 1;
       groups.set([]);
       hasSearched.set(false);
       isSearching.set(false);

--- a/src/lib/api/routes/calendar-subscriptions.ts
+++ b/src/lib/api/routes/calendar-subscriptions.ts
@@ -35,7 +35,7 @@ export async function getCurrentCalendarSubscriptionRoute(request: Request) {
     if (auth instanceof Response) return auth;
     const { userId } = auth;
 
-    return runWithWorkspaceRouteAttribution(
+    return await runWithWorkspaceRouteAttribution(
       "subscriptions_current",
       request,
       async () => {

--- a/src/lib/log/workspace-route-attribution.ts
+++ b/src/lib/log/workspace-route-attribution.ts
@@ -6,7 +6,6 @@ import { isProductionEnvironment } from "@/lib/log/app-logger-core";
 import {
   type WorkspaceHomeworksRouteStage,
   type WorkspaceRouteName,
-  type WorkspaceRouteStage,
   type WorkspaceSubscriptionsCurrentRouteStage,
   writeWorkspaceRouteStageAnalytics,
 } from "@/lib/metrics/analytics-engine";
@@ -60,7 +59,10 @@ function shouldLogWorkspaceStage(
 
 function workspaceTraceSpanName(
   route: WorkspaceRouteName,
-  stage: WorkspaceRouteStage,
+  stage:
+    | WorkspaceHomeworksRouteStage
+    | WorkspaceSubscriptionsCurrentRouteStage
+    | "db_context",
 ) {
   if (route === "homeworks") {
     return `workspace.homeworks.${stage}`;
@@ -79,7 +81,10 @@ function logWorkspaceRouteStage(input: {
   ioObservedDurationMs: number;
   requestId: string | undefined;
   route: WorkspaceRouteName;
-  stage: WorkspaceRouteStage;
+  stage:
+    | WorkspaceHomeworksRouteStage
+    | WorkspaceSubscriptionsCurrentRouteStage
+    | "db_context";
   status: "error" | "success";
 }) {
   if (
@@ -165,8 +170,23 @@ export async function runWorkspaceRouteStage<T>(
   work: () => Promise<T>,
 ): Promise<T>;
 export async function runWorkspaceRouteStage<T>(
+  route: "homeworks",
+  stage: WorkspaceHomeworksRouteStage | "db_context",
+  input: { request?: Request },
+  work: () => Promise<T>,
+): Promise<T>;
+export async function runWorkspaceRouteStage<T>(
+  route: "subscriptions_current",
+  stage: WorkspaceSubscriptionsCurrentRouteStage | "db_context",
+  input: { request?: Request },
+  work: () => Promise<T>,
+): Promise<T>;
+export async function runWorkspaceRouteStage<T>(
   route: WorkspaceRouteName,
-  stage: WorkspaceRouteStage,
+  stage:
+    | WorkspaceHomeworksRouteStage
+    | WorkspaceSubscriptionsCurrentRouteStage
+    | "db_context",
   input: { request?: Request },
   work: () => Promise<T>,
 ): Promise<T> {

--- a/src/lib/log/workspace-route-attribution.ts
+++ b/src/lib/log/workspace-route-attribution.ts
@@ -112,42 +112,43 @@ function logWorkspaceRouteStage(input: {
   );
 }
 
-function writeWorkspaceRouteStageAnalyticsForRoute(input: {
-  ioObservedDurationMs: number;
-  route: WorkspaceRouteName;
-  stage: WorkspaceRouteStage;
-  status: "error" | "success";
-}) {
-  if (input.route === "homeworks") {
-    writeWorkspaceRouteStageAnalytics({
-      ioObservedDurationMs: input.ioObservedDurationMs,
-      route: "homeworks",
-      stage: input.stage as WorkspaceHomeworksRouteStage | "db_context",
-      status: input.status,
-    });
-    return;
-  }
-
-  writeWorkspaceRouteStageAnalytics({
-    ioObservedDurationMs: input.ioObservedDurationMs,
-    route: "subscriptions_current",
-    stage: input.stage as
-      | WorkspaceSubscriptionsCurrentRouteStage
-      | "db_context",
-    status: input.status,
-  });
+function writeWorkspaceRouteStageAnalyticsForRoute(
+  input:
+    | {
+        ioObservedDurationMs: number;
+        route: "homeworks";
+        stage: WorkspaceHomeworksRouteStage | "db_context";
+        status: "error" | "success";
+      }
+    | {
+        ioObservedDurationMs: number;
+        route: "subscriptions_current";
+        stage: WorkspaceSubscriptionsCurrentRouteStage | "db_context";
+        status: "error" | "success";
+      },
+) {
+  writeWorkspaceRouteStageAnalytics(input);
 }
 
 export function recordWorkspaceRouteDbContext(ioObservedDurationMs: number) {
   const attribution = getWorkspaceRouteAttribution();
   if (!attribution) return;
 
-  writeWorkspaceRouteStageAnalyticsForRoute({
-    ioObservedDurationMs,
-    route: attribution.route,
-    stage: "db_context",
-    status: "success",
-  });
+  writeWorkspaceRouteStageAnalyticsForRoute(
+    attribution.route === "homeworks"
+      ? {
+          ioObservedDurationMs,
+          route: "homeworks",
+          stage: "db_context",
+          status: "success",
+        }
+      : {
+          ioObservedDurationMs,
+          route: "subscriptions_current",
+          stage: "db_context",
+          status: "success",
+        },
+  );
   logWorkspaceRouteStage({
     ioObservedDurationMs,
     requestId: attribution.requestId,
@@ -157,18 +158,6 @@ export function recordWorkspaceRouteDbContext(ioObservedDurationMs: number) {
   });
 }
 
-export async function runWorkspaceRouteStage<T>(
-  route: "homeworks",
-  stage: WorkspaceHomeworksRouteStage | "db_context",
-  input: { request?: Request },
-  work: () => Promise<T>,
-): Promise<T>;
-export async function runWorkspaceRouteStage<T>(
-  route: "subscriptions_current",
-  stage: WorkspaceSubscriptionsCurrentRouteStage | "db_context",
-  input: { request?: Request },
-  work: () => Promise<T>,
-): Promise<T>;
 export async function runWorkspaceRouteStage<T>(
   route: "homeworks",
   stage: WorkspaceHomeworksRouteStage | "db_context",
@@ -205,12 +194,21 @@ export async function runWorkspaceRouteStage<T>(
       work,
     );
     const ioObservedDurationMs = Date.now() - startMs;
-    writeWorkspaceRouteStageAnalyticsForRoute({
-      ioObservedDurationMs,
-      route,
-      stage,
-      status: "success",
-    });
+    if (route === "homeworks") {
+      writeWorkspaceRouteStageAnalyticsForRoute({
+        ioObservedDurationMs,
+        route,
+        stage: stage as WorkspaceHomeworksRouteStage | "db_context",
+        status: "success",
+      });
+    } else {
+      writeWorkspaceRouteStageAnalyticsForRoute({
+        ioObservedDurationMs,
+        route,
+        stage: stage as WorkspaceSubscriptionsCurrentRouteStage | "db_context",
+        status: "success",
+      });
+    }
     logWorkspaceRouteStage({
       ioObservedDurationMs,
       requestId,
@@ -221,12 +219,21 @@ export async function runWorkspaceRouteStage<T>(
     return result;
   } catch (error) {
     const ioObservedDurationMs = Date.now() - startMs;
-    writeWorkspaceRouteStageAnalyticsForRoute({
-      ioObservedDurationMs,
-      route,
-      stage,
-      status: "error",
-    });
+    if (route === "homeworks") {
+      writeWorkspaceRouteStageAnalyticsForRoute({
+        ioObservedDurationMs,
+        route,
+        stage: stage as WorkspaceHomeworksRouteStage | "db_context",
+        status: "error",
+      });
+    } else {
+      writeWorkspaceRouteStageAnalyticsForRoute({
+        ioObservedDurationMs,
+        route,
+        stage: stage as WorkspaceSubscriptionsCurrentRouteStage | "db_context",
+        status: "error",
+      });
+    }
     logWorkspaceRouteStage({
       ioObservedDurationMs,
       requestId,

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -4,6 +4,11 @@ import type {
   McpRequestSummary,
   McpResponsePhase,
 } from "@/lib/mcp/observability-types";
+import type {
+  PageAuthSignalPresence,
+  PageCatalogDetailTab,
+  PageSsrClass,
+} from "@/lib/metrics/page-request-attribution";
 
 type ApiRequestAnalyticsInput = {
   authMode: string;
@@ -18,15 +23,15 @@ type PageRequestAnalyticsInput = {
   appIoObservedDurationMs: number;
   authIoObservedDurationMs: number;
   authMode: "anonymous" | "authenticated";
-  authSignalPresence: "absent" | "present";
-  catalogDetailTab: string;
+  authSignalPresence: PageAuthSignalPresence;
+  catalogDetailTab: PageCatalogDetailTab;
   event: "finish" | "error";
   ioObservedDurationMs: number;
   locale: string;
   method: string;
   responseBytes?: number;
   route: string;
-  ssrClass: "dynamic-ssr" | "public-ssr";
+  ssrClass: PageSsrClass;
   status: number;
 };
 

--- a/src/lib/metrics/page-request-attribution.ts
+++ b/src/lib/metrics/page-request-attribution.ts
@@ -26,6 +26,7 @@ const COURSE_TEACHER_DETAIL_TABS = new Set([
 ]);
 
 const SECTION_DETAIL_ROUTE = "/catalog/sections/[jwId]";
+const SECTION_DETAIL_SECTION_ROUTE = "/catalog/sections/[jwId]/[section]";
 const COURSE_DETAIL_ROUTE = "/catalog/courses/[jwId]";
 const COURSE_DETAIL_SECTION_ROUTE = "/catalog/courses/[jwId]/[section]";
 const TEACHER_DETAIL_ROUTE = "/catalog/teachers/[id]";
@@ -61,6 +62,10 @@ export function resolvePageCatalogDetailTab(
     return parseSectionDetailTab(
       url.searchParams.get(SECTION_DETAIL_TAB_QUERY),
     );
+  }
+
+  if (routeId === SECTION_DETAIL_SECTION_ROUTE) {
+    return parseSectionDetailTab(params.section);
   }
 
   if (routeId === COURSE_DETAIL_ROUTE || routeId === TEACHER_DETAIL_ROUTE) {

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -59,7 +59,7 @@ The matrix is **opt-in** so default CI stays fast:
 | --- | --- |
 | Local update | `bun run build && bun run e2e:visual:update` |
 | Local verify | `bun run build && bun run e2e:visual` |
-| CI check phase | Set repository variable `VISUAL_REGRESSION=1` to enable the `Visual regression (opt-in)` job, or export `VISUAL_REGRESSION=1` when invoking `ci:verify` with Playwright installed |
+| CI check phase | Set repository variable `VISUAL_REGRESSION=1` to enable the dedicated `Visual regression (opt-in)` workflow job |
 | Default E2E shards | Skipped (`VISUAL_REGRESSION` unset) |
 
 Tradeoff: pixel baselines catch real UI regressions but add maintenance cost (update snapshots on intentional design changes) and roughly double Playwright runtime when enabled. Keeping them opt-in avoids blocking every PR on screenshot drift while the baseline set is still small.

--- a/tests/e2e/visual-matrix/matrix-setup.ts
+++ b/tests/e2e/visual-matrix/matrix-setup.ts
@@ -39,8 +39,10 @@ export async function syncAuthenticatedLocale(
   locale: VisualMatrixLocale,
 ) {
   const sessionResponse = await page.request.get("/api/auth/get-session");
-  if (sessionResponse.status() !== 200) {
-    return;
+  if (!sessionResponse.ok()) {
+    throw new Error(
+      `Failed to load session before locale sync: ${sessionResponse.status()}`,
+    );
   }
 
   const session = (await sessionResponse.json()) as {

--- a/tests/e2e/visual-matrix/screenshots.spec.ts
+++ b/tests/e2e/visual-matrix/screenshots.spec.ts
@@ -19,7 +19,6 @@ const OVERVIEW_WEEK_START = "2026-04-26";
 type VisualScreen = {
   id: string;
   path: string;
-  requiresAuth?: boolean;
   prepare?: (
     page: import("@playwright/test").Page,
     locale: VisualMatrixLocale,
@@ -72,7 +71,6 @@ const VISUAL_SCREENS: VisualScreen[] = [
   {
     id: "workspace-overview",
     path: `/workspace/overview?overviewWeek=${OVERVIEW_WEEK_START}`,
-    requiresAuth: true,
     prepare: async (page, locale) => {
       await page.clock.setFixedTime(
         new Date(DEV_SEED_ANCHOR.recommendedAtTime),

--- a/tests/integration/comment-rls.test.ts
+++ b/tests/integration/comment-rls.test.ts
@@ -63,6 +63,7 @@ describe.skipIf(process.env.RLS_TEST_ENABLED !== "true")(
         { policyName: "Comment_admin_moderator", command: "UPDATE" },
         { policyName: "Comment_admin_reader", command: "SELECT" },
         { policyName: "Comment_authenticated_reader", command: "SELECT" },
+        { policyName: "Comment_hidden_count_reader", command: "SELECT" },
         { policyName: "Comment_owner_isolation", command: "ALL" },
         { policyName: "Comment_public_reader", command: "SELECT" },
       ]);

--- a/tests/integration/fixtures/rls-runtime-bootstrap.sql
+++ b/tests/integration/fixtures/rls-runtime-bootstrap.sql
@@ -463,6 +463,7 @@ GRANT EXECUTE ON FUNCTION
   public.comment_attachment_summaries(text[]),
   public.get_public_profile_upload_stats(text, timestamp without time zone),
   public.comment_reaction_summaries(text[]),
+  public.comment_hidden_root_count(integer, integer, integer, text, integer),
   public.get_public_profile_homework_completions(
     text,
     timestamp without time zone

--- a/tests/integration/fixtures/rls-runtime-bootstrap.sql
+++ b/tests/integration/fixtures/rls-runtime-bootstrap.sql
@@ -398,6 +398,13 @@ ALTER FUNCTION public.get_public_profile_upload_stats(
 ) OWNER TO life_ustc_function_owner;
 ALTER FUNCTION public.comment_reaction_summaries(text[])
   OWNER TO life_ustc_function_owner;
+ALTER FUNCTION public.comment_hidden_root_count(
+  integer,
+  integer,
+  integer,
+  text,
+  integer
+) OWNER TO life_ustc_function_owner;
 ALTER FUNCTION public.get_public_profile_homework_completions(
   text,
   timestamp without time zone
@@ -426,6 +433,10 @@ CREATE POLICY "Upload_definer_read" ON "Upload"
 
 DROP POLICY IF EXISTS "CommentReaction_definer_read" ON "CommentReaction";
 ALTER POLICY "CommentReaction_summary_reader" ON "CommentReaction"
+  TO life_ustc_function_owner;
+
+DROP POLICY IF EXISTS "Comment_hidden_count_definer_read" ON "Comment";
+ALTER POLICY "Comment_hidden_count_reader" ON "Comment"
   TO life_ustc_function_owner;
 
 ALTER POLICY "HomeworkCompletion_profile_reader" ON "HomeworkCompletion"

--- a/tests/integration/function-owner-role-contract.test.ts
+++ b/tests/integration/function-owner-role-contract.test.ts
@@ -29,6 +29,13 @@ const expectedFunctions = [
   },
   {
     securityDefiner: true,
+    settings: ['search_path=""'],
+    signature:
+      "public.comment_hidden_root_count(p_section_id integer, p_course_id integer, p_teacher_id integer, p_homework_id text, p_section_teacher_id integer)",
+    volatility: "STABLE",
+  },
+  {
+    securityDefiner: true,
     settings: ['search_path=""', "app.comment_reaction_summary=on"],
     signature: "public.comment_reaction_summaries(comment_ids text[])",
     volatility: "STABLE",

--- a/tests/integration/function-owner-role-contract.test.ts
+++ b/tests/integration/function-owner-role-contract.test.ts
@@ -211,7 +211,7 @@ describe.skipIf(process.env.FUNCTION_OWNER_ROLE_TEST_ENABLED !== "true")(
       expect(ownedSchemas).toEqual([]);
     });
 
-    it("owns exactly the eleven audited SECURITY DEFINER functions", async () => {
+    it("owns exactly the twelve audited SECURITY DEFINER functions", async () => {
       const functions = await adminPrisma.$queryRaw<
         Array<{
           securityDefiner: boolean;

--- a/tests/integration/function-owner-role-contract.test.ts
+++ b/tests/integration/function-owner-role-contract.test.ts
@@ -423,7 +423,7 @@ describe.skipIf(process.env.FUNCTION_OWNER_ROLE_TEST_ENABLED !== "true")(
       expect(sequencePrivileges).toEqual([]);
     });
 
-    it("is the sole role on exactly five audited definer-read policies", async () => {
+    it("is the sole role on exactly six audited definer-read policies", async () => {
       const policies = await adminPrisma.$queryRaw<
         Array<{
           checkExpression: string | null;
@@ -456,6 +456,16 @@ describe.skipIf(process.env.FUNCTION_OWNER_ROLE_TEST_ENABLED !== "true")(
           usingExpression: policy.usingExpression.replaceAll("::text", ""),
         })),
       ).toEqual([
+        {
+          checkExpression: null,
+          command: "SELECT",
+          permissive: "PERMISSIVE",
+          policyName: "Comment_hidden_count_reader",
+          roles: [functionOwnerRole],
+          schemaName: "public",
+          tableName: "Comment",
+          usingExpression: "true",
+        },
         {
           checkExpression: null,
           command: "SELECT",

--- a/tests/integration/rls-database-contract.test.ts
+++ b/tests/integration/rls-database-contract.test.ts
@@ -38,6 +38,7 @@ const protectedTables = [
 
 const expectedRuntimeFunctionPrivileges = [
   "public.comment_attachment_summaries(p_comment_ids text[]):EXECUTE",
+  "public.comment_hidden_root_count(p_section_id integer, p_course_id integer, p_teacher_id integer, p_homework_id text, p_section_teacher_id integer):EXECUTE",
   "public.comment_reaction_summaries(comment_ids text[]):EXECUTE",
   "public.find_downloadable_upload(p_upload_id text):EXECUTE",
   "public.get_public_profile_homework_completions(p_user_id text, p_since timestamp without time zone):EXECUTE",

--- a/tests/unit/e2e-full-suite-parity.test.ts
+++ b/tests/unit/e2e-full-suite-parity.test.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 
-const repoRoot = resolve(import.meta.dirname, "../..");
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
 describe("E2E full-suite parity orchestration", () => {
   test("package.json routes e2e:test through the CI-parity script", () => {

--- a/tests/unit/global-search-controller.test.ts
+++ b/tests/unit/global-search-controller.test.ts
@@ -76,6 +76,52 @@ describe("createGlobalSearchController", () => {
     vi.useRealTimers();
   });
 
+  it("drops in-flight results after the query drops below the minimum length", async () => {
+    vi.useFakeTimers();
+    let resolveSearch: ((response: unknown) => void) | undefined;
+    const fetchMock = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSearch = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const controller = createGlobalSearchController({ limit: 5 });
+    controller.query.set("ab");
+    controller.scheduleSearch();
+    await vi.advanceTimersByTimeAsync(GLOBAL_SEARCH_DEBOUNCE_MS);
+
+    controller.query.set("a");
+    controller.scheduleSearch();
+
+    resolveSearch?.({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          groups: [
+            {
+              type: "courses",
+              items: [
+                {
+                  id: "course:stale",
+                  title: "Stale",
+                  description: null,
+                  href: "/catalog/courses/stale",
+                },
+              ],
+            },
+          ],
+        }),
+    });
+    await vi.runAllTimersAsync();
+
+    expect(get(controller.groups)).toEqual([]);
+    expect(get(controller.hasSearched)).toBe(false);
+
+    vi.useRealTimers();
+  });
+
   it("ignores stale responses when a newer search starts", async () => {
     vi.useFakeTimers();
     let resolveFirst: ((response: unknown) => void) | undefined;

--- a/tests/unit/page-request-attribution.test.ts
+++ b/tests/unit/page-request-attribution.test.ts
@@ -31,6 +31,23 @@ describe("page request attribution", () => {
     ).toBe("calendar");
   });
 
+  it("resolves section detail legacy redirect routes from path params", () => {
+    expect(
+      resolvePageCatalogDetailTab(
+        "/catalog/sections/[jwId]/[section]",
+        new URL("https://life.example/catalog/sections/12345/homework"),
+        { section: "homework" },
+      ),
+    ).toBe("homework");
+    expect(
+      resolvePageCatalogDetailTab(
+        "/catalog/sections/[jwId]/[section]",
+        new URL("https://life.example/catalog/sections/12345/unknown"),
+        { section: "unknown" },
+      ),
+    ).toBe("overview");
+  });
+
   it("defaults section and course detail routes without tabs to overview", () => {
     expect(
       resolvePageCatalogDetailTab(


### PR DESCRIPTION
## Summary
- Cleaned up merged local branches and stale worktrees from the #715–#724 batch.
- Fixed valuable unresolved Copilot review items across observability, search, RLS, workspace routes, and E2E/docs.
- Added `comment_hidden_root_count` definer policy/owner bootstrap so anonymous `hiddenCount` works under FORCE RLS.

## Changes by source PR
| PR | Fix |
| --- | --- |
| #715 | Attribute section-detail legacy redirect routes; tighten `PageRequestAnalyticsInput` tab/auth/ssr types |
| #717 | Replace non-portable `import.meta.dirname` in parity unit test |
| #719 | Fail fast on broken session during visual locale sync; remove unused `requiresAuth`; clarify README; drop visual regression from `ci:verify` |
| #721 | Invalidate in-flight search when query drops below minimum length |
| #722 | `await` subscription route attribution wrapper; route-specific `runWorkspaceRouteStage` overloads |
| #723 | Definer policy + `REVOKE PUBLIC` for `comment_hidden_root_count`; admin home counts via transaction client |

## Skipped (already addressed or intentional)
- #720 lazy-load SSR empty HTML — intentional client-tab pattern (#703)
- #724 legacy tab redirect validation — already on `main`

## Verification
```bash
bun run app:prepare
bunx biome check
bunx tsc --noEmit -p tsconfig.typecheck.json
bunx tsc --noEmit -p tsconfig.typecheck.tests.json
bunx vitest run
```

## Residual risk
- New migration requires deploy before production `hiddenCount` is correct under FORCE RLS.
- Integration/RLS tests not run locally in this pass (migration + bootstrap contract updated).