### PR TITLE
fix(ci): allow self-signed TLS in Node PrismaPg cron CLIs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY prisma ./prisma
 RUN DATABASE_URL="postgresql://localhost:5432/life_ustc" bun run db:generate
 COPY src/static-loader ./src/static-loader
 COPY src/lib/db/section-lifecycle-lock.ts ./src/lib/db/section-lifecycle-lock.ts
+COPY src/lib/db/node-pg-pool-config.ts ./src/lib/db/node-pg-pool-config.ts
 COPY scripts/load-static-sqlite.sh ./scripts/load-static-sqlite.sh
 COPY docker-entrypoint.load.sh /usr/local/bin/docker-entrypoint.load.sh
 

--- a/scripts/analytics-query.sh
+++ b/scripts/analytics-query.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Query Cloudflare Analytics Engine SQL for the life_ustc_runtime dataset.
+# Requires CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID (or uses wrangler whoami).
+
+if [[ $# -lt 1 ]]; then
+  cat <<'EOF'
+Usage: scripts/analytics-query.sh "SELECT ..."
+
+Examples:
+  scripts/analytics-query.sh "SELECT blob2, COUNT() FROM life_ustc_runtime WHERE timestamp > NOW() - INTERVAL '1' DAY AND blob1 = 'public_runtime_cache_v2' AND index1 LIKE 'cache:page:section-detail:overview:%' GROUP BY blob2"
+EOF
+  exit 1
+fi
+
+account_id="${CLOUDFLARE_ACCOUNT_ID:-}"
+if [[ -z "$account_id" ]]; then
+  account_id="$(wrangler whoami 2>/dev/null | rg -o '[0-9a-f]{32}' | head -1 || true)"
+fi
+
+if [[ -z "$account_id" ]]; then
+  echo "CLOUDFLARE_ACCOUNT_ID is required (or run wrangler whoami)." >&2
+  exit 1
+fi
+
+if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+  echo "CLOUDFLARE_API_TOKEN is required." >&2
+  exit 1
+fi
+
+curl -sS \
+  "https://api.cloudflare.com/client/v4/accounts/${account_id}/analytics_engine/sql" \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+  -d "$1"

--- a/src/features/auth/server/auth-record-cleanup-cli.ts
+++ b/src/features/auth/server/auth-record-cleanup-cli.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/generated/prisma-node/client";
+import { createNodePgPoolConfig } from "@/lib/db/node-pg-pool-config";
 import { cleanupExpiredAuthRecords } from "./auth-record-cleanup";
 
 async function main() {
@@ -10,7 +11,7 @@ async function main() {
   }
 
   const prisma = new PrismaClient({
-    adapter: new PrismaPg({ connectionString }),
+    adapter: new PrismaPg(createNodePgPoolConfig(connectionString)),
   });
 
   try {

--- a/src/features/uploads/server/upload-pending-cleanup-cli.ts
+++ b/src/features/uploads/server/upload-pending-cleanup-cli.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/generated/prisma-node/client";
+import { createNodePgPoolConfig } from "@/lib/db/node-pg-pool-config";
 import { cleanupStaleUploadPendingStorage } from "./upload-pending-cleanup";
 
 async function main() {
@@ -10,7 +11,7 @@ async function main() {
   }
 
   const prisma = new PrismaClient({
-    adapter: new PrismaPg({ connectionString }),
+    adapter: new PrismaPg(createNodePgPoolConfig(connectionString)),
   });
 
   try {

--- a/src/lib/db/node-pg-pool-config.ts
+++ b/src/lib/db/node-pg-pool-config.ts
@@ -1,5 +1,5 @@
 import type { PoolConfig } from "pg";
-import parseConnectionString from "pg-connection-string";
+import { parse as parseConnectionString } from "pg-connection-string";
 
 /**
  * Pool config for Node-side PrismaPg CLIs (static loader, maintenance crons).

--- a/src/lib/db/node-pg-pool-config.ts
+++ b/src/lib/db/node-pg-pool-config.ts
@@ -1,0 +1,15 @@
+import type { PoolConfig } from "pg";
+import parseConnectionString from "pg-connection-string";
+
+/**
+ * Pool config for Node-side PrismaPg CLIs (static loader, maintenance crons).
+ *
+ * pg v8+ treats sslmode=require/prefer/verify-ca as verify-full unless libpq
+ * compatibility is enabled. Production role URLs use sslmode=require with
+ * self-signed certs; Prisma migrate tolerates them but node-pg rejects them.
+ */
+export function createNodePgPoolConfig(connectionString: string): PoolConfig {
+  return parseConnectionString(connectionString, {
+    useLibpqCompat: true,
+  }) as PoolConfig;
+}

--- a/src/static-loader/prisma.ts
+++ b/src/static-loader/prisma.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
+import { createNodePgPoolConfig } from "@/lib/db/node-pg-pool-config";
 import { PrismaClient } from "../generated/prisma-node/client";
 
 export function createPrismaClient(): PrismaClient {
@@ -8,6 +9,6 @@ export function createPrismaClient(): PrismaClient {
     throw new Error("DATABASE_URL is required");
   }
 
-  const adapter = new PrismaPg({ connectionString });
+  const adapter = new PrismaPg(createNodePgPoolConfig(connectionString));
   return new PrismaClient({ adapter });
 }

--- a/src/static-loader/prisma.ts
+++ b/src/static-loader/prisma.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
-import { createNodePgPoolConfig } from "../lib/db/node-pg-pool-config";
 import { PrismaClient } from "../generated/prisma-node/client";
+import { createNodePgPoolConfig } from "../lib/db/node-pg-pool-config";
 
 export function createPrismaClient(): PrismaClient {
   const connectionString = process.env.DATABASE_URL;

--- a/src/static-loader/prisma.ts
+++ b/src/static-loader/prisma.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { PrismaPg } from "@prisma/adapter-pg";
-import { createNodePgPoolConfig } from "@/lib/db/node-pg-pool-config";
+import { createNodePgPoolConfig } from "../lib/db/node-pg-pool-config";
 import { PrismaClient } from "../generated/prisma-node/client";
 
 export function createPrismaClient(): PrismaClient {

--- a/tests/unit/node-pg-pool-config.test.ts
+++ b/tests/unit/node-pg-pool-config.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { createNodePgPoolConfig } from "@/lib/db/node-pg-pool-config";
+
+describe("createNodePgPoolConfig", () => {
+  it("allows self-signed certs for sslmode=require", () => {
+    const config = createNodePgPoolConfig(
+      "postgresql://user:pass@db.example.test:5432/life_ustc?sslmode=require",
+    );
+
+    expect(config.host).toBe("db.example.test");
+    expect(config.ssl).toEqual({ rejectUnauthorized: false });
+  });
+
+  it("keeps ssl disabled for sslmode=disable", () => {
+    const config = createNodePgPoolConfig(
+      "postgresql://user:pass@127.0.0.1:5432/life_ustc?sslmode=disable",
+    );
+
+    expect(config.ssl).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add shared `createNodePgPoolConfig()` using `pg-connection-string` with libpq-compatible SSL handling so `sslmode=require` tolerates self-signed production certs
- Apply to static loader, auth record cleanup, and upload pending cleanup CLIs
- Add `scripts/analytics-query.sh` helper for Analytics Engine SQL queries

## Context
Since Jul 30 (`2b0a5b2d`), scheduled Static Sync, Auth Record Cleanup, and Upload Pending Storage Cleanup have failed with `TlsConnectionError: self signed certificate`. Prisma migrate deploy still succeeds because it uses a different connection path; `@prisma/adapter-pg` + `pg` reject the cert unless libpq compat is enabled.

## Test plan
- [x] `bunx vitest run tests/unit/node-pg-pool-config.test.ts`
- [ ] CI Check passes
- [ ] After merge: manually dispatch Static Sync workflow and confirm import completes
- [ ] After merge: confirm Auth Record Cleanup and Upload Pending Storage Cleanup succeed on next schedule