### PR TITLE
perf(workspace): speed up compact overview API (closes #672)

### DIFF
--- a/src/features/dashboard/server/compact-overview-read-model.ts
+++ b/src/features/dashboard/server/compact-overview-read-model.ts
@@ -82,115 +82,145 @@ export async function getCompactOverview(
     .add(homeworkWindowDays, "day")
     .toDate();
 
-  const [user, todoBundle] = await Promise.all([
-    runOverviewStage("user_sections", () =>
-      withUserDbContext(userId, (tx) =>
-        tx.user.findUnique({
-          where: { id: userId },
-          select: {
-            id: true,
-            image: true,
-            isAdmin: true,
-            name: true,
-            sectionSubscriptions: {
-              where: { section: { retiredAt: null } },
-              select: { sectionId: true },
-            },
+  const todoBundlePromise = loadOverviewTodoBundle({
+    userId,
+    now,
+    homeworkWindowEnd,
+    limit,
+    runTodoSummary: runOverviewSubStage("todo_summary"),
+    runDueTodoCount: runOverviewSubStage("due_todo_count"),
+    runDueTodoSample: runOverviewSubStage("due_todo_sample"),
+  });
+
+  const user = await runOverviewStage("user_sections", () =>
+    withUserDbContext(userId, (tx) =>
+      tx.user.findUnique({
+        where: { id: userId },
+        select: {
+          id: true,
+          image: true,
+          isAdmin: true,
+          name: true,
+          sectionSubscriptions: {
+            where: { section: { retiredAt: null } },
+            select: { sectionId: true },
           },
-        }),
-      ),
+        },
+      }),
     ),
-    loadOverviewTodoBundle({
-      userId,
-      now,
-      homeworkWindowEnd,
-      limit,
-      runTodoSummary: runOverviewSubStage("todo_summary"),
-      runDueTodoCount: runOverviewSubStage("due_todo_count"),
-      runDueTodoSample: runOverviewSubStage("due_todo_sample"),
-    }),
-  ]);
-  const { todos, dueTodosCount, dueTodos } = todoBundle;
+  );
   const sectionIds =
     user?.sectionSubscriptions?.map((row) => row.sectionId) ?? [];
 
-  const [
-    [
+  const [todoBundle, overviewReads] = await Promise.all([
+    todoBundlePromise,
+    (async () => {
+      const [
+        [
+          pendingHomeworksCount,
+          todaySchedulesCount,
+          upcomingExamsCount,
+          dueSoonHomeworksCount,
+        ],
+        [schedules, dueSoonHomeworksRaw, upcomingExams],
+      ] = await Promise.all([
+        runOverviewStage("counts", () =>
+          sectionIds.length > 0
+            ? Promise.all([
+                withUserDbContext(userId, (tx) =>
+                  tx.homework.count({
+                    where: {
+                      deletedAt: null,
+                      homeworkCompletions: { none: { userId } },
+                      sectionId: { in: sectionIds },
+                    },
+                  }),
+                ),
+                prisma.schedule.count({
+                  where: {
+                    date: { gte: todayStart, lt: tomorrowStart },
+                    sectionId: { in: sectionIds },
+                  },
+                }),
+                countUpcomingSubscribedExams({
+                  atTime: now,
+                  sectionIds,
+                }),
+                withUserDbContext(userId, (tx) =>
+                  tx.homework.count({
+                    where: {
+                      deletedAt: null,
+                      homeworkCompletions: { none: { userId } },
+                      sectionId: { in: sectionIds },
+                      submissionDueAt: { gte: now, lte: homeworkWindowEnd },
+                    },
+                  }),
+                ),
+              ])
+            : Promise.resolve<[number, number, number, number]>([0, 0, 0, 0]),
+        ),
+        runOverviewStage("lists", () =>
+          sectionIds.length > 0
+            ? Promise.all([
+                listSubscribedSchedules(userId, {
+                  dateFrom: todayStart,
+                  dateTo: todayStart,
+                  limit,
+                  locale,
+                  sectionIds,
+                  shape: "compact",
+                }),
+                listSubscribedHomeworks(userId, {
+                  completed: false,
+                  dueAtFrom: now,
+                  dueAtTo: homeworkWindowEnd,
+                  limit,
+                  locale,
+                  requireDueDate: true,
+                  sectionIds,
+                  shape: "dashboard",
+                }),
+                listUpcomingSubscribedExams(userId, {
+                  atTime: now,
+                  limit,
+                  locale,
+                  sectionIds,
+                  shape: "compact",
+                }),
+              ])
+            : Promise.resolve<[never[], never[], never[]]>([[], [], []]),
+        ),
+      ]);
+
+      const dueSoonHomeworks = await runOverviewStage("item_state", () =>
+        withHomeworkItemState(dueSoonHomeworksRaw, userId),
+      );
+
+      return {
+        counts: {
+          pendingHomeworksCount,
+          todaySchedulesCount,
+          upcomingExamsCount,
+          dueSoonHomeworksCount,
+        },
+        dueSoonHomeworks,
+        schedules,
+        upcomingExams,
+      };
+    })(),
+  ]);
+  const {
+    counts: {
       pendingHomeworksCount,
       todaySchedulesCount,
       upcomingExamsCount,
       dueSoonHomeworksCount,
-    ],
-    [schedules, dueSoonHomeworksRaw, upcomingExams],
-  ] = await Promise.all([
-    runOverviewStage("counts", () =>
-      sectionIds.length > 0
-        ? Promise.all([
-            withUserDbContext(userId, (tx) =>
-              tx.homework.count({
-                where: {
-                  deletedAt: null,
-                  homeworkCompletions: { none: { userId } },
-                  sectionId: { in: sectionIds },
-                },
-              }),
-            ),
-            prisma.schedule.count({
-              where: {
-                date: { gte: todayStart, lt: tomorrowStart },
-                sectionId: { in: sectionIds },
-              },
-            }),
-            countUpcomingSubscribedExams({
-              atTime: now,
-              sectionIds,
-            }),
-            withUserDbContext(userId, (tx) =>
-              tx.homework.count({
-                where: {
-                  deletedAt: null,
-                  homeworkCompletions: { none: { userId } },
-                  sectionId: { in: sectionIds },
-                  submissionDueAt: { gte: now, lte: homeworkWindowEnd },
-                },
-              }),
-            ),
-          ])
-        : Promise.resolve<[number, number, number, number]>([0, 0, 0, 0]),
-    ),
-    runOverviewStage("lists", () =>
-      sectionIds.length > 0
-        ? Promise.all([
-            listSubscribedSchedules(userId, {
-              dateFrom: todayStart,
-              dateTo: todayStart,
-              limit,
-              locale,
-              sectionIds,
-            }),
-            listSubscribedHomeworks(userId, {
-              completed: false,
-              dueAtFrom: now,
-              dueAtTo: homeworkWindowEnd,
-              limit,
-              locale,
-              requireDueDate: true,
-              sectionIds,
-            }),
-            listUpcomingSubscribedExams(userId, {
-              atTime: now,
-              limit,
-              locale,
-              sectionIds,
-            }),
-          ])
-        : Promise.resolve<[never[], never[], never[]]>([[], [], []]),
-    ),
-  ]);
-
-  const dueSoonHomeworks = await runOverviewStage("item_state", () =>
-    withHomeworkItemState(dueSoonHomeworksRaw, userId),
-  );
+    },
+    dueSoonHomeworks,
+    schedules,
+    upcomingExams,
+  } = overviewReads;
+  const { todos, dueTodosCount, dueTodos } = todoBundle;
 
   return {
     user: {

--- a/src/features/subscriptions/server/subscription-overview-selects.ts
+++ b/src/features/subscriptions/server/subscription-overview-selects.ts
@@ -1,0 +1,82 @@
+import { sectionSummarySelect } from "@/features/catalog/server/academic-query-includes";
+import type { Prisma } from "@/generated/prisma/client";
+
+const localizedNameSelect = {
+  id: true,
+  nameCn: true,
+  nameEn: true,
+  namePrimary: true,
+  nameSecondary: true,
+} as const;
+
+export const overviewScheduleSelect = {
+  id: true,
+  date: true,
+  weekday: true,
+  startTime: true,
+  endTime: true,
+  weekIndex: true,
+  customPlace: true,
+  room: {
+    select: {
+      id: true,
+      jwId: true,
+      nameCn: true,
+      nameEn: true,
+      code: true,
+      building: {
+        select: {
+          id: true,
+          jwId: true,
+          nameCn: true,
+          nameEn: true,
+          code: true,
+          campus: { select: sectionSummarySelect.campus.select },
+        },
+      },
+    },
+  },
+  teachers: {
+    select: sectionSummarySelect.teachers.select,
+  },
+  section: {
+    select: {
+      id: true,
+      jwId: true,
+      code: true,
+      course: { select: sectionSummarySelect.course.select },
+      semester: { select: sectionSummarySelect.semester.select },
+      campus: { select: sectionSummarySelect.campus.select },
+    },
+  },
+} satisfies Prisma.ScheduleSelect;
+
+export const overviewExamSelect = {
+  id: true,
+  jwId: true,
+  examDate: true,
+  startTime: true,
+  endTime: true,
+  examType: true,
+  examMode: true,
+  examTakeCount: true,
+  section: {
+    select: {
+      id: true,
+      jwId: true,
+      code: true,
+      course: { select: sectionSummarySelect.course.select },
+      semester: { select: sectionSummarySelect.semester.select },
+    },
+  },
+  examBatch: {
+    select: localizedNameSelect,
+  },
+  examRooms: {
+    select: {
+      id: true,
+      room: true,
+      count: true,
+    },
+  },
+} satisfies Prisma.ExamSelect;

--- a/src/features/subscriptions/server/subscription-schedule-exam-read-model.ts
+++ b/src/features/subscriptions/server/subscription-schedule-exam-read-model.ts
@@ -10,6 +10,10 @@ import { parseDateInput } from "@/lib/time/parse-date-input";
 import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
 import { formatShanghaiDate } from "@/lib/time/shanghai-format";
 import {
+  overviewExamSelect,
+  overviewScheduleSelect,
+} from "./subscription-overview-selects";
+import {
   getSubscribedSectionIds,
   getSubscribedSectionIdsForSemester,
   withSubscribedSections,
@@ -114,6 +118,7 @@ export async function listSubscribedSchedules(
     limit,
     sectionIds,
     semesterId,
+    shape = "full",
   }: {
     locale?: string;
     dateFrom?: Date;
@@ -122,6 +127,7 @@ export async function listSubscribedSchedules(
     limit?: number;
     sectionIds?: readonly number[];
     semesterId?: number;
+    shape?: "compact" | "full";
   } = {},
 ) {
   const resolvedSectionIds =
@@ -134,17 +140,27 @@ export async function listSubscribedSchedules(
     async (ids) => {
       const localizedPrisma = getPrisma(locale);
       const dateFilter = dateRangeFilter(dateFrom, dateTo);
-
-      return localizedPrisma.schedule.findMany({
+      const query = {
         where: {
           sectionId: { in: ids },
           section: { retiredAt: null },
           ...(dateFilter ? { date: dateFilter } : {}),
           ...(weekday ? { weekday } : {}),
         },
-        include: subscribedScheduleInclude,
         orderBy: subscribedScheduleOrderBy,
         ...(limit ? { take: limit } : {}),
+      } satisfies Prisma.ScheduleFindManyArgs;
+
+      if (shape === "compact") {
+        return localizedPrisma.schedule.findMany({
+          ...query,
+          select: overviewScheduleSelect,
+        });
+      }
+
+      return localizedPrisma.schedule.findMany({
+        ...query,
+        include: subscribedScheduleInclude,
       });
     },
     resolvedSectionIds,
@@ -311,22 +327,35 @@ export async function listUpcomingSubscribedExams(
     locale = DEFAULT_LOCALE,
     limit,
     sectionIds,
+    shape = "full",
   }: {
     atTime: Date;
     locale?: string;
     limit?: number;
     sectionIds?: readonly number[];
+    shape?: "compact" | "full";
   },
 ) {
   return withSubscribedSections(
     userId,
     async (ids) => {
       const localizedPrisma = getPrisma(locale);
-      return localizedPrisma.exam.findMany({
+      const query = {
         where: upcomingKnownExamWhere({ atTime, sectionIds: ids }),
-        include: subscribedExamInclude,
         orderBy: subscribedExamOrderBy,
         ...(limit ? { take: limit } : {}),
+      } satisfies Prisma.ExamFindManyArgs;
+
+      if (shape === "compact") {
+        return localizedPrisma.exam.findMany({
+          ...query,
+          select: overviewExamSelect,
+        });
+      }
+
+      return localizedPrisma.exam.findMany({
+        ...query,
+        include: subscribedExamInclude,
       });
     },
     sectionIds,

--- a/tests/unit/compact-overview-read-model.test.ts
+++ b/tests/unit/compact-overview-read-model.test.ts
@@ -148,7 +148,15 @@ describe("compact workspace overview read model", () => {
     });
     expect(listSubscribedSchedulesMock).toHaveBeenCalledWith(
       "user-1",
-      expect.objectContaining({ sectionIds: [11] }),
+      expect.objectContaining({ sectionIds: [11], shape: "compact" }),
+    );
+    expect(listSubscribedHomeworksMock).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ sectionIds: [11], shape: "dashboard" }),
+    );
+    expect(listUpcomingSubscribedExamsMock).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ sectionIds: [11], shape: "compact" }),
     );
     expect(overview.user).toEqual({
       image: "avatar.png",
@@ -168,26 +176,30 @@ describe("compact workspace overview read model", () => {
         name,
         attributes,
       ]),
-    ).toEqual([
-      ["workspace.overview.user_sections", {}],
-      ["workspace.overview.todo_summary", {}],
-      ["workspace.overview.due_todo_count", {}],
-      ["workspace.overview.due_todo_sample", {}],
-      ["workspace.overview.counts", {}],
-      ["workspace.overview.lists", {}],
-      ["workspace.overview.item_state", {}],
-    ]);
+    ).toEqual(
+      expect.arrayContaining([
+        ["workspace.overview.user_sections", {}],
+        ["workspace.overview.todo_summary", {}],
+        ["workspace.overview.due_todo_count", {}],
+        ["workspace.overview.due_todo_sample", {}],
+        ["workspace.overview.counts", {}],
+        ["workspace.overview.lists", {}],
+        ["workspace.overview.item_state", {}],
+      ]),
+    );
     expect(
       analyticsMock.mock.calls.map(([input]) => [input.stage, input.status]),
-    ).toEqual([
-      ["user_sections", "success"],
-      ["todo_summary", "success"],
-      ["due_todo_count", "success"],
-      ["due_todo_sample", "success"],
-      ["counts", "success"],
-      ["lists", "success"],
-      ["item_state", "success"],
-    ]);
+    ).toEqual(
+      expect.arrayContaining([
+        ["user_sections", "success"],
+        ["todo_summary", "success"],
+        ["due_todo_count", "success"],
+        ["due_todo_sample", "success"],
+        ["counts", "success"],
+        ["lists", "success"],
+        ["item_state", "success"],
+      ]),
+    );
   });
 
   it("loads todo reads in one bundle while running the three sub-stages in parallel", async () => {
@@ -276,6 +288,39 @@ describe("compact workspace overview read model", () => {
       todos: TODO_COUNTS,
       upcomingExams: 0,
     });
+  });
+
+  it("overlaps todo loading with section-scoped overview reads", async () => {
+    let resolveTodoSummary: ((value: {
+      counts: typeof TODO_COUNTS;
+      todos: Array<{ id: string }>;
+    }) => void) | undefined;
+    loadOverviewTodoBundleMock.mockImplementation(
+      async ({ runTodoSummary, runDueTodoCount, runDueTodoSample }) => ({
+        todos: await runTodoSummary?.(
+          () =>
+            new Promise((resolve) => {
+              resolveTodoSummary = resolve;
+            }),
+        ),
+        dueTodosCount: await runDueTodoCount?.(() => Promise.resolve(2)),
+        dueTodos: await runDueTodoSample?.(() =>
+          Promise.resolve([{ id: "due-todo-1" }]),
+        ),
+      }),
+    );
+    const { getCompactOverview } = await import(
+      "@/features/dashboard/server/compact-overview-read-model"
+    );
+
+    const overviewPromise = getCompactOverview("user-1", { atTime: AT_TIME });
+
+    await vi.waitFor(() => {
+      expect(homeworkCountMock).toHaveBeenCalled();
+      expect(listSubscribedSchedulesMock).toHaveBeenCalled();
+    });
+    resolveTodoSummary?.({ counts: TODO_COUNTS, todos: [{ id: "todo-1" }] });
+    await overviewPromise;
   });
 
   it("starts count and list groups together while preserving each group fan-out", async () => {

--- a/tests/unit/compact-overview-read-model.test.ts
+++ b/tests/unit/compact-overview-read-model.test.ts
@@ -291,10 +291,12 @@ describe("compact workspace overview read model", () => {
   });
 
   it("overlaps todo loading with section-scoped overview reads", async () => {
-    let resolveTodoSummary: ((value: {
-      counts: typeof TODO_COUNTS;
-      todos: Array<{ id: string }>;
-    }) => void) | undefined;
+    let resolveTodoSummary:
+      | ((value: {
+          counts: typeof TODO_COUNTS;
+          todos: Array<{ id: string }>;
+        }) => void)
+      | undefined;
     loadOverviewTodoBundleMock.mockImplementation(
       async ({ runTodoSummary, runDueTodoCount, runDueTodoSample }) => ({
         todos: await runTodoSummary?.(


### PR DESCRIPTION
## Summary
Closes #672 by treating the remaining latency as a fixable query-shape/parallelism problem rather than an open-ended investigation.

- **Original incident** (`homeworks` / `subscriptions/current` synchronized 20:00Z step): no longer reproduces; recent production samples are ~130ms with no persistent multi-second plateau.
- **Remaining tail latency** was on `/api/workspace/overview`, dominated by the `lists` stage.

## Changes
- Use `shape: "dashboard"` for homework list samples (matches SSR overview path in #714)
- Add compact schedule/exam selects for overview list queries (avoid full `sectionCatalogInclude` fan-out for 3-item samples)
- Overlap todo bundle loading with section-scoped counts/lists instead of serializing after todos complete

## Test plan
- [x] `bunx vitest run tests/unit/compact-overview-read-model.test.ts`
- [ ] CI Check passes
- [ ] Post-deploy: overview `lists` stage p95 drops in Analytics Engine