### PR TITLE
fix(comments): repair the migration that left anonymous comment reads failing

### DIFF
--- a/prisma/migrations/20260802120000_comment_hidden_count_definer/migration.sql
+++ b/prisma/migrations/20260802120000_comment_hidden_count_definer/migration.sql
@@ -1,20 +1,85 @@
 BEGIN;
 
--- FORCE RLS applies to the function owner too. This policy is bound to the
--- migration owner and activated only by the hidden-count helper below.
+-- `20260801120000_comment_collaborative_rls` was applied in some environments
+-- from a revision that did not yet contain this function, so this migration
+-- cannot assume it exists. Create it when missing and leave an existing one
+-- alone: once the roles bootstrap has run, the function is owned by
+-- `life_ustc_function_owner` and the migrator may no longer replace it.
+-- Keep the body in sync with 20260801120000.
+DO $do$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_proc AS p
+    JOIN pg_namespace AS n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'comment_hidden_root_count'
+  ) THEN
+    EXECUTE $fn$
+      CREATE FUNCTION public.comment_hidden_root_count(
+        p_section_id integer DEFAULT NULL,
+        p_course_id integer DEFAULT NULL,
+        p_teacher_id integer DEFAULT NULL,
+        p_homework_id text DEFAULT NULL,
+        p_section_teacher_id integer DEFAULT NULL
+      ) RETURNS bigint
+      LANGUAGE sql
+      STABLE
+      SECURITY DEFINER
+      SET search_path = ''
+      AS $function$
+        SELECT COUNT(*)::bigint
+        FROM public."Comment"
+        WHERE "parentId" IS NULL
+          AND "status" = 'active'
+          AND "visibility" = 'logged_in_only'
+          AND (
+            (p_section_id IS NOT NULL AND "sectionId" = p_section_id)
+            OR (p_course_id IS NOT NULL AND "courseId" = p_course_id)
+            OR (p_teacher_id IS NOT NULL AND "teacherId" = p_teacher_id)
+            OR (p_homework_id IS NOT NULL AND "homeworkId" = p_homework_id)
+            OR (p_section_teacher_id IS NOT NULL
+                AND "sectionTeacherId" = p_section_teacher_id)
+          );
+      $function$;
+    $fn$;
+  END IF;
+END
+$do$;
+
+-- FORCE RLS applies to the definer too, and no other policy exposes
+-- `logged_in_only` rows, so the definer needs its own SELECT policy. The roles
+-- bootstrap re-binds this policy to `life_ustc_function_owner`; before it runs
+-- the migrator is the only role that executes the function.
+DROP POLICY IF EXISTS "Comment_hidden_count_reader" ON "Comment";
 CREATE POLICY "Comment_hidden_count_reader" ON "Comment"
   FOR SELECT
   TO CURRENT_USER
   USING (true);
 
-REVOKE ALL
-  ON FUNCTION public.comment_hidden_root_count(
-    integer,
-    integer,
-    integer,
-    text,
-    integer
-  )
-  FROM PUBLIC;
+-- Only the function owner may change its privileges, and after the bootstrap
+-- that is `life_ustc_function_owner` rather than the migrator.
+DO $do$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_proc AS p
+    JOIN pg_namespace AS n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'comment_hidden_root_count'
+      AND pg_get_userbyid(p.proowner) = current_user
+  ) THEN
+    EXECUTE 'REVOKE ALL ON FUNCTION public.comment_hidden_root_count('
+      || 'integer, integer, integer, text, integer'
+      || ') FROM PUBLIC';
+
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'life_ustc_runtime') THEN
+      EXECUTE 'GRANT EXECUTE ON FUNCTION public.comment_hidden_root_count('
+        || 'integer, integer, integer, text, integer'
+        || ') TO life_ustc_runtime';
+    END IF;
+  END IF;
+END
+$do$;
 
 COMMIT;

--- a/src/lib/log/app-logger-core.ts
+++ b/src/lib/log/app-logger-core.ts
@@ -30,11 +30,29 @@ export function shouldLog(level: AppLogLevel): boolean {
   return LOG_LEVEL_INDEX[level] >= LOG_LEVEL_INDEX[parseConfiguredLogLevel()];
 }
 
+const PRISMA_ERROR_CODE_PATTERN = /^P\d{4}$/;
+
+/**
+ * Prisma error codes are stable, documented identifiers with no request data in
+ * them, so they are safe to keep in production where the message is not.
+ * Without the code a production `PrismaClientKnownRequestError` is undiagnosable.
+ */
+function safePrismaErrorCode(error: unknown) {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return undefined;
+  }
+  const { code } = error as { code: unknown };
+  return typeof code === "string" && PRISMA_ERROR_CODE_PATTERN.test(code)
+    ? code
+    : undefined;
+}
+
 export function serializeError(error: unknown) {
   if (!error) return undefined;
 
   if (isProductionEnvironment()) {
-    return { name: getSafeErrorName(error) };
+    const code = safePrismaErrorCode(error);
+    return { name: getSafeErrorName(error), ...(code ? { code } : {}) };
   }
 
   if (error instanceof Error) {

--- a/tests/integration/comment-list-anonymous.test.ts
+++ b/tests/integration/comment-list-anonymous.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { getCommentsRoute } from "@/lib/api/routes/comments-list-route";
+import { prisma } from "@/lib/db/prisma";
+import { DEV_SEED } from "../fixtures/dev-seed";
+
+/**
+ * The anonymous branch of `loadCommentThread` is the only caller of the
+ * `comment_hidden_root_count` SQL function, so it is the only path that fails
+ * when that function is missing or its privileges drift. Signed-in requests
+ * skip it entirely, which is how a broken deploy reached production unnoticed.
+ */
+async function getAnonymously(query: string) {
+  return getCommentsRoute(
+    new Request(`https://example.test/api/community/comments?${query}`),
+  );
+}
+
+describe("GET /api/community/comments (anonymous)", () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it("lists section comments without a viewer and reports a hidden count", async () => {
+    const response = await getAnonymously(
+      `targetType=section&sectionJwId=${DEV_SEED.section.jwId}`,
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data?: unknown[];
+      meta?: { hiddenCount?: number; viewer?: { isAuthenticated?: boolean } };
+    };
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.meta?.viewer?.isAuthenticated).toBe(false);
+    expect(typeof body.meta?.hiddenCount).toBe("number");
+    expect(body.meta?.hiddenCount).toBeGreaterThanOrEqual(0);
+  });
+
+  it("resolves every anonymous comment target type", async () => {
+    const teacher = await prisma.teacher.findFirstOrThrow({
+      where: { code: DEV_SEED.teacher.code },
+      select: { id: true },
+    });
+
+    for (const query of [
+      `targetType=section&sectionJwId=${DEV_SEED.section.jwId}`,
+      `targetType=course&courseJwId=${DEV_SEED.course.jwId}`,
+      `targetType=teacher&teacherId=${teacher.id}`,
+    ]) {
+      const response = await getAnonymously(query);
+      expect(response.status, query).toBe(200);
+    }
+  });
+});


### PR DESCRIPTION
Closes #729

## What was broken

`GET /api/community/comments` returned **500 for every unauthenticated request** in production, and `prisma migrate deploy` was failing, which blocks all further deploys.

The anonymous branch of `loadCommentThread` is the only caller of `comment_hidden_root_count`, and that function did not exist. Migration `20260801120000` is recorded as applied from a revision that predated its `CREATE FUNCTION` — the checksum proves the file changed afterwards (`13ce66c5…` recorded vs `374851a1…` on disk). `20260802120000` then ran `REVOKE ALL ON FUNCTION` against the missing function, failed, and left a `finished_at IS NULL` row in `_prisma_migrations`.

CI stayed green because `ci:integration` and `ci:rls` build a fresh database, where `20260801120000` runs from the current file and creates the function. Only databases migrated from the earlier revision are affected.

## The fix

`20260802120000` now creates the function when it is absent and leaves an existing one alone — after the roles bootstrap runs, the function is owned by `life_ustc_function_owner` and the migrator can no longer replace it. Privilege changes are guarded on current ownership for the same reason, and the policy is still created unconditionally because both `prisma/roles/production-runtime-bootstrap.sql` and `tests/integration/fixtures/rls-runtime-bootstrap.sql` expect to `ALTER POLICY` it afterwards.

`serializeError` now keeps the Prisma error code in production. It previously emitted only `{ name: "PrismaClientKnownRequestError" }`, which is precisely why this was undiagnosable from logs. Codes such as `P2010` are stable documented identifiers with no request data in them, unlike the message.

## Test plan

- [x] Applies cleanly on a drifted database (function dropped, migration record cleared) — reproduces the production state
- [x] Applies cleanly on a fresh database, where `20260801120000` already created the function
- [x] Re-running the migration SQL directly is idempotent
- [x] New `tests/integration/comment-list-anonymous.test.ts` drives the real route handler anonymously against Postgres; verified it **fails** when the function is dropped and passes when present
- [x] `biome check`, three `tsc` configs, `svelte-check`, 1911 unit and 258 integration tests
- [ ] CI `PostgreSQL RLS Isolation Test` exercises `db:migrate:deploy`

## Deploy note

Production still holds the failed `_prisma_migrations` row, so it must be cleared before this can apply:

```
bunx prisma migrate resolve --rolled-back 20260802120000_comment_hidden_count_definer
bunx prisma migrate deploy
```

Re-running `prisma/roles/production-runtime-bootstrap.sql` afterwards is still needed to transfer function ownership and re-bind the policy to `life_ustc_function_owner`.