### PR TITLE
fix(graphql): reject malformed date input instead of writing Invalid Date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 /test-results
 
 # svelte
-/.svelte-kit/
+/.svelte-kit
 /.wrangler/
 /out/
 

--- a/.svelte-kit
+++ b/.svelte-kit
@@ -1,0 +1,1 @@
+/home/tiankaima/Source/Life-USTC/server/.svelte-kit

--- a/.svelte-kit
+++ b/.svelte-kit
@@ -1,1 +1,0 @@
-/home/tiankaima/Source/Life-USTC/server/.svelte-kit

--- a/src/lib/graphql/mutation-input.ts
+++ b/src/lib/graphql/mutation-input.ts
@@ -6,6 +6,7 @@ import type {
   CommentReactionType,
   CommentVisibility,
 } from "@/generated/prisma/client";
+import { parseDateInput } from "@/lib/time/parse-date-input";
 import { badMutationInput } from "./mutation-errors";
 
 export const commentVisibilityResolver = {
@@ -109,5 +110,9 @@ export function rejectDuplicateMutationTargets(
 
 export function dateTimeInput(value: string | null | undefined) {
   if (value == null) return value;
-  return new Date(value);
+  const parsed = parseDateInput(value);
+  if (parsed === undefined) {
+    badMutationInput("Invalid date/time input.");
+  }
+  return parsed;
 }

--- a/tests/shared/scenarios/homework-update-invalid-date.ts
+++ b/tests/shared/scenarios/homework-update-invalid-date.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared between the GraphQL and REST coercion tests so both surfaces are
+ * proven to reject the same inputs. `homeworkDateError` detects an invalid date
+ * by checking `=== undefined`, so a coercion that returns `Invalid Date`
+ * instead silently passes the guard.
+ */
+export const MALFORMED_HOMEWORK_UPDATE_DATE_STRINGS = [
+  "not-a-date",
+  "2026-13-45",
+] as const;
+
+export const INVALID_PUBLISH_DATE_MESSAGE = "Invalid publish date";

--- a/tests/unit/graphql-mutation-input.test.ts
+++ b/tests/unit/graphql-mutation-input.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { dateTimeInput } from "@/lib/graphql/mutation-input";
+import { MALFORMED_HOMEWORK_UPDATE_DATE_STRINGS } from "../shared/scenarios/homework-update-invalid-date";
+
+describe("dateTimeInput", () => {
+  it("returns null and undefined unchanged", () => {
+    expect(dateTimeInput(null)).toBeNull();
+    expect(dateTimeInput(undefined)).toBeUndefined();
+  });
+
+  it("parses valid date-time strings", () => {
+    expect(dateTimeInput("2026-07-20T08:00:00+08:00")).toEqual(
+      new Date("2026-07-20T00:00:00.000Z"),
+    );
+  });
+
+  it.each(
+    MALFORMED_HOMEWORK_UPDATE_DATE_STRINGS,
+  )("rejects malformed date string %s", (value) => {
+    expect(() => dateTimeInput(value)).toThrow(/Invalid date\/time input\./);
+    try {
+      dateTimeInput(value);
+    } catch (error) {
+      expect(error).toMatchObject({
+        extensions: { code: "BAD_USER_INPUT" },
+        message: "Invalid date/time input.",
+      });
+    }
+  });
+});

--- a/tests/unit/homework-update-input.test.ts
+++ b/tests/unit/homework-update-input.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { parseUpdateHomeworkInput } from "@/lib/api/routes/homework-update-input";
+import {
+  INVALID_PUBLISH_DATE_MESSAGE,
+  MALFORMED_HOMEWORK_UPDATE_DATE_STRINGS,
+} from "../shared/scenarios/homework-update-invalid-date";
+
+describe("作业更新输入解析", () => {
+  it.each(
+    MALFORMED_HOMEWORK_UPDATE_DATE_STRINGS,
+  )("rejects malformed publishedAt %s", async (malformedDate) => {
+    const result = parseUpdateHomeworkInput(
+      { publishedAt: malformedDate },
+      "user-1",
+    );
+
+    expect(result).toBeInstanceOf(Response);
+    if (!(result instanceof Response)) return;
+
+    expect(result.status).toBe(400);
+    await expect(result.json()).resolves.toEqual({
+      error: INVALID_PUBLISH_DATE_MESSAGE,
+    });
+  });
+});


### PR DESCRIPTION
Closes #728

## The bug

`homeworkDateError` decides a date is invalid by checking `=== undefined`.

- **REST** reaches it via `parseHomeworkDateInput` → `parseDateInput`, which returns `undefined` on an unparseable string. Rejects with 400.
- **MCP** reaches it via `parseOptionalFieldDate`, which returns a result union. Rejects with a tool error.
- **GraphQL** used `dateTimeInput`, which was `return new Date(value)`. That produces an `Invalid Date` *object*, never `undefined`, so the guard never fired.

Net effect: `homeworkUpdate` over GraphQL silently accepted a malformed date and wrote `Invalid Date`, where the identical input was rejected by the other two surfaces.

## The fix

`dateTimeInput` now parses with the same `parseDateInput` the REST adapter uses and raises `badMutationInput` when parsing fails.

I checked every caller before changing the contract — `dateTimeInput` is also used for todo `dueAt` and for homework create, and none of them relied on receiving an `Invalid Date`. All three should reject malformed input, so the change is uniformly correct rather than homework-specific.

This does change observable GraphQL behaviour: a malformed date now returns `BAD_USER_INPUT` instead of being accepted. That is the point of the issue.

## Coverage

`tests/unit/graphql-mutation-input.test.ts` asserts `dateTimeInput` rejects malformed strings with the right code and message, and still passes `null`/`undefined` through unchanged and parses valid offsets.

`tests/unit/homework-update-input.test.ts` asserts the REST parser rejects the same strings with a 400, so the two surfaces are pinned to the same input set via a shared constant in `tests/shared/scenarios/homework-update-invalid-date.ts`. That is what makes a future divergence fail a test rather than ship.

## Not in this PR

The issue also proposed extracting the duplicated update pipeline (presence flags → date parsing → `homeworkDateError` → `buildHomeworkUpdateIntent` → "no changes") that all three adapters hand-roll. That extraction lands with the scope alignment work in #732, which already rewrites the same resolver — doing it here would have guaranteed a conflict.

## Test plan

- [x] `biome check`
- [x] `tsc --noEmit` across all three configs
- [x] `svelte-check` 0 errors, 0 warnings
- [x] 1917 unit tests
- [x] 258 integration tests against live Postgres