### PR TITLE
fix!: align section-homework scopes, upload error mapping, and centralize comment visibility

### DIFF
--- a/.svelte-kit
+++ b/.svelte-kit
@@ -1,0 +1,1 @@
+/home/tiankaima/Source/Life-USTC/server/.svelte-kit

--- a/.svelte-kit
+++ b/.svelte-kit
@@ -1,1 +1,0 @@
-/home/tiankaima/Source/Life-USTC/server/.svelte-kit

--- a/docs/contracts/homework.json
+++ b/docs/contracts/homework.json
@@ -138,7 +138,7 @@
             "name": "homeworkCreate",
             "arguments": { "input": "CreateHomeworkInput!" },
             "returns": "HomeworkMutationPayload!",
-            "required_scopes": ["workspace.homework:write"],
+            "required_scopes": ["community.section-homework:write"],
             "rest_equivalent": "POST /api/community/section-homeworks",
             "mcp_equivalent": "community_section_homework_create",
             "notes": [
@@ -152,7 +152,7 @@
               "input": "UpdateHomeworkInput!"
             },
             "returns": "HomeworkMutationPayload!",
-            "required_scopes": ["workspace.homework:write"],
+            "required_scopes": ["community.section-homework:write"],
             "rest_equivalent": "PATCH /api/community/section-homeworks/[id]",
             "mcp_equivalent": "community_section_homework_update",
             "notes": [
@@ -164,7 +164,7 @@
             "name": "homeworkDelete",
             "arguments": { "id": "ID!" },
             "returns": "HomeworkDeleteMutationPayload!",
-            "required_scopes": ["workspace.homework:write"],
+            "required_scopes": ["community.section-homework:write"],
             "rest_equivalent": "DELETE /api/community/section-homeworks/[id]",
             "mcp_equivalent": "community_section_homework_delete",
             "notes": [

--- a/docs/graphql/schema.graphql
+++ b/docs/graphql/schema.graphql
@@ -9,10 +9,10 @@ type BatchMutationError {
 
 enum BatchMutationErrorCode {
   DELETED
-  SUSPENDED
   FORBIDDEN
   LOCKED
   NOT_FOUND
+  SUSPENDED
 }
 
 type BusCampus {

--- a/docs/graphql/schema.graphql
+++ b/docs/graphql/schema.graphql
@@ -9,6 +9,7 @@ type BatchMutationError {
 
 enum BatchMutationErrorCode {
   DELETED
+  SUSPENDED
   FORBIDDEN
   LOCKED
   NOT_FOUND

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -26165,7 +26165,8 @@
                           "enum": [
                             "not_found",
                             "forbidden",
-                            "locked"
+                            "locked",
+                            "suspended"
                           ]
                         },
                         "message": {

--- a/src/features/comments/server/comment-attachment-access.ts
+++ b/src/features/comments/server/comment-attachment-access.ts
@@ -2,6 +2,10 @@ import type {
   CommentStatus,
   CommentVisibility,
 } from "@/generated/prisma/client";
+import {
+  type CommentVisibilityViewer,
+  canViewerAccessCommentAttachment as canViewerAccessCommentAttachmentByPolicy,
+} from "./comment-visibility-policy";
 
 export type CommentAttachmentAccessComment = {
   status: CommentStatus;
@@ -9,22 +13,11 @@ export type CommentAttachmentAccessComment = {
   visibility: CommentVisibility;
 };
 
-export type CommentAttachmentAccessViewer = {
-  isAdmin: boolean;
-  isAuthenticated: boolean;
-  userId: string | null;
-};
+export type CommentAttachmentAccessViewer = CommentVisibilityViewer;
 
 export function canViewerAccessCommentAttachment(
   comment: CommentAttachmentAccessComment,
   viewer: CommentAttachmentAccessViewer,
 ) {
-  if (!viewer.isAuthenticated) return false;
-  if (comment.status === "deleted") return false;
-  if (comment.status === "softbanned") {
-    return viewer.isAdmin || comment.userId === viewer.userId;
-  }
-  return (
-    comment.visibility === "public" || comment.visibility === "logged_in_only"
-  );
+  return canViewerAccessCommentAttachmentByPolicy(comment, viewer);
 }

--- a/src/features/comments/server/comment-batch-delete.ts
+++ b/src/features/comments/server/comment-batch-delete.ts
@@ -6,7 +6,11 @@ type CommentBatchDeleteAuditMetadata = {
   userAgent?: string;
 };
 
-type CommentBatchDeleteErrorCode = "forbidden" | "locked" | "not_found";
+type CommentBatchDeleteErrorCode =
+  | "forbidden"
+  | "locked"
+  | "not_found"
+  | "suspended";
 
 function commentBatchDeleteErrorMessage(
   code: CommentBatchDeleteErrorCode,
@@ -16,6 +20,8 @@ function commentBatchDeleteErrorMessage(
       return "Comment not found";
     case "locked":
       return "Comment locked";
+    case "suspended":
+      return "Suspended";
     default:
       return "Forbidden";
   }
@@ -34,8 +40,7 @@ export async function deleteOwnCommentsBatch(input: {
         userId: input.userId,
       });
       if (!result.ok) {
-        const code: CommentBatchDeleteErrorCode =
-          result.error === "suspended" ? "forbidden" : result.error;
+        const code: CommentBatchDeleteErrorCode = result.error;
         return {
           success: false as const,
           id,

--- a/src/features/comments/server/comment-interaction-policy.ts
+++ b/src/features/comments/server/comment-interaction-policy.ts
@@ -2,6 +2,7 @@ import type {
   CommentStatus,
   CommentVisibility,
 } from "@/generated/prisma/client";
+import { isLoggedInOnlyCommentVisibleToViewer } from "./comment-visibility-policy";
 
 type CommentInteractionComment = {
   status: CommentStatus | string;
@@ -19,7 +20,7 @@ export function canViewerWriteCommentInteraction(
 ) {
   if (!viewer.isAuthenticated || viewer.isSuspended) return false;
   if (comment.status !== "active") return false;
-  if (comment.visibility === "logged_in_only" && !viewer.isAuthenticated) {
+  if (!isLoggedInOnlyCommentVisibleToViewer(comment.visibility, viewer)) {
     return false;
   }
   return true;

--- a/src/features/comments/server/comment-read-model.ts
+++ b/src/features/comments/server/comment-read-model.ts
@@ -12,6 +12,7 @@ import {
   type RawComment,
 } from "./comment-serialization";
 import type { ResolvedCommentTarget } from "./comment-utils";
+import { directlyVisibleCommentWhere } from "./comment-visibility-policy";
 
 export const commentThreadInclude = {
   user: {
@@ -234,27 +235,6 @@ export type CommentTargetLookupRecord = Prisma.CommentGetPayload<{
   select: typeof commentTargetLookupSelect;
 }>;
 
-function directlyVisibleCommentWhere(
-  viewer: ViewerContext,
-): Prisma.CommentWhereInput {
-  const visibleStatus: Prisma.CommentWhereInput = viewer.isAdmin
-    ? { status: { in: ["active", "softbanned"] } }
-    : viewer.userId
-      ? {
-          OR: [
-            { status: "active" },
-            { status: "softbanned", userId: viewer.userId },
-          ],
-        }
-      : { status: "active" };
-
-  return {
-    AND: [
-      visibleStatus,
-      ...(viewer.isAuthenticated ? [] : [{ visibility: "public" as const }]),
-    ],
-  };
-}
 
 async function countAnonymousHiddenRoots(
   whereTarget: Record<string, number | string>,

--- a/src/features/comments/server/comment-read-model.ts
+++ b/src/features/comments/server/comment-read-model.ts
@@ -235,7 +235,6 @@ export type CommentTargetLookupRecord = Prisma.CommentGetPayload<{
   select: typeof commentTargetLookupSelect;
 }>;
 
-
 async function countAnonymousHiddenRoots(
   whereTarget: Record<string, number | string>,
 ): Promise<number> {

--- a/src/features/comments/server/comment-serialization-helpers.ts
+++ b/src/features/comments/server/comment-serialization-helpers.ts
@@ -5,6 +5,7 @@ import type {
   RawComment,
   ViewerInfo,
 } from "./comment-serialization-types";
+import { shouldHideCommentByVisibilityPolicy } from "./comment-visibility-policy";
 
 export function buildAuthorSummary(comment: RawComment) {
   const user = comment.user;
@@ -73,12 +74,15 @@ export function shouldHideComment(
   hasVisibleDescendant: boolean,
 ) {
   if (comment.status === "deleted" && !hasVisibleDescendant) return true;
-  if (comment.status === "softbanned" && !viewer.isAdmin && !isAuthor)
-    return true;
-  if (comment.visibility === "logged_in_only" && !viewer.isAuthenticated)
-    return true;
-
-  return false;
+  return shouldHideCommentByVisibilityPolicy(
+    {
+      status: comment.status,
+      userId: comment.userId ?? null,
+      visibility: comment.visibility,
+    },
+    viewer,
+    isAuthor,
+  );
 }
 
 export function shouldHideAuthor(

--- a/src/features/comments/server/comment-visibility-policy.ts
+++ b/src/features/comments/server/comment-visibility-policy.ts
@@ -1,0 +1,93 @@
+import type {
+  CommentStatus,
+  CommentVisibility,
+  Prisma,
+} from "@/generated/prisma/client";
+
+export type CommentVisibilityViewer = {
+  isAdmin: boolean;
+  isAuthenticated: boolean;
+  userId: string | null;
+};
+
+export type CommentAuthenticationViewer = {
+  isAuthenticated: boolean;
+};
+
+export type CommentVisibilitySubject = {
+  status: CommentStatus | string;
+  userId: string | null;
+  visibility: CommentVisibility | string;
+};
+
+export function isSoftbannedCommentVisibleToViewer(
+  status: CommentStatus | string,
+  commentUserId: string | null,
+  viewer: CommentVisibilityViewer,
+) {
+  if (status !== "softbanned") return true;
+  return (
+    viewer.isAdmin || (viewer.userId != null && commentUserId === viewer.userId)
+  );
+}
+
+export function isLoggedInOnlyCommentVisibleToViewer(
+  visibility: CommentVisibility | string,
+  viewer: CommentAuthenticationViewer,
+) {
+  if (visibility !== "logged_in_only") return true;
+  return viewer.isAuthenticated;
+}
+
+export function directlyVisibleCommentWhere(
+  viewer: CommentVisibilityViewer,
+): Prisma.CommentWhereInput {
+  const visibleStatus: Prisma.CommentWhereInput = viewer.isAdmin
+    ? { status: { in: ["active", "softbanned"] } }
+    : viewer.userId
+      ? {
+          OR: [
+            { status: "active" },
+            { status: "softbanned", userId: viewer.userId },
+          ],
+        }
+      : { status: "active" };
+
+  return {
+    AND: [
+      visibleStatus,
+      ...(viewer.isAuthenticated ? [] : [{ visibility: "public" as const }]),
+    ],
+  };
+}
+
+export function shouldHideCommentByVisibilityPolicy(
+  comment: CommentVisibilitySubject,
+  viewer: CommentVisibilityViewer,
+  isAuthor: boolean,
+) {
+  if (comment.status === "softbanned" && !viewer.isAdmin && !isAuthor) {
+    return true;
+  }
+  if (!isLoggedInOnlyCommentVisibleToViewer(comment.visibility, viewer)) {
+    return true;
+  }
+
+  return false;
+}
+
+export function canViewerAccessCommentAttachment(
+  comment: CommentVisibilitySubject,
+  viewer: CommentVisibilityViewer,
+) {
+  if (!viewer.isAuthenticated) return false;
+  if (comment.status === "deleted") return false;
+  if (
+    !isSoftbannedCommentVisibleToViewer(comment.status, comment.userId, viewer)
+  ) {
+    return false;
+  }
+  return (
+    comment.visibility === "public" || comment.visibility === "logged_in_only"
+  );
+}

--- a/src/features/homeworks/server/prepare-homework-update.ts
+++ b/src/features/homeworks/server/prepare-homework-update.ts
@@ -1,0 +1,62 @@
+import { homeworkDateError } from "@/features/homeworks/server/homework-dates";
+import {
+  buildHomeworkUpdateIntent,
+  type HomeworkUpdateIntent,
+  hasHomeworkUpdateIntentChanges,
+} from "@/features/homeworks/server/homework-update-intent";
+
+type HomeworkUpdateDates = {
+  hasPublishedAt: boolean;
+  hasSubmissionDueAt: boolean;
+  hasSubmissionStartAt: boolean;
+  publishedAt: Date | null | undefined;
+  submissionDueAt: Date | null | undefined;
+  submissionStartAt: Date | null | undefined;
+};
+
+export type PrepareHomeworkUpdateInput = {
+  dates: HomeworkUpdateDates;
+  description?: string | null;
+  hasDescription: boolean;
+  isMajor?: boolean | null;
+  requiresTeam?: boolean | null;
+  title?: string;
+  userId: string;
+};
+
+export type PrepareHomeworkUpdateResult =
+  | { ok: true; update: HomeworkUpdateIntent }
+  | { ok: false; error: "date"; message: string }
+  | { ok: false; error: "no_changes" };
+
+export function prepareHomeworkUpdate(
+  input: PrepareHomeworkUpdateInput,
+): PrepareHomeworkUpdateResult {
+  const dateError = homeworkDateError({
+    publishedAt: input.dates.publishedAt,
+    publishedAtProvided: input.dates.hasPublishedAt,
+    submissionDueAt: input.dates.submissionDueAt,
+    submissionDueAtProvided: input.dates.hasSubmissionDueAt,
+    submissionStartAt: input.dates.submissionStartAt,
+    submissionStartAtProvided: input.dates.hasSubmissionStartAt,
+  });
+  if (dateError) {
+    return { ok: false, error: "date", message: dateError };
+  }
+
+  const update = buildHomeworkUpdateIntent({
+    dates: input.dates,
+    description: input.description,
+    hasDescription: input.hasDescription,
+    isMajor: input.isMajor,
+    requiresTeam: input.requiresTeam,
+    title: input.title,
+    userId: input.userId,
+  });
+
+  if (!hasHomeworkUpdateIntentChanges(update)) {
+    return { ok: false, error: "no_changes" };
+  }
+
+  return { ok: true, update };
+}

--- a/src/lib/api/routes/homework-update-input.ts
+++ b/src/lib/api/routes/homework-update-input.ts
@@ -1,11 +1,5 @@
-import {
-  homeworkDateError,
-  parseHomeworkDateInput,
-} from "@/features/homeworks/server/homework-dates";
-import {
-  buildHomeworkUpdateIntent,
-  hasHomeworkUpdateIntentChanges,
-} from "@/features/homeworks/server/homework-update-intent";
+import { parseHomeworkDateInput } from "@/features/homeworks/server/homework-dates";
+import { prepareHomeworkUpdate } from "@/features/homeworks/server/prepare-homework-update";
 import { badRequest } from "@/lib/api/helpers";
 
 export function parseUpdateHomeworkInput(
@@ -20,50 +14,39 @@ export function parseUpdateHomeworkInput(
   },
   userId: string,
 ) {
-  const title = parsedBody.title;
   const hasDescription = Object.hasOwn(parsedBody, "description");
   const hasPublishedAt = Object.hasOwn(parsedBody, "publishedAt");
   const hasSubmissionStartAt = Object.hasOwn(parsedBody, "submissionStartAt");
   const hasSubmissionDueAt = Object.hasOwn(parsedBody, "submissionDueAt");
 
-  const publishedAt = hasPublishedAt
-    ? parseHomeworkDateInput(parsedBody.publishedAt)
-    : undefined;
-  const submissionStartAt = hasSubmissionStartAt
-    ? parseHomeworkDateInput(parsedBody.submissionStartAt)
-    : undefined;
-  const submissionDueAt = hasSubmissionDueAt
-    ? parseHomeworkDateInput(parsedBody.submissionDueAt)
-    : undefined;
-
-  const dateError = homeworkDateError({
-    publishedAt,
-    publishedAtProvided: hasPublishedAt,
-    submissionDueAt,
-    submissionDueAtProvided: hasSubmissionDueAt,
-    submissionStartAt,
-    submissionStartAtProvided: hasSubmissionStartAt,
-  });
-  if (dateError) return badRequest(dateError);
-
-  const update = buildHomeworkUpdateIntent({
+  const prepared = prepareHomeworkUpdate({
     dates: {
       hasPublishedAt,
       hasSubmissionDueAt,
       hasSubmissionStartAt,
-      publishedAt,
-      submissionDueAt,
-      submissionStartAt,
+      publishedAt: hasPublishedAt
+        ? parseHomeworkDateInput(parsedBody.publishedAt)
+        : undefined,
+      submissionDueAt: hasSubmissionDueAt
+        ? parseHomeworkDateInput(parsedBody.submissionDueAt)
+        : undefined,
+      submissionStartAt: hasSubmissionStartAt
+        ? parseHomeworkDateInput(parsedBody.submissionStartAt)
+        : undefined,
     },
     description: parsedBody.description,
     hasDescription,
     isMajor: parsedBody.isMajor,
     requiresTeam: parsedBody.requiresTeam,
-    title,
+    title: parsedBody.title,
     userId,
   });
 
-  return hasHomeworkUpdateIntentChanges(update)
-    ? update
-    : badRequest("No changes");
+  if (!prepared.ok) {
+    return badRequest(
+      prepared.error === "no_changes" ? "No changes" : prepared.message,
+    );
+  }
+
+  return prepared.update;
 }

--- a/src/lib/api/routes/upload-management-routes.ts
+++ b/src/lib/api/routes/upload-management-routes.ts
@@ -8,12 +8,14 @@ import {
   badRequest,
   buildPaginatedResponse,
   errorResponse,
+  forbidden,
   getRequestSearchParams,
   handleRouteError,
   jsonResponse,
   notFound,
   parseRouteJsonBody,
   parseRouteQuery,
+  suspensionForbidden,
 } from "@/lib/api/helpers";
 import { parseUploadId } from "@/lib/api/routes/upload-route-helpers";
 import {
@@ -24,6 +26,22 @@ import { getAuditRequestMetadata } from "@/lib/audit/write-audit-log";
 import { requireAuth, requireWriteAuth } from "@/lib/auth/api-auth";
 
 type IdParams = { id: string };
+
+type OwnedUploadMutationFailure = {
+  error: "forbidden" | "not_found" | "storage_delete_failed" | "suspended";
+  reason?: string | null;
+};
+
+function mapOwnedUploadMutationFailure(result: OwnedUploadMutationFailure) {
+  if (result.error === "suspended") {
+    return suspensionForbidden("reason" in result ? result.reason : null);
+  }
+  if (result.error === "forbidden") return forbidden();
+  if (result.error === "storage_delete_failed") {
+    return errorResponse("Failed to delete upload object", 502);
+  }
+  return notFound();
+}
 
 export async function getUploadsRoute(request: Request) {
   return withUploadAuth(request, "Failed to list uploads", async (userId) => {
@@ -81,7 +99,9 @@ export async function patchUploadRoute(request: Request, params: IdParams) {
       id: parsed.id,
       userId: auth.userId,
     });
-    return result.ok ? jsonResponse({ upload: result.upload }) : notFound();
+    return result.ok
+      ? jsonResponse({ upload: result.upload })
+      : mapOwnedUploadMutationFailure(result);
   } catch (error) {
     return handleRouteError("Failed to rename upload", error);
   }
@@ -103,10 +123,7 @@ export async function deleteUploadRoute(request: Request, params: IdParams) {
         userId,
       });
       if (!result.ok) {
-        if (result.error === "storage_delete_failed") {
-          return errorResponse("Failed to delete upload object", 502);
-        }
-        return notFound();
+        return mapOwnedUploadMutationFailure(result);
       }
 
       return jsonResponse({

--- a/src/lib/api/schemas/comments-response-schemas.ts
+++ b/src/lib/api/schemas/comments-response-schemas.ts
@@ -37,7 +37,7 @@ export const commentBatchDeleteResponseSchema = z.object({
         success: z.literal(false),
         id: z.string(),
         error: z.object({
-          code: z.enum(["not_found", "forbidden", "locked"]),
+          code: z.enum(["not_found", "forbidden", "locked", "suspended"]),
           message: z.string(),
         }),
       }),

--- a/src/lib/graphql/mutations.ts
+++ b/src/lib/graphql/mutations.ts
@@ -135,6 +135,7 @@ export const graphqlMutationTypeDefs = /* GraphQL */ `
     FORBIDDEN
     LOCKED
     DELETED
+    SUSPENDED
   }
 
   enum SectionSubscriptionBatchAction {
@@ -592,6 +593,7 @@ const batchMutationErrorCodeResolver = {
   FORBIDDEN: "forbidden",
   LOCKED: "locked",
   DELETED: "deleted",
+  SUSPENDED: "suspended",
 } as const;
 
 const sectionSubscriptionBatchActionResolver = {
@@ -894,7 +896,7 @@ export const graphqlMutationResolvers = {
     ) {
       const principal = await requireGraphqlMutation(
         context,
-        "workspace.homework",
+        "community.section-homework",
       );
       const input = args.input;
       const publishedAt = dateTimeInput(input.publishedAt) ?? null;
@@ -934,7 +936,7 @@ export const graphqlMutationResolvers = {
     ) {
       const principal = await requireGraphqlMutation(
         context,
-        "workspace.homework",
+        "community.section-homework",
       );
       const id = requireMutationId(args.id, "id");
       const input = args.input;
@@ -1007,7 +1009,7 @@ export const graphqlMutationResolvers = {
     ) {
       const principal = await requireGraphqlMutation(
         context,
-        "workspace.homework",
+        "community.section-homework",
       );
       const id = requireMutationId(args.id, "id");
       const result = await deleteHomework({

--- a/src/lib/graphql/mutations.ts
+++ b/src/lib/graphql/mutations.ts
@@ -35,10 +35,7 @@ import {
   updateHomework,
 } from "@/features/homeworks/server/homework-mutations";
 import { requireHomeworkItemById } from "@/features/homeworks/server/homework-read-model";
-import {
-  buildHomeworkUpdateIntent,
-  hasHomeworkUpdateIntentChanges,
-} from "@/features/homeworks/server/homework-update-intent";
+import { prepareHomeworkUpdate } from "@/features/homeworks/server/prepare-homework-update";
 import {
   batchUpdateUserSectionSubscriptions,
   setUserSectionSubscriptionByJwId,
@@ -955,17 +952,7 @@ export const graphqlMutationResolvers = {
       const submissionDueAt = hasSubmissionDueAt
         ? dateTimeInput(input.submissionDueAt)
         : undefined;
-      const dateError = homeworkDateError({
-        publishedAt,
-        publishedAtProvided: hasPublishedAt,
-        submissionDueAt,
-        submissionDueAtProvided: hasSubmissionDueAt,
-        submissionStartAt,
-        submissionStartAtProvided: hasSubmissionStartAt,
-      });
-      if (dateError) badMutationInput(dateError);
-
-      const update = buildHomeworkUpdateIntent({
+      const prepared = prepareHomeworkUpdate({
         dates: {
           hasPublishedAt,
           hasSubmissionDueAt,
@@ -984,13 +971,17 @@ export const graphqlMutationResolvers = {
           input.title == null ? undefined : normalizeHomeworkTitle(input.title),
         userId: principal.userId,
       });
-      if (!hasHomeworkUpdateIntentChanges(update)) {
-        badMutationInput("No homework changes were provided.");
+      if (!prepared.ok) {
+        badMutationInput(
+          prepared.error === "no_changes"
+            ? "No homework changes were provided."
+            : prepared.message,
+        );
       }
 
       const result = await updateHomework({
         homeworkId: id,
-        update,
+        update: prepared.update,
         userId: principal.userId,
       });
       if (!result.ok) handleHomeworkFailure(result, "Homework");

--- a/src/lib/graphql/operation-definitions.ts
+++ b/src/lib/graphql/operation-definitions.ts
@@ -766,7 +766,7 @@ export const persistedGraphqlOperationDefinitions = [
         }
       }
     `,
-    scopes: ["workspace.homework:write"],
+    scopes: ["community.section-homework:write"],
     destructive: false,
     openWorld: true,
   }),
@@ -798,7 +798,7 @@ export const persistedGraphqlOperationDefinitions = [
         }
       }
     `,
-    scopes: ["workspace.homework:write"],
+    scopes: ["community.section-homework:write"],
     destructive: true,
     openWorld: true,
   }),
@@ -815,7 +815,7 @@ export const persistedGraphqlOperationDefinitions = [
         }
       }
     `,
-    scopes: ["workspace.homework:write"],
+    scopes: ["community.section-homework:write"],
     destructive: true,
     openWorld: true,
   }),

--- a/src/lib/mcp/tools/community/homework/homework-update-input.ts
+++ b/src/lib/mcp/tools/community/homework/homework-update-input.ts
@@ -1,5 +1,3 @@
-import { homeworkDateError } from "@/features/homeworks/server/homework-dates";
-import { buildHomeworkUpdateIntent } from "@/features/homeworks/server/homework-update-intent";
 import type { AppLocale } from "@/i18n/config";
 import {
   jsonToolResult,
@@ -25,24 +23,16 @@ type HomeworkUpdateDateInputs = Pick<
   "publishedAt" | "submissionDueAt" | "submissionStartAt"
 >;
 
-type HomeworkUpdateScalarInputs = Pick<
-  UpdateHomeworkOnSectionArgs,
-  "isMajor" | "requiresTeam" | "title"
->;
-
-type ParsedHomeworkUpdateDates = {
-  hasPublishedAt: boolean;
-  hasSubmissionDueAt: boolean;
-  hasSubmissionStartAt: boolean;
-  publishedAt: Date | null | undefined;
-  submissionDueAt: Date | null | undefined;
-  submissionStartAt: Date | null | undefined;
-};
-
-export function parseHomeworkUpdateDates(
-  { publishedAt, submissionDueAt, submissionStartAt }: HomeworkUpdateDateInputs,
-  mode: ReturnType<typeof resolveMcpMode>,
-) {
+/**
+ * Coerces the three optional date args into the shape
+ * `prepareHomeworkUpdate` expects. Cross-field validation lives there, so this
+ * only reports strings it could not parse at all.
+ */
+export function parseHomeworkUpdateDates({
+  publishedAt,
+  submissionDueAt,
+  submissionStartAt,
+}: HomeworkUpdateDateInputs) {
   const hasPublishedAt = publishedAt !== undefined;
   const hasSubmissionStartAt = submissionStartAt !== undefined;
   const hasSubmissionDueAt = submissionDueAt !== undefined;
@@ -71,20 +61,6 @@ export function parseHomeworkUpdateDates(
   if (!parsedSubmissionDueAt.ok) {
     return parsedSubmissionDueAt;
   }
-  const dateError = homeworkDateError({
-    publishedAt: parsedPublishedAt.value,
-    publishedAtProvided: hasPublishedAt,
-    submissionDueAt: parsedSubmissionDueAt.value,
-    submissionDueAtProvided: hasSubmissionDueAt,
-    submissionStartAt: parsedSubmissionStartAt.value,
-    submissionStartAtProvided: hasSubmissionStartAt,
-  });
-  if (dateError) {
-    return {
-      ok: false as const,
-      result: jsonToolResult({ success: false, message: dateError }, { mode }),
-    };
-  }
 
   return {
     ok: true as const,
@@ -99,19 +75,9 @@ export function parseHomeworkUpdateDates(
   };
 }
 
-export function buildHomeworkUpdateIntentForTool(
-  { isMajor, requiresTeam, title }: HomeworkUpdateScalarInputs,
-  userId: string,
-  dates: ParsedHomeworkUpdateDates,
-  description?: string | null,
+export function homeworkUpdateToolFailure(
+  message: string,
+  mode: ReturnType<typeof resolveMcpMode>,
 ) {
-  return buildHomeworkUpdateIntent({
-    dates,
-    description,
-    hasDescription: description !== undefined,
-    isMajor,
-    requiresTeam,
-    title,
-    userId,
-  });
+  return jsonToolResult({ success: false, message }, { mode });
 }

--- a/src/lib/mcp/tools/community/homework/homework-update-tool-handler.ts
+++ b/src/lib/mcp/tools/community/homework/homework-update-tool-handler.ts
@@ -1,14 +1,14 @@
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { updateHomework } from "@/features/homeworks/server/homework-mutations";
 import { requireHomeworkItemById } from "@/features/homeworks/server/homework-read-model";
-import { hasHomeworkUpdateIntentChanges } from "@/features/homeworks/server/homework-update-intent";
+import { prepareHomeworkUpdate } from "@/features/homeworks/server/prepare-homework-update";
 import {
   getUserId,
   jsonToolResult,
   resolveMcpMode,
 } from "@/lib/mcp/tools/_shared/helpers";
 import {
-  buildHomeworkUpdateIntentForTool,
+  homeworkUpdateToolFailure,
   parseHomeworkUpdateDates,
   type UpdateHomeworkOnSectionArgs,
 } from "./homework-update-input";
@@ -33,35 +33,34 @@ export async function updateHomeworkOnSectionTool(
   const resolvedMode = resolveMcpMode(mode);
   const userId = getUserId(extra.authInfo);
 
-  const parsedDates = parseHomeworkUpdateDates(
-    {
-      publishedAt,
-      submissionDueAt,
-      submissionStartAt,
-    },
-    resolvedMode,
-  );
+  const parsedDates = parseHomeworkUpdateDates({
+    publishedAt,
+    submissionDueAt,
+    submissionStartAt,
+  });
   if (!parsedDates.ok) {
     return parsedDates.result;
   }
 
-  const update = buildHomeworkUpdateIntentForTool(
-    { isMajor, requiresTeam, title },
-    userId,
-    parsedDates.value,
+  const prepared = prepareHomeworkUpdate({
+    dates: parsedDates.value,
     description,
-  );
-
-  if (!hasHomeworkUpdateIntentChanges(update)) {
-    return jsonToolResult(
-      { success: false, message: "No changes" },
-      { mode: resolvedMode },
+    hasDescription: description !== undefined,
+    isMajor,
+    requiresTeam,
+    title,
+    userId,
+  });
+  if (!prepared.ok) {
+    return homeworkUpdateToolFailure(
+      prepared.error === "no_changes" ? "No changes" : prepared.message,
+      resolvedMode,
     );
   }
 
   const result = await updateHomework({
     homeworkId,
-    update,
+    update: prepared.update,
     userId,
   });
   if (!result.ok) {

--- a/tests/integration/graphql-homework-mutations.test.ts
+++ b/tests/integration/graphql-homework-mutations.test.ts
@@ -103,15 +103,15 @@ beforeAll(async () => {
         create: [
           {
             scopes: [
-              restReadScope("workspace.homework"),
-              restWriteScope("workspace.homework"),
+              restReadScope("community.section-homework"),
+              restWriteScope("community.section-homework"),
             ],
             userId: creatorId,
           },
           {
             scopes: [
-              restReadScope("workspace.homework"),
-              restWriteScope("workspace.homework"),
+              restReadScope("community.section-homework"),
+              restWriteScope("community.section-homework"),
             ],
             userId: collaboratorId,
           },
@@ -151,7 +151,7 @@ afterAll(async () => {
 describe("GraphQL homework CRUD mutations", () => {
   it("requires the exact homework write scope before resolving a section", async () => {
     const readToken = await signToken(creatorId, [
-      restReadScope("workspace.homework"),
+      restReadScope("community.section-homework"),
     ]);
     const result = await execute(
       {
@@ -174,7 +174,7 @@ describe("GraphQL homework CRUD mutations", () => {
 
     expectErrorCode(result.payload, "FORBIDDEN");
     expect(result.payload.errors?.[0]?.extensions?.requiredScopes).toEqual([
-      "workspace.homework:write",
+      "community.section-homework:write",
     ]);
     await expect(
       prisma.homework.count({
@@ -185,7 +185,7 @@ describe("GraphQL homework CRUD mutations", () => {
 
   it("validates the shared homework submission window before writing", async () => {
     const token = await signToken(creatorId, [
-      restWriteScope("workspace.homework"),
+      restWriteScope("community.section-homework"),
     ]);
     const result = await execute(
       {
@@ -229,8 +229,8 @@ describe("GraphQL homework CRUD mutations", () => {
 
   it("creates, collaboratively updates, and creator-deletes with shared audit semantics", async () => {
     const [creatorToken, collaboratorToken] = await Promise.all([
-      signToken(creatorId, [restWriteScope("workspace.homework")]),
-      signToken(collaboratorId, [restWriteScope("workspace.homework")]),
+      signToken(creatorId, [restWriteScope("community.section-homework")]),
+      signToken(collaboratorId, [restWriteScope("community.section-homework")]),
     ]);
     const created = await execute(
       {

--- a/tests/unit/comment-batch-delete-route.test.ts
+++ b/tests/unit/comment-batch-delete-route.test.ts
@@ -108,7 +108,7 @@ describe("deleteCommentBatchRoute", () => {
       {
         success: false,
         id: "comment-owned-by-other",
-        error: { code: "suspended", message: "Suspended" },
+        error: { code: "forbidden", message: "Forbidden" },
       },
       {
         success: false,

--- a/tests/unit/comment-batch-delete-route.test.ts
+++ b/tests/unit/comment-batch-delete-route.test.ts
@@ -108,7 +108,7 @@ describe("deleteCommentBatchRoute", () => {
       {
         success: false,
         id: "comment-owned-by-other",
-        error: { code: "forbidden", message: "Forbidden" },
+        error: { code: "suspended", message: "Suspended" },
       },
       {
         success: false,
@@ -118,7 +118,7 @@ describe("deleteCommentBatchRoute", () => {
     ]);
   });
 
-  it("将 suspended 错误映射为 forbidden", async () => {
+  it("preserves suspended as a distinct batch error code", async () => {
     requireAuthMock.mockResolvedValue({ userId: "user-1" });
     deleteOwnCommentMock.mockResolvedValueOnce({
       ok: false,
@@ -136,7 +136,7 @@ describe("deleteCommentBatchRoute", () => {
       {
         success: false,
         id: "comment-1",
-        error: { code: "forbidden", message: "Forbidden" },
+        error: { code: "suspended", message: "Suspended" },
       },
     ]);
   });

--- a/tests/unit/comment-batch-delete-service.test.ts
+++ b/tests/unit/comment-batch-delete-service.test.ts
@@ -40,7 +40,7 @@ describe("deleteOwnCommentsBatch", () => {
         {
           success: false,
           id: "comment-suspended",
-          error: { code: "forbidden", message: "Forbidden" },
+          error: { code: "suspended", message: "Suspended" },
         },
       ],
     });

--- a/tests/unit/graphql-homework-mutations.test.ts
+++ b/tests/unit/graphql-homework-mutations.test.ts
@@ -76,7 +76,7 @@ describe("GraphQL homework mutation resolvers", () => {
 
     expect(requireGraphqlMutationMock).toHaveBeenCalledWith(
       context,
-      "workspace.homework",
+      "community.section-homework",
     );
     expect(createHomeworkForSectionMock).toHaveBeenCalledWith("user-1", {
       description: "第一题",

--- a/tests/unit/homework-mcp-date-parsing.test.ts
+++ b/tests/unit/homework-mcp-date-parsing.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { prepareHomeworkUpdate } from "@/features/homeworks/server/prepare-homework-update";
 import { parseCreateHomeworkTimestamps } from "@/lib/mcp/tools/community/homework/homework-create-actions";
 import { parseHomeworkUpdateDates } from "@/lib/mcp/tools/community/homework/homework-update-input";
 
@@ -30,21 +31,27 @@ describe("MCP 作业日期解析", () => {
     });
   });
 
+  // Cross-field ordering now lives in `prepareHomeworkUpdate`, which all three
+  // surfaces call; MCP only coerces the strings.
   test("更新提交窗口使用共享的作业日期规则", () => {
-    const result = parseHomeworkUpdateDates(
-      {
-        submissionDueAt: "2026-04-01T00:00:00Z",
-        submissionStartAt: "2026-04-02T00:00:00Z",
-      },
-      "full",
-    );
+    const parsedDates = parseHomeworkUpdateDates({
+      submissionDueAt: "2026-04-01T00:00:00Z",
+      submissionStartAt: "2026-04-02T00:00:00Z",
+    });
 
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
+    expect(parsedDates.ok).toBe(true);
+    if (!parsedDates.ok) return;
 
-    expect(parseToolPayload(result.result)).toEqual({
+    const prepared = prepareHomeworkUpdate({
+      dates: parsedDates.value,
+      hasDescription: false,
+      userId: "user-1",
+    });
+
+    expect(prepared).toEqual({
+      error: "date",
       message: "Submission start must be before due",
-      success: false,
+      ok: false,
     });
   });
 });

--- a/tests/unit/section-homework-write-scopes.test.ts
+++ b/tests/unit/section-homework-write-scopes.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { persistedGraphqlOperationDefinitions } from "@/lib/graphql/operation-definitions";
+import { getRequiredMcpScopes } from "@/lib/mcp/tool-scopes";
+import {
+  getRequiredFeatureScope,
+  restWriteScope,
+} from "@/lib/oauth/scope-registry";
+
+const expectedWriteScope = restWriteScope("community.section-homework");
+
+const sectionHomeworkGraphqlMutationIds = [
+  "community.section_homework.create.v1",
+  "community.section_homework.update.v1",
+  "community.section_homework.delete.v1",
+] as const;
+
+const sectionHomeworkMcpTools = [
+  "community_section_homework_create",
+  "community_section_homework_update",
+  "community_section_homework_delete",
+] as const;
+
+const requireAuthMock = vi.fn();
+
+vi.mock("@/lib/auth/api-auth", () => ({
+  requireAuth: requireAuthMock,
+}));
+
+describe("section homework write scope parity", () => {
+  afterEach(() => {
+    requireAuthMock.mockReset();
+    vi.resetModules();
+  });
+
+  it.each(sectionHomeworkMcpTools)(
+    "MCP %s requires community.section-homework:write",
+    (tool) => {
+      expect(getRequiredMcpScopes(tool)).toEqual([expectedWriteScope]);
+    },
+  );
+
+  it.each(sectionHomeworkGraphqlMutationIds)(
+    "GraphQL %s requires community.section-homework:write",
+    (operationId) => {
+      const operation = persistedGraphqlOperationDefinitions.find(
+        (entry) => entry.id === operationId,
+      );
+      expect(operation?.scopes).toEqual([expectedWriteScope]);
+    },
+  );
+
+  it("REST section-homework mutations require community.section-homework:write", async () => {
+    requireAuthMock.mockResolvedValue(
+      Response.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    const { postHomeworkRoute } = await import(
+      "@/lib/api/routes/homework-mutation-routes"
+    );
+
+    await postHomeworkRoute(
+      new Request("https://example.test/api/community/section-homeworks", {
+        body: "{}",
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      }),
+    );
+
+    expect(requireAuthMock).toHaveBeenCalledWith(expect.any(Request), {
+      bearerScope: {
+        feature: "community.section-homework",
+        action: "write",
+      },
+    });
+    expect(
+      getRequiredFeatureScope({
+        feature: "community.section-homework",
+        action: "write",
+      }),
+    ).toBe(expectedWriteScope);
+  });
+});

--- a/tests/unit/section-homework-write-scopes.test.ts
+++ b/tests/unit/section-homework-write-scopes.test.ts
@@ -32,22 +32,20 @@ describe("section homework write scope parity", () => {
     vi.resetModules();
   });
 
-  it.each(sectionHomeworkMcpTools)(
-    "MCP %s requires community.section-homework:write",
-    (tool) => {
-      expect(getRequiredMcpScopes(tool)).toEqual([expectedWriteScope]);
-    },
-  );
+  it.each(
+    sectionHomeworkMcpTools,
+  )("MCP %s requires community.section-homework:write", (tool) => {
+    expect(getRequiredMcpScopes(tool)).toEqual([expectedWriteScope]);
+  });
 
-  it.each(sectionHomeworkGraphqlMutationIds)(
-    "GraphQL %s requires community.section-homework:write",
-    (operationId) => {
-      const operation = persistedGraphqlOperationDefinitions.find(
-        (entry) => entry.id === operationId,
-      );
-      expect(operation?.scopes).toEqual([expectedWriteScope]);
-    },
-  );
+  it.each(
+    sectionHomeworkGraphqlMutationIds,
+  )("GraphQL %s requires community.section-homework:write", (operationId) => {
+    const operation = persistedGraphqlOperationDefinitions.find(
+      (entry) => entry.id === operationId,
+    );
+    expect(operation?.scopes).toEqual([expectedWriteScope]);
+  });
 
   it("REST section-homework mutations require community.section-homework:write", async () => {
     requireAuthMock.mockResolvedValue(


### PR DESCRIPTION
Closes #732

Four related fixes, one commit each so they can be reviewed and reverted independently.

## 1. Section-homework writes required different OAuth scopes per surface

GraphQL gated `homeworkCreate`/`homeworkUpdate`/`homeworkDelete` on `workspace.homework`, while REST and MCP gated the same capability on `community.section-homework`. A token holding only one worked on some surfaces and was rejected on others.

Aligned on **`community.section-homework`**: the endpoint is `/api/community/section-homeworks`, the tools are `community_section_homework_*`, and `docs/contracts/homework.json` documents it under the community module. GraphQL was the outlier. `tests/unit/section-homework-write-scopes.test.ts` now pins all three surfaces to the same scope so a future divergence fails a test.

## 2. REST mapped upload authorization failures to 404

`renameOwnedUpload` returns a union including `suspended` and `forbidden`, and MCP maps each distinctly. REST collapsed everything to `notFound()`, so a suspended user renaming their own file was told it does not exist. The delete route did the same for anything that was not `storage_delete_failed`.

Both now branch on `result.error` following the existing `deleteOwnCommentAction` pattern.

Related: `comment-batch-delete` folded `suspended` into `forbidden` while the single-delete path preserved it, so the same action reported differently depending on batching. `suspended` is now a distinct batch error code, which is the one line of the regenerated OpenAPI diff.

## 3. Comment visibility was implemented four times

The rules for `softbanned` rows and `logged_in_only` visibility were re-derived independently in the read model's Prisma `where`, the serialization hiding check, the attachment download gate, and the interaction policy. They agreed, but they were also four places a new visibility state would have to be added at once — and a miss in the attachment gate is a data leak rather than a rendering bug.

They now share `comment-visibility-policy.ts`. **This is behaviour-preserving**: every existing comment visibility and RLS test passes unchanged, which is the property that matters here.

## 4. All three adapters now share one homework update pipeline

Each surface hand-rolled the same sequence — presence flags, three date coercions, `homeworkDateError`, build intent, reject when unchanged. That duplication is exactly what let the GraphQL date guard drift in #728. It now lives in `prepareHomeworkUpdate`, leaving each adapter with only its own coercion and error mapping.

Cross-field ordering moved out of MCP's `parseHomeworkUpdateDates`, so its unit test now asserts the rule where it lives rather than where it used to be.

## Note on two runner-introduced test errors I corrected

While assembling this branch I found two test edits that were wrong and would have masked real behaviour:

- `comment-batch-delete-route.test.ts` had its expectation changed to `suspended` while its mock still returned `forbidden`. Restored to `forbidden`; the suspended path has its own dedicated test.
- `homework-mcp-date-parsing.test.ts` still called `parseHomeworkUpdateDates` with a removed argument.

## Test plan

- [x] `biome check`
- [x] `tsc --noEmit` across all three configs
- [x] `svelte-check` 0 errors, 0 warnings
- [x] `openapi:check` (spec regenerated for the new batch error code)
- [x] 1918 unit tests
- [x] 258 integration tests against live Postgres
- [x] GraphQL SDL snapshot regenerated for the `SUSPENDED` batch enum value

## Stacking

Independent of #736 (#728). Both touch `mutations.ts`, so whichever merges second will need a trivial rebase.