### PR TITLE
perf(overview): cut the workspace overview from ~49 statements and 6 transactions

### DIFF
--- a/src/features/dashboard/server/compact-overview-subscription-bundle.ts
+++ b/src/features/dashboard/server/compact-overview-subscription-bundle.ts
@@ -1,9 +1,14 @@
 import { withHomeworkItemState } from "@/features/homeworks/server/homework-item-state";
 import {
-  listDueSoonSubscribedHomeworksWithCount,
+  fetchSubscribedHomeworkRlsSnapshot,
+  localizeSubscribedHomeworkDashboardItems,
+} from "@/features/subscriptions/server/subscription-homework-list";
+import { buildSubscribedHomeworkQuery } from "@/features/subscriptions/server/subscription-homework-read-helpers";
+import {
   listTodaySubscribedSchedulesWithCount,
   listUpcomingSubscribedExamsWithCount,
 } from "@/features/subscriptions/server/subscription-read-model";
+import type { Prisma } from "@/generated/prisma/client";
 import type { AppLocale } from "@/i18n/config";
 import { withUserDbContext } from "@/lib/db/prisma";
 import type { WorkspaceOverviewStage } from "@/lib/metrics/analytics-engine";
@@ -36,19 +41,55 @@ const emptySubscriptionReads: OverviewSubscriptionReads = {
   upcomingExams: [],
 };
 
-function countPendingOverviewHomeworks(
+function countPendingOverviewHomeworksInTransaction(
+  tx: Prisma.TransactionClient,
   userId: string,
   sectionIds: readonly number[],
 ) {
-  return withUserDbContext(userId, (tx) =>
-    tx.homework.count({
-      where: {
-        deletedAt: null,
-        homeworkCompletions: { none: { userId } },
-        sectionId: { in: [...sectionIds] },
-      },
-    }),
-  );
+  return tx.homework.count({
+    where: {
+      deletedAt: null,
+      homeworkCompletions: { none: { userId } },
+      sectionId: { in: [...sectionIds] },
+    },
+  });
+}
+
+async function loadOverviewHomeworkRlsReads(input: {
+  atTime: Date;
+  homeworkWindowEnd: Date;
+  includeSamples: boolean;
+  limit: number;
+  sectionIds: readonly number[];
+  userId: string;
+}) {
+  const dueSoonQuery = buildSubscribedHomeworkQuery({
+    completed: false,
+    dueAtFrom: input.atTime,
+    dueAtTo: input.homeworkWindowEnd,
+    includeDeleted: false,
+    limit: input.includeSamples ? input.limit : undefined,
+    requireDueDate: true,
+    sectionIds: [...input.sectionIds],
+    userId: input.userId,
+  });
+
+  return withUserDbContext(input.userId, async (tx) => {
+    const [pendingHomeworksCount, dueSoonRls] = await Promise.all([
+      countPendingOverviewHomeworksInTransaction(
+        tx,
+        input.userId,
+        input.sectionIds,
+      ),
+      fetchSubscribedHomeworkRlsSnapshot(
+        tx,
+        input.userId,
+        dueSoonQuery,
+        input.includeSamples,
+      ),
+    ]);
+    return { pendingHomeworksCount, dueSoonRls };
+  });
 }
 
 export async function loadOverviewSubscriptionReads(input: {
@@ -101,37 +142,32 @@ export async function loadOverviewSubscriptionReads(input: {
     locale,
     sectionIds,
   });
-  const dueSoonHomeworksOverviewPromise =
-    listDueSoonSubscribedHomeworksWithCount(userId, {
-      dueAtFrom: atTime,
-      dueAtTo: homeworkWindowEnd,
-      includeItems: includeSamples,
-      limit: includeSamples ? limit : undefined,
-      locale,
-      sectionIds,
-    });
+  const homeworkRlsPromise = loadOverviewHomeworkRlsReads({
+    atTime,
+    homeworkWindowEnd,
+    includeSamples,
+    limit,
+    sectionIds,
+    userId,
+  });
 
   if (!includeSamples) {
-    const [
-      pendingHomeworksCount,
-      todaySchedulesCount,
-      upcomingExamsCount,
-      dueSoonHomeworksCount,
-    ] = await runStage("counts", () =>
-      Promise.all([
-        countPendingOverviewHomeworks(userId, sectionIds),
-        schedulesOverviewPromise.then((result) => result.total),
-        examsOverviewPromise.then((result) => result.total),
-        dueSoonHomeworksOverviewPromise.then((result) => result.total),
-      ]),
+    const [homeworkRls, schedulesOverview, examsOverview] = await runStage(
+      "counts",
+      () =>
+        Promise.all([
+          homeworkRlsPromise,
+          schedulesOverviewPromise,
+          examsOverviewPromise,
+        ]),
     );
 
     return {
       counts: {
-        pendingHomeworksCount,
-        todaySchedulesCount,
-        upcomingExamsCount,
-        dueSoonHomeworksCount,
+        pendingHomeworksCount: homeworkRls.pendingHomeworksCount,
+        todaySchedulesCount: schedulesOverview.total,
+        upcomingExamsCount: examsOverview.total,
+        dueSoonHomeworksCount: homeworkRls.dueSoonRls.total,
       },
       dueSoonHomeworks: [],
       schedules: [],
@@ -139,49 +175,38 @@ export async function loadOverviewSubscriptionReads(input: {
     };
   }
 
-  const dueSoonHomeworksRawPromise = dueSoonHomeworksOverviewPromise.then(
-    (result) => result.items,
-  );
+  const dueSoonHomeworksRawPromise = homeworkRlsPromise.then((homeworkRls) => {
+    if (homeworkRls.dueSoonRls.homeworkIds.length === 0) {
+      return [];
+    }
+    return runStage("lists", () =>
+      localizeSubscribedHomeworkDashboardItems(homeworkRls.dueSoonRls, locale),
+    );
+  });
   const dueSoonHomeworksPromise = dueSoonHomeworksRawPromise.then((raw) =>
     runStage("item_state", () => withHomeworkItemState(raw, userId)),
   );
 
   const [
-    [
-      pendingHomeworksCount,
-      dueSoonHomeworksCount,
-      todaySchedulesCount,
-      upcomingExamsCount,
-    ],
-    [schedulesOverview, upcomingExamsOverview],
+    [homeworkRls, schedulesOverview, upcomingExamsOverview],
     dueSoonHomeworks,
   ] = await Promise.all([
     runStage("counts", () =>
       Promise.all([
-        countPendingOverviewHomeworks(userId, sectionIds),
-        dueSoonHomeworksOverviewPromise.then((result) => result.total),
-        schedulesOverviewPromise.then((result) => result.total),
-        examsOverviewPromise.then((result) => result.total),
-      ]),
-    ),
-    runStage("lists", () =>
-      Promise.all([
+        homeworkRlsPromise,
         schedulesOverviewPromise,
-        // Include homework in the lists fan-out so its latency is attributed
-        // to `lists` while `item_state` still chains off the same promise.
-        dueSoonHomeworksRawPromise,
         examsOverviewPromise,
-      ]).then(([schedules, , exams]) => [schedules, exams] as const),
+      ]),
     ),
     dueSoonHomeworksPromise,
   ]);
 
   return {
     counts: {
-      pendingHomeworksCount,
-      todaySchedulesCount,
-      upcomingExamsCount,
-      dueSoonHomeworksCount,
+      pendingHomeworksCount: homeworkRls.pendingHomeworksCount,
+      todaySchedulesCount: schedulesOverview.total,
+      upcomingExamsCount: upcomingExamsOverview.total,
+      dueSoonHomeworksCount: homeworkRls.dueSoonRls.total,
     },
     dueSoonHomeworks,
     schedules: schedulesOverview.items,

--- a/src/features/dashboard/server/compact-overview-subscription-bundle.ts
+++ b/src/features/dashboard/server/compact-overview-subscription-bundle.ts
@@ -88,15 +88,16 @@ export async function loadOverviewSubscriptionReads(input: {
     {
       todayStart,
       tomorrowStart,
-      // Counts-only callers still need totals; limit 1 keeps the paired findMany cheap.
-      limit: includeSamples ? limit : 1,
+      includeItems: includeSamples,
+      limit: includeSamples ? limit : undefined,
       locale,
       sectionIds,
     },
   );
   const examsOverviewPromise = listUpcomingSubscribedExamsWithCount(userId, {
     atTime,
-    limit: includeSamples ? limit : 1,
+    includeItems: includeSamples,
+    limit: includeSamples ? limit : undefined,
     locale,
     sectionIds,
   });
@@ -104,7 +105,8 @@ export async function loadOverviewSubscriptionReads(input: {
     listDueSoonSubscribedHomeworksWithCount(userId, {
       dueAtFrom: atTime,
       dueAtTo: homeworkWindowEnd,
-      limit: includeSamples ? limit : 1,
+      includeItems: includeSamples,
+      limit: includeSamples ? limit : undefined,
       locale,
       sectionIds,
     });

--- a/src/features/subscriptions/server/subscription-homework-list.ts
+++ b/src/features/subscriptions/server/subscription-homework-list.ts
@@ -1,4 +1,5 @@
 import { attachHomeworkCompletionsForViewer } from "@/features/homeworks/server/homework-read-model";
+import type { Prisma } from "@/generated/prisma/client";
 import { DEFAULT_LOCALE } from "@/i18n/config";
 import { getPrisma, withUserDbContext } from "@/lib/db/prisma";
 import type { HomeworkWithSection } from "./subscription-dashboard-types";
@@ -15,35 +16,64 @@ import {
   withSubscribedSections,
 } from "./subscription-read-model-shared";
 
-async function fetchSubscribedHomeworkDashboardItems(
+type SubscribedHomeworkIdsAndCompletions = {
+  completions: Array<{ homeworkId: string; completedAt: Date }>;
+  homeworkIds: string[];
+};
+
+type SubscribedHomeworkRlsSnapshot = SubscribedHomeworkIdsAndCompletions & {
+  total: number;
+};
+
+async function fetchSubscribedHomeworkIdsAndCompletionsInTransaction(
+  tx: Prisma.TransactionClient,
   userId: string,
   query: ReturnType<typeof buildSubscribedHomeworkQuery>,
+): Promise<SubscribedHomeworkIdsAndCompletions> {
+  const scopedHomeworks = await tx.homework.findMany({
+    ...query,
+    select: { id: true },
+  });
+  const homeworkIds = scopedHomeworks.map((homework) => homework.id);
+  if (homeworkIds.length === 0) {
+    return { homeworkIds: [], completions: [] };
+  }
+
+  const completions = await tx.homeworkCompletion.findMany({
+    where: {
+      userId,
+      homeworkId: { in: homeworkIds },
+    },
+    select: { homeworkId: true, completedAt: true },
+  });
+  return { homeworkIds, completions };
+}
+
+export async function fetchSubscribedHomeworkRlsSnapshot(
+  tx: Prisma.TransactionClient,
+  userId: string,
+  query: ReturnType<typeof buildSubscribedHomeworkQuery>,
+  includeItems: boolean,
+): Promise<SubscribedHomeworkRlsSnapshot> {
+  const total = await tx.homework.count({ where: query.where });
+  if (!includeItems) {
+    return { total, homeworkIds: [], completions: [] };
+  }
+
+  const { homeworkIds, completions } =
+    await fetchSubscribedHomeworkIdsAndCompletionsInTransaction(
+      tx,
+      userId,
+      query,
+    );
+  return { total, homeworkIds, completions };
+}
+
+export async function localizeSubscribedHomeworkDashboardItems(
+  snapshot: Pick<SubscribedHomeworkRlsSnapshot, "completions" | "homeworkIds">,
   locale: string,
 ): Promise<HomeworkWithSection[]> {
-  const { homeworkIds, completions } = await withUserDbContext(
-    userId,
-    async (tx) => {
-      const scopedHomeworks = await tx.homework.findMany({
-        ...query,
-        select: { id: true },
-      });
-      const idsForCompletions = scopedHomeworks.map((homework) => homework.id);
-      if (idsForCompletions.length === 0) {
-        return { homeworkIds: [] as string[], completions: [] };
-      }
-      const completionRows = await tx.homeworkCompletion.findMany({
-        where: {
-          userId,
-          homeworkId: { in: idsForCompletions },
-        },
-        select: { homeworkId: true, completedAt: true },
-      });
-      return {
-        homeworkIds: idsForCompletions,
-        completions: completionRows,
-      };
-    },
-  );
+  const { homeworkIds, completions } = snapshot;
   if (homeworkIds.length === 0) return [];
 
   const localizedPrisma = getPrisma(locale);
@@ -55,6 +85,17 @@ async function fetchSubscribedHomeworkDashboardItems(
     attachHomeworkCompletionsForViewer(homeworks, completions),
     homeworkIds,
   );
+}
+
+async function fetchSubscribedHomeworkDashboardItems(
+  userId: string,
+  query: ReturnType<typeof buildSubscribedHomeworkQuery>,
+  locale: string,
+): Promise<HomeworkWithSection[]> {
+  const snapshot = await withUserDbContext(userId, (tx) =>
+    fetchSubscribedHomeworkIdsAndCompletionsInTransaction(tx, userId, query),
+  );
+  return localizeSubscribedHomeworkDashboardItems(snapshot, locale);
 }
 
 export async function listDueSoonSubscribedHomeworksWithCount(
@@ -88,14 +129,13 @@ export async function listDueSoonSubscribedHomeworksWithCount(
         sectionIds: ids,
         userId,
       });
-      const where = query.where;
-      const total = await withUserDbContext(userId, (tx) =>
-        tx.homework.count({ where }),
+      const snapshot = await withUserDbContext(userId, (tx) =>
+        fetchSubscribedHomeworkRlsSnapshot(tx, userId, query, includeItems),
       );
       const items = includeItems
-        ? await fetchSubscribedHomeworkDashboardItems(userId, query, locale)
+        ? await localizeSubscribedHomeworkDashboardItems(snapshot, locale)
         : [];
-      return { total, items };
+      return { total: snapshot.total, items };
     },
     sectionIds,
     { total: 0, items: [] },
@@ -151,42 +191,23 @@ export async function listSubscribedHomeworks(
         return fetchSubscribedHomeworkDashboardItems(userId, query, locale);
       }
 
-      const { homeworkIds, completions } = await withUserDbContext(
-        userId,
-        async (tx) => {
-          const scopedHomeworks = await tx.homework.findMany({
-            ...query,
-            select: { id: true },
-          });
-          const idsForCompletions = scopedHomeworks.map(
-            (homework) => homework.id,
-          );
-          if (idsForCompletions.length === 0) {
-            return { homeworkIds: [] as string[], completions: [] };
-          }
-          const completionRows = await tx.homeworkCompletion.findMany({
-            where: {
-              userId,
-              homeworkId: { in: idsForCompletions },
-            },
-            select: { homeworkId: true, completedAt: true },
-          });
-          return {
-            homeworkIds: idsForCompletions,
-            completions: completionRows,
-          };
-        },
+      const snapshot = await withUserDbContext(userId, (tx) =>
+        fetchSubscribedHomeworkIdsAndCompletionsInTransaction(
+          tx,
+          userId,
+          query,
+        ),
       );
-      if (homeworkIds.length === 0) return [];
+      if (snapshot.homeworkIds.length === 0) return [];
 
       const localizedPrisma = getPrisma(locale);
       const homeworks = await localizedPrisma.homework.findMany({
-        where: { id: { in: homeworkIds } },
+        where: { id: { in: snapshot.homeworkIds } },
         include: buildSubscribedHomeworkInclude(includeEditors),
       });
       return orderHomeworksById(
-        attachHomeworkCompletionsForViewer(homeworks, completions),
-        homeworkIds,
+        attachHomeworkCompletionsForViewer(homeworks, snapshot.completions),
+        snapshot.homeworkIds,
       );
     },
     resolvedSectionIds,

--- a/src/features/subscriptions/server/subscription-homework-list.ts
+++ b/src/features/subscriptions/server/subscription-homework-list.ts
@@ -62,12 +62,14 @@ export async function listDueSoonSubscribedHomeworksWithCount(
   {
     dueAtFrom,
     dueAtTo,
+    includeItems = true,
     locale = DEFAULT_LOCALE,
     limit,
     sectionIds,
   }: {
     dueAtFrom: Date;
     dueAtTo: Date;
+    includeItems?: boolean;
     locale?: string;
     limit?: number;
     sectionIds?: readonly number[];
@@ -87,10 +89,12 @@ export async function listDueSoonSubscribedHomeworksWithCount(
         userId,
       });
       const where = query.where;
-      const [total, items] = await Promise.all([
-        withUserDbContext(userId, (tx) => tx.homework.count({ where })),
-        fetchSubscribedHomeworkDashboardItems(userId, query, locale),
-      ]);
+      const total = await withUserDbContext(userId, (tx) =>
+        tx.homework.count({ where }),
+      );
+      const items = includeItems
+        ? await fetchSubscribedHomeworkDashboardItems(userId, query, locale)
+        : [];
       return { total, items };
     },
     sectionIds,

--- a/src/features/subscriptions/server/subscription-schedule-exam-read-model.ts
+++ b/src/features/subscriptions/server/subscription-schedule-exam-read-model.ts
@@ -225,12 +225,14 @@ export async function listTodaySubscribedSchedulesWithCount(
   {
     todayStart,
     tomorrowStart,
+    includeItems = true,
     locale = DEFAULT_LOCALE,
     limit,
     sectionIds,
   }: {
     todayStart: Date;
     tomorrowStart: Date;
+    includeItems?: boolean;
     locale?: string;
     limit?: number;
     sectionIds?: readonly number[];
@@ -245,15 +247,15 @@ export async function listTodaySubscribedSchedulesWithCount(
         date: { gte: todayStart, lt: tomorrowStart },
       } satisfies Prisma.ScheduleWhereInput;
       const localizedPrisma = getPrisma(locale);
-      const [total, items] = await Promise.all([
-        localizedPrisma.schedule.count({ where }),
-        localizedPrisma.schedule.findMany({
-          where,
-          select: overviewScheduleSelect,
-          orderBy: subscribedScheduleOrderBy,
-          ...(limit ? { take: limit } : {}),
-        }),
-      ]);
+      const total = await localizedPrisma.schedule.count({ where });
+      const items = includeItems
+        ? await localizedPrisma.schedule.findMany({
+            where,
+            select: overviewScheduleSelect,
+            orderBy: subscribedScheduleOrderBy,
+            ...(limit ? { take: limit } : {}),
+          })
+        : [];
       return { total, items };
     },
     sectionIds,
@@ -265,11 +267,13 @@ export async function listUpcomingSubscribedExamsWithCount(
   userId: string,
   {
     atTime,
+    includeItems = true,
     locale = DEFAULT_LOCALE,
     limit,
     sectionIds,
   }: {
     atTime: Date;
+    includeItems?: boolean;
     locale?: string;
     limit?: number;
     sectionIds?: readonly number[];
@@ -279,16 +283,18 @@ export async function listUpcomingSubscribedExamsWithCount(
     userId,
     async (ids) => {
       const where = upcomingKnownExamWhere({ atTime, sectionIds: ids });
-      const localizedPrisma = getPrisma(locale);
-      const [total, items] = await Promise.all([
-        localizedPrisma.exam.count({ where }),
-        localizedPrisma.exam.findMany({
-          where,
-          select: overviewExamSelect,
-          orderBy: subscribedExamOrderBy,
-          ...(limit ? { take: limit } : {}),
-        }),
-      ]);
+      const total = await countUpcomingSubscribedExams({
+        atTime,
+        sectionIds: ids,
+      });
+      const items = includeItems
+        ? await getPrisma(locale).exam.findMany({
+            where,
+            select: overviewExamSelect,
+            orderBy: subscribedExamOrderBy,
+            ...(limit ? { take: limit } : {}),
+          })
+        : [];
       return { total, items };
     },
     sectionIds,

--- a/src/features/todos/server/todo-service.ts
+++ b/src/features/todos/server/todo-service.ts
@@ -253,6 +253,108 @@ function countDueTodosInTransaction(
   });
 }
 
+export type OverviewTodoBundleCounts = {
+  completed: number;
+  dueSoon: number;
+  incomplete: number;
+  overdue: number;
+};
+
+export async function countOverviewTodoBundleInTransaction(
+  tx: Prisma.TransactionClient,
+  input: {
+    homeworkWindowEnd: Date;
+    now: Date;
+    userId: string;
+  },
+): Promise<OverviewTodoBundleCounts> {
+  const userId = normalizeTodoUserId(input.userId);
+  const rows = await tx.$queryRaw<
+    [
+      {
+        completed: bigint;
+        due_soon: bigint;
+        incomplete: bigint;
+        overdue: bigint;
+      },
+    ]
+  >`
+    SELECT
+      count(*) FILTER (WHERE NOT completed) AS incomplete,
+      count(*) FILTER (WHERE completed) AS completed,
+      count(*) FILTER (
+        WHERE NOT completed AND "dueAt" IS NOT NULL AND "dueAt" < ${input.now}
+      ) AS overdue,
+      count(*) FILTER (
+        WHERE NOT completed
+          AND "dueAt" IS NOT NULL
+          AND "dueAt" >= ${input.now}
+          AND "dueAt" <= ${input.homeworkWindowEnd}
+      ) AS due_soon
+    FROM "Todo"
+    WHERE "userId" = ${userId}
+  `;
+  const row = rows[0];
+  return {
+    incomplete: Number(row.incomplete),
+    completed: Number(row.completed),
+    overdue: Number(row.overdue),
+    dueSoon: Number(row.due_soon),
+  };
+}
+
+async function loadOverviewTodoBundleInTransaction(
+  tx: Prisma.TransactionClient,
+  input: {
+    homeworkWindowEnd: Date;
+    includeSamples: boolean;
+    limit?: number;
+    now: Date;
+    userId: string;
+  },
+) {
+  const userId = normalizeTodoUserId(input.userId);
+  const fusedCounts = await countOverviewTodoBundleInTransaction(tx, {
+    userId,
+    now: input.now,
+    homeworkWindowEnd: input.homeworkWindowEnd,
+  });
+  const dueInput = {
+    userId,
+    completed: false as const,
+    dueAtFrom: input.now,
+    dueAtTo: input.homeworkWindowEnd,
+    includeDueAtTo: true as const,
+  };
+  const [todos, dueTodos] = await Promise.all([
+    input.includeSamples
+      ? findTodoSnapshots(tx, {
+          where: buildTodoListWhere(userId, { completed: false }),
+          take: input.limit,
+        })
+      : Promise.resolve([]),
+    input.includeSamples
+      ? listDueTodoSamplesInTransaction(tx, {
+          ...dueInput,
+          take: input.limit,
+        })
+      : Promise.resolve([]),
+  ]);
+
+  return {
+    todos: {
+      counts: {
+        incomplete: fusedCounts.incomplete,
+        completed: fusedCounts.completed,
+        overdue: fusedCounts.overdue,
+      },
+      todos,
+    },
+    dueTodosCount: fusedCounts.dueSoon,
+    dueTodos,
+  };
+}
+
 function buildDueTodoWhere(input: {
   completed?: boolean;
   dueAtFrom?: Date;
@@ -337,31 +439,23 @@ export async function loadOverviewTodoBundle(input: {
   const runTodoSummary = input.runTodoSummary ?? identity;
   const runDueTodoCount = input.runDueTodoCount ?? identity;
   const runDueTodoSample = input.runDueTodoSample ?? identity;
-  const dueInput = {
-    userId,
-    completed: false as const,
-    dueAtFrom: input.now,
-    dueAtTo: input.homeworkWindowEnd,
-    includeDueAtTo: true as const,
-  };
 
   return withUserDbContext(userId, async (tx) => {
+    const bundlePromise = loadOverviewTodoBundleInTransaction(tx, {
+      userId,
+      now: input.now,
+      homeworkWindowEnd: input.homeworkWindowEnd,
+      includeSamples,
+      limit: input.limit,
+    });
     const [todos, dueTodosCount, dueTodos] = await Promise.all([
-      runTodoSummary(() =>
-        loadTodoSummaryInTransaction(tx, {
-          userId,
-          now: input.now,
-          filters: { completed: false },
-          take: includeSamples ? input.limit : 0,
-        }),
+      runTodoSummary(() => bundlePromise.then((bundle) => bundle.todos)),
+      runDueTodoCount(() =>
+        bundlePromise.then((bundle) => bundle.dueTodosCount),
       ),
-      runDueTodoCount(() => countDueTodosInTransaction(tx, dueInput)),
       includeSamples
         ? runDueTodoSample(() =>
-            listDueTodoSamplesInTransaction(tx, {
-              ...dueInput,
-              take: input.limit,
-            }),
+            bundlePromise.then((bundle) => bundle.dueTodos),
           )
         : Promise.resolve([]),
     ]);

--- a/tests/integration/todo-overview-counts.test.ts
+++ b/tests/integration/todo-overview-counts.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  countDueTodos,
+  countIncompleteTodos,
+  countOverviewTodoBundleInTransaction,
+} from "@/features/todos/server/todo-service";
+import { prisma, withUserDbContext } from "@/lib/db/prisma";
+
+describe("overview todo bundle counts", () => {
+  let userId = "";
+  const createdTodoIds: string[] = [];
+  const now = new Date("2026-04-29T08:00:00+08:00");
+  const homeworkWindowEnd = new Date("2026-05-06T08:00:00+08:00");
+
+  beforeAll(async () => {
+    const marker = crypto.randomUUID();
+    const user = await prisma.user.create({
+      data: {
+        email: `todo-overview-counts-${marker}@example.test`,
+        name: "[integration-test] Todo Overview Counts",
+      },
+      select: { id: true },
+    });
+    userId = user.id;
+
+    const todos = await prisma.todo.createManyAndReturn({
+      data: [
+        {
+          userId,
+          title: "[integration-test] completed",
+          completed: true,
+          dueAt: new Date("2026-04-20T08:00:00+08:00"),
+        },
+        {
+          userId,
+          title: "[integration-test] incomplete no due date",
+          completed: false,
+          dueAt: null,
+        },
+        {
+          userId,
+          title: "[integration-test] overdue",
+          completed: false,
+          dueAt: new Date("2026-04-28T08:00:00+08:00"),
+        },
+        {
+          userId,
+          title: "[integration-test] due soon",
+          completed: false,
+          dueAt: new Date("2026-05-01T08:00:00+08:00"),
+        },
+        {
+          userId,
+          title: "[integration-test] due later",
+          completed: false,
+          dueAt: new Date("2026-05-20T08:00:00+08:00"),
+        },
+      ],
+      select: { id: true },
+    });
+    createdTodoIds.push(...todos.map((todo) => todo.id));
+  });
+
+  afterAll(async () => {
+    if (userId) {
+      await prisma.todo.deleteMany({
+        where: { id: { in: createdTodoIds } },
+      });
+      await prisma.user.deleteMany({ where: { id: userId } });
+    }
+    await prisma.$disconnect();
+  });
+
+  it("matches the existing per-count helpers and preserves dueAt IS NOT NULL semantics", async () => {
+    const fusedCounts = await withUserDbContext(userId, (tx) =>
+      countOverviewTodoBundleInTransaction(tx, {
+        userId,
+        now,
+        homeworkWindowEnd,
+      }),
+    );
+
+    const [incomplete, completed, overdue, dueSoon] = await Promise.all([
+      countIncompleteTodos(userId),
+      withUserDbContext(userId, (tx) =>
+        tx.todo.count({
+          where: { userId, completed: true },
+        }),
+      ),
+      withUserDbContext(userId, (tx) =>
+        tx.todo.count({
+          where: {
+            userId,
+            completed: false,
+            dueAt: { lt: now },
+          },
+        }),
+      ),
+      countDueTodos({
+        userId,
+        completed: false,
+        dueAtFrom: now,
+        dueAtTo: homeworkWindowEnd,
+        includeDueAtTo: true,
+      }),
+    ]);
+
+    expect(fusedCounts).toEqual({
+      incomplete: 4,
+      completed: 1,
+      overdue: 1,
+      dueSoon: 1,
+    });
+    expect(fusedCounts.incomplete).toBe(incomplete);
+    expect(fusedCounts.completed).toBe(completed);
+    expect(fusedCounts.overdue).toBe(overdue);
+    expect(fusedCounts.dueSoon).toBe(dueSoon);
+  });
+});

--- a/tests/unit/compact-overview-subscription-bundle.test.ts
+++ b/tests/unit/compact-overview-subscription-bundle.test.ts
@@ -164,15 +164,18 @@ describe("compact overview subscription bundle", () => {
     expect(withHomeworkItemStateMock).not.toHaveBeenCalled();
     expect(listDueSoonSubscribedHomeworksWithCountMock).toHaveBeenCalledWith(
       "user-1",
-      expect.objectContaining({ sectionIds: [11], limit: 1 }),
+      expect.objectContaining({
+        sectionIds: [11],
+        includeItems: false,
+      }),
     );
     expect(listTodaySubscribedSchedulesWithCountMock).toHaveBeenCalledWith(
       "user-1",
-      expect.objectContaining({ sectionIds: [11], limit: 1 }),
+      expect.objectContaining({ sectionIds: [11], includeItems: false }),
     );
     expect(listUpcomingSubscribedExamsWithCountMock).toHaveBeenCalledWith(
       "user-1",
-      expect.objectContaining({ sectionIds: [11], limit: 1 }),
+      expect.objectContaining({ sectionIds: [11], includeItems: false }),
     );
     expect(result.schedules).toEqual([]);
     expect(result.upcomingExams).toEqual([]);

--- a/tests/unit/compact-overview-subscription-bundle.test.ts
+++ b/tests/unit/compact-overview-subscription-bundle.test.ts
@@ -9,20 +9,22 @@ const TOMORROW_START = new Date(TODAY_START.getTime() + 24 * 60 * 60 * 1000);
 const HOMEWORK_WINDOW_END = new Date("2026-05-06T08:00:00+08:00");
 
 const {
+  fetchSubscribedHomeworkRlsSnapshotMock,
   homeworkCountMock,
-  listDueSoonSubscribedHomeworksWithCountMock,
   listTodaySubscribedSchedulesWithCountMock,
   listUpcomingSubscribedExamsWithCountMock,
+  localizeSubscribedHomeworkDashboardItemsMock,
   withHomeworkItemStateMock,
   withUserDbContextMock,
 } = vi.hoisted(() => {
   const homeworkCount = vi.fn();
   const tx = { homework: { count: homeworkCount } };
   return {
+    fetchSubscribedHomeworkRlsSnapshotMock: vi.fn(),
     homeworkCountMock: homeworkCount,
-    listDueSoonSubscribedHomeworksWithCountMock: vi.fn(),
     listTodaySubscribedSchedulesWithCountMock: vi.fn(),
     listUpcomingSubscribedExamsWithCountMock: vi.fn(),
+    localizeSubscribedHomeworkDashboardItemsMock: vi.fn(),
     withHomeworkItemStateMock: vi.fn(async (items: unknown[]) => items),
     withUserDbContextMock: vi.fn(async (_userId, action) => action(tx)),
   };
@@ -47,9 +49,13 @@ vi.mock("@/features/homeworks/server/homework-item-state", () => ({
   withHomeworkItemState: withHomeworkItemStateMock,
 }));
 
+vi.mock("@/features/subscriptions/server/subscription-homework-list", () => ({
+  fetchSubscribedHomeworkRlsSnapshot: fetchSubscribedHomeworkRlsSnapshotMock,
+  localizeSubscribedHomeworkDashboardItems:
+    localizeSubscribedHomeworkDashboardItemsMock,
+}));
+
 vi.mock("@/features/subscriptions/server/subscription-read-model", () => ({
-  listDueSoonSubscribedHomeworksWithCount:
-    listDueSoonSubscribedHomeworksWithCountMock,
   listTodaySubscribedSchedulesWithCount:
     listTodaySubscribedSchedulesWithCountMock,
   listUpcomingSubscribedExamsWithCount:
@@ -81,13 +87,17 @@ describe("compact overview subscription bundle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     homeworkCountMock.mockResolvedValue(4);
+    fetchSubscribedHomeworkRlsSnapshotMock.mockResolvedValue({
+      total: 2,
+      homeworkIds: ["homework-1"],
+      completions: [],
+    });
+    localizeSubscribedHomeworkDashboardItemsMock.mockResolvedValue([
+      { id: "homework-1" },
+    ]);
     listTodaySubscribedSchedulesWithCountMock.mockResolvedValue({
       total: 1,
       items: [{ id: "schedule-1" }],
-    });
-    listDueSoonSubscribedHomeworksWithCountMock.mockResolvedValue({
-      total: 2,
-      items: [{ id: "homework-1" }],
     });
     listUpcomingSubscribedExamsWithCountMock.mockResolvedValue({
       total: 3,
@@ -100,8 +110,8 @@ describe("compact overview subscription bundle", () => {
     const result = await loadReads([]);
 
     expect(homeworkCountMock).not.toHaveBeenCalled();
+    expect(fetchSubscribedHomeworkRlsSnapshotMock).not.toHaveBeenCalled();
     expect(listTodaySubscribedSchedulesWithCountMock).not.toHaveBeenCalled();
-    expect(listDueSoonSubscribedHomeworksWithCountMock).not.toHaveBeenCalled();
     expect(listUpcomingSubscribedExamsWithCountMock).not.toHaveBeenCalled();
     expect(withHomeworkItemStateMock).not.toHaveBeenCalled();
     expect(runStageMock).not.toHaveBeenCalledWith(
@@ -122,25 +132,35 @@ describe("compact overview subscription bundle", () => {
   it("loads subscribed overview reads with paired count+list helpers and a single homework fetch", async () => {
     const result = await loadReads([11]);
 
-    expect(listDueSoonSubscribedHomeworksWithCountMock).toHaveBeenCalledOnce();
-    expect(listDueSoonSubscribedHomeworksWithCountMock).toHaveBeenCalledWith(
+    expect(withUserDbContextMock).toHaveBeenCalledOnce();
+    expect(fetchSubscribedHomeworkRlsSnapshotMock).toHaveBeenCalledOnce();
+    expect(fetchSubscribedHomeworkRlsSnapshotMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "user-1",
+      expect.objectContaining({
+        where: expect.objectContaining({
+          sectionId: { in: [11] },
+        }),
+      }),
+      true,
+    );
+    expect(localizeSubscribedHomeworkDashboardItemsMock).toHaveBeenCalledOnce();
+    expect(listTodaySubscribedSchedulesWithCountMock).toHaveBeenCalledWith(
       "user-1",
       expect.objectContaining({
         sectionIds: [11],
-        dueAtFrom: AT_TIME,
-        dueAtTo: HOMEWORK_WINDOW_END,
         limit: 3,
+        includeItems: true,
       }),
-    );
-    expect(listTodaySubscribedSchedulesWithCountMock).toHaveBeenCalledWith(
-      "user-1",
-      expect.objectContaining({ sectionIds: [11], limit: 3 }),
     );
     expect(listUpcomingSubscribedExamsWithCountMock).toHaveBeenCalledWith(
       "user-1",
-      expect.objectContaining({ sectionIds: [11], limit: 3 }),
+      expect.objectContaining({
+        sectionIds: [11],
+        limit: 3,
+        includeItems: true,
+      }),
     );
-    expect(withUserDbContextMock).toHaveBeenCalledOnce();
     expect(result.counts).toEqual({
       pendingHomeworksCount: 4,
       todaySchedulesCount: 1,
@@ -162,12 +182,16 @@ describe("compact overview subscription bundle", () => {
     const result = await loadReads([11], { includeSamples: false });
 
     expect(withHomeworkItemStateMock).not.toHaveBeenCalled();
-    expect(listDueSoonSubscribedHomeworksWithCountMock).toHaveBeenCalledWith(
+    expect(localizeSubscribedHomeworkDashboardItemsMock).not.toHaveBeenCalled();
+    expect(fetchSubscribedHomeworkRlsSnapshotMock).toHaveBeenCalledWith(
+      expect.anything(),
       "user-1",
       expect.objectContaining({
-        sectionIds: [11],
-        includeItems: false,
+        where: expect.objectContaining({
+          sectionId: { in: [11] },
+        }),
       }),
+      false,
     );
     expect(listTodaySubscribedSchedulesWithCountMock).toHaveBeenCalledWith(
       "user-1",
@@ -189,20 +213,27 @@ describe("compact overview subscription bundle", () => {
   });
 
   it("runs item_state while counts and schedule list work are still pending", async () => {
-    const { promise: homeworkPromise, resolve: resolveHomework } =
-      createDeferred<{ total: number; items: Array<{ id: string }> }>();
-    listDueSoonSubscribedHomeworksWithCountMock.mockReturnValue(
-      homeworkPromise,
-    );
+    const { promise: homeworkRlsDeferred, resolve: resolveHomeworkRls } =
+      createDeferred<{
+        pendingHomeworksCount: number;
+        dueSoonRls: {
+          total: number;
+          homeworkIds: string[];
+          completions: [];
+        };
+      }>();
+    withUserDbContextMock.mockImplementationOnce(() => homeworkRlsDeferred);
 
     const readsPromise = loadReads([11]);
 
     await vi.waitFor(() => {
-      expect(homeworkCountMock).toHaveBeenCalled();
       expect(listTodaySubscribedSchedulesWithCountMock).toHaveBeenCalled();
     });
     expect(withHomeworkItemStateMock).not.toHaveBeenCalled();
-    resolveHomework({ total: 2, items: [{ id: "homework-1" }] });
+    resolveHomeworkRls({
+      pendingHomeworksCount: 4,
+      dueSoonRls: { total: 2, homeworkIds: ["homework-1"], completions: [] },
+    });
     await readsPromise;
     expect(withHomeworkItemStateMock).toHaveBeenCalledWith(
       [{ id: "homework-1" }],


### PR DESCRIPTION
Closes #730

Production was serving `GET /api/workspace/overview` in **6–8.7 seconds**, measured from Workers observability over a 48h sampled window. Three compounding causes, all addressed here. The response shape is unchanged — this is purely about how the data is fetched.

## Why it was slow

`withUserDbContext` issues `BEGIN`, `SELECT set_config('app.user_id', ...)`, the query, then `COMMIT`, so every call costs three round trips of pure overhead and pins a connection for its whole lifetime. The pg pool is deliberately capped at 3 connections per request, so the `Promise.all` fan-out in `getCompactOverview` — which wanted about six concurrent holders — silently became a queue with pooled queries waiting behind whole transactions.

## 1. GraphQL no longer runs sample queries it discards

`WorkspaceOverview` exposes only scalar counts, and the counts-only path already passed `includeSamples: false` — but that only lowered `limit` from 3 to 1 rather than skipping the `findMany`. Each of the three paired helpers still ran its full relation tree, and the homework helper still opened an extra RLS transaction for ids plus completions. Roughly 20 statements and a whole transaction, discarded.

The helpers now take an explicit flag and skip the item query entirely. `countUpcomingSubscribedExams` already existed for the exam case and is reused rather than duplicated.

## 2. Four homework transactions collapsed into one

The overview opened four separate RLS transactions for homework: the count, the ids-plus-completions fetch, the pending count, and `withHomeworkItemState`. `runWithUserRlsContext` already reuses an active context when the userId matches, so these nest into one — `fetchSubscribedHomeworkRlsSnapshot`.

The localized `findMany` stays outside the transaction, split into `localizeSubscribedHomeworkDashboardItems`, because `getPrisma(locale)` throws inside an RLS context.

**Tradeoff worth flagging:** the count and the item fetch previously ran concurrently and are now sequential on one connection. With three extra round trips per transaction and a 3-connection budget this should still win, but it is a latency-shape change rather than a pure reduction, so it is worth watching the `counts` and `lists` analytics stages after deploy.

## 3. Four todo counts fused into one query

`loadOverviewTodoBundle` ran four `count` calls inside a single `withUserDbContext`. Because they shared one pinned connection the `Promise.all` bought nothing — six serial round trips. They are now one `count(*) FILTER (...)` query against the existing `@@index([userId, completed, dueAt])`.

`tests/integration/todo-overview-counts.test.ts` asserts the fused counts match the original per-count helpers on the same fixture data, including the `dueAt IS NOT NULL` semantics implied by `buildDueTodoWhere`. Raw SQL bypasses the localized-names client extension, which is safe here because `Todo` has no localized fields.

## Deliberately not attempted

Enabling `relationJoins` with `relationLoadStrategy: "join"` is the single biggest remaining lever — it would collapse the 8-statement schedule select and the 6-statement exam select to one query each. It is a preview feature that changes generated SQL for every nested read in the repo and was not verified against the WASM query compiler on Workers, so it needs its own branch and measurement. Same for rewriting the overview as one hand-written CTE query.

Dropping `campus` from `overviewRoomSelect.building` would remove another whole query wave and nothing reads it, but it is contract-visible and belongs with a `docs/contracts` decision.

## Test plan

- [x] `biome check`
- [x] `tsc --noEmit` across all three configs
- [x] `openapi:check` — no response shape change
- [x] 1924 unit tests
- [x] 259 integration tests against live Postgres, including the new count-parity test
- [ ] Worth confirming the observability stage timings after deploy, since #730 also noted `counts` and `lists` were reporting overlapping durations