### PR TITLE
test(e2e): fail the audit-row wait on timeout and drop dead helpers

### DIFF
--- a/tests/e2e/utils/description-state.ts
+++ b/tests/e2e/utils/description-state.ts
@@ -144,13 +144,19 @@ export async function waitForDescriptionAuditRows(
   snapshot: DescriptionSnapshot,
   expectedNewRows: number,
 ) {
+  let count = 0;
   for (let attempt = 0; attempt < 40; attempt += 1) {
-    const count = await withE2ePrisma((prisma) =>
+    count = await withE2ePrisma((prisma) =>
       prisma.auditLog.count({ where: newAuditWhere(snapshot) }),
     );
     if (count >= expectedNewRows) return;
     await sleep(25);
   }
+  // Returning quietly here would let a caller assert against audit rows that
+  // were never written, so the timeout has to fail the test.
+  throw new Error(
+    `Timed out waiting for ${expectedNewRows} new description audit row(s); saw ${count}.`,
+  );
 }
 
 export async function restoreDescriptionSnapshot(

--- a/tests/e2e/utils/locators.ts
+++ b/tests/e2e/utils/locators.ts
@@ -4,10 +4,6 @@ export function visibleText(page: Page, text: string | RegExp): Locator {
   return page.getByText(text).filter({ visible: true }).first();
 }
 
-export function visible(locator: Locator): Locator {
-  return locator.filter({ visible: true }).first();
-}
-
 export function appSidebar(page: Page): Locator {
   return page.getByTestId("app-sidebar");
 }

--- a/tests/e2e/utils/uploads.ts
+++ b/tests/e2e/utils/uploads.ts
@@ -5,58 +5,6 @@ function escapeForRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-export async function uploadFileFromDashboard(
-  page: Page,
-  options: {
-    filename: string;
-    mimeType?: string;
-    contents: string;
-  },
-) {
-  const createResponsePromise = page.waitForResponse(
-    (response) =>
-      response.url().includes("/api/workspace/uploads") &&
-      response.request().method() === "POST" &&
-      response.status() === 200,
-  );
-  const completeResponsePromise = page.waitForResponse(
-    (response) =>
-      response.url().includes("/api/workspace/uploads/complete") &&
-      response.request().method() === "POST" &&
-      response.status() === 200,
-  );
-  const putResponsePromise = page.waitForResponse(
-    (response) =>
-      response.request().method() === "PUT" &&
-      response.status() === 200 &&
-      response.url().startsWith("http"),
-  );
-
-  await page.locator("input#upload-file").setInputFiles({
-    name: options.filename,
-    mimeType: options.mimeType ?? "text/plain",
-    buffer: Buffer.from(options.contents),
-  });
-
-  const createResponse = await createResponsePromise;
-  const createBody = (await createResponse.json()) as { url?: string };
-  expect(createBody.url).toMatch(/^https?:\/\//);
-
-  await putResponsePromise;
-
-  const completeResponse = await completeResponsePromise;
-  const completeBody = (await completeResponse.json()) as {
-    upload?: { id?: string; filename?: string };
-  };
-  expect(typeof completeBody.upload?.id).toBe("string");
-
-  const row = await expectUploadRow(page, options.filename);
-  return {
-    row,
-    uploadId: completeBody.upload?.id as string,
-  };
-}
-
 export async function expectUploadRow(page: Page, filename: string) {
   const row = page
     .locator("tr")


### PR DESCRIPTION
Part of #733. Small, verifiable subset — see the issue for why the SSR items are not here.

## `waitForDescriptionAuditRows` failed silently

It polled 40 times and then simply returned, so a caller could proceed to assert against audit rows that were never written. The failure then surfaced as a confusing assertion mismatch somewhere downstream instead of a timeout at the actual cause. It now throws with the observed count.

## Dead helpers removed

`uploadFileFromDashboard` in `tests/e2e/utils/uploads.ts` and `visible()` in `tests/e2e/utils/locators.ts` had zero callers.

## Test plan

- [x] `biome check`
- [x] `tsc --noEmit` across all three configs
- [x] `svelte-check` 0 errors, 0 warnings
- [x] 1925 unit tests