### PR TITLE
fix(auth)!: harden webhook login with opt-in gate, cookie-only session, and audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ ALLOW_DATABASE_SEED="true"
 # Defaults to the same value in wrangler.jsonc when running wrangler locally.
 # CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE="postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev"
 # CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE_AUTH="postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev"
+# Ops/debug webhook login. Both are required to register the endpoint.
+# Leave WEBHOOK_LOGIN_ENABLED unset (or false) in production unless actively debugging.
+# WEBHOOK_LOGIN_ENABLED="true"
 WEBHOOK_SECRET="replace-with-random-secret"
 AUTH_SECRET="replace-with-random-secret"
 # Required in production. Local dev falls back to http://localhost:3000.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           {
             echo "DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_copilot"
+            echo "WEBHOOK_LOGIN_ENABLED=true"
             echo "WEBHOOK_SECRET=copilot-local-secret"
             echo "AUTH_SECRET=copilot-local-secret"
           } >> "$GITHUB_ENV"

--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -100,6 +100,7 @@ jobs:
             echo "ALLOW_DATABASE_SEED=true"
             if [ -n "${{ inputs.webhook-secret }}" ]; then
               echo "WEBHOOK_SECRET=${{ inputs.webhook-secret }}"
+              echo "WEBHOOK_LOGIN_ENABLED=true"
             fi
             if [ -n "${{ inputs.extra-env }}" ]; then
               printf '%s\n' "${{ inputs.extra-env }}"

--- a/docs/contracts/_audit.json
+++ b/docs/contracts/_audit.json
@@ -47,6 +47,10 @@
     "admin_description_moderate": {
       "trigger": "PATCH /api/admin/descriptions/[id] or /admin/moderation description action",
       "description": "Admin updates description content from the moderation workflow. The description row, edit history, and audit row are committed together."
+    },
+    "webhook_login": {
+      "trigger": "POST /api/auth/webhook/login",
+      "description": "Ops/debug webhook login creates a Better Auth session for a resolved user. Metadata records the lookup mode only; secrets and session tokens are never stored."
     }
   },
   "writer": "writeAuditLog records app audit rows and Cloudflare Analytics Engine datapoints. The Node-only static loader writes Section lifecycle rows directly with its import transaction. Required trails are awaited in the same transaction where practical; fireAuditLog remains non-critical telemetry."

--- a/docs/contracts/webhook-login.json
+++ b/docs/contracts/webhook-login.json
@@ -3,13 +3,16 @@
   "access": {
     "anon": "Not applicable.",
     "user": "Not applicable.",
-    "admin": "Must hold the WEBHOOK_SECRET environment variable value.",
+    "admin": "Must set WEBHOOK_LOGIN_ENABLED=true and hold the WEBHOOK_SECRET value.",
     "agent": "Not applicable."
   },
   "rules": {
-    "requires-secret": "Only available when the server is configured with the WEBHOOK_SECRET environment variable; all requests return 403 when not configured.",
+    "requires-opt-in": "Plugin is registered only when WEBHOOK_LOGIN_ENABLED=true and WEBHOOK_SECRET is non-empty. Secret alone is insufficient; unset the flag in production except during active debugging.",
+    "requires-secret": "Authenticated requests must supply the WEBHOOK_SECRET value; invalid or missing secrets return 403.",
     "debug-only": "Used for passwordless login in production debugging scenarios; not a regular user sign-in entry point.",
-    "session-via-betterauth": "Locates the target user by email or userId and establishes a session via Better Auth session primitives; no longer hand-writes session cookie signing."
+    "cookie-only-session": "Establishes a Better Auth session via setSessionCookie. The session token is never returned in the JSON body.",
+    "rate-limited": "Better Auth customRules throttle /webhook/login to 5 requests per 60 seconds when rate limiting is enabled.",
+    "audited": "Successful logins write an AuditAction.webhook_login row (no secrets or session tokens in metadata)."
   },
   "capabilities": {
     "webhook-login": {
@@ -29,7 +32,7 @@
         "fields": [
           "Webhook URL handled through Better Auth catch-all",
           "User info payload",
-          "Session creation JSON response"
+          "Session cookie + JSON without sessionToken"
         ]
       }
     }

--- a/prisma/migrations/20260803140000_audit_webhook_login/migration.sql
+++ b/prisma/migrations/20260803140000_audit_webhook_login/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "AuditAction" ADD VALUE 'webhook_login';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,6 +56,7 @@ enum AuditAction {
   admin_description_moderate
   section_retire
   section_reactivate
+  webhook_login
 }
 
 enum TodoPriority {

--- a/src/lib/auth/better-auth-options.ts
+++ b/src/lib/auth/better-auth-options.ts
@@ -16,6 +16,7 @@ import {
   betterAuthVerificationOptions,
 } from "@/lib/auth/better-auth-schema-options";
 import { buildBetterAuthSocialProviders } from "@/lib/auth/better-auth-social-providers";
+import { webhookLoginRateLimitRules } from "@/lib/auth/webhook-login-plugin";
 import { authPrisma } from "@/lib/db/auth-prisma";
 
 export function buildBetterAuthOptions() {
@@ -41,7 +42,13 @@ export function buildBetterAuthOptions() {
     // don't get throttled with 429 responses.
     rateLimit: debugAuthAllowed
       ? { enabled: false }
-      : { enabled: true, customRules: betterAuthPasskeyRateLimitRules },
+      : {
+          enabled: true,
+          customRules: {
+            ...betterAuthPasskeyRateLimitRules,
+            ...webhookLoginRateLimitRules,
+          },
+        },
     advanced: {
       ipAddress: {
         ipAddressHeaders: ["cf-connecting-ip"],

--- a/src/lib/auth/better-auth-plugins.ts
+++ b/src/lib/auth/better-auth-plugins.ts
@@ -11,6 +11,7 @@ import {
 import { buildUstcOidcProviderEndpoints } from "@/lib/auth/ustc-oidc-endpoints";
 import { ustcOidcIdentityPlugin } from "@/lib/auth/ustc-oidc-identity-plugin";
 import { stageUstcOidcIdentityFromProfile } from "@/lib/auth/ustc-oidc-identity-profile";
+import { isWebhookLoginEnabled } from "@/lib/auth/webhook-login-handler";
 import { webhookLoginPlugin } from "@/lib/auth/webhook-login-plugin";
 import { getCanonicalOAuthIssuer } from "@/lib/mcp/urls";
 import { OAUTH_OPENID_SCOPE } from "@/lib/oauth/constants";
@@ -41,7 +42,7 @@ export function buildBetterAuthPlugins(input: {
       currentURL: input.authPublicOrigin,
       ...(input.oauthProxySecret ? { secret: input.oauthProxySecret } : {}),
     }),
-    webhookLoginPlugin(),
+    ...(isWebhookLoginEnabled() ? [webhookLoginPlugin()] : []),
     buildBetterAuthPasskeyPlugin(),
     ustcOidcIdentityPlugin(),
     buildOAuthProviderPlugin({

--- a/src/lib/auth/webhook-login-handler.ts
+++ b/src/lib/auth/webhook-login-handler.ts
@@ -1,6 +1,9 @@
+import { timingSafeEqual } from "node:crypto";
 import type { GenericEndpointContext } from "@better-auth/core";
 import { setSessionCookie } from "better-auth/cookies";
 import { getOptionalTrimmedEnv } from "@/app-env";
+import { getAuditRequestMetadata } from "@/lib/audit/request-metadata";
+import { fireAuditLog } from "@/lib/audit/write-audit-log";
 import { authPrisma as prisma } from "@/lib/db/auth-prisma";
 import { logOAuthDebug } from "@/lib/log/oauth-debug";
 
@@ -11,6 +14,14 @@ function jsonError(status: number, body: Record<string, string>) {
       "content-type": "application/json",
     },
   });
+}
+
+function secretsEqual(provided: string | undefined, expected: string) {
+  if (!provided) return false;
+  const left = Buffer.from(provided);
+  const right = Buffer.from(expected);
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
 }
 
 type WebhookLoginBody = {
@@ -41,10 +52,16 @@ type WebhookLoginContext = {
   request?: Request;
 };
 
+export function isWebhookLoginEnabled() {
+  const enabled = getOptionalTrimmedEnv("WEBHOOK_LOGIN_ENABLED");
+  const secret = getOptionalTrimmedEnv("WEBHOOK_SECRET");
+  return enabled === "true" && Boolean(secret);
+}
+
 export async function handleWebhookLogin(ctx: WebhookLoginContext) {
   const { secret, email, userId } = ctx.body;
   const webhookSecret = getOptionalTrimmedEnv("WEBHOOK_SECRET");
-  if (!webhookSecret || secret !== webhookSecret) {
+  if (!webhookSecret || !secretsEqual(secret, webhookSecret)) {
     logOAuthDebug("webhook-login.auth-failed", ctx.request, {
       reason: "invalid_or_missing_secret",
     });
@@ -93,13 +110,24 @@ export async function handleWebhookLogin(ctx: WebhookLoginContext) {
     user: authUser as never,
   });
 
+  const requestMeta = ctx.request ? getAuditRequestMetadata(ctx.request) : {};
+  await fireAuditLog({
+    action: "webhook_login",
+    userId: authUser.id,
+    targetId: authUser.id,
+    targetType: "user",
+    metadata: {
+      lookup: email ? "email" : "userId",
+    },
+    ...requestMeta,
+  });
+
   logOAuthDebug("webhook-login.success", ctx.request, {});
 
   return ctx.json({
     ok: true,
     userId: authUser.id,
     email: authUser.email,
-    sessionToken: session.token,
     expires: new Date(session.expiresAt).toISOString(),
   });
 }

--- a/src/lib/auth/webhook-login-plugin.ts
+++ b/src/lib/auth/webhook-login-plugin.ts
@@ -8,6 +8,13 @@ const webhookLoginBodySchema = z.object({
   userId: z.string().optional(),
 });
 
+export const webhookLoginRateLimitRules = {
+  "/webhook/login": {
+    window: 60,
+    max: 5,
+  },
+} as const;
+
 export function webhookLoginPlugin() {
   return {
     id: "life-webhook-login",
@@ -20,7 +27,7 @@ export function webhookLoginPlugin() {
           metadata: {
             openapi: {
               description:
-                "Debug-only webhook login endpoint backed by Better Auth session creation.",
+                "Opt-in ops/debug webhook login. Requires WEBHOOK_LOGIN_ENABLED=true and WEBHOOK_SECRET. Sets a session cookie; does not return the session token in the body.",
             },
           },
         },

--- a/tests/unit/better-auth-options.test.ts
+++ b/tests/unit/better-auth-options.test.ts
@@ -84,6 +84,10 @@ describe("Better Auth options", () => {
           window: 60,
           max: 10,
         },
+        "/webhook/login": {
+          window: 60,
+          max: 5,
+        },
       },
     });
     expect(options.trustedOrigins).toEqual(["https://life.example.com"]);

--- a/tests/unit/webhook-login-handler.test.ts
+++ b/tests/unit/webhook-login-handler.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getOptionalTrimmedEnvMock,
+  findFirstMock,
+  createSessionMock,
+  findUserByIdMock,
+  setSessionCookieMock,
+  fireAuditLogMock,
+} = vi.hoisted(() => ({
+  getOptionalTrimmedEnvMock: vi.fn(),
+  findFirstMock: vi.fn(),
+  createSessionMock: vi.fn(),
+  findUserByIdMock: vi.fn(),
+  setSessionCookieMock: vi.fn(),
+  fireAuditLogMock: vi.fn(),
+}));
+
+vi.mock("@/app-env", () => ({
+  getOptionalTrimmedEnv: getOptionalTrimmedEnvMock,
+}));
+
+vi.mock("@/lib/db/auth-prisma", () => ({
+  authPrisma: {
+    user: {
+      findFirst: findFirstMock,
+    },
+  },
+}));
+
+vi.mock("better-auth/cookies", () => ({
+  setSessionCookie: setSessionCookieMock,
+}));
+
+vi.mock("@/lib/audit/write-audit-log", () => ({
+  fireAuditLog: fireAuditLogMock,
+}));
+
+vi.mock("@/lib/log/oauth-debug", () => ({
+  logOAuthDebug: vi.fn(),
+}));
+
+import {
+  handleWebhookLogin,
+  isWebhookLoginEnabled,
+} from "@/lib/auth/webhook-login-handler";
+
+function envMap(values: Record<string, string | undefined>) {
+  getOptionalTrimmedEnvMock.mockImplementation((key: string) => values[key]);
+}
+
+describe("webhook login hardening", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fireAuditLogMock.mockResolvedValue(undefined);
+    setSessionCookieMock.mockResolvedValue(undefined);
+  });
+
+  it("is disabled unless both WEBHOOK_LOGIN_ENABLED=true and WEBHOOK_SECRET are set", () => {
+    envMap({ WEBHOOK_LOGIN_ENABLED: "true", WEBHOOK_SECRET: "secret" });
+    expect(isWebhookLoginEnabled()).toBe(true);
+
+    envMap({ WEBHOOK_LOGIN_ENABLED: undefined, WEBHOOK_SECRET: "secret" });
+    expect(isWebhookLoginEnabled()).toBe(false);
+
+    envMap({ WEBHOOK_LOGIN_ENABLED: "true", WEBHOOK_SECRET: undefined });
+    expect(isWebhookLoginEnabled()).toBe(false);
+
+    envMap({ WEBHOOK_LOGIN_ENABLED: "false", WEBHOOK_SECRET: "secret" });
+    expect(isWebhookLoginEnabled()).toBe(false);
+  });
+
+  it("rejects invalid secrets with 403", async () => {
+    envMap({ WEBHOOK_SECRET: "expected-secret" });
+
+    const response = (await handleWebhookLogin({
+      body: { secret: "wrong-secret", email: "user@example.com" },
+      context: {
+        internalAdapter: {
+          createSession: createSessionMock,
+          findUserById: findUserByIdMock,
+        },
+      },
+      json: vi.fn(),
+      request: new Request("https://example.test/api/auth/webhook/login"),
+    })) as Response;
+
+    expect(response.status).toBe(403);
+    expect(createSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("sets a session cookie and omits sessionToken from the body", async () => {
+    envMap({ WEBHOOK_SECRET: "expected-secret" });
+    findFirstMock.mockResolvedValue({
+      id: "user-1",
+      email: "user@example.com",
+    });
+    findUserByIdMock.mockResolvedValue({
+      id: "user-1",
+      email: "user@example.com",
+    });
+    createSessionMock.mockResolvedValue({
+      token: "must-not-leak",
+      expiresAt: new Date("2030-01-01T00:00:00.000Z"),
+    });
+    const json = vi.fn(async (body: Record<string, unknown>) => body);
+
+    const body = await handleWebhookLogin({
+      body: { secret: "expected-secret", email: "user@example.com" },
+      context: {
+        internalAdapter: {
+          createSession: createSessionMock,
+          findUserById: findUserByIdMock,
+        },
+      },
+      json,
+      request: new Request("https://example.test/api/auth/webhook/login", {
+        headers: {
+          "user-agent": "vitest",
+          "x-forwarded-for": "203.0.113.10",
+        },
+      }),
+    });
+
+    expect(setSessionCookieMock).toHaveBeenCalledOnce();
+    expect(fireAuditLogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "webhook_login",
+        userId: "user-1",
+        targetId: "user-1",
+        targetType: "user",
+        metadata: { lookup: "email" },
+      }),
+    );
+    expect(body).toEqual({
+      ok: true,
+      userId: "user-1",
+      email: "user@example.com",
+      expires: "2030-01-01T00:00:00.000Z",
+    });
+    expect(body).not.toHaveProperty("sessionToken");
+  });
+});


### PR DESCRIPTION
## Summary
- Dual-gate `WEBHOOK_LOGIN_ENABLED=true` + `WEBHOOK_SECRET` before registering the plugin (secret alone is insufficient).
- Timing-safe secret compare; cookie-only session (no `sessionToken` in JSON); Better Auth rate limit 5/60s; `AuditAction.webhook_login` on success.
- Docs/contracts/.env.example/CI updated. **Ops:** leave `WEBHOOK_LOGIN_ENABLED` unset in production except during active debugging.

Closes #731

## Test plan
- [ ] Unit tests for enablement, 403 on bad secret, cookie set without body token
- [ ] DB Migrate Deploy applies `webhook_login` enum value
- [ ] With flag unset in prod, `/api/auth/webhook/login` is not registered