### PR TITLE
fix(worker): bypass PublicSsr edge cache when auth signal is present

### DIFF
--- a/src/lib/cloudflare/public-ssr-gateway.ts
+++ b/src/lib/cloudflare/public-ssr-gateway.ts
@@ -110,12 +110,20 @@ function isCanonicalCatalogDetailPath(pathname: string) {
   return !section;
 }
 
+export function shouldRoutePublicSsrCache(
+  request: Request,
+  mode: PublicSsrMode | null,
+): mode is PublicSsrMode {
+  return mode !== null && !hasRequestAuthSignal(request.headers);
+}
+
 export function resolvePublicSsrMode(
   request: Request,
   resolveFeatureRoute?: PublicSsrRouteResolver,
 ): PublicSsrMode | null {
   if (request.method !== "GET" && request.method !== "HEAD") return null;
   if (!acceptsHtml(request)) return null;
+  if (hasRequestAuthSignal(request.headers)) return null;
 
   const url = new URL(request.url);
   if (url.pathname.endsWith("/__data.json")) return null;
@@ -124,9 +132,7 @@ export function resolvePublicSsrMode(
   if (featureMode !== undefined) return featureMode;
 
   if (isCanonicalCatalogDetailPath(url.pathname)) {
-    return !url.search && !hasRequestAuthSignal(request.headers)
-      ? "page"
-      : null;
+    return !url.search ? "page" : null;
   }
 
   if (

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,4 +1,3 @@
-import { PUBLIC_SSR_HEADER } from "@/lib/cloudflare/public-ssr-gateway";
 import {
   buildLayoutCopy,
   layoutUserSummary,
@@ -6,7 +5,7 @@ import {
 import { buildSocialMetadata } from "@/lib/social-metadata";
 import type { LayoutServerLoad } from "./$types";
 
-export const load: LayoutServerLoad = async ({ locals, request, url }) => {
+export const load: LayoutServerLoad = async ({ locals, url }) => {
   const copy = buildLayoutCopy(locals.locale);
 
   return {
@@ -21,6 +20,6 @@ export const load: LayoutServerLoad = async ({ locals, request, url }) => {
       title: copy.metadata.title,
     }),
     user: layoutUserSummary(locals.authUser),
-    resolveViewerOnClient: request.headers.get(PUBLIC_SSR_HEADER) === "1",
+    resolveViewerOnClient: locals.publicSsr,
   };
 };

--- a/src/worker.js
+++ b/src/worker.js
@@ -23,6 +23,7 @@ import {
   resolvePublicSsrMode,
   resolveSectionDetailTabRedirect,
   resolveTeacherDetailTabRedirect,
+  shouldRoutePublicSsrCache,
 } from "./lib/cloudflare/public-ssr-gateway";
 import { buildContentSecurityPolicy } from "./lib/security/csp";
 import { CONTENT_SIGNAL } from "./lib/seo/content-signal";
@@ -228,7 +229,9 @@ export default {
       });
     }
     const mode = resolvePublicSsrMode(request, resolveCatalogListPublicSsrMode);
-    if (!mode) return app.fetch(directRequest(request), env, context);
+    if (!shouldRoutePublicSsrCache(request, mode)) {
+      return app.fetch(directRequest(request), env, context);
+    }
 
     const locale = resolvePublicSsrLocale(request);
     if (mode === "not-found") {

--- a/tests/e2e/src/app/privacy/test.ts
+++ b/tests/e2e/src/app/privacy/test.ts
@@ -39,9 +39,7 @@ test.describe("/privacy 隐私政策页", () => {
 
     const documentResponse = await page.request.get("/privacy");
     expect(documentResponse.status()).toBe(200);
-    expect(documentResponse.headers()["cache-control"]).toBe(
-      "private, no-store",
-    );
+    expect(documentResponse.headers()["cache-control"]).toMatch(/no-store/);
     const html = await documentResponse.text();
     // Authenticated requests skip anonymous PublicSsr HTML, so the viewer is
     // already present in the document instead of a client-only skeleton.

--- a/tests/e2e/src/app/privacy/test.ts
+++ b/tests/e2e/src/app/privacy/test.ts
@@ -34,7 +34,7 @@ test.describe("/privacy 隐私政策页", () => {
     expect(await listItems.count()).toBeGreaterThan(0);
   });
 
-  test("登录用户复用匿名 SSR 后在 hydration 恢复 viewer", async ({ page }) => {
+  test("登录用户绕过 PublicSsr 缓存并直接 SSR viewer", async ({ page }) => {
     await signInAsDebugUser(page, "/privacy", "/privacy");
 
     const documentResponse = await page.request.get("/privacy");
@@ -42,12 +42,11 @@ test.describe("/privacy 隐私政策页", () => {
     expect(documentResponse.headers()["cache-control"]).toBe(
       "private, no-store",
     );
-    expect(documentResponse.headers()["cloudflare-cdn-cache-control"]).toBe(
-      "no-store",
-    );
     const html = await documentResponse.text();
-    expect(html).toContain('data-testid="viewer-loading"');
-    expect(html).not.toContain('id="app-user-menu"');
+    // Authenticated requests skip anonymous PublicSsr HTML, so the viewer is
+    // already present in the document instead of a client-only skeleton.
+    expect(html).not.toContain('data-testid="viewer-loading"');
+    expect(html).toContain('id="app-user-menu"');
 
     await gotoAndWaitForReady(page, "/privacy");
     await expect(page.getByTestId("viewer-loading")).toHaveCount(0);

--- a/tests/unit/public-ssr-gateway.test.ts
+++ b/tests/unit/public-ssr-gateway.test.ts
@@ -10,6 +10,7 @@ import {
   resolvePublicSsrLocale,
   resolveSectionDetailTabRedirect,
   resolveTeacherDetailTabRedirect,
+  shouldRoutePublicSsrCache,
 } from "@/lib/cloudflare/public-ssr-gateway";
 
 function resolvePublicSsrMode(request: Request) {
@@ -177,14 +178,25 @@ describe("public SSR gateway", () => {
     ).toBeNull();
   });
 
-  test("keeps viewer-independent catalog list caching with auth signals", () => {
-    expect(
-      resolvePublicSsrMode(
-        request("/catalog/courses", {
-          cookie: "better-auth.session_token=session-token",
-        }),
-      ),
-    ).toBe("page");
+  test.each([
+    "/catalog/courses",
+    "/catalog/sections",
+    "/privacy",
+    "/wp-login.php",
+  ])("bypasses public SSR cache routing for authenticated page %s", (path) => {
+    const authenticated = request(path, {
+      cookie: "better-auth.session_token=session-token",
+    });
+    expect(resolvePublicSsrMode(authenticated)).toBeNull();
+    expect(shouldRoutePublicSsrCache(authenticated, "page")).toBe(false);
+    expect(shouldRoutePublicSsrCache(authenticated, "not-found")).toBe(false);
+  });
+
+  test("routes anonymous catalog list pages through public SSR cache", () => {
+    const anonymous = request("/catalog/courses");
+    expect(resolvePublicSsrMode(anonymous)).toBe("page");
+    expect(shouldRoutePublicSsrCache(anonymous, "page")).toBe(true);
+    expect(shouldRoutePublicSsrCache(anonymous, null)).toBe(false);
   });
 
   test("bypasses non-read and non-document catalog detail requests", () => {

--- a/tests/unit/public-ssr-worker-routing.test.ts
+++ b/tests/unit/public-ssr-worker-routing.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import { resolveCatalogListPublicSsrMode } from "@/features/catalog/lib/catalog-list-query";
+import {
+  resolvePublicSsrMode as resolveBasePublicSsrMode,
+  shouldRoutePublicSsrCache,
+} from "@/lib/cloudflare/public-ssr-gateway";
+
+function resolvePublicSsrMode(request: Request) {
+  return resolveBasePublicSsrMode(request, resolveCatalogListPublicSsrMode);
+}
+
+function workerSsrRoute(request: Request) {
+  const mode = resolvePublicSsrMode(request);
+  return shouldRoutePublicSsrCache(request, mode)
+    ? "public-ssr"
+    : "dynamic-ssr";
+}
+
+function request(path: string, headers: HeadersInit = {}) {
+  return new Request(`https://life-ustc.test${path}`, {
+    headers: { accept: "text/html", ...headers },
+  });
+}
+
+describe("public SSR worker routing", () => {
+  test.each([
+    "/catalog/courses",
+    "/catalog/sections/159446",
+    "/privacy",
+    "/catalog/bus/map",
+  ])("serves anonymous %s through the PublicSsr cache path", (path) => {
+    expect(workerSsrRoute(request(path))).toBe("public-ssr");
+  });
+
+  test.each([
+    ["/catalog/courses", { cookie: "better-auth.session_token=session-token" }],
+    ["/catalog/sections/159446", { authorization: "Bearer access-token" }],
+    ["/privacy", { cookie: "session=private" }],
+    ["/wp-login.php", { cookie: "session=private" }],
+  ])("bypasses PublicSsr for authenticated document request %s", (path, headers) => {
+    expect(workerSsrRoute(request(path, headers))).toBe("dynamic-ssr");
+  });
+});


### PR DESCRIPTION
## Summary
- Skip the `PublicSsr` edge-cache path when a request carries an auth cookie or bearer token, so cookies are not stripped and layout SSR includes the signed-in viewer.
- Add `shouldRoutePublicSsrCache` and use it in the worker fetch handler; anonymous HTML traffic continues through the cached PublicSsr route.
- Drive `resolveViewerOnClient` from `locals.publicSsr` instead of the raw PublicSsr header so the shell stays aligned with hook-level auth bypass.

## Test plan
- [x] `bunx biome check` on touched files
- [x] `bun test tests/unit/public-ssr-gateway.test.ts tests/unit/public-ssr-worker-routing.test.ts tests/unit/public-ssr-detail-safety.test.ts tests/unit/page-request-attribution.test.ts`

Refs #733 Partial