### PR TITLE
fix(ui): nav presentation cleanup (PR C, #733)

### DIFF
--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -1686,6 +1686,7 @@
     "listView": "List",
     "filterEmptyTitle": "No homework under this filter",
     "filterEmptyDescription": "Try another filter, or check back later.",
+    "clearFilter": "Clear filter",
     "addButton": "Add homework",
     "sectionLabel": "Section",
     "sectionPlaceholder": "Select a section",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -1652,6 +1652,7 @@
     "listView": "列表",
     "filterEmptyTitle": "当前筛选下暂无作业",
     "filterEmptyDescription": "切换筛选条件，或稍后再试。",
+    "clearFilter": "清除筛选",
     "addButton": "添加作业",
     "sectionLabel": "班级",
     "sectionPlaceholder": "选择班级",

--- a/src/features/catalog/components/CourseDetailPageController.svelte
+++ b/src/features/catalog/components/CourseDetailPageController.svelte
@@ -8,6 +8,7 @@ import DetailSectionNav from "$lib/components/DetailSectionNav.svelte";
 import PageHeader from "$lib/components/PageHeader.svelte";
 import TruncatedCode from "$lib/components/TruncatedCode.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
+import { courseDetailPagePath } from "../lib/catalog-detail-tab";
 import type { CatalogNamed } from "../lib/catalog-list-display";
 import {
   formatCatalogDetailMessage as formatMessage,
@@ -102,7 +103,7 @@ $: detailCopy = copy satisfies CourseDetailCopy;
 $: notAvailable = copy.courseDetail.notAvailable;
 $: displayName = primaryName(data.course) || data.course.code;
 $: secondaryDisplayName = secondaryName(data.course);
-$: courseBaseHref = `/catalog/courses/${data.course.jwId}`;
+$: courseJwId = data.course.jwId;
 $: commentsCount = data.commentsData
   ? Object.values(data.commentsData.commentMap).reduce(
       (sum, comments) => sum + comments.length,
@@ -111,26 +112,26 @@ $: commentsCount = data.commentsData
   : 0;
 $: sectionNavItems = [
   {
-    href: courseBaseHref,
+    href: courseDetailPagePath(courseJwId, "overview"),
     icon: InfoIcon,
     key: "overview" as const,
     label: copy.course.basicInfo,
   },
   {
-    href: `${courseBaseHref}/introduction`,
+    href: courseDetailPagePath(courseJwId, "introduction"),
     icon: BookOpenTextIcon,
     key: "introduction" as const,
     label: copy.courseDetail.tabs.description,
   },
   {
-    href: `${courseBaseHref}/sections`,
+    href: courseDetailPagePath(courseJwId, "sections"),
     icon: ListIcon,
     key: "sections" as const,
     label: copy.courseDetail.teachingSections,
     meta: data.course.sectionCount,
   },
   {
-    href: `${courseBaseHref}/comments`,
+    href: courseDetailPagePath(courseJwId, "comments"),
     icon: MessageSquareIcon,
     key: "comments" as const,
     label: copy.courseDetail.tabs.comments,
@@ -178,7 +179,7 @@ $: activeNavItem =
 
   <div class="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] bg-card lg:grid-cols-[auto_minmax(0,1fr)] lg:grid-rows-none">
     <DetailSectionNav
-      activeHref={activeNavItem?.href ?? courseBaseHref}
+      activeHref={activeNavItem?.href ?? courseDetailPagePath(courseJwId)}
       ariaLabel={formatMessage(copy.metadata.pages.courseDetail, { name: displayName })}
       items={sectionNavItems}
       label={copy.common.courses}

--- a/src/features/catalog/components/TeacherDetailPageController.svelte
+++ b/src/features/catalog/components/TeacherDetailPageController.svelte
@@ -7,6 +7,7 @@ import { commentTargetPermalinkBaseHref } from "@/features/comments/lib/comment-
 import DetailSectionNav from "$lib/components/DetailSectionNav.svelte";
 import PageHeader from "$lib/components/PageHeader.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
+import { teacherDetailPagePath } from "../lib/catalog-detail-tab";
 import {
   type CatalogNamed,
   catalogPrimaryName as primaryName,
@@ -93,7 +94,7 @@ $: secondaryDisplayName = secondaryName(data.teacher);
 $: teacherDescription = data.teacher.department
   ? primaryName(data.teacher.department)
   : secondaryDisplayName;
-$: teacherBaseHref = `/catalog/teachers/${data.teacher.id}`;
+$: teacherId = data.teacher.id;
 $: commentsCount = data.commentsData
   ? Object.values(data.commentsData.commentMap).reduce(
       (sum, comments) => sum + comments.length,
@@ -102,26 +103,26 @@ $: commentsCount = data.commentsData
   : 0;
 $: sectionNavItems = [
   {
-    href: teacherBaseHref,
+    href: teacherDetailPagePath(teacherId, "overview"),
     icon: InfoIcon,
     key: "overview" as const,
     label: copy.teacherDetail.basicInfo,
   },
   {
-    href: `${teacherBaseHref}/introduction`,
+    href: teacherDetailPagePath(teacherId, "introduction"),
     icon: BookOpenTextIcon,
     key: "introduction" as const,
     label: copy.descriptions.title,
   },
   {
-    href: `${teacherBaseHref}/sections`,
+    href: teacherDetailPagePath(teacherId, "sections"),
     icon: ListIcon,
     key: "sections" as const,
     label: copy.teacherDetail.teachingSectionsTitle,
     meta: data.teacher.sectionCount,
   },
   {
-    href: `${teacherBaseHref}/comments`,
+    href: teacherDetailPagePath(teacherId, "comments"),
     icon: MessageSquareIcon,
     key: "comments" as const,
     label: copy.comments.title,
@@ -164,7 +165,7 @@ $: activeNavItem =
 
   <div class="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] bg-card lg:grid-cols-[auto_minmax(0,1fr)] lg:grid-rows-none">
     <DetailSectionNav
-      activeHref={activeNavItem?.href ?? teacherBaseHref}
+      activeHref={activeNavItem?.href ?? teacherDetailPagePath(teacherId)}
       ariaLabel={formatMessage(copy.metadata.pages.teacherDetail, { name: displayName })}
       items={sectionNavItems}
       label={copy.common.teachers}

--- a/src/features/catalog/server/catalog-detail-comments.ts
+++ b/src/features/catalog/server/catalog-detail-comments.ts
@@ -1,43 +1,28 @@
-import { getCommentsPayload } from "@/features/comments/server/comments-server";
 import { emptyDescriptionPayload } from "@/features/descriptions/server/description-payload";
 import { getDescriptionPayload } from "@/features/descriptions/server/descriptions-server";
 import type { ViewerContext } from "@/lib/auth/viewer-context";
 
 export async function loadCatalogDetailCommentsData({
-  includeComments,
   includeDescription,
   includeDescriptionHistory,
   targetId,
   type,
   viewer,
 }: {
-  includeComments: boolean;
   includeDescription: boolean;
   includeDescriptionHistory: boolean;
   targetId: number;
   type: "course" | "teacher";
   viewer: ViewerContext;
 }) {
-  const [descriptionData, comments] = await Promise.all([
-    includeDescription
-      ? getDescriptionPayload(type, targetId, viewer, {
-          includeHistory: includeDescriptionHistory,
-        })
-      : Promise.resolve(emptyDescriptionPayload(viewer)),
-    includeComments
-      ? getCommentsPayload({ type, targetId }, viewer, { pageSize: 20 })
-      : Promise.resolve(null),
-  ]);
+  const descriptionData = includeDescription
+    ? await getDescriptionPayload(type, targetId, viewer, {
+        includeHistory: includeDescriptionHistory,
+      })
+    : emptyDescriptionPayload(viewer);
 
   return {
-    commentsData: comments
-      ? {
-          commentMap: { [type]: comments.comments },
-          complete: comments.complete,
-          hiddenCount: comments.hiddenCount,
-          viewer,
-        }
-      : null,
+    commentsData: null,
     descriptionData,
   };
 }

--- a/src/features/catalog/server/catalog-detail-page-server.ts
+++ b/src/features/catalog/server/catalog-detail-page-server.ts
@@ -130,7 +130,6 @@ export async function loadCourseDetailPage({
     initialTab === "introduction" || initialTab === "overview";
   const { commentsData, descriptionData } = await loadCatalogDetailCommentsData(
     {
-      includeComments: false,
       includeDescription,
       includeDescriptionHistory: initialTab === "introduction",
       targetId: course.id,
@@ -231,7 +230,6 @@ export async function loadTeacherDetailPage({
     initialTab === "introduction" || initialTab === "overview";
   const { commentsData, descriptionData } = await loadCatalogDetailCommentsData(
     {
-      includeComments: false,
       includeDescription,
       includeDescriptionHistory: initialTab === "introduction",
       targetId: teacher.id,

--- a/src/features/dashboard/components/ExamsCardsView.svelte
+++ b/src/features/dashboard/components/ExamsCardsView.svelte
@@ -16,6 +16,7 @@ export let dashboardTabHref: DashboardTabHref;
 export let exams: DashboardExamRow[];
 export let examMetadataLabels: ExamMetadataLabels;
 export let examTimeLabel: ExamTimeLabel;
+export let fmtExamDate: (value: Date | string | null | undefined) => string;
 export let namePrimary: NamePrimary;
 export let sectionCopy: ExamsCopyProps["sectionCopy"];
 export let subscriptionsCopy: ExamsCopyProps["subscriptionsCopy"];
@@ -43,7 +44,7 @@ export let subscriptionsCopy: ExamsCopyProps["subscriptionsCopy"];
         <dl class="grid gap-2 text-sm">
           <div class="flex items-center justify-between gap-3">
             <dt class="text-muted-foreground">{sectionCopy.examDate}</dt>
-            <dd class="font-medium">{#if exam.dateKey}{exam.dateKey}{:else}<span class="text-muted-foreground">{sectionCopy.examDateTBD}</span>{/if}</dd>
+            <dd class="font-medium">{#if exam.examDate}{fmtExamDate(exam.examDate)}{:else}<span class="text-muted-foreground">{sectionCopy.examDateTBD}</span>{/if}</dd>
           </div>
           <div class="flex items-center justify-between gap-3">
             <dt class="text-muted-foreground">{sectionCopy.examTime}</dt>

--- a/src/features/dashboard/components/ExamsListView.svelte
+++ b/src/features/dashboard/components/ExamsListView.svelte
@@ -12,6 +12,7 @@ import type {
 export let dashboardTabHref: DashboardTabHref;
 export let exams: DashboardExamRow[];
 export let examTimeLabel: ExamTimeLabel;
+export let fmtExamDate: (value: Date | string | null | undefined) => string;
 export let sectionCopy: ExamsCopyProps["sectionCopy"];
 export let subscriptionsCopy: ExamsCopyProps["subscriptionsCopy"];
 </script>
@@ -39,7 +40,7 @@ export let subscriptionsCopy: ExamsCopyProps["subscriptionsCopy"];
           <TruncatedText text={exam.section.code ?? subscriptionsCopy.section} />
         </Table.Cell>
         <Table.Cell class="text-center">
-          {#if exam.dateKey}{exam.dateKey}{:else}<span class="text-muted-foreground">{sectionCopy.examDateTBD}</span>{/if}
+          {#if exam.examDate}{fmtExamDate(exam.examDate)}{:else}<span class="text-muted-foreground">{sectionCopy.examDateTBD}</span>{/if}
         </Table.Cell>
         <Table.Cell class="text-center">{examTimeLabel(exam.startTime, exam.endTime) || "—"}</Table.Cell>
         <Table.Cell class="max-w-56">

--- a/src/features/dashboard/components/ExamsTab.svelte
+++ b/src/features/dashboard/components/ExamsTab.svelte
@@ -7,6 +7,7 @@ import type {
   SignedDashboardData,
 } from "@/features/dashboard/lib/dashboard-controller-types";
 import { hasDashboardSubscriptions } from "@/features/dashboard/lib/dashboard-subscription-state";
+import { createExamTabDisplayActions } from "@/features/dashboard/lib/exams-tab-display";
 import { Button } from "$lib/components/ui/button/index.js";
 import * as Empty from "$lib/components/ui/empty/index.js";
 import DashboardNoSubscriptionsState from "./DashboardNoSubscriptionsState.svelte";
@@ -41,6 +42,13 @@ export let examView: ExamView;
 export let examFilter: DashboardExamFilter;
 export let examRows: DashboardExamRow[];
 export let filteredExamRows: DashboardExamRow[];
+export let locale: string;
+
+$: ({ fmtExamDate } = createExamTabDisplayActions({
+  locale,
+  referenceNow: signedData.referenceNow,
+  sectionCopy,
+}));
 </script>
 
 <section class="grid gap-4">
@@ -97,6 +105,7 @@ export let filteredExamRows: DashboardExamRow[];
           {examMetadataLabels}
           exams={filteredExamRows}
           {examTimeLabel}
+          {fmtExamDate}
           {namePrimary}
           {sectionCopy}
           {subscriptionsCopy}
@@ -107,6 +116,7 @@ export let filteredExamRows: DashboardExamRow[];
           {dashboardTabHref}
           {examTimeLabel}
           exams={filteredExamRows}
+          {fmtExamDate}
           {sectionCopy}
           {subscriptionsCopy}
         />
@@ -118,6 +128,7 @@ export let filteredExamRows: DashboardExamRow[];
         {examMetadataLabels}
         exams={filteredExamRows}
         {examTimeLabel}
+        {fmtExamDate}
         {namePrimary}
         {sectionCopy}
         {subscriptionsCopy}

--- a/src/features/dashboard/components/HomeworksCardsView.svelte
+++ b/src/features/dashboard/components/HomeworksCardsView.svelte
@@ -14,6 +14,8 @@ type HomeworkOverduePredicate = (
 type HomeworkAction = (homework: DashboardHomeworkItem) => string;
 
 export let filteredHomeworkItems: DashboardHomeworkItem[];
+export let hasHomeworkItems: boolean;
+export let onClearFilter: () => void;
 export let fmtDate: HomeworkDateFormatter;
 export let homeworkCompletionActionLabel: HomeworkAction;
 export let homeworkCopy: Record<string, string>;
@@ -80,10 +82,22 @@ export let toggleHomeworkCompletion: (
       </Card.Footer>
     </Card.Root>
   {:else}
-    <Empty.Root class="min-h-24 md:col-span-2">
-      <Empty.Header>
+    <Empty.Root class="min-h-24 items-start text-left md:col-span-2">
+      <Empty.Header class="items-start text-left">
         <Empty.Title>{homeworksCopy.filterEmptyTitle}</Empty.Title>
+        {#if hasHomeworkItems}
+          <Empty.Description>
+            {homeworksCopy.filterEmptyDescription}
+          </Empty.Description>
+        {/if}
       </Empty.Header>
+      {#if hasHomeworkItems}
+        <Empty.Content class="items-start">
+          <Button variant="outline" onclick={onClearFilter}>
+            {homeworksCopy.clearFilter}
+          </Button>
+        </Empty.Content>
+      {/if}
     </Empty.Root>
   {/each}
 </div>

--- a/src/features/dashboard/components/HomeworksListView.svelte
+++ b/src/features/dashboard/components/HomeworksListView.svelte
@@ -15,6 +15,8 @@ type HomeworkOverduePredicate = (
 type HomeworkAction = (homework: DashboardHomeworkItem) => string;
 
 export let filteredHomeworkItems: DashboardHomeworkItem[];
+export let hasHomeworkItems: boolean;
+export let onClearFilter: () => void;
 export let fmtDate: HomeworkDateFormatter;
 export let homeworkCompletionActionLabel: HomeworkAction;
 export let homeworkCopy: Record<string, string>;
@@ -107,10 +109,22 @@ export let toggleHomeworkCompletion: (
     {:else}
       <Table.Row>
         <Table.Cell class="p-0" colspan={5}>
-          <Empty.Root class="py-8">
-            <Empty.Header>
+          <Empty.Root class="items-start py-8 text-left">
+            <Empty.Header class="items-start text-left">
               <Empty.Title>{homeworksCopy.filterEmptyTitle}</Empty.Title>
+              {#if hasHomeworkItems}
+                <Empty.Description>
+                  {homeworksCopy.filterEmptyDescription}
+                </Empty.Description>
+              {/if}
             </Empty.Header>
+            {#if hasHomeworkItems}
+              <Empty.Content class="items-start">
+                <Button variant="outline" onclick={onClearFilter}>
+                  {homeworksCopy.clearFilter}
+                </Button>
+              </Empty.Content>
+            {/if}
           </Empty.Root>
         </Table.Cell>
       </Table.Row>

--- a/src/features/dashboard/components/HomeworksTab.svelte
+++ b/src/features/dashboard/components/HomeworksTab.svelte
@@ -89,6 +89,11 @@ $: filteredHomeworkItems = filterDashboardHomeworks(
   homeworkItems,
   homeworkFilter,
 );
+$: hasHomeworkItems = homeworkItems.length > 0;
+
+function clearHomeworkFilter() {
+  homeworkFilter = "all";
+}
 
 $: ({
   fmtDate,
@@ -139,6 +144,8 @@ $: ({
       <div class="md:hidden">
         <HomeworksCardsView
           {filteredHomeworkItems}
+          {hasHomeworkItems}
+          onClearFilter={clearHomeworkFilter}
           {fmtDate}
           {homeworkCompletionActionLabel}
           {homeworkCopy}
@@ -153,6 +160,8 @@ $: ({
       <div class="hidden min-w-0 overflow-x-auto md:block">
         <HomeworksListView
           {filteredHomeworkItems}
+          {hasHomeworkItems}
+          onClearFilter={clearHomeworkFilter}
           {fmtDate}
           {homeworkCompletionActionLabel}
           {homeworkCopy}
@@ -167,6 +176,8 @@ $: ({
     {:else}
       <HomeworksCardsView
         {filteredHomeworkItems}
+        {hasHomeworkItems}
+        onClearFilter={clearHomeworkFilter}
         {fmtDate}
         {homeworkCompletionActionLabel}
         {homeworkCopy}

--- a/src/features/dashboard/components/SignedDashboardExamsTaskBranch.svelte
+++ b/src/features/dashboard/components/SignedDashboardExamsTaskBranch.svelte
@@ -28,6 +28,7 @@ export let examRows: DashboardExamRow[];
 export let examTimeLabel: ExamTimeLabel;
 export let examView: ExamView;
 export let filteredExamRows: DashboardExamRow[];
+export let locale: string;
 export let namePrimary: NamePrimary;
 export let sectionCopy: DashboardSectionCopy;
 export let setExamView: (view: ExamView) => void;
@@ -48,5 +49,6 @@ export let subscriptionsCopy: DashboardSubscriptionsCopy;
   {examView}
   {examRows}
   {filteredExamRows}
+  {locale}
   bind:examFilter
 />

--- a/src/features/dashboard/components/SignedDashboardTaskTabs.svelte
+++ b/src/features/dashboard/components/SignedDashboardTaskTabs.svelte
@@ -152,6 +152,7 @@ export let updateTodoAction: DashboardTaskTabsProps["updateTodoAction"];
     {examView}
     {examRows}
     {filteredExamRows}
+    locale={data.locale}
     bind:examFilter
   />
 {/if}

--- a/src/features/dashboard/lib/dashboard-controller-types.ts
+++ b/src/features/dashboard/lib/dashboard-controller-types.ts
@@ -170,6 +170,7 @@ export type DashboardDashboardCopy = DashboardRecord & {
 
 export type DashboardSectionCopy = DashboardRecord & {
   dateTBD: string;
+  examDateTBD: string;
   examCount: string;
   examTypeFinal: string;
   examTypeMidterm: string;

--- a/src/features/dashboard/lib/exam-rows.ts
+++ b/src/features/dashboard/lib/exam-rows.ts
@@ -36,6 +36,7 @@ export function flattenExamRows<Section extends DashboardExamSection>(
           dateKey: exam.examDate
             ? formatDateOnly(exam.examDate, options.dateFallback)
             : null,
+          examDate: exam.examDate,
           startTime: exam.startTime,
           endTime: exam.endTime,
           examType: exam.examType,

--- a/src/features/dashboard/lib/exam-types.ts
+++ b/src/features/dashboard/lib/exam-types.ts
@@ -35,6 +35,7 @@ export type DashboardExamRow<Section extends DashboardExamSection> = {
   section: Section;
   courseName: string;
   dateKey: string | null;
+  examDate: Date | string | null;
   startTime: number | null;
   endTime: number | null;
   examType: number | null;

--- a/src/features/dashboard/lib/exams-tab-display.ts
+++ b/src/features/dashboard/lib/exams-tab-display.ts
@@ -1,0 +1,26 @@
+import type {
+  DashboardSectionCopy,
+  SignedDashboardData,
+} from "./dashboard-controller-types";
+import { formatDashboardDateTime } from "./date-formatters";
+import { referenceDate } from "./overview";
+
+export function createExamTabDisplayActions({
+  locale,
+  referenceNow,
+  sectionCopy,
+}: {
+  locale: string;
+  referenceNow: SignedDashboardData["referenceNow"];
+  sectionCopy: DashboardSectionCopy;
+}) {
+  return {
+    fmtExamDate: (value: Date | string | null | undefined) =>
+      formatDashboardDateTime(
+        value,
+        sectionCopy.examDateTBD,
+        referenceDate(referenceNow),
+        locale,
+      ),
+  };
+}

--- a/src/features/section-detail/components/SectionDetailMainContent.svelte
+++ b/src/features/section-detail/components/SectionDetailMainContent.svelte
@@ -17,6 +17,7 @@ import DetailSectionNav from "$lib/components/DetailSectionNav.svelte";
 import * as Alert from "$lib/components/ui/alert/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
 import { Separator } from "$lib/components/ui/separator/index.js";
+import { Spinner } from "$lib/components/ui/spinner/index.js";
 import { cn } from "$lib/utils.js";
 import SectionBasicInfoCard from "./SectionBasicInfoCard.svelte";
 import SectionDetailHeader from "./SectionDetailHeader.svelte";
@@ -226,9 +227,13 @@ $: sectionNavItems = [
       data-detail-scroll-container
     >
       {#if tabPanelLoading}
-        <p class="sr-only">
-          {data.locale === "zh-cn" ? "加载中..." : "Loading..."}
-        </p>
+        <div
+          class="text-muted-foreground flex items-center justify-center gap-2 px-2 py-10 text-sm"
+          role="status"
+        >
+          <Spinner class="size-4 shrink-0" />
+          <span>{data.locale === "zh-cn" ? "加载中..." : "Loading..."}</span>
+        </div>
       {/if}
       {#if activeTab === "overview"}
       <section id="section-overview">

--- a/src/features/section-detail/server/section-detail-comments-data.ts
+++ b/src/features/section-detail/server/section-detail-comments-data.ts
@@ -1,4 +1,3 @@
-import { getCommentsPayload } from "@/features/comments/server/comments-server";
 import { emptyDescriptionPayload } from "@/features/descriptions/server/description-payload";
 import { getDescriptionPayload } from "@/features/descriptions/server/descriptions-server";
 import { getViewerContext } from "@/lib/auth/viewer-context";
@@ -6,81 +5,25 @@ import { getViewerContext } from "@/lib/auth/viewer-context";
 export async function getSectionDetailDescriptionAndComments(
   section: {
     id: number;
-    course: { id: number };
-    teachers: { id: number }[];
   },
   userId: string | null,
   {
-    includeComments,
     includeDescription,
     includeDescriptionHistory,
   }: {
-    includeComments: boolean;
     includeDescription: boolean;
     includeDescriptionHistory: boolean;
   },
 ) {
   const descriptionViewer = await getViewerContext({ userId });
-  const descriptionDataPromise = includeDescription
-    ? getDescriptionPayload("section", section.id, descriptionViewer, {
+  const descriptionData = includeDescription
+    ? await getDescriptionPayload("section", section.id, descriptionViewer, {
         includeHistory: includeDescriptionHistory,
       })
-    : Promise.resolve(emptyDescriptionPayload(descriptionViewer));
-  if (!includeComments) {
-    return {
-      commentsData: null,
-      descriptionData: await descriptionDataPromise,
-    };
-  }
-  const firstCommentTeacher = section.teachers[0] ?? null;
-  const [descriptionData, sectionComments, courseComments, teacherComments] =
-    await Promise.all([
-      descriptionDataPromise,
-      getCommentsPayload(
-        { type: "section", targetId: section.id },
-        descriptionViewer,
-        { pageSize: 20 },
-      ),
-      getCommentsPayload(
-        { type: "course", targetId: section.course.id },
-        descriptionViewer,
-        { pageSize: 20 },
-      ),
-      firstCommentTeacher
-        ? getCommentsPayload(
-            {
-              type: "section-teacher",
-              sectionId: section.id,
-              teacherId: firstCommentTeacher.id,
-            },
-            descriptionViewer,
-            { pageSize: 20 },
-          )
-        : Promise.resolve({
-            comments: [],
-            complete: true,
-            hiddenCount: 0,
-            viewer: descriptionViewer,
-          }),
-    ]);
+    : emptyDescriptionPayload(descriptionViewer);
 
   return {
-    commentsData: {
-      commentMap: {
-        course: courseComments.comments,
-        section: sectionComments.comments,
-        "section-teacher": teacherComments.comments,
-      },
-      hiddenCount:
-        sectionComments.hiddenCount +
-        courseComments.hiddenCount +
-        teacherComments.hiddenCount,
-      complete:
-        sectionComments.complete &&
-        courseComments.complete &&
-        teacherComments.complete,
-      viewer: descriptionViewer,
-    },
+    commentsData: null,
     descriptionData,
   };
 }

--- a/src/features/section-detail/server/section-detail-page-server.ts
+++ b/src/features/section-detail/server/section-detail-page-server.ts
@@ -155,7 +155,6 @@ export async function loadSectionDetailPage({
           ).getUserSectionSubscriptionState(userId)
         : null,
       getSectionDetailDescriptionAndComments(section, userId, {
-        includeComments: false,
         includeDescription,
         includeDescriptionHistory: false,
       }),

--- a/src/lib/components/shell/AppShell.svelte
+++ b/src/lib/components/shell/AppShell.svelte
@@ -137,7 +137,9 @@ function buildShellNavGroups(
   pathname: string,
   pageData: Record<string, unknown>,
 ): ShellNavGroup[] {
-  const detailSecondaryLinks = buildDetailSecondaryLinks(pathname, pageData);
+  const detailSecondaryLinks = isDetailWorkspacePath(pathname)
+    ? undefined
+    : buildDetailSecondaryLinks(pathname, pageData);
   const catalogLinks: ShellLink[] = [
     {
       href: "/catalog/courses",
@@ -283,7 +285,9 @@ function buildMobileSecondaryNavGroups(
   pathname: string,
   pageData: Record<string, unknown>,
 ): ShellNavGroup[] {
-  const detailSecondaryLinks = buildDetailSecondaryLinks(pathname, pageData);
+  const detailSecondaryLinks = isDetailWorkspacePath(pathname)
+    ? undefined
+    : buildDetailSecondaryLinks(pathname, pageData);
   const dashboardNavStats = pageData.navStats as
     | {
         examsCount?: number;

--- a/tests/e2e/src/app/_shared/page-contract.ts
+++ b/tests/e2e/src/app/_shared/page-contract.ts
@@ -241,9 +241,7 @@ export async function assertPageContract(
           .getByRole("link", { name: /班级|Sections/i }),
       ).toBeVisible();
       await expect(
-        page
-          .getByTestId("detail-section-nav")
-          .locator('[aria-current="page"]'),
+        page.getByTestId("detail-section-nav").locator('[aria-current="page"]'),
       ).toBeVisible();
       await maybeCapture(page, testInfo, "courses-jwId");
       return;
@@ -263,9 +261,7 @@ export async function assertPageContract(
           .getByRole("link", { name: /授课班级|Teaching Sections/i }),
       ).toBeVisible();
       await expect(
-        page
-          .getByTestId("detail-section-nav")
-          .locator('[aria-current="page"]'),
+        page.getByTestId("detail-section-nav").locator('[aria-current="page"]'),
       ).toBeVisible();
       await maybeCapture(page, testInfo, "teachers-id");
       return;

--- a/tests/e2e/src/app/_shared/page-contract.ts
+++ b/tests/e2e/src/app/_shared/page-contract.ts
@@ -219,16 +219,9 @@ export async function assertPageContract(
       await expectMainContent(page);
       await expect(visibleText(page, DEV_SEED.section.code)).toBeVisible();
       await expect(visibleText(page, DEV_SEED.course.nameCn)).toBeVisible();
-      await expect(
-        appSidebar(page)
-          .getByRole("link", {
-            name: localizedNamePattern(
-              DEV_SEED.course.nameCn,
-              DEV_SEED.course.nameEn,
-            ),
-          })
-          .first(),
-      ).toHaveAttribute("aria-current", "page");
+      // Detail workspace pages no longer inject the current entity into the
+      // global sidebar; the in-page DetailSectionNav is the current location.
+      await expect(page.getByTestId("detail-section-nav")).toBeVisible();
       await maybeCapture(page, testInfo, "sections-jwId");
       return;
     }
@@ -248,15 +241,10 @@ export async function assertPageContract(
           .getByRole("link", { name: /班级|Sections/i }),
       ).toBeVisible();
       await expect(
-        appSidebar(page)
-          .getByRole("link", {
-            name: localizedNamePattern(
-              DEV_SEED.course.nameCn,
-              DEV_SEED.course.nameEn,
-            ),
-          })
-          .first(),
-      ).toHaveAttribute("aria-current", "page");
+        page
+          .getByTestId("detail-section-nav")
+          .locator('[aria-current="page"]'),
+      ).toBeVisible();
       await maybeCapture(page, testInfo, "courses-jwId");
       return;
     }
@@ -275,15 +263,10 @@ export async function assertPageContract(
           .getByRole("link", { name: /授课班级|Teaching Sections/i }),
       ).toBeVisible();
       await expect(
-        appSidebar(page)
-          .getByRole("link", {
-            name: localizedNamePattern(
-              DEV_SEED.teacher.nameCn,
-              DEV_SEED.teacher.nameEn,
-            ),
-          })
-          .first(),
-      ).toHaveAttribute("aria-current", "page");
+        page
+          .getByTestId("detail-section-nav")
+          .locator('[aria-current="page"]'),
+      ).toBeVisible();
       await maybeCapture(page, testInfo, "teachers-id");
       return;
     }

--- a/tests/e2e/src/app/_shared/page-contract.ts
+++ b/tests/e2e/src/app/_shared/page-contract.ts
@@ -6,7 +6,6 @@ import {
 } from "../../../utils/auth";
 import { DEV_SEED } from "../../../utils/dev-seed";
 import {
-  appSidebar,
   expandWorkspaceSidebarGroup,
   sidebarNavigationLink,
   visibleText,
@@ -45,14 +44,6 @@ async function maybeCapture(
     return;
   }
   await captureStepScreenshot(page, testInfo, name);
-}
-
-function escapeForRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function localizedNamePattern(nameCn: string, nameEn: string) {
-  return new RegExp(`${escapeForRegExp(nameCn)}|${escapeForRegExp(nameEn)}`);
 }
 
 async function gotoContractPage(

--- a/tests/e2e/src/app/dashboard/exams/test.ts
+++ b/tests/e2e/src/app/dashboard/exams/test.ts
@@ -163,14 +163,15 @@ test.describe("仪表盘考试", () => {
     ).toHaveText(/.+/);
 
     // exam.examDate — smart datetime (or TBD), not necessarily YYYY-MM-DD
-    await expect(
-      firstCard.locator("dl dd").first(),
-    ).toBeVisible();
+    await expect(firstCard.locator("dl dd").first()).toBeVisible();
     await expect(firstCard.locator("dl dd").first()).toHaveText(/.+/);
 
     // exam.startTime - endTime — HH:mm-HH:mm format
     await expect(
-      firstCard.locator("dl dd").nth(1).getByText(/\d{2}:\d{2}/),
+      firstCard
+        .locator("dl dd")
+        .nth(1)
+        .getByText(/\d{2}:\d{2}/),
     ).toBeVisible();
 
     // exam.examMode — Exam.examMode is a raw string (e.g. "闭卷"), not locale-dependent

--- a/tests/e2e/src/app/dashboard/exams/test.ts
+++ b/tests/e2e/src/app/dashboard/exams/test.ts
@@ -162,13 +162,16 @@ test.describe("仪表盘考试", () => {
       firstCard.locator('a[href^="/catalog/sections/"]').first(),
     ).toHaveText(/.+/);
 
-    // exam.examDate — YYYY-MM-DD format visible
+    // exam.examDate — smart datetime (or TBD), not necessarily YYYY-MM-DD
     await expect(
-      firstCard.getByText(/\d{4}-\d{2}-\d{2}/).first(),
+      firstCard.locator("dl dd").first(),
     ).toBeVisible();
+    await expect(firstCard.locator("dl dd").first()).toHaveText(/.+/);
 
     // exam.startTime - endTime — HH:mm-HH:mm format
-    await expect(firstCard.getByText(/\d{2}:\d{2}/).first()).toBeVisible();
+    await expect(
+      firstCard.locator("dl dd").nth(1).getByText(/\d{2}:\d{2}/),
+    ).toBeVisible();
 
     // exam.examMode — Exam.examMode is a raw string (e.g. "闭卷"), not locale-dependent
     await expect(


### PR DESCRIPTION
## Summary

- Skip `buildDetailSecondaryLinks` injection in `AppShell` when `isDetailWorkspacePath(pathname)` is true (desktop and mobile nav builders), removing duplicate sidebar entries on catalog detail pages.
- Update `CourseDetailPageController` and `TeacherDetailPageController` tab links to use `courseDetailPagePath` / `teacherDetailPagePath` (`?tab=`) instead of legacy `/introduction` path segments.
- Presentation consistency:
  - Homework filtered-empty states now show title, description, and a clear-filter action (matching `ExamsTab`).
  - Section detail tab loading shows a visible `Spinner` (matching `GlobalSearchResults`) instead of sr-only text.
  - Exam dates in `ExamsListView` / `ExamsCardsView` use smart datetime formatting via `formatDashboardDateTime` (matching the overview exam card).
- Remove unused `includeComments` plumbing from catalog/section detail comment loaders; comments remain client-fetched only.

Refs #733 (Partial)

## Test plan

- [x] `biome check` on changed files
- [x] `vitest run tests/unit` (1925 passed)
- [ ] Manual: open a course/teacher detail page and confirm sidebar no longer nests the current entity under Courses/Teachers/Sections
- [ ] Manual: click catalog detail tabs and confirm URLs use `?tab=` without 308 redirects
- [ ] Manual: filter homeworks to empty and confirm description + clear-filter button appear
- [ ] Manual: switch section detail tabs and confirm visible loading spinner
- [ ] Manual: verify exam list/card dates show localized smart formatting instead of raw `YYYY-MM-DD`