### PR TITLE
fix(section-detail): seed SSR tab panels and narrow section detail fetches

### DIFF
--- a/docs/contracts/section.json
+++ b/docs/contracts/section.json
@@ -106,7 +106,8 @@
             "path": "/api/catalog/sections/[jwId]",
             "returns": "SectionDetail (schedules without room/teacher expansion)",
             "notes": [
-              "Direct historical lookup remains available for retired Sections; retiredAt identifies retirement and sourceLastSeenAt records the last successful source observation."
+              "Direct historical lookup remains available for retired Sections; retiredAt identifies retirement and sourceLastSeenAt records the last successful source observation.",
+              "Optional includeExams, includeSchedules, and includeTeacherDepartments query flags return narrow tab payloads without loading unrelated child collections."
             ]
           }
         ]

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -5142,6 +5142,39 @@
                 "zh-cn"
               ]
             }
+          },
+          {
+            "in": "query",
+            "name": "includeExams",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "includeSchedules",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "includeTeacherDepartments",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
           }
         ],
         "responses": {

--- a/src/features/catalog/server/course-section-read-queries.ts
+++ b/src/features/catalog/server/course-section-read-queries.ts
@@ -94,18 +94,80 @@ export async function findSectionByJwId(
 export async function findSectionDetailByJwId(
   jwId: number,
   locale: AppLocale = DEFAULT_LOCALE,
+  options?: {
+    includeExams?: boolean;
+    includeSchedules?: boolean;
+    includeTeacherDepartments?: boolean;
+  },
 ) {
+  const hasPartialFlags =
+    options != null &&
+    (options.includeExams !== undefined ||
+      options.includeSchedules !== undefined ||
+      options.includeTeacherDepartments !== undefined);
+
+  const include = hasPartialFlags
+    ? buildPartialSectionDetailInclude(options)
+    : sectionDetailInclude;
+
   const section = await getPrisma(locale).section.findUnique({
     where: { jwId },
-    include: sectionDetailInclude,
+    include,
   });
 
   if (!section) return null;
 
   return {
     ...section,
-    schedules: section.schedules.map(serializeScheduleTimeFields),
+    exams: "exams" in section && section.exams ? section.exams : [],
+    scheduleGroups:
+      "scheduleGroups" in section && section.scheduleGroups
+        ? section.scheduleGroups
+        : [],
+    schedules:
+      "schedules" in section && section.schedules
+        ? section.schedules.map(serializeScheduleTimeFields)
+        : [],
+    teacherAssignments:
+      "teacherAssignments" in section && section.teacherAssignments
+        ? section.teacherAssignments
+        : [],
+    teachers: section.teachers ?? [],
   };
+}
+
+function buildPartialSectionDetailInclude(options: {
+  includeExams?: boolean;
+  includeSchedules?: boolean;
+  includeTeacherDepartments?: boolean;
+}) {
+  const includeExams = options.includeExams === true;
+  const includeSchedules = options.includeSchedules === true;
+  const includeTeacherDepartments = options.includeTeacherDepartments === true;
+
+  return {
+    ...sectionInclude,
+    roomType: true,
+    schedules: includeSchedules,
+    scheduleGroups: includeSchedules,
+    teachers: includeTeacherDepartments
+      ? {
+          include: {
+            department: true,
+            teacherTitle: true,
+          },
+        }
+      : true,
+    teacherAssignments: includeTeacherDepartments,
+    exams: includeExams
+      ? {
+          include: {
+            examBatch: true,
+            examRooms: true,
+          },
+        }
+      : false,
+  } as const;
 }
 
 export async function findSectionsByJwIds(

--- a/src/features/section-detail/components/SectionDetailPageController.svelte
+++ b/src/features/section-detail/components/SectionDetailPageController.svelte
@@ -14,7 +14,10 @@ import { createSectionDetailCalendarDisplayActions } from "@/features/section-de
 import { createSectionCalendarClipboardActions } from "@/features/section-detail/lib/section-detail-calendar-clipboard-actions";
 import { sectionDetailCalendarUrls } from "@/features/section-detail/lib/section-detail-calendar-urls";
 import { mountSectionDetailController } from "@/features/section-detail/lib/section-detail-controller-mount";
-import { createSectionDetailTabPanelStore } from "@/features/section-detail/lib/section-detail-tab-client";
+import {
+  createSectionDetailTabPanelStore,
+  createSectionDetailTabPanelSsrSeedFromPageData,
+} from "@/features/section-detail/lib/section-detail-tab-client";
 import {
   parseSectionDetailTab,
   SECTION_DETAIL_TAB_QUERY,
@@ -79,6 +82,10 @@ let activeTab: SectionDetailTab = parseSectionDetailTab(data.detailSection);
 let tabPanelLoading = false;
 const tabPanelStore = createSectionDetailTabPanelStore(
   data.homeworkData.viewer.userId ?? null,
+  createSectionDetailTabPanelSsrSeedFromPageData(
+    data,
+    data.homeworkData.viewer.userId ?? null,
+  ),
 );
 let tabPanelState = tabPanelStore.getState();
 

--- a/src/features/section-detail/lib/section-detail-controller-types.ts
+++ b/src/features/section-detail/lib/section-detail-controller-types.ts
@@ -15,6 +15,7 @@ export type SectionDetailNamed = {
 };
 
 export type SectionDetailTeacher = SectionDetailNamed & {
+  department?: SectionDetailNamed | null;
   id: string | number;
 };
 

--- a/src/features/section-detail/lib/section-detail-tab-client.ts
+++ b/src/features/section-detail/lib/section-detail-tab-client.ts
@@ -3,6 +3,8 @@ import type { DescriptionPayload } from "@/features/descriptions/lib/description
 import { fetchDescriptionPayload } from "@/features/descriptions/lib/description-card-client";
 import { emptyDescriptionPayload } from "@/features/descriptions/lib/description-empty-payload";
 import type { DescriptionViewer } from "@/features/descriptions/lib/description-payload-types";
+import type { SectionDetailPageData } from "@/features/section-detail/lib/section-detail-controller-types";
+import { buildSectionDetailTabPanelSsrSeed } from "@/features/section-detail/lib/section-detail-tab-ssr-seed";
 import type { AppLocale } from "@/i18n/config";
 import { apiClient } from "@/lib/api/client";
 import { loadSectionHomeworks } from "./homeworks";
@@ -39,6 +41,11 @@ type SectionDetailTabPanelPatch = Partial<
   sectionOverlay?: Partial<SectionDetailTabPanelState["sectionOverlay"]>;
 };
 
+export type SectionDetailTabPanelSsrSeed = {
+  loadedTabs: readonly SectionDetailTab[];
+  state: SectionDetailTabPanelState;
+};
+
 const emptyHomeworkViewer = (userId: string | null): HomeworkViewer => ({
   isAdmin: false,
   isAuthenticated: Boolean(userId),
@@ -59,7 +66,9 @@ function emptyDescriptionViewer(userId: string | null): DescriptionViewer {
   };
 }
 
-function emptyPanelState(userId: string | null): SectionDetailTabPanelState {
+export function emptySectionDetailTabPanelState(
+  userId: string | null,
+): SectionDetailTabPanelState {
   return {
     commentsData: null,
     descriptionData: emptyDescriptionPayload(emptyDescriptionViewer(userId)),
@@ -70,7 +79,7 @@ function emptyPanelState(userId: string | null): SectionDetailTabPanelState {
   };
 }
 
-function applyPanelPatch(
+export function applySectionDetailTabPanelPatch(
   state: SectionDetailTabPanelState,
   patch: SectionDetailTabPanelPatch,
 ): SectionDetailTabPanelState {
@@ -84,12 +93,29 @@ function applyPanelPatch(
   };
 }
 
-async function fetchSectionDetailApi(jwId: number, locale: AppLocale) {
+type SectionDetailPartialQuery = {
+  includeExams?: boolean;
+  includeSchedules?: boolean;
+  includeTeacherDepartments?: boolean;
+};
+
+async function fetchSectionDetailPartial(
+  jwId: number,
+  locale: AppLocale,
+  query: SectionDetailPartialQuery,
+) {
   const result = await apiClient.GET<SectionDetailApiRecord>(
     `/api/catalog/sections/${jwId}`,
     {
       params: {
-        query: { locale },
+        query: {
+          locale,
+          ...(query.includeExams ? { includeExams: "true" } : {}),
+          ...(query.includeSchedules ? { includeSchedules: "true" } : {}),
+          ...(query.includeTeacherDepartments
+            ? { includeTeacherDepartments: "true" }
+            : {}),
+        },
       },
     },
   );
@@ -103,7 +129,10 @@ async function loadCalendarPanel(
   jwId: number,
   locale: AppLocale,
 ): Promise<SectionDetailTabPanelPatch> {
-  const detail = await fetchSectionDetailApi(jwId, locale);
+  const detail = await fetchSectionDetailPartial(jwId, locale, {
+    includeExams: true,
+    includeSchedules: true,
+  });
   return {
     sectionOverlay: {
       exams: detail.exams ?? [],
@@ -112,11 +141,27 @@ async function loadCalendarPanel(
   };
 }
 
+async function loadExamsPanel(
+  jwId: number,
+  locale: AppLocale,
+): Promise<SectionDetailTabPanelPatch> {
+  const detail = await fetchSectionDetailPartial(jwId, locale, {
+    includeExams: true,
+  });
+  return {
+    sectionOverlay: {
+      exams: detail.exams ?? [],
+    },
+  };
+}
+
 async function loadTeachersPanel(
   jwId: number,
   locale: AppLocale,
 ): Promise<SectionDetailTabPanelPatch> {
-  const detail = await fetchSectionDetailApi(jwId, locale);
+  const detail = await fetchSectionDetailPartial(jwId, locale, {
+    includeTeacherDepartments: true,
+  });
   return {
     sectionOverlay: {
       teachers: detail.teachers ?? [],
@@ -166,15 +211,28 @@ const tabLoaders: Record<
 > = {
   introduction: ({ sectionId }) => loadIntroductionPanel(sectionId),
   calendar: ({ jwId, locale }) => loadCalendarPanel(jwId, locale),
-  exams: ({ jwId, locale }) => loadCalendarPanel(jwId, locale),
+  exams: ({ jwId, locale }) => loadExamsPanel(jwId, locale),
   homework: ({ errorMessage, sectionId, state }) =>
     loadHomeworkPanel(sectionId, errorMessage, state),
   teachers: ({ jwId, locale }) => loadTeachersPanel(jwId, locale),
 };
 
-export function createSectionDetailTabPanelStore(userId: string | null) {
-  const loaded = new Set<SectionDetailTab>();
-  let state = emptyPanelState(userId);
+export function createSectionDetailTabPanelSsrSeedFromPageData(
+  data: SectionDetailPageData,
+  userId: string | null,
+): SectionDetailTabPanelSsrSeed {
+  return buildSectionDetailTabPanelSsrSeed(data, userId, {
+    applyPatch: applySectionDetailTabPanelPatch,
+    createEmptyState: emptySectionDetailTabPanelState,
+  });
+}
+
+export function createSectionDetailTabPanelStore(
+  userId: string | null,
+  ssrSeed?: SectionDetailTabPanelSsrSeed,
+) {
+  const loaded = new Set<SectionDetailTab>(ssrSeed?.loadedTabs ?? []);
+  let state = ssrSeed?.state ?? emptySectionDetailTabPanelState(userId);
 
   return {
     getState: () => state,
@@ -195,13 +253,13 @@ export function createSectionDetailTabPanelStore(userId: string | null) {
 
       const loader = tabLoaders[tab];
       const patch = await loader({ ...input, state });
-      state = applyPanelPatch(state, patch);
+      state = applySectionDetailTabPanelPatch(state, patch);
       loaded.add(tab);
       return state;
     },
     reset() {
       loaded.clear();
-      state = emptyPanelState(userId);
+      state = emptySectionDetailTabPanelState(userId);
     },
   };
 }

--- a/src/features/section-detail/lib/section-detail-tab-ssr-seed.ts
+++ b/src/features/section-detail/lib/section-detail-tab-ssr-seed.ts
@@ -1,0 +1,129 @@
+import type { SectionDetailPageData } from "@/features/section-detail/lib/section-detail-controller-types";
+import type { SectionDetailTab } from "@/features/section-detail/lib/section-detail-tab";
+import type {
+  SectionDetailTabPanelSsrSeed,
+  SectionDetailTabPanelState,
+} from "@/features/section-detail/lib/section-detail-tab-client";
+
+export function sectionTeachersIncludeDepartments(
+  teachers: SectionDetailPageData["section"]["teachers"],
+): boolean {
+  return teachers.some(
+    (teacher) =>
+      teacher != null &&
+      typeof teacher === "object" &&
+      "department" in teacher &&
+      teacher.department != null,
+  );
+}
+
+export function getSsrLoadedSectionDetailTabs(
+  data: Pick<
+    SectionDetailPageData,
+    "descriptionData" | "detailSection" | "focusedHomeworkId" | "section"
+  >,
+): SectionDetailTab[] {
+  const loaded: SectionDetailTab[] = [];
+
+  if (data.detailSection === "homework" || data.focusedHomeworkId != null) {
+    loaded.push("homework");
+  }
+
+  if (
+    data.detailSection === "introduction" ||
+    data.descriptionData.description.content
+  ) {
+    loaded.push("introduction");
+  }
+
+  if (
+    data.detailSection === "teachers" &&
+    sectionTeachersIncludeDepartments(data.section.teachers)
+  ) {
+    loaded.push("teachers");
+  }
+
+  if (data.detailSection === "calendar") {
+    loaded.push("calendar");
+  }
+
+  if (data.detailSection === "exams" || data.detailSection === "calendar") {
+    loaded.push("exams");
+  }
+
+  return loaded;
+}
+
+export function buildSectionDetailTabPanelSsrState(
+  data: SectionDetailPageData,
+  createEmptyState: (userId: string | null) => SectionDetailTabPanelState,
+  applyPatch: (
+    state: SectionDetailTabPanelState,
+    patch: Partial<SectionDetailTabPanelState> & {
+      sectionOverlay?: Partial<SectionDetailTabPanelState["sectionOverlay"]>;
+    },
+  ) => SectionDetailTabPanelState,
+  userId: string | null,
+): SectionDetailTabPanelState {
+  const loadedTabs = getSsrLoadedSectionDetailTabs(data);
+  let state = createEmptyState(userId);
+
+  if (loadedTabs.includes("homework")) {
+    state = applyPatch(state, {
+      homeworkAuditLogs: data.homeworkData.auditLogs,
+      homeworkViewer: data.homeworkData.viewer,
+      homeworks: data.homeworkData.homeworks,
+    });
+  }
+
+  if (loadedTabs.includes("introduction")) {
+    state = applyPatch(state, {
+      descriptionData: data.descriptionData,
+    });
+  }
+
+  if (loadedTabs.includes("teachers")) {
+    state = applyPatch(state, {
+      sectionOverlay: { teachers: data.section.teachers },
+    });
+  }
+
+  if (loadedTabs.includes("calendar")) {
+    state = applyPatch(state, {
+      sectionOverlay: {
+        exams: data.section.exams,
+        schedules: data.section.schedules,
+      },
+    });
+  } else if (loadedTabs.includes("exams")) {
+    state = applyPatch(state, {
+      sectionOverlay: { exams: data.section.exams },
+    });
+  }
+
+  return state;
+}
+
+export function buildSectionDetailTabPanelSsrSeed(
+  data: SectionDetailPageData,
+  userId: string | null,
+  helpers: {
+    applyPatch: (
+      state: SectionDetailTabPanelState,
+      patch: Partial<SectionDetailTabPanelState> & {
+        sectionOverlay?: Partial<SectionDetailTabPanelState["sectionOverlay"]>;
+      },
+    ) => SectionDetailTabPanelState;
+    createEmptyState: (userId: string | null) => SectionDetailTabPanelState;
+  },
+): SectionDetailTabPanelSsrSeed {
+  return {
+    loadedTabs: getSsrLoadedSectionDetailTabs(data),
+    state: buildSectionDetailTabPanelSsrState(
+      data,
+      helpers.createEmptyState,
+      helpers.applyPatch,
+      userId,
+    ),
+  };
+}

--- a/src/features/section-detail/lib/section-detail-tab-ssr-seed.ts
+++ b/src/features/section-detail/lib/section-detail-tab-ssr-seed.ts
@@ -1,8 +1,10 @@
 import type { SectionDetailPageData } from "@/features/section-detail/lib/section-detail-controller-types";
 import type { SectionDetailTab } from "@/features/section-detail/lib/section-detail-tab";
-import type {
-  SectionDetailTabPanelSsrSeed,
-  SectionDetailTabPanelState,
+import {
+  applySectionDetailTabPanelPatch,
+  emptySectionDetailTabPanelState,
+  type SectionDetailTabPanelSsrSeed,
+  type SectionDetailTabPanelState,
 } from "@/features/section-detail/lib/section-detail-tab-client";
 
 export function sectionTeachersIncludeDepartments(
@@ -57,12 +59,7 @@ export function getSsrLoadedSectionDetailTabs(
 export function buildSectionDetailTabPanelSsrState(
   data: SectionDetailPageData,
   createEmptyState: (userId: string | null) => SectionDetailTabPanelState,
-  applyPatch: (
-    state: SectionDetailTabPanelState,
-    patch: Partial<SectionDetailTabPanelState> & {
-      sectionOverlay?: Partial<SectionDetailTabPanelState["sectionOverlay"]>;
-    },
-  ) => SectionDetailTabPanelState,
+  applyPatch: typeof applySectionDetailTabPanelPatch,
   userId: string | null,
 ): SectionDetailTabPanelState {
   const loadedTabs = getSsrLoadedSectionDetailTabs(data);
@@ -108,21 +105,16 @@ export function buildSectionDetailTabPanelSsrSeed(
   data: SectionDetailPageData,
   userId: string | null,
   helpers: {
-    applyPatch: (
-      state: SectionDetailTabPanelState,
-      patch: Partial<SectionDetailTabPanelState> & {
-        sectionOverlay?: Partial<SectionDetailTabPanelState["sectionOverlay"]>;
-      },
-    ) => SectionDetailTabPanelState;
-    createEmptyState: (userId: string | null) => SectionDetailTabPanelState;
-  },
+    applyPatch?: typeof applySectionDetailTabPanelPatch;
+    createEmptyState?: (userId: string | null) => SectionDetailTabPanelState;
+  } = {},
 ): SectionDetailTabPanelSsrSeed {
   return {
     loadedTabs: getSsrLoadedSectionDetailTabs(data),
     state: buildSectionDetailTabPanelSsrState(
       data,
-      helpers.createEmptyState,
-      helpers.applyPatch,
+      helpers.createEmptyState ?? emptySectionDetailTabPanelState,
+      helpers.applyPatch ?? applySectionDetailTabPanelPatch,
       userId,
     ),
   };

--- a/src/lib/api/routes/academic-section-detail-action.ts
+++ b/src/lib/api/routes/academic-section-detail-action.ts
@@ -1,15 +1,22 @@
 import type { AppLocale } from "@/i18n/config";
 import { jsonResponse, notFound } from "@/lib/api/helpers";
 
+export type SectionDetailActionOptions = {
+  includeExams?: boolean;
+  includeSchedules?: boolean;
+  includeTeacherDepartments?: boolean;
+};
+
 export async function getSectionDetailAction(
   parsedJwId: number,
   locale: AppLocale,
   cacheHeaders: HeadersInit,
+  options: SectionDetailActionOptions = {},
 ) {
   const { findSectionDetailByJwId } = await import(
     "@/features/catalog/server/course-section-queries"
   );
-  const section = await findSectionDetailByJwId(parsedJwId, locale);
+  const section = await findSectionDetailByJwId(parsedJwId, locale, options);
 
   if (!section) {
     return notFound("Section not found");

--- a/src/lib/api/routes/academic-section-route-request.ts
+++ b/src/lib/api/routes/academic-section-route-request.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/api/helpers";
 import {
   matchSectionCodesRequestSchema,
+  sectionDetailQuerySchema,
   sectionSchedulesQuerySchema,
   sectionsQuerySchema,
 } from "@/lib/api/schemas/request-schemas";
@@ -27,6 +28,16 @@ export function parseSectionSchedulesRouteQuery(request: Request) {
     searchParams,
     sectionSchedulesQuerySchema,
     "Invalid section schedule query",
+    { logErrors: true },
+  );
+}
+
+export function parseSectionDetailRouteQuery(request: Request) {
+  const searchParams = new URL(request.url).searchParams;
+  return parseRouteSearchParams(
+    searchParams,
+    sectionDetailQuerySchema,
+    "Invalid section detail query",
     { logErrors: true },
   );
 }

--- a/src/lib/api/routes/academic-section-routes.ts
+++ b/src/lib/api/routes/academic-section-routes.ts
@@ -4,6 +4,7 @@ import { withParsedSectionJwId } from "@/lib/api/routes/academic-section-jw-rout
 import { listSectionsAction } from "@/lib/api/routes/academic-section-list-action";
 import { matchSectionCodesAction } from "@/lib/api/routes/academic-section-match-action";
 import {
+  parseSectionDetailRouteQuery,
   parseSectionMatchCodesRequest,
   parseSectionSchedulesRouteQuery,
   parseSectionsRouteQuery,
@@ -56,6 +57,11 @@ export async function getSectionDetailRoute(
     return localeResolution;
   }
 
+  const parsedQuery = parseSectionDetailRouteQuery(request);
+  if (parsedQuery instanceof Response) {
+    return parsedQuery;
+  }
+
   return withParsedSectionJwId(
     params,
     "Failed to fetch section",
@@ -64,6 +70,11 @@ export async function getSectionDetailRoute(
         parsedJwId,
         localeResolution.locale,
         localeResolution.cacheHeaders,
+        {
+          includeExams: parsedQuery.includeExams,
+          includeSchedules: parsedQuery.includeSchedules,
+          includeTeacherDepartments: parsedQuery.includeTeacherDepartments,
+        },
       ),
   );
 }

--- a/src/lib/api/schemas/catalog-query-schemas.ts
+++ b/src/lib/api/schemas/catalog-query-schemas.ts
@@ -1,6 +1,7 @@
 import * as z from "zod";
 import { APP_LOCALES } from "@/i18n/config";
 import {
+  booleanQuerySchema,
   dateQuerySchema,
   deprecatedPaginationLimitParam,
   integerQueryRangeSchema,
@@ -69,6 +70,12 @@ export const sectionSchedulesQuerySchema = catalogLocaleQuerySchema.extend({
   dateFrom: dateQuerySchema().optional(),
   dateTo: dateQuerySchema().optional(),
   limit: sectionScheduleLimitSchema.optional(),
+});
+
+export const sectionDetailQuerySchema = catalogLocaleQuerySchema.extend({
+  includeExams: booleanQuerySchema.optional(),
+  includeSchedules: booleanQuerySchema.optional(),
+  includeTeacherDepartments: booleanQuerySchema.optional(),
 });
 
 export const teachersQuerySchema = catalogLocaleQuerySchema.extend({

--- a/src/lib/api/schemas/request-query-schemas.ts
+++ b/src/lib/api/schemas/request-query-schemas.ts
@@ -8,6 +8,7 @@ export {
   catalogLocaleQuerySchema,
   coursesQuerySchema,
   schedulesQuerySchema,
+  sectionDetailQuerySchema,
   sectionSchedulesQuerySchema,
   sectionsQuerySchema,
   teachersQuerySchema,

--- a/src/routes/api/catalog/sections/[jwId]/+server.ts
+++ b/src/routes/api/catalog/sections/[jwId]/+server.ts
@@ -5,7 +5,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
 /**
  * Get section.
  * @pathParams jwIdPathParamsSchema
- * @params catalogLocaleQuerySchema
+ * @params sectionDetailQuerySchema
  * @response sectionDetailSchema
  * @response 400:openApiErrorSchema
  * @response 404:openApiErrorSchema

--- a/tests/unit/academic-route-locale.test.ts
+++ b/tests/unit/academic-route-locale.test.ts
@@ -175,8 +175,33 @@ describe("academic REST 语言适配器", () => {
       },
     );
 
-    expect(findSectionDetailByJwIdMock).toHaveBeenCalledWith(123, "en-us");
+    expect(findSectionDetailByJwIdMock).toHaveBeenCalledWith(123, "en-us", {
+      includeExams: undefined,
+      includeSchedules: undefined,
+      includeTeacherDepartments: undefined,
+    });
     expect(response.headers.get("Vary")).toBe("Accept-Language, Cookie");
+  });
+
+  it("将部分查询标志传递给班级详情读取", async () => {
+    const { getSectionDetailRoute } = await import(
+      "@/lib/api/routes/academic-section-routes"
+    );
+
+    await getSectionDetailRoute(
+      request(
+        "/api/catalog/sections/123?includeExams=true&includeSchedules=true",
+      ),
+      {
+        jwId: "123",
+      },
+    );
+
+    expect(findSectionDetailByJwIdMock).toHaveBeenCalledWith(123, "en-us", {
+      includeExams: true,
+      includeSchedules: true,
+      includeTeacherDepartments: undefined,
+    });
   });
 
   it("将请求语言传递给教师详情读取", async () => {
@@ -385,7 +410,11 @@ describe("academic REST 语言适配器", () => {
 
     expect(findCourseDetailByJwIdMock).toHaveBeenCalledWith(123, "zh-cn");
     expect(findTeacherDetailByIdMock).toHaveBeenCalledWith(456, "zh-cn");
-    expect(findSectionDetailByJwIdMock).toHaveBeenCalledWith(123, "zh-cn");
+    expect(findSectionDetailByJwIdMock).toHaveBeenCalledWith(123, "zh-cn", {
+      includeExams: undefined,
+      includeSchedules: undefined,
+      includeTeacherDepartments: undefined,
+    });
     expect(listPublicSchedulesMock).toHaveBeenCalledWith(
       expect.objectContaining({ locale: "zh-cn" }),
     );

--- a/tests/unit/api-schemas.test.ts
+++ b/tests/unit/api-schemas.test.ts
@@ -30,6 +30,7 @@ import {
   localeUpdateRequestSchema,
   matchSectionCodesRequestSchema,
   schedulesQuerySchema,
+  sectionDetailQuerySchema,
   sectionSchedulesQuerySchema,
   sectionsQuerySchema,
   semestersQuerySchema,
@@ -564,6 +565,17 @@ describe("其他请求 schema", () => {
 
     expect(sectionSchedulesQuerySchema.parse({ limit: "25" })).toMatchObject({
       limit: 25,
+    });
+    expect(
+      sectionDetailQuerySchema.parse({
+        includeExams: "true",
+        includeSchedules: "false",
+        includeTeacherDepartments: "true",
+      }),
+    ).toMatchObject({
+      includeExams: true,
+      includeSchedules: false,
+      includeTeacherDepartments: true,
     });
     expect(
       busRouteSearchQuerySchema.parse({

--- a/tests/unit/section-detail-tab-client.test.ts
+++ b/tests/unit/section-detail-tab-client.test.ts
@@ -52,7 +52,7 @@ describe("createSectionDetailTabPanelStore", () => {
         homeworks: [],
         sectionOverlay: {
           exams: [{ examRooms: [], id: 1 }],
-          schedules: [{ id: 2, teachers: [] }],
+          schedules: [{ teachers: [] }],
           teachers: [],
         },
       },
@@ -73,7 +73,7 @@ describe("createSectionDetailTabPanelStore", () => {
     getMock.mockResolvedValue({
       data: {
         exams: [{ examRooms: [], id: 3 }],
-        schedules: [{ id: 4, teachers: [] }],
+        schedules: [{ teachers: [] }],
         teachers: [
           {
             department: { namePrimary: "CS" },

--- a/tests/unit/section-detail-tab-client.test.ts
+++ b/tests/unit/section-detail-tab-client.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSectionDetailTabPanelStore } from "@/features/section-detail/lib/section-detail-tab-client";
+
+const { getMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  apiClient: {
+    GET: getMock,
+  },
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createSectionDetailTabPanelStore", () => {
+  it("skips client fetch for SSR-seeded tabs", async () => {
+    const store = createSectionDetailTabPanelStore("user-1", {
+      loadedTabs: ["calendar", "exams"],
+      state: {
+        commentsData: null,
+        descriptionData: {
+          description: {
+            content: "",
+            id: null,
+            lastEditedAt: null,
+            lastEditedBy: null,
+            renderedHtml: "",
+            updatedAt: null,
+          },
+          history: [],
+          viewer: {
+            image: null,
+            isAdmin: false,
+            isAuthenticated: true,
+            isSuspended: false,
+            name: null,
+            suspensionExpiresAt: null,
+            suspensionReason: null,
+            userId: "user-1",
+          },
+        },
+        homeworkAuditLogs: [],
+        homeworkViewer: {
+          isAdmin: false,
+          isAuthenticated: true,
+          isSuspended: false,
+          userId: "user-1",
+        },
+        homeworks: [],
+        sectionOverlay: {
+          exams: [{ examRooms: [], id: 1 }],
+          schedules: [{ id: 2, teachers: [] }],
+          teachers: [],
+        },
+      },
+    });
+
+    await store.ensureLoaded("calendar", {
+      errorMessage: "failed",
+      jwId: 301,
+      locale: "zh-cn",
+      sectionId: 31,
+    });
+
+    expect(getMock).not.toHaveBeenCalled();
+    expect(store.isLoaded("calendar")).toBe(true);
+  });
+
+  it("requests narrow section detail payloads per tab", async () => {
+    getMock.mockResolvedValue({
+      data: {
+        exams: [{ examRooms: [], id: 3 }],
+        schedules: [{ id: 4, teachers: [] }],
+        teachers: [
+          {
+            department: { namePrimary: "CS" },
+            id: 5,
+            namePrimary: "Ada",
+          },
+        ],
+      },
+      response: { ok: true },
+    });
+
+    const store = createSectionDetailTabPanelStore(null);
+    const input = {
+      errorMessage: "failed",
+      jwId: 301,
+      locale: "zh-cn" as const,
+      sectionId: 31,
+    };
+
+    await store.ensureLoaded("calendar", input);
+    expect(getMock).toHaveBeenLastCalledWith("/api/catalog/sections/301", {
+      params: {
+        query: {
+          includeExams: "true",
+          includeSchedules: "true",
+          locale: "zh-cn",
+        },
+      },
+    });
+
+    await store.ensureLoaded("exams", input);
+    expect(getMock).toHaveBeenLastCalledWith("/api/catalog/sections/301", {
+      params: {
+        query: {
+          includeExams: "true",
+          locale: "zh-cn",
+        },
+      },
+    });
+
+    await store.ensureLoaded("teachers", input);
+    expect(getMock).toHaveBeenLastCalledWith("/api/catalog/sections/301", {
+      params: {
+        query: {
+          includeTeacherDepartments: "true",
+          locale: "zh-cn",
+        },
+      },
+    });
+  });
+});

--- a/tests/unit/section-detail-tab-ssr-seed.test.ts
+++ b/tests/unit/section-detail-tab-ssr-seed.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import { emptyDescriptionPayload } from "@/features/descriptions/lib/description-empty-payload";
+import type { SectionDetailPageData } from "@/features/section-detail/lib/section-detail-controller-types";
+import {
+  applySectionDetailTabPanelPatch,
+  emptySectionDetailTabPanelState,
+} from "@/features/section-detail/lib/section-detail-tab-client";
+import {
+  buildSectionDetailTabPanelSsrState,
+  getSsrLoadedSectionDetailTabs,
+  sectionTeachersIncludeDepartments,
+} from "@/features/section-detail/lib/section-detail-tab-ssr-seed";
+
+const userId = "user-1";
+
+function basePageData(
+  overrides: Partial<SectionDetailPageData> = {},
+): SectionDetailPageData {
+  return {
+    commentsData: null,
+    copy: {} as SectionDetailPageData["copy"],
+    descriptionData: emptyDescriptionPayload({
+      image: null,
+      isAdmin: false,
+      isAuthenticated: false,
+      isSuspended: false,
+      name: null,
+      suspensionExpiresAt: null,
+      suspensionReason: null,
+      userId: null,
+    }),
+    detailSection: "overview",
+    focusedHomeworkId: null,
+    homeworkData: {
+      auditLogs: [],
+      homeworks: [],
+      viewer: {
+        isAdmin: false,
+        isAuthenticated: false,
+        isSuspended: false,
+        userId: null,
+      },
+    },
+    homeworkView: "cards",
+    locale: "zh-cn",
+    section: {
+      adminClasses: [],
+      code: "001",
+      course: { id: 1, jwId: 101, namePrimary: "Calculus" },
+      courseId: 1,
+      examCount: 1,
+      exams: [{ examRooms: [], id: 9 }],
+      id: 31,
+      jwId: 301,
+      sameSemesterOtherTeachers: [],
+      sameTeacherOtherSemesters: [],
+      scheduleCount: 1,
+      schedules: [{ id: 8, teachers: [] }],
+      teachers: [{ id: 1, namePrimary: "Ada" }],
+    },
+    showSubscribeDialog: false,
+    structuredDataJson: "{}",
+    todayCalendarKey: "2026-03-01",
+    viewer: { signedIn: false },
+    ...overrides,
+  };
+}
+
+describe("getSsrLoadedSectionDetailTabs", () => {
+  it("marks homework when the homework tab or focused homework is SSR-loaded", () => {
+    expect(
+      getSsrLoadedSectionDetailTabs(
+        basePageData({ detailSection: "homework" }),
+      ),
+    ).toContain("homework");
+    expect(
+      getSsrLoadedSectionDetailTabs(
+        basePageData({ focusedHomeworkId: "hw-1" }),
+      ),
+    ).toContain("homework");
+    expect(getSsrLoadedSectionDetailTabs(basePageData())).not.toContain(
+      "homework",
+    );
+  });
+
+  it("marks introduction when SSR fetched description content", () => {
+    expect(
+      getSsrLoadedSectionDetailTabs(
+        basePageData({ detailSection: "introduction" }),
+      ),
+    ).toContain("introduction");
+    expect(
+      getSsrLoadedSectionDetailTabs(
+        basePageData({
+          descriptionData: {
+            ...basePageData().descriptionData,
+            description: {
+              ...basePageData().descriptionData.description,
+              content: "Course intro",
+            },
+          },
+        }),
+      ),
+    ).toContain("introduction");
+    expect(getSsrLoadedSectionDetailTabs(basePageData())).not.toContain(
+      "introduction",
+    );
+  });
+
+  it("marks teachers only when department-expanded teachers were SSR-loaded", () => {
+    expect(
+      getSsrLoadedSectionDetailTabs(
+        basePageData({
+          detailSection: "teachers",
+          section: {
+            ...basePageData().section,
+            teachers: [
+              {
+                department: { namePrimary: "CS" },
+                id: 1,
+                namePrimary: "Ada",
+              },
+            ],
+          },
+        }),
+      ),
+    ).toContain("teachers");
+
+    expect(
+      getSsrLoadedSectionDetailTabs(
+        basePageData({
+          detailSection: "teachers",
+          section: {
+            ...basePageData().section,
+            teachers: [{ id: 1, namePrimary: "Ada" }],
+          },
+        }),
+      ),
+    ).not.toContain("teachers");
+  });
+
+  it("marks calendar and exams from the matching SSR tab", () => {
+    expect(
+      getSsrLoadedSectionDetailTabs(
+        basePageData({ detailSection: "calendar" }),
+      ),
+    ).toEqual(expect.arrayContaining(["calendar", "exams"]));
+
+    expect(
+      getSsrLoadedSectionDetailTabs(basePageData({ detailSection: "exams" })),
+    ).toEqual(["exams"]);
+
+    expect(getSsrLoadedSectionDetailTabs(basePageData())).not.toContain(
+      "calendar",
+    );
+  });
+
+  it("does not treat overview schedules as calendar SSR data", () => {
+    const loaded = getSsrLoadedSectionDetailTabs(basePageData());
+    expect(loaded).not.toContain("calendar");
+    expect(loaded).not.toContain("exams");
+  });
+});
+
+describe("buildSectionDetailTabPanelSsrState", () => {
+  it("seeds overlay fields from SSR section data", () => {
+    const data = basePageData({
+      detailSection: "calendar",
+      section: {
+        ...basePageData().section,
+        exams: [{ examRooms: [], id: 42 }],
+        schedules: [{ id: 7, teachers: [] }],
+      },
+    });
+
+    const state = buildSectionDetailTabPanelSsrState(
+      data,
+      emptySectionDetailTabPanelState,
+      applySectionDetailTabPanelPatch,
+      userId,
+    );
+
+    expect(state.sectionOverlay.schedules).toEqual([{ id: 7, teachers: [] }]);
+    expect(state.sectionOverlay.exams).toEqual([{ examRooms: [], id: 42 }]);
+  });
+
+  it("leaves overlay empty when SSR tab mapping does not match", () => {
+    const state = buildSectionDetailTabPanelSsrState(
+      basePageData({
+        detailSection: "teachers",
+        section: {
+          ...basePageData().section,
+          teachers: [{ id: 1, namePrimary: "Ada" }],
+        },
+      }),
+      emptySectionDetailTabPanelState,
+      applySectionDetailTabPanelPatch,
+      userId,
+    );
+
+    expect(state.sectionOverlay.teachers).toEqual([]);
+  });
+});
+
+describe("sectionTeachersIncludeDepartments", () => {
+  it("detects department-expanded teacher payloads", () => {
+    expect(
+      sectionTeachersIncludeDepartments([
+        { department: { namePrimary: "CS" }, id: 1, namePrimary: "Ada" },
+      ]),
+    ).toBe(true);
+    expect(
+      sectionTeachersIncludeDepartments([{ id: 1, namePrimary: "Ada" }]),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/section-detail-tab-ssr-seed.test.ts
+++ b/tests/unit/section-detail-tab-ssr-seed.test.ts
@@ -55,7 +55,7 @@ function basePageData(
       sameSemesterOtherTeachers: [],
       sameTeacherOtherSemesters: [],
       scheduleCount: 1,
-      schedules: [{ id: 8, teachers: [] }],
+      schedules: [{ teachers: [] }],
       teachers: [{ id: 1, namePrimary: "Ada" }],
     },
     showSubscribeDialog: false,
@@ -119,7 +119,7 @@ describe("getSsrLoadedSectionDetailTabs", () => {
                 department: { namePrimary: "CS" },
                 id: 1,
                 namePrimary: "Ada",
-              },
+              } as SectionDetailPageData["section"]["teachers"][number],
             ],
           },
         }),
@@ -169,7 +169,7 @@ describe("buildSectionDetailTabPanelSsrState", () => {
       section: {
         ...basePageData().section,
         exams: [{ examRooms: [], id: 42 }],
-        schedules: [{ id: 7, teachers: [] }],
+        schedules: [{ teachers: [] }],
       },
     });
 
@@ -180,7 +180,7 @@ describe("buildSectionDetailTabPanelSsrState", () => {
       userId,
     );
 
-    expect(state.sectionOverlay.schedules).toEqual([{ id: 7, teachers: [] }]);
+    expect(state.sectionOverlay.schedules).toEqual([{ teachers: [] }]);
     expect(state.sectionOverlay.exams).toEqual([{ examRooms: [], id: 42 }]);
   });
 
@@ -206,7 +206,11 @@ describe("sectionTeachersIncludeDepartments", () => {
   it("detects department-expanded teacher payloads", () => {
     expect(
       sectionTeachersIncludeDepartments([
-        { department: { namePrimary: "CS" }, id: 1, namePrimary: "Ada" },
+        {
+          department: { namePrimary: "CS" },
+          id: 1,
+          namePrimary: "Ada",
+        } as SectionDetailPageData["section"]["teachers"][number],
       ]),
     ).toBe(true);
     expect(


### PR DESCRIPTION
## Summary
Partial for #733.

- Seed `tabPanelStore` from SSR page data so deep-linked section tabs (calendar, exams, teachers, homework, introduction) skip redundant client fetches on mount when the server already loaded the matching payload.
- Add `includeExams`, `includeSchedules`, and `includeTeacherDepartments` query flags to `GET /api/catalog/sections/[jwId]` and use them from calendar/exams/teachers tab loaders instead of fetching the full section record.
- Split the exams tab loader from the calendar loader so exams-only navigation requests only exam data.

## Test plan
- [x] `bunx biome check` on touched files
- [x] `bunx vitest run tests/unit/section-detail-tab-ssr-seed.test.ts tests/unit/section-detail-tab-client.test.ts tests/unit/api-schemas.test.ts tests/unit/academic-route-locale.test.ts`
- [x] `bun run openapi:check`
- [ ] Browser/E2E verification of deep-linked `?tab=calendar|exams|teachers|homework` (not run in this environment)

## Remaining risks
- SSR tab seeding relies on `detailSection` plus field-shape checks (e.g. teachers require department expansion); a future SSR shape change could still produce a silently empty panel if mappings drift.
- Comments tab remains client-loaded by design (no SSR comments on PublicSsr cache paths).
- Partial section detail responses still return the full `sectionDetailSchema` envelope with omitted collections defaulted to empty arrays.