### PR TITLE
fix(links): replace visit POST forms with GET tracking redirects

### DIFF
--- a/docs/contracts/dashboard-link.json
+++ b/docs/contracts/dashboard-link.json
@@ -2,7 +2,7 @@
   "name": "Catalog Link and Workspace Link Pin",
   "access": {
     "anon": "Can browse frequent links and follow public visit redirects but cannot pin them.",
-    "user": "Can pin and unpin links; authenticated POST visits record click counts before redirecting.",
+    "user": "Can pin and unpin links; authenticated GET visit redirects record click counts before redirecting.",
     "admin": "Has no dedicated link management interface separate from regular users.",
     "agent": "Can list/search catalog links and manage the authenticated user's link-pin state through MCP; visit redirects remain browser/REST navigation."
   },
@@ -12,7 +12,8 @@
     "links-vs-buttons": "Links are for navigation; buttons are for actions.",
     "pin-limit": "Currently a maximum of 4 links can be pinned; exceeding this displaces the earliest pinned link.",
     "semantic-public-route": "Legacy query navigation resolves to the canonical /catalog/links page for both anonymous and signed-in users.",
-    "pin-error-clear": "When pin/unpin writes fail, the endpoint returns a clear error; failures are not disguised as successes."
+    "pin-error-clear": "When pin/unpin writes fail, the endpoint returns a clear error; failures are not disguised as successes.",
+    "visit-tracking-link": "Campus link cards use GET /api/catalog/links/resolve?slug=… tracking links (not POST forms) so navigation works as a normal hyperlink."
   },
   "capabilities": {
     "link-browse": {
@@ -128,16 +129,11 @@
           },
           {
             "path": "/api/catalog/links/resolve",
+            "method": "GET",
             "returns": "307 redirect",
             "auth": "anon",
-            "notes": ["Invalid or missing slug redirects to /."]
-          },
-          {
-            "path": "/api/catalog/links/resolve",
-            "method": "POST",
-            "returns": "303 redirect",
-            "auth": "anon",
             "notes": [
+              "Query: slug. Invalid or missing slug redirects to /.",
               "Redirect is public; click count is recorded only when the request has an authenticated user."
             ]
           }

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -5055,7 +5055,7 @@
     "/api/catalog/links/resolve": {
       "get": {
         "operationId": "catalog_link_resolve",
-        "summary": "Resolve a public campus link",
+        "summary": "Resolve a public campus link and record an authenticated visit",
         "tags": [
           "catalog.link"
         ],
@@ -5072,37 +5072,7 @@
         ],
         "responses": {
           "307": {
-            "description": "Temporary redirect to target link",
-            "headers": {
-              "Location": {
-                "description": "Redirect target URL",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "operationId": "catalog_link_visit_record",
-        "summary": "Resolve a public campus link and record an authenticated visit",
-        "tags": [
-          "catalog.link"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/catalogLinkVisitRequestSchema"
-              }
-            }
-          }
-        },
-        "responses": {
-          "303": {
-            "description": "Redirect after recording link click",
+            "description": "Temporary redirect to target link after recording visit",
             "headers": {
               "Location": {
                 "description": "Redirect target URL",
@@ -23014,19 +22984,6 @@
           "gradation",
           "type",
           "sections"
-        ],
-        "additionalProperties": false
-      },
-      "catalogLinkVisitRequestSchema": {
-        "type": "object",
-        "properties": {
-          "slug": {
-            "type": "string",
-            "minLength": 1
-          }
-        },
-        "required": [
-          "slug"
         ],
         "additionalProperties": false
       },

--- a/scripts/openapi/route-collector.ts
+++ b/scripts/openapi/route-collector.ts
@@ -49,7 +49,6 @@ const FORM_URLENCODED_PATHS = new Set([
   "POST /api/auth/oauth2/token",
   "POST /api/auth/oauth2/device-authorization",
   "POST /api/workspace/link-pins",
-  "POST /api/catalog/links/resolve",
 ]);
 
 const REDIRECT_DESCRIPTIONS: Record<
@@ -69,18 +68,7 @@ const REDIRECT_DESCRIPTIONS: Record<
   },
   "GET /api/catalog/links/resolve": {
     "307": {
-      description: "Temporary redirect to target link",
-      headers: {
-        Location: {
-          description: "Redirect target URL",
-          schema: { type: "string" },
-        },
-      },
-    },
-  },
-  "POST /api/catalog/links/resolve": {
-    "303": {
-      description: "Redirect after recording link click",
+      description: "Temporary redirect to target link after recording visit",
       headers: {
         Location: {
           description: "Redirect target URL",
@@ -161,7 +149,6 @@ const OPERATION_ID_OVERRIDES: Record<string, string> = {
   "GET /api/catalog/courses/{jwId}": "getCourse",
   "GET /api/catalog/links": "catalog_link_list",
   "GET /api/catalog/links/resolve": "catalog_link_resolve",
-  "POST /api/catalog/links/resolve": "catalog_link_visit_record",
   "GET /api/workspace/link-pins": "workspace_link_pin_list",
   "POST /api/workspace/link-pins": "workspace_link_pin_set",
   "POST /api/workspace/link-pins/batch": "workspace_link_pin_batch_set",

--- a/src/features/dashboard-links/lib/dashboard-links.ts
+++ b/src/features/dashboard-links/lib/dashboard-links.ts
@@ -34,6 +34,11 @@ export function getDashboardLinkGroup(slug: string): DashboardLinkGroup {
 
 export type LinkClickStats = Record<string, number>;
 
+/** Tracking redirect that records an authenticated visit then 307s to the target. */
+export function dashboardLinkVisitHref(slug: string) {
+  return `/api/catalog/links/resolve?slug=${encodeURIComponent(slug)}`;
+}
+
 export function recommendDashboardLinks(
   clickStats: LinkClickStats,
   options: {

--- a/src/features/dashboard/components/DashboardLinkTableCell.svelte
+++ b/src/features/dashboard/components/DashboardLinkTableCell.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { DashboardOverviewLinkItem } from "@/features/dashboard/lib/dashboard-controller-helpers";
+import { dashboardLinkVisitHref } from "@/features/dashboard-links/lib/dashboard-links";
 import { cn } from "$lib/utils.js";
 
 export let link: DashboardOverviewLinkItem;
@@ -9,21 +10,14 @@ let className = "";
 export { className as class };
 </script>
 
-<form
-  action="/api/catalog/links/resolve"
-  class="h-full min-w-0"
-  method="POST"
-  rel="noopener"
+<a
+  class={cn(
+    "flex h-full min-h-12 min-w-0 w-full items-center overflow-hidden px-3 text-left text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-inset",
+    className,
+  )}
+  href={dashboardLinkVisitHref(link.slug)}
+  rel="noopener noreferrer"
   target="_blank"
 >
-  <input name="slug" type="hidden" value={link.slug} />
-  <button
-    class={cn(
-      "flex h-full min-h-12 min-w-0 w-full items-center overflow-hidden px-3 text-left text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-inset",
-      className,
-    )}
-    type="submit"
-  >
-    <slot />
-  </button>
-</form>
+  <slot />
+</a>

--- a/src/features/dashboard/components/DashboardLinkVisitAction.svelte
+++ b/src/features/dashboard/components/DashboardLinkVisitAction.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { DashboardOverviewLinkItem } from "@/features/dashboard/lib/dashboard-controller-helpers";
+import { dashboardLinkVisitHref } from "@/features/dashboard-links/lib/dashboard-links";
 import * as Item from "$lib/components/ui/item/index.js";
 import { cn } from "$lib/utils.js";
 
@@ -7,19 +8,12 @@ export let link: DashboardOverviewLinkItem;
 export let linkIconLabel: (icon: string) => string;
 export let reserveActionSpace = false;
 
-function visitButtonClass(props: Record<string, unknown>) {
+function visitLinkClass(props: Record<string, unknown>) {
   return cn(props.class as string, "bg-background text-left hover:bg-muted");
 }
 </script>
 
-<form
-  action="/api/catalog/links/resolve"
-  class="h-full min-w-0"
-  method="POST"
-  rel="noopener"
-  target="_blank"
->
-  <input name="slug" type="hidden" value={link.slug} />
+<div class="h-full min-w-0">
   <Item.Root
     class={cn(
       "h-full min-h-24 min-w-0 items-start overflow-hidden text-left",
@@ -28,7 +22,13 @@ function visitButtonClass(props: Record<string, unknown>) {
     variant="outline"
   >
     {#snippet child({ props })}
-      <button {...props} class={visitButtonClass(props)} type="submit">
+      <a
+        {...props}
+        class={visitLinkClass(props)}
+        href={dashboardLinkVisitHref(link.slug)}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
         <Item.Media aria-hidden="true" class="size-8" variant="icon">
           {linkIconLabel(link.icon)}
         </Item.Media>
@@ -38,7 +38,7 @@ function visitButtonClass(props: Record<string, unknown>) {
             {link.description}
           </Item.Description>
         </Item.Content>
-      </button>
+      </a>
     {/snippet}
   </Item.Root>
-</form>
+</div>

--- a/src/features/dashboard/components/OverviewLinksGrid.svelte
+++ b/src/features/dashboard/components/OverviewLinksGrid.svelte
@@ -5,6 +5,7 @@ import type {
   DashboardOverviewLinkItem,
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
 import { DASHBOARD_OVERVIEW_PREVIEW_LIMIT } from "@/features/dashboard/lib/overview-preview";
+import { dashboardLinkVisitHref } from "@/features/dashboard-links/lib/dashboard-links";
 import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import type { DashboardCalendarTabHref } from "./dashboard-calendar-component-types";
 import LinksTabPinButton from "./LinksTabPinButton.svelte";
@@ -46,33 +47,26 @@ function pinAction(link: DashboardOverviewLinkItem): DashboardLinkPinAction {
     <div class="grid min-w-0 gap-1 sm:grid-cols-2 xl:grid-cols-4">
       {#each previewLinks as link}
         <div class="group relative min-w-0">
-          <form
-            action="/api/catalog/links/resolve"
-            class="min-w-0"
-            method="POST"
-            rel="noopener"
+          <a
+            class="flex w-full min-w-0 items-start gap-3 rounded-lg px-2 py-2.5 text-left transition-colors hover:bg-muted/50"
+            class:pe-10={true}
+            href={dashboardLinkVisitHref(link.slug)}
+            rel="noopener noreferrer"
             target="_blank"
           >
-            <input name="slug" type="hidden" value={link.slug} />
-            <button
-              class="flex w-full min-w-0 items-start gap-3 rounded-lg px-2 py-2.5 text-left transition-colors hover:bg-muted/50"
-              class:pe-10={true}
-              type="submit"
+            <span
+              aria-hidden="true"
+              class="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-xs font-medium"
             >
-              <span
-                aria-hidden="true"
-                class="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-xs font-medium"
+              {linkIconLabel(link.icon)}
+            </span>
+            <span class="grid min-w-0 gap-0.5">
+              <span class="truncate font-medium text-sm">{link.title}</span>
+              <span class="line-clamp-2 text-muted-foreground text-xs"
+                >{link.description}</span
               >
-                {linkIconLabel(link.icon)}
-              </span>
-              <span class="grid min-w-0 gap-0.5">
-                <span class="truncate font-medium text-sm">{link.title}</span>
-                <span class="line-clamp-2 text-muted-foreground text-xs"
-                  >{link.description}</span
-                >
-              </span>
-            </button>
-          </form>
+            </span>
+          </a>
           <div
             class={`absolute top-2 right-1 ${link.isPinned ? "" : "md:pointer-events-none md:opacity-0 md:transition-opacity md:group-focus-within:pointer-events-auto md:group-focus-within:opacity-100 md:group-hover:pointer-events-auto md:group-hover:opacity-100"}`}
           >

--- a/src/lib/api/routes/dashboard-link-visit-routes.ts
+++ b/src/lib/api/routes/dashboard-link-visit-routes.ts
@@ -2,44 +2,21 @@ import {
   recordDashboardLinkClick,
   resolveDashboardLinkBySlug,
 } from "@/features/dashboard-links/server/dashboard-link-service";
-import {
-  catalogLinkVisitRequestSchema,
-  dashboardLinkVisitQuerySchema,
-} from "@/lib/api/schemas/request-schemas";
+import { dashboardLinkVisitQuerySchema } from "@/lib/api/schemas/request-schemas";
 import { resolveApiUserId } from "@/lib/auth/api-auth";
 import { checkUserMutationRateLimit } from "@/lib/security/user-mutation-rate-limit";
 
-function resolveVisitTarget(
-  schema: typeof dashboardLinkVisitQuerySchema,
-  slug: FormDataEntryValue | string | null,
-) {
-  const parsed = schema.safeParse({ slug });
-  return parsed.success ? resolveDashboardLinkBySlug(parsed.data.slug) : null;
-}
-
 export async function getDashboardLinkVisitRoute(request: Request) {
   const { searchParams } = new URL(request.url);
-  const target = resolveVisitTarget(
-    dashboardLinkVisitQuerySchema,
-    searchParams.get("slug"),
-  );
+  const parsed = dashboardLinkVisitQuerySchema.safeParse({
+    slug: searchParams.get("slug"),
+  });
+  const target = parsed.success
+    ? resolveDashboardLinkBySlug(parsed.data.slug)
+    : null;
 
   if (!target) {
     return Response.redirect(new URL("/", request.url), 307);
-  }
-
-  return Response.redirect(target.url, 307);
-}
-
-export async function postDashboardLinkVisitRoute(request: Request) {
-  const formData = await request.formData();
-  const target = resolveVisitTarget(
-    catalogLinkVisitRequestSchema,
-    formData.get("slug"),
-  );
-
-  if (!target) {
-    return Response.redirect(new URL("/", request.url), 303);
   }
 
   const userId = await resolveApiUserId(request);
@@ -56,5 +33,5 @@ export async function postDashboardLinkVisitRoute(request: Request) {
     }
   }
 
-  return Response.redirect(target.url, 303);
+  return Response.redirect(target.url, 307);
 }

--- a/src/lib/api/schemas/request-mutation-schemas.ts
+++ b/src/lib/api/schemas/request-mutation-schemas.ts
@@ -38,7 +38,6 @@ export {
   calendarSubscriptionCreateRequestSchema,
   calendarSubscriptionQueryRequestSchema,
   calendarSubscriptionRemoveRequestSchema,
-  catalogLinkVisitRequestSchema,
   localeUpdateRequestSchema,
   todoBatchDeleteRequestSchema,
   todoCompletionBatchRequestSchema,

--- a/src/lib/api/schemas/request-user-mutation-schemas.ts
+++ b/src/lib/api/schemas/request-user-mutation-schemas.ts
@@ -92,10 +92,6 @@ export const localeUpdateRequestSchema = z.object({
   locale: z.enum(APP_LOCALES),
 });
 
-export const catalogLinkVisitRequestSchema = z.object({
-  slug: z.string().trim().min(1),
-});
-
 export const workspaceLinkPinRequestSchema = z.object({
   slug: z.string().trim().min(1),
   returnTo: z.string().trim().optional(),

--- a/src/lib/auth/oauth-user-email.ts
+++ b/src/lib/auth/oauth-user-email.ts
@@ -16,7 +16,9 @@ export function isPlaceholderUserEmail(email: string | null | undefined) {
   return false;
 }
 
-export function isPublishableUserEmail(email: string | null | undefined) {
+export function isPublishableUserEmail(
+  email: string | null | undefined,
+): email is string {
   return (
     typeof email === "string" &&
     email.trim().length > 0 &&

--- a/src/routes/api/catalog/links/resolve/+server.ts
+++ b/src/routes/api/catalog/links/resolve/+server.ts
@@ -1,24 +1,12 @@
-import {
-  getDashboardLinkVisitRoute,
-  postDashboardLinkVisitRoute,
-} from "@/lib/api/routes/dashboard-link-visit-routes";
+import { getDashboardLinkVisitRoute } from "@/lib/api/routes/dashboard-link-visit-routes";
 import { svelteRequestHandler } from "@/lib/api/svelte-route";
 import { observedApiRoute } from "@/lib/log/api-observability";
 
 /**
- * Resolve a public campus link.
+ * Resolve a public campus link and record an authenticated visit.
  * @params dashboardLinkVisitQuerySchema
  * @response 307
  */
 export const GET = svelteRequestHandler(
   observedApiRoute(getDashboardLinkVisitRoute),
-);
-
-/**
- * Resolve a public campus link and record an authenticated visit.
- * @body catalogLinkVisitRequestSchema
- * @response 303
- */
-export const POST = svelteRequestHandler(
-  observedApiRoute(postDashboardLinkVisitRoute),
 );

--- a/tests/e2e/src/app/dashboard/links/test.ts
+++ b/tests/e2e/src/app/dashboard/links/test.ts
@@ -5,7 +5,7 @@
  * - Dashboard links grouped by category (study, life, tech, classroom, etc.)
  *   sourced from USTC_DASHBOARD_LINKS
  * - Each link card: name, description, visit tracking via
- *   POST /api/catalog/links/resolve
+ *   GET /api/catalog/links/resolve?slug=…
  * - Pin state per user via POST /api/workspace/link-pins
  *
  * ## UI/UX Elements
@@ -58,7 +58,7 @@ test.describe("仪表盘网站链接", () => {
     });
     await expect(searchInput).toBeVisible();
     await expect(
-      page.getByRole("button", { name: /教务系统/i }).first(),
+      page.getByRole("link", { name: /教务系统/i }).first(),
     ).toBeVisible();
 
     // No pin forms in public view
@@ -91,7 +91,7 @@ test.describe("仪表盘网站链接", () => {
     });
     await expect(searchInput).toBeVisible();
     await expect(
-      page.getByRole("button", { name: /Academic Affairs System/i }).first(),
+      page.getByRole("link", { name: /Academic Affairs System/i }).first(),
     ).toBeVisible();
 
     await expect(async () => {
@@ -99,10 +99,10 @@ test.describe("仪表盘网站链接", () => {
       await searchInput.clear();
       await searchInput.pressSequentially("email");
       await expect(
-        page.getByRole("button", { name: /USTC Email/i }).first(),
+        page.getByRole("link", { name: /USTC Email/i }).first(),
       ).toBeVisible({ timeout: 3_000 });
       await expect(
-        page.getByRole("button", { name: /Academic Affairs System/i }),
+        page.getByRole("link", { name: /Academic Affairs System/i }),
       ).toHaveCount(0, { timeout: 3_000 });
     }).toPass({
       timeout: 10_000,
@@ -157,10 +157,10 @@ test.describe("仪表盘网站链接", () => {
       await searchInput.clear();
       await searchInput.pressSequentially("邮箱");
       await expect(
-        page.getByRole("button", { name: /邮箱/i }).first(),
+        page.getByRole("link", { name: /邮箱/i }).first(),
       ).toBeVisible({ timeout: 3_000 });
       await expect(
-        page.getByRole("button", { name: /教务系统/i }).first(),
+        page.getByRole("link", { name: /教务系统/i }).first(),
       ).toHaveCount(0);
     }).toPass({
       timeout: 10_000,
@@ -184,7 +184,7 @@ test.describe("仪表盘网站链接", () => {
 
     const locatePinButton = async () => {
       const linkButton = page
-        .getByRole("button", { name: /教务系统/i })
+        .getByRole("link", { name: /教务系统/i })
         .filter({ visible: true })
         .first();
       await expect(linkButton).toBeVisible();
@@ -287,7 +287,7 @@ test.describe("仪表盘网站链接", () => {
 
     const locateJwPinButton = async () => {
       const linkButton = page
-        .getByRole("button", { name: /教务系统/i })
+        .getByRole("link", { name: /教务系统/i })
         .filter({ visible: true })
         .first();
       await expect(linkButton).toBeVisible();

--- a/tests/e2e/src/app/dashboard/test.ts
+++ b/tests/e2e/src/app/dashboard/test.ts
@@ -126,7 +126,7 @@ test.describe("仪表盘", () => {
       48,
     );
     await expect(
-      page.locator('form[action="/api/catalog/links/resolve"]'),
+      page.locator('a[href^="/api/catalog/links/resolve?slug="]'),
     ).toHaveCount(DEV_SEED.dashboardLinks.overviewLimit);
     await expect(page.locator("vite-error-overlay")).toHaveCount(0);
 

--- a/tests/integration/rest/dashboard-links/visit/test.ts
+++ b/tests/integration/rest/dashboard-links/visit/test.ts
@@ -1,24 +1,18 @@
 /**
- * E2E tests for GET & POST /api/catalog/links/resolve
+ * E2E tests for GET /api/catalog/links/resolve
  *
  * ## Endpoints
- * - `GET /api/catalog/links/resolve?slug=X` — Redirect to the dashboard link URL (no side effects)
- * - `POST /api/catalog/links/resolve` — Record a visit click and redirect to the link URL
+ * - `GET /api/catalog/links/resolve?slug=X` — Record an authenticated visit
+ *   (best-effort) and redirect to the dashboard link URL
  *
  * ## GET Request
  * - Query: `{ slug: string }`
  * - 307: redirect to the link's URL
+ * - Records click count for authenticated users (upsert with increment)
  * - Invalid/missing slug: redirect to /
  *
- * ## POST Request
- * - Form data: `{ slug: string }`
- * - 303: redirect to the link's URL
- * - Records click count for authenticated users (upsert with increment)
- * - Invalid/missing slug: 303 redirect to /
- *
  * ## Auth Requirements
- * - GET: no auth required (pure redirect)
- * - POST: no auth required for redirect, but click is only recorded when authenticated
+ * - No auth required for redirect; click is only recorded when authenticated
  *
  * ## Edge Cases
  * - Invalid slug redirects to / instead of erroring
@@ -29,8 +23,18 @@ import { signInAsDebugUserApi } from "../../_harness/auth";
 
 const BASE = "/api/catalog/links/resolve";
 
-test.describe("GET & POST /api/catalog/links/resolve 接口", () => {
+test.describe("GET /api/catalog/links/resolve 接口", () => {
   test("GET 重定向到目标链接 URL", async ({ request }) => {
+    const response = await request.get(`${BASE}?slug=jw`, {
+      maxRedirects: 0,
+    });
+    expect(response.status()).toBe(307);
+    expect(response.headers().location).toBe("https://jw.ustc.edu.cn/");
+  });
+
+  test("GET 登录后仍重定向到目标 URL", async ({ request }) => {
+    await signInAsDebugUserApi(request, "/");
+
     const response = await request.get(`${BASE}?slug=jw`, {
       maxRedirects: 0,
     });
@@ -52,36 +56,5 @@ test.describe("GET & POST /api/catalog/links/resolve 接口", () => {
     });
     expect(response.status()).toBe(307);
     expect(response.headers().location).toMatch(/\/$/);
-  });
-
-  test("POST 有效 slug 重定向到目标 URL", async ({ request }) => {
-    await signInAsDebugUserApi(request, "/");
-
-    const response = await request.post(BASE, {
-      form: { slug: "jw" },
-      maxRedirects: 0,
-    });
-    expect(response.status()).toBe(303);
-    expect(response.headers().location).toBe("https://jw.ustc.edu.cn/");
-  });
-
-  test("POST 无效 slug 重定向到 /", async ({ request }) => {
-    await signInAsDebugUserApi(request, "/");
-
-    const response = await request.post(BASE, {
-      form: { slug: "nonexistent-e2e" },
-      maxRedirects: 0,
-    });
-    expect(response.status()).toBe(303);
-    expect(response.headers().location).toMatch(/\/$/);
-  });
-
-  test("POST 未登录仍重定向", async ({ request }) => {
-    const response = await request.post(BASE, {
-      form: { slug: "jw" },
-      maxRedirects: 0,
-    });
-    expect(response.status()).toBe(303);
-    expect(response.headers().location).toBe("https://jw.ustc.edu.cn/");
   });
 });

--- a/tests/integration/rest/openapi/test.ts
+++ b/tests/integration/rest/openapi/test.ts
@@ -148,8 +148,8 @@ test.describe("GET /api/openapi - OpenAPI 规范", () => {
       body.paths?.["/api/catalog/links/resolve"]?.get?.responses?.["307"],
     ).toBeTruthy();
     expect(
-      body.paths?.["/api/catalog/links/resolve"]?.post?.responses?.["303"],
-    ).toBeTruthy();
+      body.paths?.["/api/catalog/links/resolve"]?.post,
+    ).toBeUndefined();
     expect(
       body.paths?.["/api/workspace/link-pins"]?.post?.requestBody?.content?.[
         "application/x-www-form-urlencoded"
@@ -225,9 +225,6 @@ test.describe("GET /api/openapi - OpenAPI 规范", () => {
     ).toBe("admin");
     expect(
       body.paths?.["/api/catalog/links/resolve"]?.get?.security,
-    ).toBeUndefined();
-    expect(
-      body.paths?.["/api/catalog/links/resolve"]?.post?.security,
     ).toBeUndefined();
     const mcpGetOperation = body.paths?.["/api/mcp"]?.get as
       | { responses?: Record<string, unknown>; security?: unknown[] }

--- a/tests/integration/rest/openapi/test.ts
+++ b/tests/integration/rest/openapi/test.ts
@@ -147,9 +147,7 @@ test.describe("GET /api/openapi - OpenAPI 规范", () => {
     expect(
       body.paths?.["/api/catalog/links/resolve"]?.get?.responses?.["307"],
     ).toBeTruthy();
-    expect(
-      body.paths?.["/api/catalog/links/resolve"]?.post,
-    ).toBeUndefined();
+    expect(body.paths?.["/api/catalog/links/resolve"]?.post).toBeUndefined();
     expect(
       body.paths?.["/api/workspace/link-pins"]?.post?.requestBody?.content?.[
         "application/x-www-form-urlencoded"

--- a/tests/unit/dashboard-link-visit-route.test.ts
+++ b/tests/unit/dashboard-link-visit-route.test.ts
@@ -18,7 +18,7 @@ vi.mock("@/lib/auth/api-auth", () => ({
   resolveApiUserId: resolveApiUserIdMock,
 }));
 
-describe("POST /api/catalog/links/resolve", () => {
+describe("GET /api/catalog/links/resolve", () => {
   beforeEach(() => {
     setCloudflareRuntimeEnv(undefined);
     resolveApiUserIdMock.mockResolvedValue("user-1");
@@ -32,20 +32,15 @@ describe("POST /api/catalog/links/resolve", () => {
   it("超过点击写入预算时跳过计数但仍重定向", async () => {
     const limit = vi.fn().mockResolvedValue({ success: false });
     setCloudflareRuntimeEnv({ USER_WRITE_RATE_LIMITER: { limit } });
-    const { postDashboardLinkVisitRoute } = await import(
+    const { getDashboardLinkVisitRoute } = await import(
       "@/lib/api/routes/dashboard-link-visit-routes"
     );
-    const form = new FormData();
-    form.set("slug", "jw");
 
-    const response = await postDashboardLinkVisitRoute(
-      new Request("https://life.example/api/catalog/links/resolve", {
-        method: "POST",
-        body: form,
-      }),
+    const response = await getDashboardLinkVisitRoute(
+      new Request("https://life.example/api/catalog/links/resolve?slug=jw"),
     );
 
-    expect(response.status).toBe(303);
+    expect(response.status).toBe(307);
     expect(response.headers.get("Location")).toBe("https://jw.ustc.edu.cn/");
     expect(recordDashboardLinkClickMock).not.toHaveBeenCalled();
     expect(limit).toHaveBeenCalledOnce();
@@ -57,20 +52,30 @@ describe("POST /api/catalog/links/resolve", () => {
         limit: vi.fn().mockResolvedValue({ success: true }),
       },
     });
-    const { postDashboardLinkVisitRoute } = await import(
+    const { getDashboardLinkVisitRoute } = await import(
       "@/lib/api/routes/dashboard-link-visit-routes"
     );
-    const form = new FormData();
-    form.set("slug", "jw");
 
-    const response = await postDashboardLinkVisitRoute(
-      new Request("https://life.example/api/catalog/links/resolve", {
-        method: "POST",
-        body: form,
-      }),
+    const response = await getDashboardLinkVisitRoute(
+      new Request("https://life.example/api/catalog/links/resolve?slug=jw"),
     );
 
-    expect(response.status).toBe(303);
+    expect(response.status).toBe(307);
     expect(recordDashboardLinkClickMock).toHaveBeenCalledWith("user-1", "jw");
+  });
+
+  it("未登录时不记录点击但仍重定向", async () => {
+    resolveApiUserIdMock.mockResolvedValue(null);
+    const { getDashboardLinkVisitRoute } = await import(
+      "@/lib/api/routes/dashboard-link-visit-routes"
+    );
+
+    const response = await getDashboardLinkVisitRoute(
+      new Request("https://life.example/api/catalog/links/resolve?slug=jw"),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("Location")).toBe("https://jw.ustc.edu.cn/");
+    expect(recordDashboardLinkClickMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Campus link cards now use `GET /api/catalog/links/resolve?slug=…` tracking links instead of POST forms.
- Authenticated click recording moves onto that GET handler; the POST resolve endpoint and form schema are removed.
- Contracts, OpenAPI, and e2e/unit tests are updated for the new navigation model.

## Test plan
- [x] `vitest run tests/unit/dashboard-link-visit-route.test.ts`
- [ ] CI unit / REST / e2e checks on this PR
- [ ] Click a campus link from `/catalog/links` and overview: opens target via GET redirect
- [ ] Signed-in visit still records click counts; anonymous visit still redirects