### PR TITLE
fix(worker): worker CPU, comment P2010 grants, and observability gaps

### DIFF
--- a/prisma/migrations/20260807143000_comment_summary_runtime_grants/migration.sql
+++ b/prisma/migrations/20260807143000_comment_summary_runtime_grants/migration.sql
@@ -7,9 +7,12 @@ BEGIN;
 -- then fails with Prisma P2010 (raw query failed) on every thread that hits
 -- the summary helpers.
 --
--- Prefer an unconditional GRANT when we can. If ownership already moved to
--- `life_ustc_function_owner` and the migrator lacks privilege, notice and leave
--- the roles bootstrap responsible (same pattern as comment_hidden_root_count).
+-- Mirror `20260803120000_comment_hidden_count_runtime_grant`: only change
+-- privileges / definer policies while the migrator still owns the helpers.
+-- After `production-runtime-bootstrap.sql` moves ownership to
+-- `life_ustc_function_owner` (and retargets policies there), skipping here is
+-- correct — a privileged migrator must not retarget those policies back to
+-- itself.
 
 DO $do$
 DECLARE
@@ -17,6 +20,8 @@ DECLARE
     'public.comment_reaction_summaries(text[])';
   attachment_signature CONSTANT text :=
     'public.comment_attachment_summaries(text[])';
+  owns_reaction boolean := false;
+  owns_attachment boolean := false;
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'life_ustc_runtime') THEN
     RAISE NOTICE
@@ -24,47 +29,62 @@ BEGIN
     RETURN;
   END IF;
 
-  IF to_regprocedure(reaction_signature) IS NOT NULL THEN
-    BEGIN
-      EXECUTE format(
-        'GRANT EXECUTE ON FUNCTION %s TO life_ustc_runtime',
-        reaction_signature
-      );
-    EXCEPTION
-      WHEN insufficient_privilege THEN
-        RAISE NOTICE
-          'Could not GRANT EXECUTE on comment_reaction_summaries; re-run roles bootstrap.';
-    END;
+  owns_reaction :=
+    to_regprocedure(reaction_signature) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM pg_proc AS p
+      JOIN pg_namespace AS n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public'
+        AND p.proname = 'comment_reaction_summaries'
+        AND pg_get_userbyid(p.proowner) = current_user
+    );
+
+  owns_attachment :=
+    to_regprocedure(attachment_signature) IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM pg_proc AS p
+      JOIN pg_namespace AS n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public'
+        AND p.proname = 'comment_attachment_summaries'
+        AND pg_get_userbyid(p.proowner) = current_user
+    );
+
+  IF to_regprocedure(reaction_signature) IS NOT NULL AND NOT owns_reaction THEN
+    RAISE NOTICE
+      'comment_reaction_summaries is not owned by %; leaving privileges to the roles bootstrap.',
+      current_user;
+  ELSIF owns_reaction THEN
+    EXECUTE format(
+      'GRANT EXECUTE ON FUNCTION %s TO life_ustc_runtime',
+      reaction_signature
+    );
   END IF;
 
-  IF to_regprocedure(attachment_signature) IS NOT NULL THEN
-    BEGIN
-      EXECUTE format(
-        'GRANT EXECUTE ON FUNCTION %s TO life_ustc_runtime',
-        attachment_signature
-      );
-    EXCEPTION
-      WHEN insufficient_privilege THEN
-        RAISE NOTICE
-          'Could not GRANT EXECUTE on comment_attachment_summaries; re-run roles bootstrap.';
-    END;
+  IF to_regprocedure(attachment_signature) IS NOT NULL AND NOT owns_attachment THEN
+    RAISE NOTICE
+      'comment_attachment_summaries is not owned by %; leaving privileges to the roles bootstrap.',
+      current_user;
+  ELSIF owns_attachment THEN
+    EXECUTE format(
+      'GRANT EXECUTE ON FUNCTION %s TO life_ustc_runtime',
+      attachment_signature
+    );
   END IF;
 
-  -- Definer policies created as TO CURRENT_USER (the migrator) must follow the
-  -- current owner so SECURITY DEFINER helpers keep reading under FORCE RLS.
-  IF EXISTS (
-    SELECT 1 FROM pg_policy WHERE polname = 'CommentReaction_summary_reader'
-  ) THEN
-    BEGIN
-      EXECUTE format(
-        'ALTER POLICY "CommentReaction_summary_reader" ON "CommentReaction" TO %I',
-        current_user
-      );
-    EXCEPTION
-      WHEN insufficient_privilege OR undefined_object THEN
-        RAISE NOTICE
-          'Could not retarget CommentReaction_summary_reader; leaving to roles bootstrap.';
-    END;
+  -- Only retarget the summary-reader policy when we still own the reaction
+  -- helper. Otherwise the policy is already (or must stay) bound to
+  -- `life_ustc_function_owner` from the roles bootstrap.
+  IF owns_reaction
+    AND EXISTS (
+      SELECT 1 FROM pg_policy WHERE polname = 'CommentReaction_summary_reader'
+    )
+  THEN
+    EXECUTE format(
+      'ALTER POLICY "CommentReaction_summary_reader" ON "CommentReaction" TO %I',
+      current_user
+    );
   END IF;
 END
 $do$;

--- a/prisma/migrations/20260807143000_comment_summary_runtime_grants/migration.sql
+++ b/prisma/migrations/20260807143000_comment_summary_runtime_grants/migration.sql
@@ -1,0 +1,72 @@
+BEGIN;
+
+-- `comment_reaction_summaries` / `comment_attachment_summaries` revoke EXECUTE
+-- from PUBLIC when created. Production bootstrap grants them to
+-- `life_ustc_runtime`, but where that bootstrap has not been re-run since the
+-- functions were introduced the app role never received EXECUTE. Comment list
+-- then fails with Prisma P2010 (raw query failed) on every thread that hits
+-- the summary helpers.
+--
+-- Prefer an unconditional GRANT when we can. If ownership already moved to
+-- `life_ustc_function_owner` and the migrator lacks privilege, notice and leave
+-- the roles bootstrap responsible (same pattern as comment_hidden_root_count).
+
+DO $do$
+DECLARE
+  reaction_signature CONSTANT text :=
+    'public.comment_reaction_summaries(text[])';
+  attachment_signature CONSTANT text :=
+    'public.comment_attachment_summaries(text[])';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'life_ustc_runtime') THEN
+    RAISE NOTICE
+      'Skipping comment summary grants; role life_ustc_runtime does not exist.';
+    RETURN;
+  END IF;
+
+  IF to_regprocedure(reaction_signature) IS NOT NULL THEN
+    BEGIN
+      EXECUTE format(
+        'GRANT EXECUTE ON FUNCTION %s TO life_ustc_runtime',
+        reaction_signature
+      );
+    EXCEPTION
+      WHEN insufficient_privilege THEN
+        RAISE NOTICE
+          'Could not GRANT EXECUTE on comment_reaction_summaries; re-run roles bootstrap.';
+    END;
+  END IF;
+
+  IF to_regprocedure(attachment_signature) IS NOT NULL THEN
+    BEGIN
+      EXECUTE format(
+        'GRANT EXECUTE ON FUNCTION %s TO life_ustc_runtime',
+        attachment_signature
+      );
+    EXCEPTION
+      WHEN insufficient_privilege THEN
+        RAISE NOTICE
+          'Could not GRANT EXECUTE on comment_attachment_summaries; re-run roles bootstrap.';
+    END;
+  END IF;
+
+  -- Definer policies created as TO CURRENT_USER (the migrator) must follow the
+  -- current owner so SECURITY DEFINER helpers keep reading under FORCE RLS.
+  IF EXISTS (
+    SELECT 1 FROM pg_policy WHERE polname = 'CommentReaction_summary_reader'
+  ) THEN
+    BEGIN
+      EXECUTE format(
+        'ALTER POLICY "CommentReaction_summary_reader" ON "CommentReaction" TO %I',
+        current_user
+      );
+    EXCEPTION
+      WHEN insufficient_privilege OR undefined_object THEN
+        RAISE NOTICE
+          'Could not retarget CommentReaction_summary_reader; leaving to roles bootstrap.';
+    END;
+  END IF;
+END
+$do$;
+
+COMMIT;

--- a/src/features/calendar/server/calendar-export-cache.ts
+++ b/src/features/calendar/server/calendar-export-cache.ts
@@ -6,7 +6,9 @@ import { sha256Base64Url } from "@/lib/crypto/web-crypto";
 import { writeCalendarFeedCacheAnalytics } from "@/lib/metrics/analytics-engine";
 
 const USER_CALENDAR_EXPORT_CACHE_VERSION = 1;
-export const USER_CALENDAR_EXPORT_FRESH_TTL_MS = 5 * 60_000;
+// Keep feeds "fresh" longer so calendar clients that poll often do not force a
+// rebuild on every hit after 5 minutes. Writes still invalidate the cache.
+export const USER_CALENDAR_EXPORT_FRESH_TTL_MS = 30 * 60_000;
 export const USER_CALENDAR_EXPORT_STALE_TTL_MS = 24 * 60 * 60_000;
 const USER_CALENDAR_EXPORT_KV_CACHE_TTL_SECONDS = 3_600;
 const USER_CALENDAR_EXPORT_KV_EXPIRATION_TTL_SECONDS =
@@ -186,17 +188,6 @@ function refreshUserCalendarExport(
   return refresh;
 }
 
-function backgroundRefresh(
-  refresh: Promise<UserCalendarExportWithEtag | null>,
-) {
-  return refresh.then(
-    () => undefined,
-    () => {
-      recordCalendarFeedCacheStatus("refresh_error");
-    },
-  );
-}
-
 export async function getCachedUserCalendarExport(
   userId: string,
   buildExport: () => Promise<UserCalendarExport | null>,
@@ -217,9 +208,12 @@ export async function getCachedUserCalendarExport(
     }
 
     if (ageMs <= USER_CALENDAR_EXPORT_STALE_TTL_MS) {
-      const refresh = refreshUserCalendarExport(userId, buildExport);
+      // Do not rebuild ICS inside waitUntil/defer. Production showed Worker wall
+      // ~12s / CPU p95 ~3s on this path (cpu_ms limit 1000) while the response
+      // itself returned in ~100ms — calendar clients re-poll and the deferred
+      // rebuilds cancel or hit the CPU limit. Freshness comes from write-time
+      // invalidation plus a sync rebuild once the entry is past STALE_TTL.
       if (options.defer) {
-        options.defer(backgroundRefresh(refresh));
         recordCalendarFeedCacheStatus("stale");
         return {
           calendar: cached,
@@ -228,7 +222,7 @@ export async function getCachedUserCalendarExport(
       }
 
       try {
-        const refreshed = await refresh;
+        const refreshed = await refreshUserCalendarExport(userId, buildExport);
         if (refreshed) {
           return {
             calendar: refreshed,

--- a/src/features/calendar/server/calendar-export-service.ts
+++ b/src/features/calendar/server/calendar-export-service.ts
@@ -54,7 +54,7 @@ export async function buildUserCalendarExport(
   });
 
   return {
-    cacheControl: "private, max-age=300",
+    cacheControl: "private, max-age=1800",
     filename: "life-ustc-subscriptions.ics",
     text: calendar.toString(),
   };

--- a/src/features/dashboard/server/dashboard-page-tab-data.ts
+++ b/src/features/dashboard/server/dashboard-page-tab-data.ts
@@ -17,21 +17,30 @@ export async function timeDashboardStage<T>(
 ) {
   const startMs = Date.now();
   let status: "error" | "ok" = "error";
+  let stageError: unknown;
   try {
     const result = await work();
     status = "ok";
     return result;
+  } catch (error) {
+    stageError = error;
+    throw error;
   } finally {
-    logAppEvent(status === "ok" ? "info" : "warn", "dashboard.load.stage", {
-      event: "dashboard.load.stage",
-      ioObservedDurationMs: Date.now() - startMs,
-      requestId: input.requestId,
-      source: "dashboard",
-      stage,
-      status,
-      subscribedSectionCount: input.subscribedSectionCount,
-      tab: input.tab,
-    });
+    logAppEvent(
+      status === "ok" ? "info" : "warn",
+      "dashboard.load.stage",
+      {
+        event: "dashboard.load.stage",
+        ioObservedDurationMs: Date.now() - startMs,
+        requestId: input.requestId,
+        source: "dashboard",
+        stage,
+        status,
+        subscribedSectionCount: input.subscribedSectionCount,
+        tab: input.tab,
+      },
+      stageError,
+    );
   }
 }
 

--- a/src/features/subscriptions/server/subscription-calendar-read-model.ts
+++ b/src/features/subscriptions/server/subscription-calendar-read-model.ts
@@ -1,6 +1,7 @@
 import { sectionCompactInclude } from "@/features/catalog/server/academic-query-includes";
 import { type AppLocale, DEFAULT_LOCALE } from "@/i18n/config";
 import { prisma, withUserDbContext } from "@/lib/db/prisma";
+import { logAppEvent } from "@/lib/log/app-logger";
 import { getPublicOrigin } from "@/lib/site-url";
 import {
   buildCalendarFeedPath,
@@ -79,13 +80,28 @@ export async function getCalendarSubscriptionUrl(
   userId: string,
   calendarFeedToken?: string | null,
 ) {
-  if (calendarFeedToken !== undefined) {
-    return buildCalendarFeedPath(userId, calendarFeedToken);
+  try {
+    if (calendarFeedToken !== undefined) {
+      return await buildCalendarFeedPath(userId, calendarFeedToken);
+    }
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, calendarFeedToken: true },
+    });
+    if (!user) return null;
+    return await buildCalendarFeedPath(user.id, user.calendarFeedToken);
+  } catch (error) {
+    // Token minting can fail on missing column grants; empty subscription SSR
+    // should still render instead of 500ing the whole workspace tab.
+    logAppEvent(
+      "warn",
+      "calendar.subscription-url.failed",
+      {
+        event: "calendar.subscription-url.failed",
+        source: "subscriptions",
+      },
+      error,
+    );
+    return null;
   }
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { id: true, calendarFeedToken: true },
-  });
-  if (!user) return null;
-  return buildCalendarFeedPath(user.id, user.calendarFeedToken);
 }

--- a/src/lib/log/app-logger-core.ts
+++ b/src/lib/log/app-logger-core.ts
@@ -38,15 +38,38 @@ const SQLSTATE_CODE_PATTERN = /^[0-9A-Z]{5}$/;
  * identifiers with no request data in them, so they are safe to keep in
  * production where the message is not. Without the code a production
  * permission or constraint failure is undiagnosable.
+ *
+ * Walk `cause` / Prisma `meta` because driver-adapter failures often nest the
+ * real SQLSTATE under the top-level Prisma wrapper.
  */
-function safeDatabaseErrorCode(error: unknown) {
-  if (typeof error !== "object" || error === null || !("code" in error)) {
+function safeDatabaseErrorCode(error: unknown, depth = 0): string | undefined {
+  if (depth > 5 || typeof error !== "object" || error === null) {
     return undefined;
   }
-  const { code } = error as { code: unknown };
-  if (typeof code !== "string") return undefined;
-  if (PRISMA_ERROR_CODE_PATTERN.test(code)) return code;
-  if (SQLSTATE_CODE_PATTERN.test(code)) return code;
+
+  if ("code" in error) {
+    const { code } = error as { code: unknown };
+    if (typeof code === "string") {
+      if (PRISMA_ERROR_CODE_PATTERN.test(code)) return code;
+      if (SQLSTATE_CODE_PATTERN.test(code)) return code;
+    }
+  }
+
+  if ("meta" in error) {
+    const fromMeta = safeDatabaseErrorCode(
+      (error as { meta: unknown }).meta,
+      depth + 1,
+    );
+    if (fromMeta) return fromMeta;
+  }
+
+  if ("cause" in error) {
+    return safeDatabaseErrorCode(
+      (error as { cause: unknown }).cause,
+      depth + 1,
+    );
+  }
+
   return undefined;
 }
 

--- a/src/lib/log/safe-error-name.ts
+++ b/src/lib/log/safe-error-name.ts
@@ -48,13 +48,26 @@ function normalizeSafeErrorName(name: string) {
   return name;
 }
 
-export function getSafeErrorName(error: unknown) {
-  const name = readErrorName(error);
-  if (!name) return "UnknownError";
+export function getSafeErrorName(error: unknown, depth = 0): string {
+  if (depth > 5) return "UnknownError";
 
-  const normalized = normalizeSafeErrorName(name);
-  if (!SAFE_ERROR_NAMES.has(normalized)) {
-    return "UnknownError";
+  const name = readErrorName(error);
+  if (name) {
+    const normalized = normalizeSafeErrorName(name);
+    if (SAFE_ERROR_NAMES.has(normalized)) {
+      return normalized;
+    }
   }
-  return normalized;
+
+  if (typeof error === "object" && error !== null && "cause" in error) {
+    const nested = getSafeErrorName(
+      (error as { cause: unknown }).cause,
+      depth + 1,
+    );
+    if (nested !== "UnknownError") {
+      return nested;
+    }
+  }
+
+  return "UnknownError";
 }

--- a/tests/unit/app-logger.test.ts
+++ b/tests/unit/app-logger.test.ts
@@ -129,4 +129,56 @@ describe("应用日志记录器", () => {
       route: "/api/todos/:id",
     });
   });
+
+  it("生产环境保留嵌套 cause / meta 上的数据库错误码", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const cause = Object.assign(new Error("permission denied"), {
+      code: "42501",
+      name: "error",
+    });
+    const prismaError = Object.assign(new Error("raw query failed"), {
+      cause,
+      code: "P2010",
+      name: "PrismaClientKnownRequestError",
+    });
+
+    logRouteFailure("Failed to fetch comments", 500, prismaError, {
+      route: "/api/community/comments",
+    });
+
+    const [payload] = errorSpy.mock.calls[0] ?? [];
+    expect(JSON.parse(String(payload))).toMatchObject({
+      error: {
+        code: "P2010",
+        name: "PrismaClientKnownRequestError",
+      },
+    });
+    expect(String(payload)).not.toContain("permission denied");
+  });
+
+  it("生产环境从仅含 cause SQLSTATE 的包装错误提取 code", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const cause = Object.assign(new Error("permission denied for function"), {
+      code: "42501",
+      name: "error",
+    });
+    const wrapper = Object.assign(new Error("wrapped"), {
+      cause,
+      name: "DriverAdapterError",
+    });
+
+    logRouteFailure("Failed to fetch comments", 500, wrapper);
+
+    const [payload] = errorSpy.mock.calls[0] ?? [];
+    expect(JSON.parse(String(payload))).toMatchObject({
+      error: {
+        code: "42501",
+        name: "DriverAdapterError",
+      },
+    });
+  });
 });

--- a/tests/unit/calendar-export-cache.test.ts
+++ b/tests/unit/calendar-export-cache.test.ts
@@ -9,7 +9,7 @@ import {
 import { setCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
 
 const calendarExport = {
-  cacheControl: "private, max-age=300",
+  cacheControl: "private, max-age=1800",
   filename: "life-ustc-subscriptions.ics",
   text: "BEGIN:VCALENDAR\nEND:VCALENDAR",
 };
@@ -80,7 +80,7 @@ describe("用户 iCal 导出缓存", () => {
     expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain("user-1");
   });
 
-  it("stale 导出立即返回并通过 defer 后台刷新", async () => {
+  it("stale 导出立即返回且不通过 defer 后台重建", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-07T00:00:00.000Z"));
     const namespace = kvNamespace();
@@ -102,11 +102,12 @@ describe("用户 iCal 导出缓存", () => {
 
     expect(stale.status).toBe("stale");
     expect(stale.calendar?.text).toBe(calendarExport.text);
-    expect(tasks).toHaveLength(1);
+    expect(tasks).toHaveLength(0);
+    expect(buildExport).toHaveBeenCalledTimes(1);
 
-    await tasks[0];
+    // Without defer (e.g. local/Node), stale still rebuilds synchronously.
     const refreshed = await getCachedUserCalendarExport("user-1", buildExport);
-    expect(refreshed.status).toBe("fresh");
+    expect(refreshed.status).toBe("miss");
     expect(refreshed.calendar?.text).toContain("X-UPDATED:1");
     expect(buildExport).toHaveBeenCalledTimes(2);
   });
@@ -160,7 +161,7 @@ describe("用户 iCal 导出缓存", () => {
     expect(namespace.put).toHaveBeenCalledTimes(1);
   });
 
-  it("后台刷新失败时继续返回 stale 导出", async () => {
+  it("无 defer 时同步刷新失败仍返回 stale 导出", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-07T00:00:00.000Z"));
     const buildExport = vi
@@ -170,14 +171,11 @@ describe("用户 iCal 导出缓存", () => {
 
     await getCachedUserCalendarExport("user-1", buildExport);
     vi.advanceTimersByTime(USER_CALENDAR_EXPORT_FRESH_TTL_MS + 1);
-    const tasks: Promise<unknown>[] = [];
-    const stale = await getCachedUserCalendarExport("user-1", buildExport, {
-      defer: (promise) => tasks.push(promise),
-    });
+    const stale = await getCachedUserCalendarExport("user-1", buildExport);
 
-    await expect(tasks[0]).resolves.toBeUndefined();
     expect(stale.status).toBe("stale");
     expect(stale.calendar?.text).toBe(calendarExport.text);
+    expect(buildExport).toHaveBeenCalledTimes(2);
   });
 
   it("KV 不可用时仍使用 isolate 内存缓存", async () => {

--- a/tests/unit/calendar-feed-token.test.ts
+++ b/tests/unit/calendar-feed-token.test.ts
@@ -18,6 +18,10 @@ vi.mock("@/lib/db/prisma", () => ({
   },
 }));
 
+vi.mock("@/lib/log/app-logger", () => ({
+  logAppEvent: vi.fn(),
+}));
+
 const findUniqueMock = vi.mocked(prisma.user.findUnique);
 const randomBytesBase64UrlMock = vi.mocked(randomBytesBase64Url);
 const updateMock = vi.mocked(prisma.user.update);
@@ -117,5 +121,20 @@ describe("getCalendarSubscriptionUrl 日历订阅地址", () => {
       where: { id: "user-1" },
       select: { id: true, calendarFeedToken: true },
     });
+  });
+
+  it("令牌写入失败时返回 null 而不抛出", async () => {
+    findUniqueMock.mockResolvedValueOnce(userWithToken(null));
+    randomBytesBase64UrlMock.mockReturnValue("generated-token");
+    updateManyMock.mockRejectedValueOnce(
+      Object.assign(new Error("permission denied"), {
+        code: "42501",
+        name: "error",
+      }),
+    );
+
+    await expect(
+      getCalendarSubscriptionUrl("user-1", null),
+    ).resolves.toBeNull();
   });
 });

--- a/tests/unit/calendar-route-actions.test.ts
+++ b/tests/unit/calendar-route-actions.test.ts
@@ -41,7 +41,7 @@ describe("personal calendar route cache ordering", () => {
   it("does not load calendar relations when the rendered export is cached", async () => {
     getCachedExportMock.mockResolvedValue({
       calendar: {
-        cacheControl: "private, max-age=300",
+        cacheControl: "private, max-age=1800",
         etag: '"sha256-cached"',
         filename: "life-ustc-subscriptions.ics",
         text: "BEGIN:VCALENDAR\nEND:VCALENDAR",
@@ -66,7 +66,7 @@ describe("personal calendar route cache ordering", () => {
     const user = { id: "user-1", sectionSubscriptions: [], todos: [] };
     getUserRecordMock.mockResolvedValue(user);
     buildUserCalendarExportMock.mockResolvedValue({
-      cacheControl: "private, max-age=300",
+      cacheControl: "private, max-age=1800",
       filename: "life-ustc-subscriptions.ics",
       text: "BEGIN:VCALENDAR\nEND:VCALENDAR",
     });

--- a/tests/unit/dashboard-subscription-calendar-token.test.ts
+++ b/tests/unit/dashboard-subscription-calendar-token.test.ts
@@ -109,4 +109,40 @@ describe("dashboard subscription calendar token reuse", () => {
       sectionIds: [12],
     });
   });
+
+  it("records the thrown error on a failed dashboard stage", async () => {
+    const { logAppEvent } = await import("@/lib/log/app-logger");
+    const { timeDashboardStage } = await import(
+      "@/features/dashboard/server/dashboard-page-tab-data"
+    );
+    const stageError = Object.assign(new Error("permission denied"), {
+      code: "P2010",
+      name: "PrismaClientKnownRequestError",
+    });
+
+    await expect(
+      timeDashboardStage(
+        "subscriptions",
+        {
+          requestId: "request-1",
+          subscribedSectionCount: 0,
+          tab: "subscriptions",
+        },
+        async () => {
+          throw stageError;
+        },
+      ),
+    ).rejects.toBe(stageError);
+
+    expect(logAppEvent).toHaveBeenCalledWith(
+      "warn",
+      "dashboard.load.stage",
+      expect.objectContaining({
+        stage: "subscriptions",
+        status: "error",
+        subscribedSectionCount: 0,
+      }),
+      stageError,
+    );
+  });
 });

--- a/tests/unit/safe-error-name.test.ts
+++ b/tests/unit/safe-error-name.test.ts
@@ -30,4 +30,14 @@ describe("safe error names", () => {
   it("rejects non-errors", () => {
     expect(getSafeErrorName("private detail")).toBe("UnknownError");
   });
+
+  it("walks cause for allowlisted nested names", () => {
+    const cause = new Error("permission denied");
+    cause.name = "PrismaClientKnownRequestError";
+    const wrapper = new Error("route failed");
+    wrapper.name = "ApiKeyABC123";
+    (wrapper as Error & { cause: Error }).cause = cause;
+
+    expect(getSafeErrorName(wrapper)).toBe("PrismaClientKnownRequestError");
+  });
 });

--- a/tests/unit/wrangler-rate-limit-config.test.ts
+++ b/tests/unit/wrangler-rate-limit-config.test.ts
@@ -38,20 +38,28 @@ describe("Wrangler mutation rate-limit bindings", () => {
     ]);
   });
 
-  it("keeps public workers.dev and automatic request metadata logs disabled", async () => {
+  it("keeps public workers.dev disabled and enables invocation logs for CPU diagnosis", async () => {
     const source = await readFile(
       new URL("../../wrangler.jsonc", import.meta.url),
       "utf8",
     );
     const config = JSON.parse(source) as {
-      observability?: { logs?: { invocation_logs?: boolean } };
+      observability?: {
+        logs?: {
+          head_sampling_rate?: number;
+          invocation_logs?: boolean;
+        };
+        traces?: { head_sampling_rate?: number };
+      };
       preview_urls?: boolean;
       workers_dev?: boolean;
     };
 
     expect(config.preview_urls).toBe(false);
     expect(config.workers_dev).toBe(false);
-    expect(config.observability?.logs?.invocation_logs).toBe(false);
+    expect(config.observability?.logs?.invocation_logs).toBe(true);
+    expect(config.observability?.logs?.head_sampling_rate).toBe(0.5);
+    expect(config.observability?.traces?.head_sampling_rate).toBe(0.1);
   });
 
   it("uploads production source maps for trace and exception symbolication", async () => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -34,13 +34,13 @@
     "enabled": true,
     "logs": {
       "enabled": true,
-      "head_sampling_rate": 0.25,
-      "invocation_logs": false,
+      "head_sampling_rate": 0.5,
+      "invocation_logs": true,
       "persist": true
     },
     "traces": {
       "enabled": true,
-      "head_sampling_rate": 0.05
+      "head_sampling_rate": 0.1
     }
   },
   "routes": [


### PR DESCRIPTION
## Summary
Follow-up to Cloudflare Observability review of `life-ustc`.

- **Calendar feeds:** stop rebuilding ICS inside `waitUntil` on stale hits (was ~12s wall / ~3s CPU p95 vs `cpu_ms: 1000`); extend fresh TTL to 30m; rely on write-time invalidation + sync rebuild after stale TTL.
- **Comments:** migration granting `EXECUTE` on `comment_reaction_summaries` / `comment_attachment_summaries` to `life_ustc_runtime` (Prisma **P2010** on `/api/community/comments`).
- **Subscriptions SSR:** soft-fail calendar URL minting so empty-subscription tabs render instead of 500.
- **Observability:** log the thrown error from `timeDashboardStage`; walk nested `cause`/`meta` for Prisma/SQLSTATE codes; enable invocation logs and raise log/trace sampling.

## Test plan
- [x] `bunx vitest run` on calendar cache/token, dashboard stage, app-logger, safe-error-name, calendar-route-actions
- [ ] Deploy migration `20260807143000_comment_summary_runtime_grants` (or re-run roles bootstrap if migrator cannot GRANT)
- [ ] After deploy, confirm calendar feed Worker wall/CPU and `waitUntil` cancellations drop in Observability
- [ ] Confirm `/api/community/comments` no longer returns 500 with P2010
- [ ] Confirm `/workspace/subscriptions` with zero subscriptions loads