### PR TITLE
feat(catalog): refresh campus link catalog

### DIFF
--- a/src/features/dashboard-links/lib/dashboard-link-catalog-campus-community.ts
+++ b/src/features/dashboard-links/lib/dashboard-link-catalog-campus-community.ts
@@ -156,6 +156,20 @@ export const USTC_CAMPUS_COMMUNITY_LINKS: DashboardLinkItem[] = [
     icon: "monitor-play",
   },
   {
+    slug: "llm-platform",
+    title: "大模型公共服务平台",
+    url: "https://llm.ustc.edu.cn/",
+    description: "校内大模型对话与 API 服务。",
+    localizations: {
+      "en-us": {
+        title: "Large Model Public Service Platform",
+        description: "Campus large-model chat and API services.",
+      },
+    },
+    category: "services",
+    icon: "monitor-play",
+  },
+  {
     slug: "classroom-2",
     title: "二教",
     url: "http://bigscreen.cmet.ustc.edu.cn/#/2",

--- a/src/features/dashboard-links/lib/dashboard-link-catalog-essential.ts
+++ b/src/features/dashboard-links/lib/dashboard-link-catalog-essential.ts
@@ -142,20 +142,6 @@ export const USTC_ESSENTIAL_LINKS: DashboardLinkItem[] = [
     icon: "building",
   },
   {
-    slug: "legacy-jw",
-    title: "旧版教务系统",
-    url: "https://mis.teach.ustc.edu.cn/",
-    description: "历史教务系统入口。",
-    localizations: {
-      "en-us": {
-        title: "Legacy Academic Affairs System",
-        description: "Entry point for the legacy academic affairs system.",
-      },
-    },
-    category: "academic",
-    icon: "clipboard-list",
-  },
-  {
     slug: "physics-lab-1",
     title: "大物实验 1",
     url: "https://jxzy.ustc.edu.cn/",

--- a/src/features/dashboard-links/lib/dashboard-link-catalog-graduate-support.ts
+++ b/src/features/dashboard-links/lib/dashboard-link-catalog-graduate-support.ts
@@ -88,7 +88,7 @@ export const USTC_GRADUATE_AND_SUPPORT_LINKS: DashboardLinkItem[] = [
   {
     slug: "payment-system",
     title: "网上缴费系统",
-    url: "https://sf.ustc.edu.cn/",
+    url: "https://cwjf.ustc.edu.cn/payment/",
     description: "校内缴费服务平台。",
     localizations: {
       "en-us": {

--- a/src/features/dashboard-links/lib/dashboard-link-catalog.ts
+++ b/src/features/dashboard-links/lib/dashboard-link-catalog.ts
@@ -100,7 +100,6 @@ export const DASHBOARD_LINK_GROUPS: Record<DashboardLinkGroup, string[]> = {
   ],
   study: [
     "staff-homepage",
-    "legacy-jw",
     "physics-lab-1",
     "catalog-query",
     "ta-management",
@@ -136,6 +135,7 @@ export const DASHBOARD_LINK_GROUPS: Record<DashboardLinkGroup, string[]> = {
     "lug-gitlab",
     "ustc-latex",
     "vlab",
+    "llm-platform",
   ],
   classroom: ["classroom-2", "classroom-3", "classroom-5"],
   external: ["zhihu", "bilibili", "weibo"],

--- a/tests/unit/dashboard-links.test.ts
+++ b/tests/unit/dashboard-links.test.ts
@@ -4,7 +4,6 @@ import {
   searchQueryToTokens,
 } from "@/features/dashboard-links/lib/dashboard-link-search";
 import {
-  DASHBOARD_LINK_GROUPS,
   localizeDashboardLink,
   recommendDashboardLinks,
   USTC_DASHBOARD_LINKS,
@@ -53,32 +52,6 @@ describe("仪表盘链接推荐", () => {
       expect(link.localizations["en-us"]?.title, link.slug).toBeTruthy();
       expect(link.localizations["en-us"]?.description, link.slug).toBeTruthy();
     }
-  });
-
-  it("目录与分组中的链接保持同步", () => {
-    const catalogSlugs = USTC_DASHBOARD_LINKS.map((link) => link.slug);
-    const groupedSlugs = Object.values(DASHBOARD_LINK_GROUPS).flat();
-
-    expect(new Set(catalogSlugs).size).toBe(catalogSlugs.length);
-    expect(new Set(groupedSlugs).size).toBe(groupedSlugs.length);
-    expect(groupedSlugs.toSorted()).toEqual(catalogSlugs.toSorted());
-  });
-
-  it("包含大模型平台并清理已停用入口", () => {
-    expect(
-      USTC_DASHBOARD_LINKS.find((link) => link.slug === "llm-platform"),
-    ).toMatchObject({
-      title: "大模型公共服务平台",
-      url: "https://llm.ustc.edu.cn/",
-    });
-    expect(
-      USTC_DASHBOARD_LINKS.find((link) => link.slug === "payment-system"),
-    ).toMatchObject({
-      url: "https://cwjf.ustc.edu.cn/payment/",
-    });
-    expect(USTC_DASHBOARD_LINKS.some((link) => link.slug === "legacy-jw")).toBe(
-      false,
-    );
   });
 
   it("按地区设置投影仪表盘链接标签", () => {

--- a/tests/unit/dashboard-links.test.ts
+++ b/tests/unit/dashboard-links.test.ts
@@ -76,9 +76,9 @@ describe("仪表盘链接推荐", () => {
     ).toMatchObject({
       url: "https://cwjf.ustc.edu.cn/payment/",
     });
-    expect(
-      USTC_DASHBOARD_LINKS.some((link) => link.slug === "legacy-jw"),
-    ).toBe(false);
+    expect(USTC_DASHBOARD_LINKS.some((link) => link.slug === "legacy-jw")).toBe(
+      false,
+    );
   });
 
   it("按地区设置投影仪表盘链接标签", () => {

--- a/tests/unit/dashboard-links.test.ts
+++ b/tests/unit/dashboard-links.test.ts
@@ -4,6 +4,7 @@ import {
   searchQueryToTokens,
 } from "@/features/dashboard-links/lib/dashboard-link-search";
 import {
+  DASHBOARD_LINK_GROUPS,
   localizeDashboardLink,
   recommendDashboardLinks,
   USTC_DASHBOARD_LINKS,
@@ -52,6 +53,32 @@ describe("仪表盘链接推荐", () => {
       expect(link.localizations["en-us"]?.title, link.slug).toBeTruthy();
       expect(link.localizations["en-us"]?.description, link.slug).toBeTruthy();
     }
+  });
+
+  it("目录与分组中的链接保持同步", () => {
+    const catalogSlugs = USTC_DASHBOARD_LINKS.map((link) => link.slug);
+    const groupedSlugs = Object.values(DASHBOARD_LINK_GROUPS).flat();
+
+    expect(new Set(catalogSlugs).size).toBe(catalogSlugs.length);
+    expect(new Set(groupedSlugs).size).toBe(groupedSlugs.length);
+    expect(groupedSlugs.toSorted()).toEqual(catalogSlugs.toSorted());
+  });
+
+  it("包含大模型平台并清理已停用入口", () => {
+    expect(
+      USTC_DASHBOARD_LINKS.find((link) => link.slug === "llm-platform"),
+    ).toMatchObject({
+      title: "大模型公共服务平台",
+      url: "https://llm.ustc.edu.cn/",
+    });
+    expect(
+      USTC_DASHBOARD_LINKS.find((link) => link.slug === "payment-system"),
+    ).toMatchObject({
+      url: "https://cwjf.ustc.edu.cn/payment/",
+    });
+    expect(
+      USTC_DASHBOARD_LINKS.some((link) => link.slug === "legacy-jw"),
+    ).toBe(false);
   });
 
   it("按地区设置投影仪表盘链接标签", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

Add the USTC large-model public service platform and refresh catalog entries confirmed to be obsolete or superseded.

## Changed Surfaces

- Added `https://llm.ustc.edu.cn/` to the technology links group with Chinese and English labels.
- Removed the retired legacy academic affairs entry; current academic affairs uses `jw.ustc.edu.cn`.
- Updated the payment-system target to the currently documented `cwjf.ustc.edu.cn/payment/` endpoint.

## Evidence

- Live probe of all 58 existing catalog targets, followed by checks against current USTC pages for inconclusive or stale entries.
- `bunx vitest run tests/unit/dashboard-links.test.ts` — 6 passed.
- `bunx biome check <five changed files>` — passed.
- Partial hard-coded catalog assertions were removed: they did not comprehensively validate the catalog and external availability is unsuitable for deterministic unit tests.

## Docs / Contracts

No contract change needed: link schemas, routes, and capabilities are unchanged; this only refreshes curated catalog data.

## Risk Areas

Low. No auth, persistence, API shape, generated output, or dependency changes. Some campus sites restrict access by network location, so inconclusive external failures were not removed.

## Cleanup

No scratch files, generated-file edits, or unrelated rewrites remain.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ff56f50-3d9a-4a39-af4d-a145abe65893?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ff56f50-3d9a-4a39-af4d-a145abe65893&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

