### PR TITLE
test(db): blocked identity migration dry-runs

### DIFF
--- a/.github/workflows/static-identity-migration.yml
+++ b/.github/workflows/static-identity-migration.yml
@@ -77,10 +77,12 @@ jobs:
         run: bun run static:migrate-identities
 
       - name: Report migration plan
-        if: success()
+        if: always()
         run: |
-          echo '## Static Identity Migration' >> "$GITHUB_STEP_SUMMARY"
-          echo '```json' >> "$GITHUB_STEP_SUMMARY"
-          cat /tmp/static-identity-migration-report.json >> "$GITHUB_STEP_SUMMARY"
-          echo '' >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          if test -f /tmp/static-identity-migration-report.json; then
+            echo '## Static Identity Migration' >> "$GITHUB_STEP_SUMMARY"
+            echo '```json' >> "$GITHUB_STEP_SUMMARY"
+            cat /tmp/static-identity-migration-report.json >> "$GITHUB_STEP_SUMMARY"
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/src/static-loader/identity-migration-cli.ts
+++ b/src/static-loader/identity-migration-cli.ts
@@ -5,6 +5,7 @@ import {
   IdentityMigrationBlockedError,
   runIdentityMigration,
 } from "./identity-migration/runner";
+import type { IdentityMigrationPlan } from "./identity-migration/types";
 import { createPrismaClient } from "./prisma";
 import {
   parseBooleanSetting,
@@ -18,6 +19,26 @@ function requiredEnvironment(name: string) {
     throw new Error(`Environment variable ${name} is required`);
   }
   return value;
+}
+
+const MAX_REPORTED_BLOCKERS = 100;
+
+function summarizePlan(plan: IdentityMigrationPlan) {
+  return {
+    report: plan.report,
+    blockers: plan.blockers.slice(0, MAX_REPORTED_BLOCKERS),
+    omittedBlockerCount: Math.max(
+      0,
+      plan.blockers.length - MAX_REPORTED_BLOCKERS,
+    ),
+  };
+}
+
+async function writeReport(report: unknown) {
+  const serialized = JSON.stringify(report, null, 2);
+  console.log(serialized);
+  const reportPath = process.env.STATIC_IDENTITY_MIGRATION_REPORT_FILE;
+  if (reportPath) await writeFile(reportPath, serialized);
 }
 
 async function main() {
@@ -52,14 +73,20 @@ async function main() {
       dryRun,
       minSemester,
     });
-    console.log(JSON.stringify(report, null, 2));
-    const reportPath = process.env.STATIC_IDENTITY_MIGRATION_REPORT_FILE;
-    if (reportPath) {
-      await writeFile(reportPath, JSON.stringify(report, null, 2));
-    }
+    await writeReport({
+      mode: report.mode,
+      outcome: report.outcome,
+      ...summarizePlan(report.plan),
+      applied: report.applied,
+    });
   } catch (error) {
     if (error instanceof IdentityMigrationBlockedError) {
-      console.error(JSON.stringify(error.plan, null, 2));
+      await writeReport({
+        mode: dryRun ? "dry-run" : "apply",
+        outcome: "blocked",
+        ...summarizePlan(error.plan),
+        applied: null,
+      });
     }
     throw error;
   } finally {
@@ -68,6 +95,9 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error("Identity migration failed:", error);
+  console.error(
+    "Identity migration failed:",
+    error instanceof Error ? error.message : String(error),
+  );
   process.exitCode = 1;
 });

--- a/src/static-loader/identity-migration/runner.ts
+++ b/src/static-loader/identity-migration/runner.ts
@@ -91,6 +91,7 @@ export async function runIdentityMigration(
         applied: null,
       };
     }
+    if (plan.blockers.length > 0) throw new IdentityMigrationBlockedError(plan);
     if (config.dryRun) {
       return {
         mode: "dry-run",
@@ -99,7 +100,6 @@ export async function runIdentityMigration(
         applied: null,
       };
     }
-    if (plan.blockers.length > 0) throw new IdentityMigrationBlockedError(plan);
     const applied = await dependencies.applyPlan(tx, plan, snapshot, database);
     return { mode: "apply", outcome: "committed", plan, applied };
   });

--- a/tests/unit/static-identity-migration-runner.test.ts
+++ b/tests/unit/static-identity-migration-runner.test.ts
@@ -140,6 +140,26 @@ describe("identity migration runner", () => {
     expect(test.applyCalls()).toBe(0);
   });
 
+  it("fails a blocked dry-run instead of reporting it as planned", async () => {
+    const database = emptyDatabase();
+    database.legacyIdentityConstraintsPresent = false;
+    const test = harness(database);
+
+    await expect(
+      runIdentityMigration(
+        test.prisma,
+        {
+          snapshotPath: "snapshot.db",
+          expectedSnapshotSha256: SHA,
+          dryRun: true,
+        },
+        test.dependencies,
+      ),
+    ).rejects.toBeInstanceOf(IdentityMigrationBlockedError);
+    expect(test.events).toEqual(["SET TRANSACTION READ ONLY", "lock", "read"]);
+    expect(test.applyCalls()).toBe(0);
+  });
+
   it("returns same-SHA completed as a zero-write operation", async () => {
     const database = emptyDatabase();
     database.migrationState = {


### PR DESCRIPTION
## Summary

- fail dry-run when the migration plan contains invariant blockers
- log and summarize only the migration report plus up to 100 blockers
- always publish the concise report when the migration command produced one

## Root cause

The dry-run path returned `planned` before checking blockers, and the CLI serialized the full entity/edge mapping plan. Production therefore showed a successful workflow for a blocked plan while GitHub truncated the 160 MB output before the useful diagnostics.

## Validation

- `bunx biome check` on changed files
- `bunx vitest run tests/unit/static-identity-migration-runner.test.ts`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`