### PR TITLE
refactor(db): identity migration blockers

### DIFF
--- a/src/static-loader/identity-migration-cli.ts
+++ b/src/static-loader/identity-migration-cli.ts
@@ -21,16 +21,28 @@ function requiredEnvironment(name: string) {
   return value;
 }
 
-const MAX_REPORTED_BLOCKERS = 100;
-
 function summarizePlan(plan: IdentityMigrationPlan) {
+  const blockersByCode = new Map<
+    string,
+    { count: number; example: (typeof plan.blockers)[number] }
+  >();
+  for (const blocker of plan.blockers) {
+    const existing = blockersByCode.get(blocker.code);
+    if (existing == null) {
+      blockersByCode.set(blocker.code, { count: 1, example: blocker });
+    } else {
+      existing.count += 1;
+    }
+  }
+  const blockerGroups = [...blockersByCode.entries()].sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
   return {
     report: plan.report,
-    blockers: plan.blockers.slice(0, MAX_REPORTED_BLOCKERS),
-    omittedBlockerCount: Math.max(
-      0,
-      plan.blockers.length - MAX_REPORTED_BLOCKERS,
+    blockerCountsByCode: Object.fromEntries(
+      blockerGroups.map(([code, group]) => [code, group.count]),
     ),
+    blockerExamples: blockerGroups.map(([, group]) => group.example),
   };
 }
 


### PR DESCRIPTION
## Summary

- report blocker counts grouped by invariant code
- include one representative blocker per code
- remove arbitrary first-100 truncation that hides later blocker categories

## Why

The production dry-run correctly failed with 633,638 blockers, but the first 100 all shared one code. Grouping keeps the report tiny and exposes the complete root-cause distribution in one run.

## Validation

- `bunx biome check src/static-loader/identity-migration-cli.ts`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`