### PR TITLE
refactor(static): the complete static history

### DIFF
--- a/.github/workflows/static-identity-migration.yml
+++ b/.github/workflows/static-identity-migration.yml
@@ -70,7 +70,6 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.MIGRATOR_DATABASE_URL }}
           STATIC_SNAPSHOT_PATH: /tmp/static-identity-artifact/life-ustc-static.sqlite
-          STATIC_LOADER_MIN_SEMESTER: ${{ vars.STATIC_LOADER_MIN_SEMESTER || '401' }}
           STATIC_IDENTITY_MIGRATION_EXPECTED_SNAPSHOT_SHA256: ${{ inputs.expected_snapshot_sha256 }}
           STATIC_IDENTITY_MIGRATION_DRY_RUN: ${{ inputs.dry_run }}
           STATIC_IDENTITY_MIGRATION_REPORT_FILE: /tmp/static-identity-migration-report.json

--- a/src/static-loader/identity-migration-cli.ts
+++ b/src/static-loader/identity-migration-cli.ts
@@ -7,11 +7,7 @@ import {
 } from "./identity-migration/runner";
 import type { IdentityMigrationPlan } from "./identity-migration/types";
 import { createPrismaClient } from "./prisma";
-import {
-  parseBooleanSetting,
-  parseOptionalSha256Setting,
-  parsePositiveIntegerSetting,
-} from "./validation";
+import { parseBooleanSetting, parseOptionalSha256Setting } from "./validation";
 
 function requiredEnvironment(name: string) {
   const value = process.env[name];
@@ -72,18 +68,12 @@ async function main() {
     process.env.STATIC_IDENTITY_MIGRATION_DRY_RUN,
     true,
   );
-  const minSemester = parsePositiveIntegerSetting(
-    "STATIC_LOADER_MIN_SEMESTER",
-    process.env.STATIC_LOADER_MIN_SEMESTER,
-    401,
-  );
   const prisma = createPrismaClient();
   try {
     const report = await runIdentityMigration(prisma, {
       snapshotPath,
       expectedSnapshotSha256,
       dryRun,
-      minSemester,
     });
     await writeReport({
       mode: report.mode,

--- a/src/static-loader/identity-migration/README.md
+++ b/src/static-loader/identity-migration/README.md
@@ -3,6 +3,8 @@
 This folder contains the deterministic planner plus the dedicated snapshot
 reader and transactional executor. The planner itself remains pure; the CLI
 pins one SQLite file by SHA-256 and applies the resulting plan to PostgreSQL.
+The migration reads the fixed snapshot's complete history because existing
+production rows may predate the runtime loader's minimum-semester boundary.
 
 The planner enforces an expand/data/contract boundary: legacy unique identities
 such as `Department.code` and `ExamBatch.nameCn` must remain enforced while raw

--- a/src/static-loader/identity-migration/runner.ts
+++ b/src/static-loader/identity-migration/runner.ts
@@ -16,7 +16,6 @@ export type IdentityMigrationRunConfig = {
   snapshotPath: string;
   expectedSnapshotSha256: string;
   dryRun: boolean;
-  minSemester?: number;
 };
 
 export type IdentityMigrationRunReport = {
@@ -67,11 +66,7 @@ export async function runIdentityMigration(
       `Expected snapshot SHA-256 ${config.expectedSnapshotSha256} does not match file SHA-256 ${fileSha256}`,
     );
   }
-  const snapshot = dependencies.readSnapshot(
-    config.snapshotPath,
-    fileSha256,
-    config.minSemester ?? 401,
-  );
+  const snapshot = dependencies.readSnapshot(config.snapshotPath, fileSha256);
 
   return runSerializableWithRetry(prisma, async (tx) => {
     if (config.dryRun) {

--- a/src/static-loader/identity-migration/snapshot-reader.ts
+++ b/src/static-loader/identity-migration/snapshot-reader.ts
@@ -40,7 +40,6 @@ export function legacyCodeCourseJwId(code: string): number {
 export function readIdentityMigrationSnapshot(
   path: string,
   sha256: string,
-  minSemester = 401,
 ): SnapshotState {
   const snapshot = new Snapshot(path);
   try {
@@ -54,7 +53,6 @@ export function readIdentityMigrationSnapshot(
     const lessons = snapshot.queryAll("catalog_teach_lesson_list_for_teach");
     const importedSectionJwIds = new Set(
       lessons
-        .filter((row) => (asInt(row.semester_id) ?? 0) >= minSemester)
         .map((row) => asInt(row.id))
         .filter((id): id is number => id != null),
     );


### PR DESCRIPTION
## Summary

- read every semester in the pinned static artifact during identity migration
- remove the runtime loader minimum-semester setting from the migration API and workflow
- document why migration scope differs from normal incremental import scope

## Root cause

Production contains historical rows from semesters 221–382. The approved immutable artifact contains semesters 221–461, but the migration incorrectly inherited the runtime loader boundary of 401. That excluded historical source edges and produced 618,433 false `SOURCE_EDGE_UNMAPPED` blockers.

## Validation

- 20 migration runner/planner unit tests
- Biome on changed code and workflow
- operational TypeScript typecheck
- exact production artifact independently confirmed to contain semesters 221–461