### PR TITLE
refactor(db): migration blockers by entity

### DIFF
--- a/src/static-loader/identity-migration-cli.ts
+++ b/src/static-loader/identity-migration-cli.ts
@@ -18,25 +18,26 @@ function requiredEnvironment(name: string) {
 }
 
 function summarizePlan(plan: IdentityMigrationPlan) {
-  const blockersByCode = new Map<
+  const blockersByKind = new Map<
     string,
     { count: number; example: (typeof plan.blockers)[number] }
   >();
   for (const blocker of plan.blockers) {
-    const existing = blockersByCode.get(blocker.code);
+    const key = `${blocker.code}:${blocker.entity}`;
+    const existing = blockersByKind.get(key);
     if (existing == null) {
-      blockersByCode.set(blocker.code, { count: 1, example: blocker });
+      blockersByKind.set(key, { count: 1, example: blocker });
     } else {
       existing.count += 1;
     }
   }
-  const blockerGroups = [...blockersByCode.entries()].sort(([left], [right]) =>
+  const blockerGroups = [...blockersByKind.entries()].sort(([left], [right]) =>
     left.localeCompare(right),
   );
   return {
     report: plan.report,
-    blockerCountsByCode: Object.fromEntries(
-      blockerGroups.map(([code, group]) => [code, group.count]),
+    blockerCountsByCodeAndEntity: Object.fromEntries(
+      blockerGroups.map(([kind, group]) => [kind, group.count]),
     ),
     blockerExamples: blockerGroups.map(([, group]) => group.example),
   };


### PR DESCRIPTION
## Summary

Group production identity-migration blocker counts and examples by both invariant code and entity kind. This distinguishes derived join-table cleanup from relationships that carry foreign keys or user content.

## Validation

- Biome
- operational TypeScript typecheck