### PR TITLE
refactor(static): derived static relationships

### DIFF
--- a/src/static-loader/identity-migration/database-reader.ts
+++ b/src/static-loader/identity-migration/database-reader.ts
@@ -158,11 +158,8 @@ export async function readIdentityMigrationDatabase(
         id: number;
         sectionId: number;
         teacherId: number;
-        legacyTeacherTitleId: number | null;
       }>
-    >(`SELECT ta."id", ta."sectionId", ta."teacherId", t."teacherTitleId" AS "legacyTeacherTitleId"
-       FROM "TeacherAssignment" ta
-       JOIN "Teacher" t ON t."id" = ta."teacherId"`),
+    >(`SELECT "id", "sectionId", "teacherId" FROM "TeacherAssignment"`),
     tx.$queryRawUnsafe<
       Array<{ scheduleId: number; sectionId: number; teacherId: number }>
     >(`SELECT st."A" AS "scheduleId", s."sectionId", st."B" AS "teacherId"

--- a/src/static-loader/identity-migration/executor.ts
+++ b/src/static-loader/identity-migration/executor.ts
@@ -28,10 +28,7 @@ export async function applyIdentityMigrationPlan(
   }
 
   await lockAffectedRows(tx);
-  const titleEdges = plan.edgeMappings.filter(
-    (edge) => edge.entity === "teacherAssignmentTitle",
-  );
-  if (titleEdges.length > 0 && !(await hasAssignmentTitleColumn(tx))) {
+  if (!(await hasAssignmentTitleColumn(tx))) {
     throw new Error(
       "TeacherAssignment title schema is not installed; refusing to guess legacy Teacher titles",
     );
@@ -286,6 +283,12 @@ async function rebuildEdges(
   targetIds: TargetIds,
 ) {
   let rebuilt = 0;
+  await tx.$executeRawUnsafe(`DELETE FROM "_SectionTeachers"`);
+  await tx.$executeRawUnsafe(`DELETE FROM "_SectionAdminClasses"`);
+  await tx.$executeRawUnsafe(`DELETE FROM "_ScheduleTeachers"`);
+  await tx.$executeRawUnsafe(
+    `UPDATE "TeacherAssignment" SET "teacherTitleId" = NULL WHERE "teacherTitleId" IS NOT NULL`,
+  );
   for (const edge of edges.filter(
     (item) =>
       item.entity !== "sectionAdminClass" &&
@@ -475,10 +478,6 @@ async function rebuildJoinEdges(
   }
   let count = 0;
   for (const [ownerId, ownerEdges] of byOwner) {
-    await tx.$executeRawUnsafe(
-      `DELETE FROM "${table}" WHERE "${ownerColumn}" = $1`,
-      ownerId,
-    );
     for (const edge of ownerEdges) {
       const targetId = targets.get(edge.targetJwId);
       if (targetId == null) throw new Error(`${edge.entity} target is missing`);

--- a/src/static-loader/identity-migration/planner.ts
+++ b/src/static-loader/identity-migration/planner.ts
@@ -69,13 +69,7 @@ export function buildIdentityMigrationPlan(
       entityMappings,
       blockers,
     );
-    planAdminClassEdges(
-      snapshotState,
-      databaseState,
-      entityMappings,
-      edgeMappings,
-      blockers,
-    );
+    planAdminClassEdges(snapshotState, databaseState, edgeMappings, blockers);
     planNamedEntities(
       "teacherTitle",
       snapshotState.teacherTitles,
@@ -144,14 +138,12 @@ export function buildIdentityMigrationPlan(
       databaseState,
       entityMappings,
       edgeMappings,
-      blockers,
     );
     planImplicitSectionTeacherEdges(
       snapshotState,
       databaseState,
       entityMappings,
       edgeMappings,
-      blockers,
     );
     validateDescriptionConflicts(
       "course",
@@ -435,7 +427,6 @@ function planSimpleEntities(
 function planAdminClassEdges(
   snapshot: SnapshotState,
   database: DatabaseState,
-  mappings: EntityMapping[],
   edges: EdgeMapping[],
   blockers: IdentityMigrationBlocker[],
 ) {
@@ -448,7 +439,6 @@ function planAdminClassEdges(
       edge.adminClassJwId,
     );
   }
-  const adminMappings = mappingByLegacyId(mappings, "adminClass");
   for (const edge of database.sectionAdminClasses) {
     const section = sectionById.get(edge.sectionId);
     if (section == null) {
@@ -472,10 +462,7 @@ function planAdminClassEdges(
           targetJwId,
         });
       }
-      continue;
     }
-    const targets = adminMappings.get(edge.adminClassId)?.targetJwIds ?? [];
-    planLegacyEdge("sectionAdminClass", section.id, targets, edges, blockers);
   }
 }
 
@@ -741,13 +728,19 @@ function planTeacherAssignmentEdges(
       teacherMappings.get(assignment.teacherId)?.targetJwIds ?? [];
     const sourceAssignments =
       section == null ? [] : (sourceBySection.get(section.jwId) ?? []);
-    const assignmentTeacherTargets = sortedNumbers(
+    const sourceTeacherTargets = sortedNumbers(
       new Set(
         sourceAssignments
           .map((row) => row.teacherJwId)
           .filter((jwId) => teacherTargets.includes(jwId)),
       ),
     );
+    const assignmentTeacherTargets =
+      sourceTeacherTargets.length > 0
+        ? sourceTeacherTargets
+        : teacherTargets.length === 1
+          ? teacherTargets
+          : [];
     planLegacyEdge(
       "teacherAssignmentTeacher",
       assignment.id,
@@ -773,16 +766,15 @@ function planTeacherAssignmentEdges(
     const validTargets = sortedNumbers(
       new Set(titleTargets.filter((jwId) => validTitleIds.has(jwId))),
     );
-    if (validTargets.length === 0 && assignment.legacyTeacherTitleId == null) {
-      continue;
+    if (validTargets.length > 0) {
+      planLegacyEdge(
+        "teacherAssignmentTitle",
+        assignment.id,
+        validTargets,
+        edges,
+        blockers,
+      );
     }
-    planLegacyEdge(
-      "teacherAssignmentTitle",
-      assignment.id,
-      validTargets,
-      edges,
-      blockers,
-    );
   }
 }
 
@@ -791,7 +783,6 @@ function planScheduleTeacherEdges(
   database: DatabaseState,
   mappings: EntityMapping[],
   edges: EdgeMapping[],
-  blockers: IdentityMigrationBlocker[],
 ) {
   const sectionById = new Map(database.sections.map((row) => [row.id, row]));
   const teacherMappings = mappingByLegacyId(mappings, "teacher");
@@ -809,13 +800,13 @@ function planScheduleTeacherEdges(
         : (sourceTargetsBySection.get(section.jwId) ?? [])
             .map((row) => row.teacherJwId)
             .filter((jwId) => legacyTargets.includes(jwId));
-    planLegacyEdge(
-      "scheduleTeacher",
-      relation.scheduleId,
-      sortedNumbers(new Set(sourceTargets)),
-      edges,
-      blockers,
-    );
+    for (const targetJwId of sortedNumbers(new Set(sourceTargets))) {
+      edges.push({
+        entity: "scheduleTeacher",
+        ownerId: relation.scheduleId,
+        targetJwId,
+      });
+    }
   }
 }
 
@@ -824,7 +815,6 @@ function planImplicitSectionTeacherEdges(
   database: DatabaseState,
   mappings: EntityMapping[],
   edges: EdgeMapping[],
-  blockers: IdentityMigrationBlocker[],
 ) {
   const sectionById = new Map(database.sections.map((row) => [row.id, row]));
   const teacherMappings = mappingByLegacyId(mappings, "teacher");
@@ -843,16 +833,6 @@ function planImplicitSectionTeacherEdges(
             .map((row) => row.teacherJwId)
             .filter((jwId) => legacyTargets.includes(jwId));
     const targets = sortedNumbers(new Set(sourceTargets));
-    if (targets.length === 0) {
-      planLegacyEdge(
-        "implicitSectionTeacher",
-        relation.sectionId,
-        targets,
-        edges,
-        blockers,
-      );
-      continue;
-    }
     for (const targetJwId of targets) {
       edges.push({
         entity: "implicitSectionTeacher",

--- a/src/static-loader/identity-migration/types.ts
+++ b/src/static-loader/identity-migration/types.ts
@@ -128,8 +128,6 @@ export type DatabaseState = {
     id: number;
     sectionId: number;
     teacherId: number;
-    /** Legacy Teacher-level title inherited by this assignment, if any. */
-    legacyTeacherTitleId: number | null;
   }[];
   scheduleTeachers: readonly {
     scheduleId: number;

--- a/tests/unit/static-identity-migration-planner.test.ts
+++ b/tests/unit/static-identity-migration-planner.test.ts
@@ -147,13 +147,11 @@ function databaseState(): DatabaseState {
         id: 71,
         sectionId: 11,
         teacherId: 6,
-        legacyTeacherTitleId: 3,
       },
       {
         id: 72,
         sectionId: 12,
         teacherId: 6,
-        legacyTeacherTitleId: 3,
       },
     ],
     scheduleTeachers: [],
@@ -465,24 +463,26 @@ describe("identity migration planner", () => {
     ]);
   });
 
-  it("does not guess a TeacherAssignment title without a snapshot edge", () => {
+  it("drops a legacy Teacher title without a snapshot assignment edge", () => {
     const snapshot = snapshotState();
-    snapshot.teacherAssignments = snapshot.teacherAssignments.filter(
-      (assignment) => assignment.sectionJwId !== 201,
+    snapshot.teacherAssignments = snapshot.teacherAssignments.map(
+      (assignment) =>
+        assignment.sectionJwId === 201
+          ? { ...assignment, titleJwId: null }
+          : assignment,
     );
 
+    const plan = buildIdentityMigrationPlan(snapshot, databaseState());
+    expect(plan.blockers).toEqual([]);
     expect(
-      buildIdentityMigrationPlan(snapshot, databaseState()).blockers,
-    ).toContainEqual(
-      expect.objectContaining({
-        code: "SOURCE_EDGE_UNMAPPED",
-        entity: "teacherAssignmentTitle",
-        legacyId: 71,
-      }),
-    );
+      plan.edgeMappings.filter(
+        (edge) =>
+          edge.entity === "teacherAssignmentTitle" && edge.ownerId === 71,
+      ),
+    ).toEqual([]);
   });
 
-  it("proves schedule teachers within a section and blocks ambiguous splits", () => {
+  it("rebuilds only source-proven derived teacher joins", () => {
     const database = databaseState();
     database.scheduleTeachers = [
       { scheduleId: 91, sectionId: 11, teacherId: 6 },
@@ -508,15 +508,12 @@ describe("identity migration planner", () => {
       ...snapshot.sectionTeachers,
       { sectionJwId: 201, teacherJwId: 802 },
     ];
+    const ambiguousPlan = buildIdentityMigrationPlan(snapshot, database);
     expect(
-      buildIdentityMigrationPlan(snapshot, database).blockers,
-    ).toContainEqual(
-      expect.objectContaining({
-        code: "LEGACY_EDGE_MULTI_TARGET",
-        entity: "scheduleTeacher",
-        legacyId: 91,
-      }),
-    );
+      ambiguousPlan.blockers.filter(
+        (blocker) => blocker.entity === "scheduleTeacher",
+      ),
+    ).toEqual([]);
   });
 
   it("treats an empty current description with edit history as UGC", () => {


### PR DESCRIPTION
## Summary

- rebuild static join tables only from source-proven snapshot edges
- clear legacy Teacher-level titles before applying assignment-level title edges
- preserve a unique teacher target for an assignment when its exact source row is absent
- stop blocking on obsolete derived joins that carry no UGC

## Root cause

The migration treated derived `_ScheduleTeachers`, `_SectionTeachers`, and `_SectionAdminClasses` rows as authoritative history, and treated inherited Teacher titles as assignment source data. Production correctly has many historical derived rows, but they must be rebuilt from the pinned snapshot rather than migrated as identities.

## Validation

- 20 planner/runner unit tests
- 3 PostgreSQL executor integration tests
- operational and test TypeScript typechecks
- Biome and diff checks