### PR TITLE
refactor(db): CourseAlias migration input

### DIFF
--- a/src/static-loader/identity-migration/README.md
+++ b/src/static-loader/identity-migration/README.md
@@ -13,11 +13,12 @@ before the data transaction would allow the runtime loader to create a second
 row for the same legacy identity. The contract migration may remove them only
 after the planner's mappings have committed and its invariants have passed.
 
-Every planned entity and edge target must exist in that fixed snapshot. A stale
-`CourseAlias` is a blocker, never a target. Teacher titles are assignment-level
-source data: the planner only emits a title edge when the snapshot proves it for
-the exact section/teacher assignment; it never copies a legacy Teacher title by
-name or by convenience.
+Every planned entity and edge target must exist in that fixed snapshot.
+`CourseAlias` is obsolete migration input and is deleted, never promoted into a
+source identity. Teacher titles are assignment-level source data: the planner
+only emits a title edge when the snapshot proves it for the exact
+section/teacher assignment; it never copies a legacy Teacher title by name or
+by convenience.
 
 Comments can be rebound when multiple legacy rows converge on one raw target.
 Descriptions are unique per target, so non-empty descriptions may converge only

--- a/src/static-loader/identity-migration/database-reader.ts
+++ b/src/static-loader/identity-migration/database-reader.ts
@@ -23,7 +23,6 @@ export async function readIdentityMigrationDatabase(
     migrationStates,
     constraintRows,
     courses,
-    aliases,
     sections,
     adminClasses,
     sectionAdminClasses,
@@ -69,9 +68,6 @@ export async function readIdentityMigrationDatabase(
     tx.$queryRawUnsafe<
       Array<{ id: number; jwId: number; code: string; nameCn: string }>
     >(`SELECT "id", "jwId", "code", "nameCn" FROM "Course"`),
-    tx.$queryRawUnsafe<Array<{ jwId: number; courseId: number }>>(
-      `SELECT "jwId", "courseId" FROM "CourseAlias"`,
-    ),
     tx.$queryRawUnsafe<
       Array<{
         id: number;
@@ -223,7 +219,6 @@ export async function readIdentityMigrationDatabase(
       directCommentCount: courseCommentCounts.get(row.id) ?? 0,
       description: descriptionByCourse.get(row.id) ?? null,
     })),
-    courseAliases: aliases,
     sections,
     adminClasses,
     sectionAdminClasses,

--- a/src/static-loader/identity-migration/planner.ts
+++ b/src/static-loader/identity-migration/planner.ts
@@ -231,11 +231,6 @@ function planCourses(
     ),
     (entry) => entry.legacyJwId,
   );
-  const aliasesByCourseId = groupBy(
-    database.courseAliases,
-    (row) => row.courseId,
-  );
-
   for (const course of database.courses) {
     const targets = new Set<number>();
     const provenance = new Set<Provenance>();
@@ -246,22 +241,6 @@ function planCourses(
     for (const target of bySynthetic.get(course.jwId) ?? []) {
       targets.add(target.row.jwId);
       provenance.add("synthetic");
-    }
-    const aliases = aliasesByCourseId.get(course.id) ?? [];
-    const validAliases = aliases.filter((alias) => {
-      if (rawByJwId.has(alias.jwId)) return true;
-      blockers.push({
-        code: "COURSE_ALIAS_TARGET_NOT_IN_SNAPSHOT",
-        entity: "course",
-        legacyId: course.id,
-        sourceJwId: alias.jwId,
-        detail: `Course alias ${alias.jwId} for ${course.id} is absent from the fixed snapshot`,
-      });
-      return false;
-    });
-    for (const alias of validAliases) {
-      targets.add(alias.jwId);
-      provenance.add("alias");
     }
     if (targets.size === 0 && course.code != null && course.code !== "") {
       const codeMatches = byCode.get(course.code) ?? [];
@@ -276,14 +255,7 @@ function planCourses(
     }
     const hasDirectUgc =
       course.directCommentCount > 0 || hasNonemptyDescription(course);
-    if (hasDirectUgc && validAliases.length > 0 && targetJwIds.length > 1) {
-      blockers.push({
-        code: "COURSE_ALIAS_UGC_PROVENANCE_LOST",
-        entity: "course",
-        legacyId: course.id,
-        detail: `Course ${course.id} has UGC and multiple source-backed alias targets whose original raw source cannot be recovered`,
-      });
-    } else if (hasDirectUgc && targetJwIds.length > 1) {
+    if (hasDirectUgc && targetJwIds.length > 1) {
       addUgcBlocker("course", course.id, targetJwIds, blockers);
     }
     mappings.push({

--- a/src/static-loader/identity-migration/types.ts
+++ b/src/static-loader/identity-migration/types.ts
@@ -86,7 +86,6 @@ export type DatabaseState = {
     completed: boolean;
   } | null;
   courses: readonly DatabaseCourse[];
-  courseAliases: readonly { jwId: number; courseId: number }[];
   sections: readonly {
     id: number;
     jwId: number;
@@ -166,8 +165,6 @@ export type IdentityMigrationBlockerCode =
   | "SOURCE_EDGE_UNMAPPED"
   | "LEGACY_EDGE_MULTI_TARGET"
   | "UGC_MULTI_TARGET"
-  | "COURSE_ALIAS_UGC_PROVENANCE_LOST"
-  | "COURSE_ALIAS_TARGET_NOT_IN_SNAPSHOT"
   | "DESCRIPTION_CONFLICT";
 
 export type IdentityMigrationBlocker = {

--- a/tests/integration/static-identity-migration-executor.test.ts
+++ b/tests/integration/static-identity-migration-executor.test.ts
@@ -70,7 +70,6 @@ function database(course: {
         description: null,
       },
     ],
-    courseAliases: [],
     sections: [],
     adminClasses: [],
     sectionAdminClasses: [],

--- a/tests/unit/static-identity-migration-planner.test.ts
+++ b/tests/unit/static-identity-migration-planner.test.ts
@@ -93,7 +93,6 @@ function databaseState(): DatabaseState {
         description: null,
       },
     ],
-    courseAliases: [{ jwId: 99, courseId: 1 }],
     sections: [
       { id: 11, jwId: 201, courseId: 1, campusId: null },
       { id: 12, jwId: 202, courseId: 1, campusId: null },
@@ -159,13 +158,13 @@ function databaseState(): DatabaseState {
 }
 
 describe("identity migration planner", () => {
-  it("plans raw, synthetic, alias, same-name, and person-split identities", () => {
+  it("plans raw, synthetic, same-name, and person-split identities", () => {
     const plan = buildIdentityMigrationPlan(snapshotState(), databaseState());
 
     expect(plan.mode).toBe("plan");
     expect(plan.blockers).toEqual([]);
     expect(plan.report.splitCounts).toEqual({
-      courses: 1,
+      courses: 0,
       adminClasses: 1,
       teachers: 1,
       retainedDepartmentPlaceholders: 0,
@@ -177,8 +176,8 @@ describe("identity migration planner", () => {
     ).toEqual({
       entity: "course",
       legacyId: 1,
-      targetJwIds: [99, 101],
-      provenance: ["alias", "synthetic"],
+      targetJwIds: [101],
+      provenance: ["synthetic"],
     });
     expect(
       plan.edgeMappings.filter((edge) => edge.entity === "sectionAdminClass"),
@@ -379,7 +378,7 @@ describe("identity migration planner", () => {
     });
   });
 
-  it("blocks alias provenance loss and multi-target teacher UGC", () => {
+  it("blocks multi-target teacher UGC", () => {
     const database = databaseState();
     database.courses = [{ ...database.courses[0], directCommentCount: 2 }];
     database.teachers = [{ ...database.teachers[0], directCommentCount: 1 }];
@@ -390,11 +389,6 @@ describe("identity migration planner", () => {
       ),
     ).toEqual([
       {
-        code: "COURSE_ALIAS_UGC_PROVENANCE_LOST",
-        entity: "course",
-        legacyId: 1,
-      },
-      {
         code: "UGC_MULTI_TARGET",
         entity: "teacher",
         legacyId: 6,
@@ -402,19 +396,8 @@ describe("identity migration planner", () => {
     ]);
   });
 
-  it("never promotes a stale CourseAlias to a snapshot target", () => {
-    const snapshot = snapshotState();
-    snapshot.courses = snapshot.courses.filter((course) => course.jwId !== 99);
-
-    const plan = buildIdentityMigrationPlan(snapshot, databaseState());
-
-    expect(plan.blockers).toContainEqual(
-      expect.objectContaining({
-        code: "COURSE_ALIAS_TARGET_NOT_IN_SNAPSHOT",
-        legacyId: 1,
-        sourceJwId: 99,
-      }),
-    );
+  it("never promotes an obsolete CourseAlias into a source target", () => {
+    const plan = buildIdentityMigrationPlan(snapshotState(), databaseState());
     expect(
       plan.entityMappings.find(
         (mapping) => mapping.entity === "course" && mapping.legacyId === 1,
@@ -426,7 +409,6 @@ describe("identity migration planner", () => {
     const snapshot = snapshotState();
     snapshot.courses = snapshot.courses.filter((course) => course.jwId === 101);
     const database = databaseState();
-    database.courseAliases = [];
     database.courses = [
       {
         ...database.courses[0],
@@ -530,13 +512,7 @@ describe("identity migration planner", () => {
 
     expect(
       buildIdentityMigrationPlan(snapshotState(), database).blockers,
-    ).toContainEqual(
-      expect.objectContaining({
-        code: "COURSE_ALIAS_UGC_PROVENANCE_LOST",
-        entity: "course",
-        legacyId: 1,
-      }),
-    );
+    ).toEqual([]);
   });
 
   it("blocks UGC when a historical synthetic ID collides across raw courses", () => {
@@ -567,7 +543,6 @@ describe("identity migration planner", () => {
         description: null,
       },
     ];
-    database.courseAliases = [];
     database.sections = [];
 
     expect(

--- a/tests/unit/static-identity-migration-runner.test.ts
+++ b/tests/unit/static-identity-migration-runner.test.ts
@@ -45,7 +45,6 @@ function emptyDatabase(): DatabaseState {
     legacyIdentityConstraintsPresent: true,
     migrationState: null,
     courses: [],
-    courseAliases: [],
     sections: [],
     adminClasses: [],
     sectionAdminClasses: [],


### PR DESCRIPTION
## Summary

- remove `CourseAlias` from identity migration database state and planning
- map Course only through raw IDs, recognized retired synthetic IDs, or one unique code match
- keep deleting the obsolete alias rows transactionally during apply

## Root cause

`CourseAlias` is an obsolete compatibility table with no UGC, but the planner treated every alias as authoritative migration input. Production had 2,440 stale aliases, creating blockers and extra target ambiguity even though apply always removes the table contents.

## Validation

- 20 planner/runner unit tests
- 3 PostgreSQL executor integration tests
- operational and test TypeScript typechecks
- Biome and diff checks