### PR TITLE
refactor(db): identity migration blockers

### DIFF
--- a/src/static-loader/identity-migration-cli.ts
+++ b/src/static-loader/identity-migration-cli.ts
@@ -20,15 +20,16 @@ function requiredEnvironment(name: string) {
 function summarizePlan(plan: IdentityMigrationPlan) {
   const blockersByKind = new Map<
     string,
-    { count: number; example: (typeof plan.blockers)[number] }
+    { count: number; examples: (typeof plan.blockers)[number][] }
   >();
   for (const blocker of plan.blockers) {
     const key = `${blocker.code}:${blocker.entity}`;
     const existing = blockersByKind.get(key);
     if (existing == null) {
-      blockersByKind.set(key, { count: 1, example: blocker });
+      blockersByKind.set(key, { count: 1, examples: [blocker] });
     } else {
       existing.count += 1;
+      if (existing.examples.length < 10) existing.examples.push(blocker);
     }
   }
   const blockerGroups = [...blockersByKind.entries()].sort(([left], [right]) =>
@@ -39,7 +40,9 @@ function summarizePlan(plan: IdentityMigrationPlan) {
     blockerCountsByCodeAndEntity: Object.fromEntries(
       blockerGroups.map(([kind, group]) => [kind, group.count]),
     ),
-    blockerExamples: blockerGroups.map(([, group]) => group.example),
+    blockerExamplesByCodeAndEntity: Object.fromEntries(
+      blockerGroups.map(([kind, group]) => [kind, group.examples]),
+    ),
   };
 }
 

--- a/src/static-loader/identity-migration/planner.ts
+++ b/src/static-loader/identity-migration/planner.ts
@@ -251,7 +251,18 @@ function planCourses(
     }
     const targetJwIds = sortedNumbers(targets);
     if (targetJwIds.length === 0) {
-      addUnmappedBlocker("course", course.id, blockers);
+      addUnmappedBlocker(
+        "course",
+        course.id,
+        blockers,
+        stableJson({
+          jwId: course.jwId,
+          code: course.code,
+          nameCn: course.nameCn,
+          directCommentCount: course.directCommentCount,
+          descriptionId: course.description?.id ?? null,
+        }),
+      );
     }
     const hasDirectUgc =
       course.directCommentCount > 0 || hasNonemptyDescription(course);
@@ -377,7 +388,7 @@ function planSimpleEntities(
       targetJwIds.length === 0 &&
       !resolved.provenance.includes("placeholder")
     ) {
-      addUnmappedBlocker(entity, row.id, blockers);
+      addUnmappedBlocker(entity, row.id, blockers, stableJson(row));
     }
     if (entity === "department" && targetJwIds.length > 1) {
       blockers.push({
@@ -637,7 +648,20 @@ function planTeachers(
     }
     const targetJwIds = sortedNumbers(targets);
     if (targetJwIds.length === 0) {
-      addUnmappedBlocker("teacher", teacher.id, blockers);
+      addUnmappedBlocker(
+        "teacher",
+        teacher.id,
+        blockers,
+        stableJson({
+          jwId: teacher.jwId,
+          teacherId: teacher.teacherId,
+          personId: teacher.personId,
+          code: teacher.code,
+          nameCn: teacher.nameCn,
+          directCommentCount: teacher.directCommentCount,
+          descriptionId: teacher.description?.id ?? null,
+        }),
+      );
     }
     if (
       (teacher.directCommentCount > 0 || hasNonemptyDescription(teacher)) &&
@@ -891,12 +915,13 @@ function addUnmappedBlocker(
   entity: MappingEntity,
   legacyId: number,
   blockers: IdentityMigrationBlocker[],
+  context: string,
 ) {
   blockers.push({
     code: "LEGACY_ENTITY_UNMAPPED",
     entity,
     legacyId,
-    detail: `${entity} ${legacyId} has no provable raw jwId`,
+    detail: `${entity} ${legacyId} has no provable raw jwId: ${context}`,
   });
 }
 


### PR DESCRIPTION
## Summary

- include up to ten representative blockers per code/entity group
- include source identity and UGC metadata for unmapped Course and Teacher rows
- include full legacy lookup row identity for other unmapped entities

This keeps production reports bounded while providing enough evidence to distinguish obsolete seed/static rows from UGC that must be preserved.

## Validation

- 20 planner/runner unit tests
- operational and test TypeScript typechecks
- Biome and diff checks