### PR TITLE
fix(static): retain historical upstream identities

### DIFF
--- a/src/static-loader/identity-migration/README.md
+++ b/src/static-loader/identity-migration/README.md
@@ -13,12 +13,16 @@ before the data transaction would allow the runtime loader to create a second
 row for the same legacy identity. The contract migration may remove them only
 after the planner's mappings have committed and its invariants have passed.
 
-Every planned entity and edge target must exist in that fixed snapshot.
-`CourseAlias` is obsolete migration input and is deleted, never promoted into a
-source identity. Teacher titles are assignment-level source data: the planner
-only emits a title edge when the snapshot proves it for the exact
-section/teacher assignment; it never copies a legacy Teacher title by name or
-by convenience.
+Every new or changed target must exist in that fixed snapshot. `CourseAlias` is
+obsolete migration input and is deleted, never promoted into a source identity.
+Teacher titles are assignment-level source data: the planner only emits a title
+edge when the snapshot proves it for the exact section/teacher assignment; it
+never copies a legacy Teacher title by name or by convenience.
+
+An existing non-synthetic `jwId` remains authoritative for historical rows no
+longer returned by the current snapshot. Name-only Teacher rows have no source
+identity: rows without UGC and their unprovable assignments are removed, while
+UGC on such a row blocks the migration.
 
 Comments can be rebound when multiple legacy rows converge on one raw target.
 Descriptions are unique per target, so non-empty descriptions may converge only

--- a/src/static-loader/identity-migration/executor.ts
+++ b/src/static-loader/identity-migration/executor.ts
@@ -44,6 +44,11 @@ export async function applyIdentityMigrationPlan(
   }
   const targetIds = await readTargetIds(tx, plan.entityMappings);
   const rebuiltEdges = await rebuildEdges(tx, plan.edgeMappings, targetIds);
+  await deleteUnmappedTeacherAssignments(
+    tx,
+    database.teacherAssignments,
+    plan.edgeMappings,
+  );
 
   await migrateComments(tx, plan.entityMappings, targetIds);
   await migrateDescriptions(tx, plan.entityMappings, targetIds, database);
@@ -112,6 +117,7 @@ async function ensureEntityTargets(
   for (const targetJwId of mapping.targetJwIds) {
     const source = sourceEntity(snapshot, mapping.entity, targetJwId);
     if (source == null) {
+      if (mapping.provenance.includes("historical")) continue;
       throw new Error(
         `${mapping.entity} target ${targetJwId} is absent from the fixed snapshot`,
       );
@@ -578,6 +584,15 @@ async function deleteLegacyRows(
   targets: TargetIds,
 ) {
   let deleted = 0;
+  await tx.$executeRawUnsafe(
+    `DELETE FROM "SectionTeacher" st
+     WHERE NOT EXISTS (
+       SELECT 1 FROM "_SectionTeachers" j
+       WHERE j."A" = st."sectionId" AND j."B" = st."teacherId"
+     ) AND NOT EXISTS (
+       SELECT 1 FROM "Comment" c WHERE c."sectionTeacherId" = st."id"
+     )`,
+  );
   for (const entity of [
     "course",
     "adminClass",
@@ -588,7 +603,14 @@ async function deleteLegacyRows(
     "teacherTitle",
   ] as const) {
     for (const mapping of mappings.filter((item) => item.entity === entity)) {
-      if (mapping.targetJwIds.length === 0) continue;
+      if (mapping.targetJwIds.length === 0) {
+        if (mapping.provenance.includes("placeholder")) continue;
+        deleted += await tx.$executeRawUnsafe(
+          `DELETE FROM "${tableForEntity(entity)}" WHERE "id" = $1`,
+          mapping.legacyId,
+        );
+        continue;
+      }
       const targetDatabaseIds = new Set(
         mapping.targetJwIds
           .map((jwId) => targets.get(entity)?.get(jwId))
@@ -607,16 +629,27 @@ async function deleteLegacyRows(
       );
     }
   }
-  await tx.$executeRawUnsafe(
-    `DELETE FROM "SectionTeacher" st
-     WHERE NOT EXISTS (
-       SELECT 1 FROM "_SectionTeachers" j
-       WHERE j."A" = st."sectionId" AND j."B" = st."teacherId"
-     ) AND NOT EXISTS (
-       SELECT 1 FROM "Comment" c WHERE c."sectionTeacherId" = st."id"
-     )`,
-  );
   return deleted;
+}
+
+async function deleteUnmappedTeacherAssignments(
+  tx: IdentityMigrationSql,
+  assignments: DatabaseState["teacherAssignments"],
+  edges: readonly EdgeMapping[],
+) {
+  const mappedIds = new Set(
+    edges
+      .filter((edge) => edge.entity === "teacherAssignmentTeacher")
+      .map((edge) => edge.ownerId),
+  );
+  const staleIds = assignments
+    .map((assignment) => assignment.id)
+    .filter((id) => !mappedIds.has(id));
+  if (staleIds.length === 0) return;
+  await tx.$executeRawUnsafe(
+    `DELETE FROM "TeacherAssignment" WHERE "id" = ANY($1::int[])`,
+    staleIds,
+  );
 }
 
 function tableForEntity(entity: EntityMapping["entity"]) {

--- a/src/static-loader/identity-migration/legacy-course-identity.ts
+++ b/src/static-loader/identity-migration/legacy-course-identity.ts
@@ -1,0 +1,29 @@
+import { createHash } from "node:crypto";
+
+const SYNTHETIC_JWID_BASE = 1_500_000_000;
+const SYNTHETIC_JWID_SPAN = 400_000_000;
+
+export function isLegacySyntheticCourseJwId(jwId: number) {
+  return (
+    jwId >= SYNTHETIC_JWID_BASE &&
+    jwId < SYNTHETIC_JWID_BASE + SYNTHETIC_JWID_SPAN
+  );
+}
+
+export function legacySemanticCourseJwId(sourceKey: string): number {
+  const digest = createHash("sha256")
+    .update(`course-variant:v1:${sourceKey}`)
+    .digest("hex");
+  return (
+    SYNTHETIC_JWID_BASE +
+    (Number.parseInt(digest.slice(0, 8), 16) % SYNTHETIC_JWID_SPAN)
+  );
+}
+
+export function legacyCodeCourseJwId(code: string): number {
+  const digest = createHash("sha256").update(`course:${code}`).digest("hex");
+  return (
+    SYNTHETIC_JWID_BASE +
+    (Number.parseInt(digest.slice(0, 8), 16) % SYNTHETIC_JWID_SPAN)
+  );
+}

--- a/src/static-loader/identity-migration/planner.ts
+++ b/src/static-loader/identity-migration/planner.ts
@@ -1,3 +1,4 @@
+import { isLegacySyntheticCourseJwId } from "./legacy-course-identity";
 import {
   type DatabaseEntity,
   type DatabaseState,
@@ -242,6 +243,10 @@ function planCourses(
       targets.add(target.row.jwId);
       provenance.add("synthetic");
     }
+    if (targets.size === 0 && !isLegacySyntheticCourseJwId(course.jwId)) {
+      targets.add(course.jwId);
+      provenance.add("historical");
+    }
     if (targets.size === 0 && course.code != null && course.code !== "") {
       const codeMatches = byCode.get(course.code) ?? [];
       if (codeMatches.length === 1) {
@@ -324,6 +329,8 @@ function planNamedEntities(
       if (row.jwId != null && snapshot.some((item) => item.jwId === row.jwId)) {
         targets.push(row.jwId);
         provenance.push("raw");
+      } else if (row.jwId != null) {
+        return { targets: [row.jwId], provenance: ["historical"] };
       }
       return { targets, provenance };
     },
@@ -346,6 +353,9 @@ function planCodeEntities(
     (row, snapshot) => {
       if (row.jwId != null && snapshot.some((item) => item.jwId === row.jwId)) {
         return { targets: [row.jwId], provenance: ["raw"] };
+      }
+      if (row.jwId != null) {
+        return { targets: [row.jwId], provenance: ["historical"] };
       }
       return {
         targets: snapshot
@@ -384,12 +394,6 @@ function planSimpleEntities(
   for (const row of databaseRows) {
     const resolved = resolve(row, snapshotRows);
     const targetJwIds = sortedNumbers(new Set(resolved.targets));
-    if (
-      targetJwIds.length === 0 &&
-      !resolved.provenance.includes("placeholder")
-    ) {
-      addUnmappedBlocker(entity, row.id, blockers, stableJson(row));
-    }
     if (entity === "department" && targetJwIds.length > 1) {
       blockers.push({
         code: "LEGACY_ENTITY_MULTI_TARGET",
@@ -632,6 +636,9 @@ function planTeachers(
     if (directJwId != null && rawByJwId.has(directJwId)) {
       targets.add(directJwId);
       provenance.add("raw");
+    } else if (directJwId != null) {
+      targets.add(directJwId);
+      provenance.add("historical");
     }
     if (teacher.personId != null) {
       for (const target of byPerson.get(teacher.personId) ?? []) {
@@ -647,7 +654,9 @@ function planTeachers(
       }
     }
     const targetJwIds = sortedNumbers(targets);
-    if (targetJwIds.length === 0) {
+    const hasDirectUgc =
+      teacher.directCommentCount > 0 || hasNonemptyDescription(teacher);
+    if (targetJwIds.length === 0 && hasDirectUgc) {
       addUnmappedBlocker(
         "teacher",
         teacher.id,
@@ -663,10 +672,7 @@ function planTeachers(
         }),
       );
     }
-    if (
-      (teacher.directCommentCount > 0 || hasNonemptyDescription(teacher)) &&
-      targetJwIds.length > 1
-    ) {
+    if (hasDirectUgc && targetJwIds.length > 1) {
       addUgcBlocker("teacher", teacher.id, targetJwIds, blockers);
     }
     mappings.push({
@@ -696,10 +702,15 @@ function planTeachers(
       constrainedTargets.length > 0
         ? sortedNumbers(new Set(constrainedTargets))
         : oldTargets;
-    if (relation.directCommentCount > 0 && targets.length > 1) {
-      addUgcBlocker("sectionTeacher", relation.id, targets, blockers);
+    if (targets.length === 1) {
+      planLegacyEdge("sectionTeacher", relation.id, targets, edges, blockers);
+    } else if (relation.directCommentCount > 0) {
+      if (targets.length > 1) {
+        addUgcBlocker("sectionTeacher", relation.id, targets, blockers);
+      } else {
+        planLegacyEdge("sectionTeacher", relation.id, targets, edges, blockers);
+      }
     }
-    planLegacyEdge("sectionTeacher", relation.id, targets, edges, blockers);
   }
 }
 
@@ -737,13 +748,15 @@ function planTeacherAssignmentEdges(
         : teacherTargets.length === 1
           ? teacherTargets
           : [];
-    planLegacyEdge(
-      "teacherAssignmentTeacher",
-      assignment.id,
-      assignmentTeacherTargets,
-      edges,
-      blockers,
-    );
+    if (assignmentTeacherTargets.length === 1) {
+      planLegacyEdge(
+        "teacherAssignmentTeacher",
+        assignment.id,
+        assignmentTeacherTargets,
+        edges,
+        blockers,
+      );
+    } else continue;
     const titleTargets = sourceAssignments
       .filter((row) => teacherTargets.includes(row.teacherJwId))
       .map((row) => row.titleJwId)

--- a/src/static-loader/identity-migration/snapshot-reader.ts
+++ b/src/static-loader/identity-migration/snapshot-reader.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { selectLatestAdminClasses } from "../admin-class-selection";
 import { selectLatestCourses } from "../course-selection";
 import {
@@ -14,28 +13,16 @@ import {
   mapTeacherTitle,
 } from "../mappers";
 import { asInt, asString, Snapshot } from "../snapshot";
+import {
+  legacyCodeCourseJwId,
+  legacySemanticCourseJwId,
+} from "./legacy-course-identity";
 import type { SnapshotCourse, SnapshotState } from "./types";
 
-const SYNTHETIC_JWID_BASE = 1_500_000_000;
-const SYNTHETIC_JWID_SPAN = 400_000_000;
-
-export function legacySemanticCourseJwId(sourceKey: string): number {
-  const digest = createHash("sha256")
-    .update(`course-variant:v1:${sourceKey}`)
-    .digest("hex");
-  return (
-    SYNTHETIC_JWID_BASE +
-    (Number.parseInt(digest.slice(0, 8), 16) % SYNTHETIC_JWID_SPAN)
-  );
-}
-
-export function legacyCodeCourseJwId(code: string): number {
-  const digest = createHash("sha256").update(`course:${code}`).digest("hex");
-  return (
-    SYNTHETIC_JWID_BASE +
-    (Number.parseInt(digest.slice(0, 8), 16) % SYNTHETIC_JWID_SPAN)
-  );
-}
+export {
+  legacyCodeCourseJwId,
+  legacySemanticCourseJwId,
+} from "./legacy-course-identity";
 
 export function readIdentityMigrationSnapshot(
   path: string,

--- a/src/static-loader/identity-migration/types.ts
+++ b/src/static-loader/identity-migration/types.ts
@@ -193,7 +193,13 @@ export type EntityMapping = {
   legacyId: number;
   targetJwIds: number[];
   provenance: Array<
-    "raw" | "synthetic" | "alias" | "code" | "name" | "person" | "placeholder"
+    | "raw"
+    | "historical"
+    | "synthetic"
+    | "code"
+    | "name"
+    | "person"
+    | "placeholder"
   >;
 };
 

--- a/tests/integration/static-identity-migration-executor.test.ts
+++ b/tests/integration/static-identity-migration-executor.test.ts
@@ -144,6 +144,26 @@ describe("identity migration executor", () => {
             openDepartmentId: placeholderDepartment.id,
           },
         });
+        const sourceLessTeacher = await tx.teacher.create({
+          data: { nameCn: `无来源教师 ${marker}` },
+        });
+        const sourceLessRelation = await tx.sectionTeacher.create({
+          data: {
+            sectionId: section.id,
+            teacherId: sourceLessTeacher.id,
+          },
+        });
+        const sourceLessAssignment = await tx.teacherAssignment.create({
+          data: {
+            sectionId: section.id,
+            teacherId: sourceLessTeacher.id,
+          },
+        });
+        await tx.$executeRawUnsafe(
+          `INSERT INTO "_SectionTeachers" ("A", "B") VALUES ($1, $2)`,
+          section.id,
+          sourceLessTeacher.id,
+        );
         const firstDescription = await tx.description.create({
           data: { courseId: legacy.id, content: "相同内容" },
         });
@@ -238,6 +258,31 @@ describe("identity migration executor", () => {
             departmentId: placeholderDepartment.id,
           },
         ];
+        databaseState.teachers = [
+          {
+            ...sourceLessTeacher,
+            directCommentCount: 0,
+            description: null,
+          },
+        ];
+        databaseState.sectionTeachers = [
+          {
+            id: sourceLessRelation.id,
+            sectionId: section.id,
+            teacherId: sourceLessTeacher.id,
+            directCommentCount: 0,
+          },
+        ];
+        databaseState.sectionTeacherJoins = [
+          { sectionId: section.id, teacherId: sourceLessTeacher.id },
+        ];
+        databaseState.teacherAssignments = [
+          {
+            id: sourceLessAssignment.id,
+            sectionId: section.id,
+            teacherId: sourceLessTeacher.id,
+          },
+        ];
         const plan = buildIdentityMigrationPlan(snapshotState, databaseState);
         expect(plan.blockers).toEqual([]);
 
@@ -287,6 +332,19 @@ describe("identity migration executor", () => {
             where: { id: "raw-jwid-v1" },
           }),
         ).toMatchObject({ snapshotSha256: SHA });
+        expect(
+          await tx.teacher.findUnique({ where: { id: sourceLessTeacher.id } }),
+        ).toBeNull();
+        expect(
+          await tx.teacherAssignment.findUnique({
+            where: { id: sourceLessAssignment.id },
+          }),
+        ).toBeNull();
+        expect(
+          await tx.sectionTeacher.findUnique({
+            where: { id: sourceLessRelation.id },
+          }),
+        ).toBeNull();
         throw rollback;
       });
     } catch (error) {

--- a/tests/unit/static-identity-migration-planner.test.ts
+++ b/tests/unit/static-identity-migration-planner.test.ts
@@ -405,6 +405,81 @@ describe("identity migration planner", () => {
     ).toEqual([101]);
   });
 
+  it("retains an existing historical raw identity absent from the snapshot", () => {
+    const snapshot = snapshotState();
+    snapshot.courses = [];
+    snapshot.sectionCourses = [];
+    const database = databaseState();
+    database.courses = [
+      {
+        ...database.courses[0],
+        jwId: 145_964,
+        code: "NSE4022",
+        nameCn: "真空技术与科学仪器",
+      },
+    ];
+    database.sections = [];
+    database.sectionAdminClasses = [];
+    database.departmentReferences = [];
+    database.sectionTeachers = [];
+    database.teacherAssignments = [];
+
+    const plan = buildIdentityMigrationPlan(snapshot, database);
+    expect(plan.blockers).toEqual([]);
+    expect(plan.entityMappings).toContainEqual({
+      entity: "course",
+      legacyId: 1,
+      targetJwIds: [145_964],
+      provenance: ["historical"],
+    });
+  });
+
+  it("drops source-less Teacher rows and relations only when they have no UGC", () => {
+    const snapshot = snapshotState();
+    snapshot.teachers = [];
+    snapshot.sectionTeachers = [];
+    snapshot.teacherAssignments = [];
+    const database = databaseState();
+    database.teachers = [
+      {
+        ...database.teachers[0],
+        jwId: null,
+        teacherId: null,
+        personId: null,
+        code: null,
+        directCommentCount: 0,
+      },
+    ];
+    database.sectionTeachers = [
+      { ...database.sectionTeachers[0], directCommentCount: 0 },
+    ];
+
+    const plan = buildIdentityMigrationPlan(snapshot, database);
+    expect(plan.blockers).toEqual([]);
+    expect(plan.entityMappings).toContainEqual({
+      entity: "teacher",
+      legacyId: 6,
+      targetJwIds: [],
+      provenance: [],
+    });
+    expect(
+      plan.edgeMappings.filter((edge) =>
+        ["sectionTeacher", "teacherAssignmentTeacher"].includes(edge.entity),
+      ),
+    ).toEqual([]);
+
+    database.teachers = [{ ...database.teachers[0], directCommentCount: 1 }];
+    expect(
+      buildIdentityMigrationPlan(snapshot, database).blockers,
+    ).toContainEqual(
+      expect.objectContaining({
+        code: "LEGACY_ENTITY_UNMAPPED",
+        entity: "teacher",
+        legacyId: 6,
+      }),
+    );
+  });
+
   it("merges identical descriptions many-to-one but blocks different content", () => {
     const snapshot = snapshotState();
     snapshot.courses = snapshot.courses.filter((course) => course.jwId === 101);


### PR DESCRIPTION
## Summary
- retain existing non-synthetic upstream jwId values when historical entities are absent from the latest static snapshot
- remove source-less legacy teachers and unprovable relations only when they contain no UGC
- keep migration execution idempotent and cover both planner and PostgreSQL executor behavior

## Verification
- bunx vitest run tests/unit/static-identity-migration-planner.test.ts tests/unit/static-identity-migration-runner.test.ts tests/unit/static-identity-migration-snapshot-reader.test.ts
- DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:56433/life_ustc_jwid_ci bunx vitest run --config vitest.integration.config.ts tests/integration/static-identity-migration-executor.test.ts
- bunx tsc --noEmit -p tsconfig.typecheck.operational.json
- bunx tsc --noEmit -p tsconfig.typecheck.tests.json
- git diff --check