### PR TITLE
fix(static): restore recorded raw course identities

### DIFF
--- a/src/static-loader/identity-migration/README.md
+++ b/src/static-loader/identity-migration/README.md
@@ -13,8 +13,10 @@ before the data transaction would allow the runtime loader to create a second
 row for the same legacy identity. The contract migration may remove them only
 after the planner's mappings have committed and its invariants have passed.
 
-Every new or changed target must exist in that fixed snapshot. `CourseAlias` is
-obsolete migration input and is deleted, never promoted into a source identity.
+Every new or changed target must exist in that fixed snapshot. The sole
+exception is a single raw `CourseAlias` recorded by the retired loader for a
+synthetic Course whose source row has since disappeared; the migration restores
+that recorded upstream `jwId` and deletes the alias table's contents.
 Teacher titles are assignment-level source data: the planner only emits a title
 edge when the snapshot proves it for the exact section/teacher assignment; it
 never copies a legacy Teacher title by name or by convenience.

--- a/src/static-loader/identity-migration/database-reader.ts
+++ b/src/static-loader/identity-migration/database-reader.ts
@@ -23,6 +23,7 @@ export async function readIdentityMigrationDatabase(
     migrationStates,
     constraintRows,
     courses,
+    courseAliases,
     sections,
     adminClasses,
     sectionAdminClasses,
@@ -68,6 +69,9 @@ export async function readIdentityMigrationDatabase(
     tx.$queryRawUnsafe<
       Array<{ id: number; jwId: number; code: string; nameCn: string }>
     >(`SELECT "id", "jwId", "code", "nameCn" FROM "Course"`),
+    tx.$queryRawUnsafe<Array<{ jwId: number; courseId: number }>>(
+      `SELECT "jwId", "courseId" FROM "CourseAlias"`,
+    ),
     tx.$queryRawUnsafe<
       Array<{
         id: number;
@@ -219,6 +223,7 @@ export async function readIdentityMigrationDatabase(
       directCommentCount: courseCommentCounts.get(row.id) ?? 0,
       description: descriptionByCourse.get(row.id) ?? null,
     })),
+    courseAliases,
     sections,
     adminClasses,
     sectionAdminClasses,

--- a/src/static-loader/identity-migration/executor.ts
+++ b/src/static-loader/identity-migration/executor.ts
@@ -118,6 +118,23 @@ async function ensureEntityTargets(
     const source = sourceEntity(snapshot, mapping.entity, targetJwId);
     if (source == null) {
       if (mapping.provenance.includes("historical")) continue;
+      if (
+        mapping.entity === "course" &&
+        mapping.provenance.includes("alias") &&
+        mapping.targetJwIds.length === 1
+      ) {
+        await tx.$executeRawUnsafe(
+          `UPDATE "Course" source
+           SET "jwId" = $2
+           WHERE source."id" = $1
+             AND NOT EXISTS (
+               SELECT 1 FROM "Course" target WHERE target."jwId" = $2
+             )`,
+          mapping.legacyId,
+          targetJwId,
+        );
+        continue;
+      }
       throw new Error(
         `${mapping.entity} target ${targetJwId} is absent from the fixed snapshot`,
       );

--- a/src/static-loader/identity-migration/planner.ts
+++ b/src/static-loader/identity-migration/planner.ts
@@ -232,6 +232,10 @@ function planCourses(
     ),
     (entry) => entry.legacyJwId,
   );
+  const aliasesByCourseId = groupBy(
+    database.courseAliases,
+    (row) => row.courseId,
+  );
   for (const course of database.courses) {
     const targets = new Set<number>();
     const provenance = new Set<Provenance>();
@@ -242,6 +246,25 @@ function planCourses(
     for (const target of bySynthetic.get(course.jwId) ?? []) {
       targets.add(target.row.jwId);
       provenance.add("synthetic");
+    }
+    if (targets.size === 0 && isLegacySyntheticCourseJwId(course.jwId)) {
+      const aliasJwIds = sortedNumbers(
+        new Set(
+          (aliasesByCourseId.get(course.id) ?? [])
+            .map((alias) => alias.jwId)
+            .filter((jwId) => !isLegacySyntheticCourseJwId(jwId)),
+        ),
+      );
+      for (const jwId of aliasJwIds) targets.add(jwId);
+      if (aliasJwIds.length > 0) provenance.add("alias");
+      if (aliasJwIds.length > 1) {
+        blockers.push({
+          code: "LEGACY_ENTITY_MULTI_TARGET",
+          entity: "course",
+          legacyId: course.id,
+          detail: `Synthetic Course ${course.id} has multiple recorded raw jwIds: ${aliasJwIds.join(", ")}`,
+        });
+      }
     }
     if (targets.size === 0 && !isLegacySyntheticCourseJwId(course.jwId)) {
       targets.add(course.jwId);

--- a/src/static-loader/identity-migration/types.ts
+++ b/src/static-loader/identity-migration/types.ts
@@ -86,6 +86,7 @@ export type DatabaseState = {
     completed: boolean;
   } | null;
   courses: readonly DatabaseCourse[];
+  courseAliases: readonly { jwId: number; courseId: number }[];
   sections: readonly {
     id: number;
     jwId: number;
@@ -195,6 +196,7 @@ export type EntityMapping = {
   provenance: Array<
     | "raw"
     | "historical"
+    | "alias"
     | "synthetic"
     | "code"
     | "name"

--- a/tests/integration/static-identity-migration-executor.test.ts
+++ b/tests/integration/static-identity-migration-executor.test.ts
@@ -70,6 +70,7 @@ function database(course: {
         description: null,
       },
     ],
+    courseAliases: [],
     sections: [],
     adminClasses: [],
     sectionAdminClasses: [],
@@ -344,6 +345,51 @@ describe("identity migration executor", () => {
           await tx.sectionTeacher.findUnique({
             where: { id: sourceLessRelation.id },
           }),
+        ).toBeNull();
+        throw rollback;
+      });
+    } catch (error) {
+      if (error !== rollback) throw error;
+    }
+  });
+
+  it("restores a synthetic Course to a historical raw alias", async () => {
+    const rollback = new Error("ROLLBACK_HISTORICAL_COURSE_ALIAS");
+    const suffix = Date.now() % 10_000_000;
+    const syntheticJwId = 1_800_000_000 + suffix;
+    const rawJwId = 1_200_000_000 + suffix;
+    try {
+      await prisma.$transaction(async (tx) => {
+        const course = await tx.course.create({
+          data: {
+            jwId: syntheticJwId,
+            code: `ALIAS-${suffix}`,
+            nameCn: `历史课程 ${suffix}`,
+          },
+          select: { id: true, jwId: true, code: true, nameCn: true },
+        });
+        await tx.courseAlias.create({
+          data: { jwId: rawJwId, courseId: course.id },
+        });
+        const snapshotState = snapshot(rawJwId, syntheticJwId);
+        snapshotState.courses = [];
+        const databaseState = database(course);
+        databaseState.courseAliases = [{ jwId: rawJwId, courseId: course.id }];
+        const plan = buildIdentityMigrationPlan(snapshotState, databaseState);
+        expect(plan.blockers).toEqual([]);
+
+        await applyIdentityMigrationPlan(
+          tx,
+          plan,
+          snapshotState,
+          databaseState,
+        );
+
+        expect(
+          await tx.course.findUnique({ where: { id: course.id } }),
+        ).toMatchObject({ jwId: rawJwId });
+        expect(
+          await tx.courseAlias.findUnique({ where: { jwId: rawJwId } }),
         ).toBeNull();
         throw rollback;
       });

--- a/tests/unit/static-identity-migration-planner.test.ts
+++ b/tests/unit/static-identity-migration-planner.test.ts
@@ -93,6 +93,7 @@ function databaseState(): DatabaseState {
         description: null,
       },
     ],
+    courseAliases: [],
     sections: [
       { id: 11, jwId: 201, courseId: 1, campusId: null },
       { id: 12, jwId: 202, courseId: 1, campusId: null },
@@ -432,6 +433,45 @@ describe("identity migration planner", () => {
       targetJwIds: [145_964],
       provenance: ["historical"],
     });
+  });
+
+  it("restores a synthetic Course from its single recorded raw jwId", () => {
+    const snapshot = snapshotState();
+    snapshot.courses = [];
+    snapshot.sectionCourses = [];
+    const database = databaseState();
+    database.courseAliases = [
+      { jwId: 145_964, courseId: 1 },
+      { jwId: 1_600_000_001, courseId: 1 },
+    ];
+    database.sections = [];
+    database.sectionAdminClasses = [];
+    database.departmentReferences = [];
+    database.sectionTeachers = [];
+    database.teacherAssignments = [];
+
+    const plan = buildIdentityMigrationPlan(snapshot, database);
+    expect(plan.blockers).toEqual([]);
+    expect(plan.entityMappings).toContainEqual({
+      entity: "course",
+      legacyId: 1,
+      targetJwIds: [145_964],
+      provenance: ["alias"],
+    });
+
+    database.courseAliases = [
+      { jwId: 145_964, courseId: 1 },
+      { jwId: 145_965, courseId: 1 },
+    ];
+    expect(
+      buildIdentityMigrationPlan(snapshot, database).blockers,
+    ).toContainEqual(
+      expect.objectContaining({
+        code: "LEGACY_ENTITY_MULTI_TARGET",
+        entity: "course",
+        legacyId: 1,
+      }),
+    );
   });
 
   it("drops source-less Teacher rows and relations only when they have no UGC", () => {

--- a/tests/unit/static-identity-migration-runner.test.ts
+++ b/tests/unit/static-identity-migration-runner.test.ts
@@ -45,6 +45,7 @@ function emptyDatabase(): DatabaseState {
     legacyIdentityConstraintsPresent: true,
     migrationState: null,
     courses: [],
+    courseAliases: [],
     sections: [],
     adminClasses: [],
     sectionAdminClasses: [],


### PR DESCRIPTION
## Summary
- use a retired loader's single recorded raw CourseAlias only to restore a synthetic Course to its upstream jwId
- ignore aliases in the synthetic namespace and block ambiguous multiple raw IDs
- remove the one-time alias after migration and cover the PostgreSQL execution path

## Verification
- bunx vitest run tests/unit/static-identity-migration-planner.test.ts tests/unit/static-identity-migration-runner.test.ts tests/unit/static-identity-migration-snapshot-reader.test.ts
- DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:56433/life_ustc_jwid_ci bunx vitest run --config vitest.integration.config.ts tests/integration/static-identity-migration-executor.test.ts
- bunx tsc --noEmit -p tsconfig.typecheck.operational.json
- bunx tsc --noEmit -p tsconfig.typecheck.tests.json
- git diff --check