### PR TITLE
fix(static): retire department code identity

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -245,7 +245,7 @@ model Department {
   id   Int  @id @default(autoincrement())
   jwId Int? @unique
 
-  code      String   @unique
+  code      String
   nameCn    String
   nameEn    String?
   isCollege Boolean?

--- a/src/static-loader/identity-migration-state.ts
+++ b/src/static-loader/identity-migration-state.ts
@@ -5,6 +5,7 @@ export const RAW_JWID_MIGRATION_ID = "raw-jwid-v1";
 export const LEGACY_STATIC_IDENTITY_INDEXES = [
   "Campus_nameCn_key",
   "AdminClass_nameCn_key",
+  "Department_code_key",
   "ExamBatch_nameCn_key",
   "TeacherTitle_nameCn_key",
   "Room_buildingId_code_key",

--- a/src/static-loader/import.ts
+++ b/src/static-loader/import.ts
@@ -1141,24 +1141,6 @@ async function upsertDepartments(
   builds: DepartmentBuild[],
   placeholders: DepartmentPlaceholderRequest[],
 ): Promise<Map<string, number>> {
-  const incomingCodes = [...new Set(builds.map((build) => build.code))];
-  const existingByCode = new Map(
-    (
-      await tx.department.findMany({
-        where: { code: { in: incomingCodes } },
-        select: { id: true, jwId: true, code: true },
-      })
-    ).map((row) => [row.code, row] as const),
-  );
-  for (const build of builds) {
-    const existing = existingByCode.get(build.code);
-    if (existing != null && existing.jwId !== build.jwId) {
-      throw new Error(
-        `Authoritative Department jwId ${build.jwId} conflicts with existing code-only or different-jwId row for code ${build.code}`,
-      );
-    }
-  }
-
   const jwIdToId = new Map<number, number>();
   for (const build of builds) {
     const result = await tx.department.upsert({
@@ -1179,38 +1161,30 @@ async function upsertDepartments(
     });
     jwIdToId.set(build.jwId, result.id);
   }
-  for (const placeholder of placeholders) {
-    const existing = await tx.department.findUnique({
-      where: { code: placeholder.code },
-      select: { id: true, jwId: true },
-    });
-    if (existing?.jwId != null) {
-      throw new Error(
-        `Code-only Department reference ${placeholder.code} conflicts with authoritative jwId ${existing.jwId}`,
-      );
-    }
-    if (existing == null) {
-      await tx.department.create({
-        data: {
-          jwId: null,
-          code: placeholder.code,
-          nameCn: placeholder.nameCn,
-          isCollege: false,
-        },
-      });
-    }
-  }
   const map = new Map<string, number>();
   for (const build of builds) {
     const id = jwIdToId.get(build.jwId);
     if (id != null) map.set(build.code, id);
   }
   for (const placeholder of placeholders) {
-    const row = await tx.department.findUnique({
-      where: { code: placeholder.code },
+    const existing = await tx.department.findFirst({
+      where: { code: placeholder.code, jwId: null },
       select: { id: true },
     });
-    if (row != null) map.set(placeholder.code, row.id);
+    const id =
+      existing?.id ??
+      (
+        await tx.department.create({
+          data: {
+            jwId: null,
+            code: placeholder.code,
+            nameCn: placeholder.nameCn,
+            isCollege: false,
+          },
+          select: { id: true },
+        })
+      ).id;
+    map.set(placeholder.code, id);
   }
   return map;
 }


### PR DESCRIPTION
## Summary
- drop the remaining legacy `Department.code` unique index inside the identity migration transaction
- align Prisma with upstream `jwId` as the sole Department identity
- remove runtime code-conflict lookup; authoritative rows upsert only by `jwId`, while genuinely source-less placeholders query `jwId IS NULL`

## Production finding
The set-based apply reached target materialization and rolled back on `Department_code_key`: a new raw-jwId row temporarily shares code with its legacy row. Code is metadata, not identity, so that legacy constraint must be retired with the other pre-jwId indexes.

## Verification
- Prisma schema validation and client generation
- all three TypeScript configurations
- focused identity migration state/executor tests
- Biome and diff checks