### PR TITLE
fix(static): promote historical teacher IDs

### DIFF
--- a/src/static-loader/identity-migration/executor.ts
+++ b/src/static-loader/identity-migration/executor.ts
@@ -104,6 +104,10 @@ async function ensureEntityTargets(
 ) {
   let created = 0;
   const recovered: Array<{ legacyId: number; targetJwId: number }> = [];
+  const historical = new Map<
+    EntityMapping["entity"],
+    Array<{ legacyId: number; targetJwId: number }>
+  >();
   const targets = new Map<
     EntityMapping["entity"],
     Array<{ legacyId: number; source: SnapshotEntity }>
@@ -115,7 +119,12 @@ async function ensureEntityTargets(
     for (const targetJwId of mapping.targetJwIds) {
       const source = snapshotByEntity.get(mapping.entity)?.get(targetJwId);
       if (source == null) {
-        if (mapping.provenance.includes("historical")) continue;
+        if (mapping.provenance.includes("historical")) {
+          const entityRows = historical.get(mapping.entity) ?? [];
+          entityRows.push({ legacyId: mapping.legacyId, targetJwId });
+          historical.set(mapping.entity, entityRows);
+          continue;
+        }
         if (
           mapping.entity === "course" &&
           mapping.provenance.includes("recovered") &&
@@ -152,6 +161,24 @@ async function ensureEntityTargets(
          )`,
       recovered.map((item) => item.legacyId),
       recovered.map((item) => item.targetJwId),
+    );
+  }
+  for (const [entity, entityRows] of historical) {
+    await tx.$executeRawUnsafe(
+      `WITH input("legacyId", "targetJwId") AS (
+         SELECT * FROM UNNEST($1::int[], $2::int[])
+       )
+       UPDATE "${tableForEntity(entity)}" source
+       SET "jwId" = input."targetJwId"
+       FROM input
+       WHERE source."id" = input."legacyId"
+         AND source."jwId" IS NULL
+         AND NOT EXISTS (
+           SELECT 1 FROM "${tableForEntity(entity)}" target
+           WHERE target."jwId" = input."targetJwId"
+         )`,
+      entityRows.map((item) => item.legacyId),
+      entityRows.map((item) => item.targetJwId),
     );
   }
   for (const [entity, entityTargets] of targets) {

--- a/tests/integration/static-identity-migration-executor.test.ts
+++ b/tests/integration/static-identity-migration-executor.test.ts
@@ -389,6 +389,64 @@ describe("identity migration executor", () => {
     }
   });
 
+  it("promotes a historical Teacher upstream ID into jwId", async () => {
+    const rollback = new Error("ROLLBACK_HISTORICAL_TEACHER_IDENTITY");
+    const marker = 710_000_000 + (Date.now() % 10_000_000);
+    const historicalJwId = marker + 1;
+    try {
+      await prisma.$transaction(async (tx) => {
+        const course = await tx.course.create({
+          data: {
+            jwId: marker,
+            code: `HISTORICAL-TEACHER-${marker}`,
+            nameCn: `历史教师测试课程 ${marker}`,
+          },
+          select: { id: true, jwId: true, code: true, nameCn: true },
+        });
+        const teacher = await tx.teacher.create({
+          data: {
+            jwId: null,
+            teacherId: historicalJwId,
+            nameCn: `历史教师 ${historicalJwId}`,
+          },
+          select: {
+            id: true,
+            jwId: true,
+            teacherId: true,
+            personId: true,
+            code: true,
+            nameCn: true,
+          },
+        });
+        const snapshotState = snapshot(marker, marker);
+        const databaseState = database(course);
+        databaseState.teachers = [
+          {
+            ...teacher,
+            directCommentCount: 0,
+            description: null,
+          },
+        ];
+        const plan = buildIdentityMigrationPlan(snapshotState, databaseState);
+        expect(plan.blockers).toEqual([]);
+
+        await applyIdentityMigrationPlan(
+          tx,
+          plan,
+          snapshotState,
+          databaseState,
+        );
+
+        expect(
+          await tx.teacher.findUnique({ where: { id: teacher.id } }),
+        ).toMatchObject({ jwId: historicalJwId });
+        throw rollback;
+      });
+    } catch (error) {
+      if (error !== rollback) throw error;
+    }
+  });
+
   it("rejects a blocked plan before mutating the database", async () => {
     const blocked = buildIdentityMigrationPlan(
       snapshot(700_000_001, 700_000_000),


### PR DESCRIPTION
## Summary
- materialize historical upstream IDs into nullable `jwId` columns before validating targets
- cover legacy Teacher rows whose upstream ID still lives in `teacherId`

## Production finding
The apply rolled back at the target completeness check because some historical Teachers have `jwId = NULL` and their fixed upstream ID in the legacy `teacherId` field. The planner correctly retained that upstream ID, but the executor had not promoted it into the canonical `jwId` column.

## Verification
- operational and test TypeScript checks
- PostgreSQL executor integration tests (5/5)
- focused executor/planner unit tests (19/19)
- Biome and diff checks