### PR TITLE
fix(static): type rebuilt teacher retirement

### DIFF
--- a/src/static-loader/identity-migration/executor.ts
+++ b/src/static-loader/identity-migration/executor.ts
@@ -499,7 +499,7 @@ async function rebuildSectionTeachers(
        JOIN "SectionTeacher" relation ON relation."id" = input."legacyId"
      ), inserted AS (
      INSERT INTO "SectionTeacher" ("sectionId", "teacherId", "createdAt", "updatedAt", "retiredAt")
-     SELECT DISTINCT "sectionId", "targetTeacherId", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL
+     SELECT DISTINCT "sectionId", "targetTeacherId", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL::timestamp
      FROM source
      ON CONFLICT ("sectionId", "teacherId") DO UPDATE SET "retiredAt" = NULL
      RETURNING "id", "sectionId", "teacherId"

--- a/tests/integration/static-identity-migration-executor.test.ts
+++ b/tests/integration/static-identity-migration-executor.test.ts
@@ -447,6 +447,88 @@ describe("identity migration executor", () => {
     }
   });
 
+  it("rebuilds a SectionTeacher relation with a raw Teacher jwId", async () => {
+    const rollback = new Error("ROLLBACK_SECTION_TEACHER_IDENTITY");
+    const marker = 720_000_000 + (Date.now() % 10_000_000);
+    const teacherJwId = marker + 1;
+    try {
+      await prisma.$transaction(async (tx) => {
+        const course = await tx.course.create({
+          data: {
+            jwId: marker,
+            code: `SECTION-TEACHER-${marker}`,
+            nameCn: `教师关系测试课程 ${marker}`,
+          },
+          select: { id: true, jwId: true, code: true, nameCn: true },
+        });
+        const teacher = await tx.teacher.create({
+          data: {
+            jwId: null,
+            teacherId: teacherJwId,
+            nameCn: `关系教师 ${teacherJwId}`,
+          },
+          select: {
+            id: true,
+            jwId: true,
+            teacherId: true,
+            personId: true,
+            code: true,
+            nameCn: true,
+          },
+        });
+        const section = await tx.section.create({
+          data: {
+            jwId: marker,
+            code: `SECTION-${marker}`,
+            courseId: course.id,
+          },
+          select: { id: true, jwId: true, courseId: true, campusId: true },
+        });
+        const relation = await tx.sectionTeacher.create({
+          data: { sectionId: section.id, teacherId: teacher.id },
+          select: { id: true, sectionId: true, teacherId: true },
+        });
+        const snapshotState = snapshot(marker, marker);
+        snapshotState.teachers = [
+          { jwId: teacherJwId, nameCn: teacher.nameCn },
+        ];
+        snapshotState.sectionTeachers = [
+          { sectionJwId: section.jwId, teacherJwId },
+        ];
+        const databaseState = database(course);
+        databaseState.sections = [section];
+        databaseState.teachers = [
+          {
+            ...teacher,
+            directCommentCount: 0,
+            description: null,
+          },
+        ];
+        databaseState.sectionTeachers = [
+          { ...relation, directCommentCount: 0 },
+        ];
+        const plan = buildIdentityMigrationPlan(snapshotState, databaseState);
+        expect(plan.blockers).toEqual([]);
+
+        await applyIdentityMigrationPlan(
+          tx,
+          plan,
+          snapshotState,
+          databaseState,
+        );
+
+        expect(
+          await tx.sectionTeacher.findFirst({
+            where: { sectionId: section.id, teacher: { jwId: teacherJwId } },
+          }),
+        ).not.toBeNull();
+        throw rollback;
+      });
+    } catch (error) {
+      if (error !== rollback) throw error;
+    }
+  });
+
   it("rejects a blocked plan before mutating the database", async () => {
     const blocked = buildIdentityMigrationPlan(
       snapshot(700_000_001, 700_000_000),


### PR DESCRIPTION
## Summary
- explicitly type the set-based `SectionTeacher.retiredAt` value as PostgreSQL timestamp
- add a PostgreSQL integration case that materializes a raw Teacher and rebuilds its SectionTeacher relation

## Production finding
The apply passed entity materialization and rolled back while rebuilding SectionTeacher because PostgreSQL resolves a bare NULL under SELECT DISTINCT as text before applying the INSERT target type.

## Verification
- operational and test TypeScript checks
- PostgreSQL identity migration executor integration tests (6/6)
- Biome and diff checks