### PR TITLE
fix(static): bound createMany batches

### DIFF
--- a/src/static-loader/import.ts
+++ b/src/static-loader/import.ts
@@ -1892,15 +1892,10 @@ export async function writeSectionTeachers(
 
   if (resolved.length > 0) {
     for (const chunk of chunks(resolved, 1000)) {
-      const values = chunk
-        .map(
-          (pair) =>
-            `(${pair.sectionId},${pair.teacherId},NULL::timestamp,CURRENT_TIMESTAMP)`,
-        )
-        .join(",");
-      await tx.$executeRawUnsafe(
-        `INSERT INTO "SectionTeacher" ("sectionId","teacherId","retiredAt","updatedAt") VALUES ${values} ON CONFLICT ("sectionId","teacherId") DO NOTHING`,
-      );
+      await tx.sectionTeacher.createMany({
+        data: chunk.map((pair) => ({ ...pair, retiredAt: null })),
+        skipDuplicates: true,
+      });
     }
   }
 
@@ -1967,7 +1962,9 @@ async function writeTeacherAssignments(
   });
 
   if (resolved.length > 0) {
-    await tx.teacherAssignment.createMany({ data: resolved });
+    for (const chunk of chunks(resolved, 1000)) {
+      await tx.teacherAssignment.createMany({ data: chunk });
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- bound SectionTeacher and TeacherAssignment createMany calls to sequential 1,000-row batches
- remove the raw SQL introduced for SectionTeacher insertion
- prevent Prisma adapter from issuing overlapping pg client queries for large createMany payloads

## Production evidence
- SectionTeacher batching moved the pg deprecation warning from `writeSectionTeachers` to the next unbounded createMany in `writeTeacherAssignments`
- production sync itself committed successfully; this change removes the remaining unbounded relation write

## Verification
- `bunx biome check src/static-loader/import.ts`
- `bunx vitest run --config vitest.integration.config.ts tests/integration/static-import-write-churn.test.ts`
- `git diff --check`