### PR TITLE
perf(bus): cache public schedules safely

### DIFF
--- a/docs/contracts/bus.json
+++ b/docs/contracts/bus.json
@@ -24,7 +24,8 @@
     "public-version-metadata-omitted": "Public bus dashboard pages omit timetable version metadata rather than showing an unlabeled or unlocalized imported value; the raw title remains available to admin, REST, and MCP consumers.",
     "responsive-route-surfaces": "Bus planner and transit-map pages keep document content within narrow viewports, provide at least 44 CSS pixels of height for primary route actions, wrap stop sequences only between complete arrow-and-stop tokens, and keep campus labels legible over route strokes.",
     "task-oriented-tool-hierarchy": "Use catalog_bus_timetable_get for raw/full datasets, catalog_bus_route_list for unfiltered discovery, catalog_bus_route_search for filtered discovery, catalog_bus_route_get for one route, catalog_bus_departure_next for immediate departure answers, and workspace_bus_preferences_get/workspace_bus_preferences_set for personal defaults.",
-    "canonical-compact-mode": "catalog_bus_timetable_get default mode returns compact counts, route/campus summaries, and relevant departures rather than the full trip dataset; the deprecated summary input is an alias for this same shape."
+    "canonical-compact-mode": "catalog_bus_timetable_get default mode returns compact counts, route/campus summaries, and relevant departures rather than the full trip dataset; the deprecated summary input is an alias for this same shape.",
+    "cache-boundaries": "Anonymous raw timetable and route-search REST responses may use revision-purged public edge caching; signed-in or auth-signaled timetable responses and all next-departure responses remain private and uncached. The bus map dynamically renders request-time active trips while reusing revision-scoped static schedule and topology data."
   },
   "capabilities": {
     "bus-dashboard": {

--- a/docs/contracts/bus.json
+++ b/docs/contracts/bus.json
@@ -25,7 +25,7 @@
     "responsive-route-surfaces": "Bus planner and transit-map pages keep document content within narrow viewports, provide at least 44 CSS pixels of height for primary route actions, wrap stop sequences only between complete arrow-and-stop tokens, and keep campus labels legible over route strokes.",
     "task-oriented-tool-hierarchy": "Use catalog_bus_timetable_get for raw/full datasets, catalog_bus_route_list for unfiltered discovery, catalog_bus_route_search for filtered discovery, catalog_bus_route_get for one route, catalog_bus_departure_next for immediate departure answers, and workspace_bus_preferences_get/workspace_bus_preferences_set for personal defaults.",
     "canonical-compact-mode": "catalog_bus_timetable_get default mode returns compact counts, route/campus summaries, and relevant departures rather than the full trip dataset; the deprecated summary input is an alias for this same shape.",
-    "cache-boundaries": "Anonymous raw timetable and route-search REST responses may use revision-purged public edge caching; signed-in or auth-signaled timetable responses and all next-departure responses remain private and uncached. The bus map dynamically renders request-time active trips while reusing revision-scoped static schedule and topology data."
+    "cache-boundaries": "Raw timetable REST responses remain private because they may contain viewer preferences; route-search REST responses may use revision-purged public edge caching, while all next-departure responses remain private and uncached. The bus map dynamically renders request-time active trips while reusing revision-scoped static schedule and topology data."
   },
   "capabilities": {
     "bus-dashboard": {

--- a/docs/rendering-and-cache.md
+++ b/docs/rendering-and-cache.md
@@ -8,7 +8,11 @@ current viewer.
 
 - Course / section / teacher list pages
 - Catalog detail **root** paths (`/catalog/{courses|sections|teachers}/:id`)
-- Bus map, mobile app, privacy, terms, Markdown guide, API docs
+- Mobile app, privacy, terms, Markdown guide, API docs
+
+The bus map stays on dynamic SSR because its active-trip positions and current
+time are request-sensitive. Its schedule and topology still use the shared
+revision-scoped runtime cache.
 
 Any recognized session or Bearer signal forces dynamic SSR. Pages that still
 embed viewer-specific data (home, links planner, community) stay dynamic.

--- a/src/features/bus/server/bus-transit-map.ts
+++ b/src/features/bus/server/bus-transit-map.ts
@@ -1,5 +1,4 @@
 import type { AppLocale } from "@/i18n/config";
-import { prisma } from "@/lib/db/prisma";
 import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
 import { resolveBusDayType } from "../lib/bus-departures";
 import { buildBusMapActiveTrips } from "../lib/bus-map-active-trips";
@@ -8,8 +7,7 @@ import {
   buildBusRouteTripCounts,
 } from "../lib/bus-map-route-edges";
 import type { BusMapCampusNode, BusMapData } from "../lib/bus-types";
-import { getBusVersionTopology } from "./bus-route-records";
-import { findEffectiveBusVersion } from "./bus-version";
+import { getStaticBusTimetableData } from "./bus-timetable-data";
 
 export async function getBusMapData(input: {
   locale: AppLocale;
@@ -18,23 +16,17 @@ export async function getBusMapData(input: {
 }): Promise<BusMapData | null> {
   const locale = input.locale;
   const now = input.now ? shanghaiDayjs(input.now) : shanghaiDayjs();
-  const dateKey = now.format("YYYY-MM-DD");
   const todayType = resolveBusDayType(undefined, now);
-  const version = await findEffectiveBusVersion(dateKey, input.versionKey);
-  if (!version) return null;
+  const timetable = await getStaticBusTimetableData({
+    locale,
+    now: now.toISOString(),
+    versionKey: input.versionKey,
+  });
+  if (!timetable) return null;
 
-  const [topology, allTrips] = await Promise.all([
-    getBusVersionTopology(locale, version.id),
-    prisma.busTrip.findMany({
-      where: { versionId: version.id },
-      orderBy: [{ dayType: "asc" }, { routeId: "asc" }, { position: "asc" }],
-    }),
-  ]);
-  if (!topology) return null;
+  const tripCounts = buildBusRouteTripCounts(timetable.trips);
 
-  const tripCounts = buildBusRouteTripCounts(allTrips);
-
-  const campusNodes: BusMapCampusNode[] = topology.campuses.map((c) => ({
+  const campusNodes: BusMapCampusNode[] = timetable.campuses.map((c) => ({
     id: c.id,
     namePrimary: c.namePrimary,
     nameSecondary: c.nameSecondary,
@@ -44,7 +36,7 @@ export async function getBusMapData(input: {
 
   const routeEdges = buildBusRouteEdges({
     locale,
-    records: topology.routes,
+    records: timetable.routes,
     tripCounts,
   });
 
@@ -52,7 +44,10 @@ export async function getBusMapData(input: {
   const activeTrips = buildBusMapActiveTrips({
     nowMinutes,
     todayType,
-    trips: allTrips,
+    trips: timetable.trips.map((trip) => ({
+      ...trip,
+      stopTimes: trip.stopTimes.map((stop) => stop.time),
+    })),
   });
 
   return {

--- a/src/lib/api/routes/bus.ts
+++ b/src/lib/api/routes/bus.ts
@@ -20,7 +20,6 @@ import {
   busRouteSearchResponseSchema,
 } from "@/lib/api/schemas/response-schemas";
 import { requireAuth, resolveApiUserId } from "@/lib/auth/api-auth";
-import { hasRequestAuthSignal } from "@/lib/auth/request-auth-signal";
 import {
   PRIVATE_LOCALE_CATALOG_HEADERS,
   PUBLIC_BUS_CACHE_HEADERS,
@@ -51,11 +50,8 @@ export async function getBusRoute(request: Request) {
     }
 
     const validated = busQueryResponseSchema.parse(result);
-    const publicResponse = !userId && !hasRequestAuthSignal(request.headers);
     return jsonResponse(validated, {
-      headers: publicResponse
-        ? PUBLIC_BUS_CACHE_HEADERS
-        : PRIVATE_LOCALE_CATALOG_HEADERS,
+      headers: PRIVATE_LOCALE_CATALOG_HEADERS,
     });
   } catch (error) {
     return handleRouteError("Failed to query shuttle bus schedules", error);

--- a/src/lib/api/routes/bus.ts
+++ b/src/lib/api/routes/bus.ts
@@ -20,6 +20,12 @@ import {
   busRouteSearchResponseSchema,
 } from "@/lib/api/schemas/response-schemas";
 import { requireAuth, resolveApiUserId } from "@/lib/auth/api-auth";
+import { hasRequestAuthSignal } from "@/lib/auth/request-auth-signal";
+import {
+  PRIVATE_LOCALE_CATALOG_HEADERS,
+  PUBLIC_BUS_CACHE_HEADERS,
+  TIME_SENSITIVE_PRIVATE_HEADERS,
+} from "@/lib/public-cache-control";
 
 export async function getBusRoute(request: Request) {
   const parsedQuery = parseBusRouteQuery(request);
@@ -45,7 +51,12 @@ export async function getBusRoute(request: Request) {
     }
 
     const validated = busQueryResponseSchema.parse(result);
-    return jsonResponse(validated);
+    const publicResponse = !userId && !hasRequestAuthSignal(request.headers);
+    return jsonResponse(validated, {
+      headers: publicResponse
+        ? PUBLIC_BUS_CACHE_HEADERS
+        : PRIVATE_LOCALE_CATALOG_HEADERS,
+    });
   } catch (error) {
     return handleRouteError("Failed to query shuttle bus schedules", error);
   }
@@ -75,7 +86,9 @@ export async function getBusRoutesSearchRoute(request: Request) {
       return notFound("Bus schedule is not available");
     }
 
-    return jsonResponse(busRouteSearchResponseSchema.parse(result));
+    return jsonResponse(busRouteSearchResponseSchema.parse(result), {
+      headers: PUBLIC_BUS_CACHE_HEADERS,
+    });
   } catch (error) {
     return handleRouteError("Failed to search shuttle bus routes", error);
   }
@@ -110,7 +123,9 @@ export async function getBusNextDeparturesRoute(request: Request) {
       return notFound("Bus schedule is not available");
     }
 
-    return jsonResponse(busNextDeparturesResponseSchema.parse(result));
+    return jsonResponse(busNextDeparturesResponseSchema.parse(result), {
+      headers: TIME_SENSITIVE_PRIVATE_HEADERS,
+    });
   } catch (error) {
     return handleRouteError("Failed to fetch next shuttle buses", error);
   }

--- a/src/lib/cloudflare/public-ssr-gateway.ts
+++ b/src/lib/cloudflare/public-ssr-gateway.ts
@@ -31,7 +31,6 @@ export type PublicSsrRouteResolver = (
 ) => PublicSsrMode | null | undefined;
 
 const STATIC_PUBLIC_PATHS = new Set([
-  "/catalog/bus/map",
   "/guides/markdown-support",
   "/api-docs",
   "/usage/mobile",

--- a/src/lib/public-cache-control.ts
+++ b/src/lib/public-cache-control.ts
@@ -22,6 +22,24 @@ export const PUBLIC_SEARCH_CACHE_HEADERS = {
   Vary: "Accept-Language",
 } as const;
 
+// Bus schedule responses are purged with the catalog revision tag. Keep the
+// edge TTL shorter than the catalog TTL so an effective-version date boundary
+// cannot leave the previous schedule cached for a full day.
+export const PUBLIC_BUS_CACHE_HEADERS = {
+  "Cache-Control":
+    "public, max-age=0, s-maxage=3600, stale-while-revalidate=300",
+  "Cache-Tag": CATALOG_EDGE_CACHE_TAG,
+  "Cloudflare-CDN-Cache-Control":
+    "public, max-age=3600, stale-while-revalidate=300",
+  Vary: "Accept-Language, Cookie",
+} as const;
+
+export const TIME_SENSITIVE_PRIVATE_HEADERS = {
+  "Cache-Control": "private, no-store",
+  "Cloudflare-CDN-Cache-Control": "no-store",
+  Vary: "Accept-Language, Cookie",
+} as const;
+
 export const PUBLIC_LOCALE_CATALOG_HEADERS = {
   ...PUBLIC_CATALOG_HEADERS,
   Vary: "Accept-Language, Cookie",

--- a/tests/unit/bus-route-cache.test.ts
+++ b/tests/unit/bus-route-cache.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getBusTimetableDataMock,
+  getNextBusDeparturesMock,
+  searchBusRoutesMock,
+} = vi.hoisted(() => ({
+  getBusTimetableDataMock: vi.fn(),
+  getNextBusDeparturesMock: vi.fn(),
+  searchBusRoutesMock: vi.fn(),
+}));
+
+vi.mock("@/features/bus/server/bus-service", () => ({
+  getBusTimetableData: getBusTimetableDataMock,
+  getNextBusDepartures: getNextBusDeparturesMock,
+  searchBusRoutes: searchBusRoutesMock,
+}));
+
+vi.mock("@/lib/auth/api-auth", () => ({
+  resolveApiUserId: vi.fn(),
+}));
+
+const campus = {
+  id: 1,
+  nameCn: "东区",
+  nameEn: null,
+  namePrimary: "东区",
+  nameSecondary: null,
+  latitude: 31.1,
+  longitude: 117.1,
+};
+
+const timetable = {
+  locale: "zh-cn" as const,
+  fetchedAt: "2026-08-14T00:00:00.000Z",
+  version: null,
+  availableVersions: [],
+  campuses: [campus],
+  routes: [],
+  trips: [],
+  preferences: null,
+  notice: null,
+};
+
+describe("bus REST cache boundaries", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("publicly edge-caches anonymous raw timetable responses", async () => {
+    const { resolveApiUserId } = await import("@/lib/auth/api-auth");
+    vi.mocked(resolveApiUserId).mockResolvedValue(null);
+    getBusTimetableDataMock.mockResolvedValue(timetable);
+    const { getBusRoute } = await import("@/lib/api/routes/bus");
+
+    const response = await getBusRoute(
+      new Request("https://life.example/api/catalog/bus"),
+    );
+
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
+      "public, max-age=3600, stale-while-revalidate=300",
+    );
+    expect(response.headers.get("Cache-Tag")).toBe("catalog");
+  });
+
+  it.each([
+    ["authorization", "Bearer token"],
+    ["cookie", "better-auth.session_token=session"],
+  ])("keeps an auth-signaled timetable response private", async (name, value) => {
+    const { resolveApiUserId } = await import("@/lib/auth/api-auth");
+    vi.mocked(resolveApiUserId).mockResolvedValue(null);
+    getBusTimetableDataMock.mockResolvedValue(timetable);
+    const { getBusRoute } = await import("@/lib/api/routes/bus");
+
+    const response = await getBusRoute(
+      new Request("https://life.example/api/catalog/bus", {
+        headers: { [name]: value },
+      }),
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
+      "no-store",
+    );
+  });
+
+  it("publicly edge-caches viewer-independent route search", async () => {
+    searchBusRoutesMock.mockResolvedValue({
+      originCampus: campus,
+      destinationCampus: null,
+      total: 0,
+      routes: [],
+    });
+    const { getBusRoutesSearchRoute } = await import("@/lib/api/routes/bus");
+
+    const response = await getBusRoutesSearchRoute(
+      new Request("https://life.example/api/catalog/bus/routes"),
+    );
+
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
+      "public, max-age=3600, stale-while-revalidate=300",
+    );
+    expect(response.headers.get("Cache-Tag")).toBe("catalog");
+  });
+
+  it("never edge-caches time-sensitive next departures", async () => {
+    const { resolveApiUserId } = await import("@/lib/auth/api-auth");
+    vi.mocked(resolveApiUserId).mockResolvedValue(null);
+    getNextBusDeparturesMock.mockResolvedValue({
+      originCampus: campus,
+      destinationCampus: null,
+      atTime: "2026-08-14T00:00:00.000Z",
+      dayType: "weekday",
+      totalRoutes: 0,
+      departures: [],
+      nextAvailableDeparture: null,
+      message: null,
+    });
+    const { getBusNextDeparturesRoute } = await import("@/lib/api/routes/bus");
+
+    const response = await getBusNextDeparturesRoute(
+      new Request(
+        "https://life.example/api/catalog/bus/next?originCampusId=1&destinationCampusId=2",
+      ),
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
+      "no-store",
+    );
+  });
+});

--- a/tests/unit/bus-route-cache.test.ts
+++ b/tests/unit/bus-route-cache.test.ts
@@ -47,7 +47,7 @@ describe("bus REST cache boundaries", () => {
     vi.clearAllMocks();
   });
 
-  it("publicly edge-caches anonymous raw timetable responses", async () => {
+  it("keeps anonymous raw timetable responses private", async () => {
     const { resolveApiUserId } = await import("@/lib/auth/api-auth");
     vi.mocked(resolveApiUserId).mockResolvedValue(null);
     getBusTimetableDataMock.mockResolvedValue(timetable);
@@ -57,16 +57,13 @@ describe("bus REST cache boundaries", () => {
       new Request("https://life.example/api/catalog/bus"),
     );
 
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
-      "public, max-age=3600, stale-while-revalidate=300",
+      "no-store",
     );
-    expect(response.headers.get("Cache-Tag")).toBe("catalog");
   });
 
-  it.each([
-    ["authorization", "Bearer token"],
-    ["cookie", "better-auth.session_token=session"],
-  ])("keeps an auth-signaled timetable response private", async (name, value) => {
+  it("keeps an auth-signaled timetable response private", async () => {
     const { resolveApiUserId } = await import("@/lib/auth/api-auth");
     vi.mocked(resolveApiUserId).mockResolvedValue(null);
     getBusTimetableDataMock.mockResolvedValue(timetable);
@@ -74,7 +71,7 @@ describe("bus REST cache boundaries", () => {
 
     const response = await getBusRoute(
       new Request("https://life.example/api/catalog/bus", {
-        headers: { [name]: value },
+        headers: { cookie: "better-auth.session_token=session" },
       }),
     );
 

--- a/tests/unit/bus-timetable-data.test.ts
+++ b/tests/unit/bus-timetable-data.test.ts
@@ -127,9 +127,11 @@ type TimetableModule =
   typeof import("@/features/bus/server/bus-timetable-data");
 type QueryServiceModule =
   typeof import("@/features/bus/server/bus-query-service");
+type TransitMapModule = typeof import("@/features/bus/server/bus-transit-map");
 
 let timetable: TimetableModule;
 let queryService: QueryServiceModule;
+let transitMap: TransitMapModule;
 
 function versionLookupCount(key: string) {
   return db.busScheduleVersionFindUnique.mock.calls.filter(([args]) => {
@@ -184,6 +186,7 @@ beforeEach(async () => {
   resetDbMocks();
   timetable = await import("@/features/bus/server/bus-timetable-data");
   queryService = await import("@/features/bus/server/bus-query-service");
+  transitMap = await import("@/features/bus/server/bus-transit-map");
 });
 
 afterEach(() => {
@@ -234,6 +237,29 @@ describe("getBusTimetableData 班车时刻表数据", () => {
     expect(db.busScheduleVersionFindUnique).not.toHaveBeenCalled();
     expect(db.busCampusFindMany).not.toHaveBeenCalled();
     expect(db.busRouteFindMany).not.toHaveBeenCalled();
+  });
+
+  it("bus map 复用静态时刻表缓存并按请求时间重算 active trips", async () => {
+    await timetable.getStaticBusTimetableData({
+      locale: "zh-cn",
+      now: "2026-02-02T00:00:00.000Z",
+      versionKey: "old-bus",
+    });
+    vi.clearAllMocks();
+
+    const data = await transitMap.getBusMapData({
+      locale: "zh-cn",
+      now: "2026-02-02T00:05:00.000Z",
+      versionKey: "old-bus",
+    });
+
+    expect(data?.now).toBe("2026-02-02T00:05:00.000Z");
+    expect(data?.activeTrips).toEqual([
+      expect.objectContaining({ routeId: 8, status: "en-route" }),
+    ]);
+    expect(db.busTripFindMany).not.toHaveBeenCalled();
+    expect(db.busScheduleVersionFindMany).not.toHaveBeenCalled();
+    expect(db.busScheduleVersionFindUnique).not.toHaveBeenCalled();
   });
 
   it("为每次调用刷新 fetchedAt 而不重新加载静态数据", async () => {

--- a/tests/unit/public-ssr-gateway.test.ts
+++ b/tests/unit/public-ssr-gateway.test.ts
@@ -84,7 +84,6 @@ describe("public SSR gateway", () => {
     "/catalog/sections?credits=2.5&sort=credits&order=asc",
     "/catalog/sections?semesterId=301&teacher=&courseCode=&sectionCode=&campusId=&departmentId=&credits=&categoryId=&educationLevelId=&classTypeId=&sort=",
     "/catalog/teachers?departmentId=1",
-    "/catalog/bus/map",
     "/api-docs",
     "/api/docs/rest/catalog",
     "/usage/mobile",
@@ -95,6 +94,10 @@ describe("public SSR gateway", () => {
     "/terms",
   ])("caches allowlisted anonymous page %s", (path) => {
     expect(resolvePublicSsrMode(request(path))).toBe("page");
+  });
+
+  test("keeps the request-time bus map out of the 24-hour HTML cache", () => {
+    expect(resolvePublicSsrMode(request("/catalog/bus/map"))).toBeNull();
   });
 
   test.each([

--- a/tests/unit/public-ssr-worker-routing.test.ts
+++ b/tests/unit/public-ssr-worker-routing.test.ts
@@ -27,9 +27,12 @@ describe("public SSR worker routing", () => {
     "/catalog/courses",
     "/catalog/sections/159446",
     "/privacy",
-    "/catalog/bus/map",
   ])("serves anonymous %s through the PublicSsr cache path", (path) => {
     expect(workerSsrRoute(request(path))).toBe("public-ssr");
+  });
+
+  test("serves the request-time bus map through dynamic SSR", () => {
+    expect(workerSsrRoute(request("/catalog/bus/map"))).toBe("dynamic-ssr");
   });
 
   test.each([


### PR DESCRIPTION
## Summary
- cache viewer-independent bus route search responses at the edge
- keep the mixed timetable/preferences endpoint and next-departure responses private
- reuse the static timetable read model so hot map requests avoid database reads
- remove dynamic bus-map SSR from the long-lived public HTML cache

## Performance impact
- hot bus-map static schedule/topology reads use the revision-scoped runtime cache
- viewer-independent route searches gain a one-hour edge TTL with stale-while-revalidate
- personalized timetable responses remain isolated from public cache entries

## Validation
- full unit suite: 333 files / 2018 tests
- focused cache-boundary unit tests
- OpenAPI/build checks
- Wrangler types, TypeScript, Svelte, and Biome checks
- PR CI caught and verified the personalized-cache boundary fix