### PR TITLE
perf(catalog): cache current semester reads

### DIFF
--- a/docs/contracts/semester.json
+++ b/docs/contracts/semester.json
@@ -8,7 +8,7 @@
   },
   "rules": {
     "organizational-dimension": "Semesters are the organizational dimension for courses, sections, schedules, and exams.",
-    "current-semester-by-rules": "The current semester must be determined by explicit business rules, not by rough natural-year inference.",
+    "current-semester-by-rules": "The current semester must be determined by explicit business rules against the current Asia/Shanghai calendar date, not by rough natural-year inference. Public REST, GraphQL, and MCP reads share a static-revision- and date-scoped runtime cache.",
     "semester-visible-in-filters": "Semesters should be clearly visible in filters, group headings, detail basic info, and cross-semester browsing."
   },
   "capabilities": {

--- a/src/features/catalog/lib/current-semester.ts
+++ b/src/features/catalog/lib/current-semester.ts
@@ -1,4 +1,6 @@
 import type { Prisma } from "@/generated/prisma/client";
+import { parseDateInput } from "@/lib/time/parse-date-input";
+import { formatShanghaiDate } from "@/lib/time/shanghai-format";
 
 type SemesterWithDateRange = {
   startDate: Date | null;
@@ -18,10 +20,19 @@ const byMostSpecific = <TSemester extends SemesterWithDateRange>(
 
 export const buildCurrentSemesterWhere = (
   referenceDate: Date,
-): Prisma.SemesterWhereInput => ({
-  startDate: { lte: referenceDate },
-  endDate: { gte: referenceDate },
-});
+): Prisma.SemesterWhereInput => {
+  const dateOnlyReference = parseDateInput(formatShanghaiDate(referenceDate));
+  if (!(dateOnlyReference instanceof Date)) {
+    throw new TypeError("Invalid current-semester reference date");
+  }
+  return {
+    startDate: { lte: dateOnlyReference },
+    endDate: { gte: dateOnlyReference },
+  };
+};
+
+export const currentSemesterDateKey = (referenceDate: Date) =>
+  formatShanghaiDate(referenceDate);
 
 export const selectCurrentSemesterFromList = <
   TSemester extends SemesterWithDateRange,

--- a/src/features/catalog/server/academic-metadata-read-model.ts
+++ b/src/features/catalog/server/academic-metadata-read-model.ts
@@ -1,7 +1,12 @@
-import { buildCurrentSemesterWhere } from "@/features/catalog/lib/current-semester";
+import {
+  buildCurrentSemesterWhere,
+  currentSemesterDateKey,
+} from "@/features/catalog/lib/current-semester";
 import type { PrismaClient, Semester } from "@/generated/prisma/client";
+import { cachedCatalogRuntimeData } from "@/lib/catalog-runtime-cache";
 import { prisma } from "@/lib/db/prisma";
 import { paginatedQuery } from "@/lib/query-pagination";
+import { getCanonicalOrigin } from "@/lib/site-url";
 
 type SemesterFindFirstDelegate = Pick<PrismaClient["semester"], "findFirst">;
 
@@ -21,6 +26,19 @@ export const findCurrentSemester = (
 
 export const getCurrentSemester = (referenceDate = new Date()) =>
   findCurrentSemester(prisma.semester, referenceDate);
+
+export function getCachedCurrentSemester(
+  referenceDate = new Date(),
+  origin = getCanonicalOrigin(),
+) {
+  const dateKey = currentSemesterDateKey(referenceDate);
+  return cachedCatalogRuntimeData(
+    "catalog:current-semester",
+    `current-semester:${dateKey}`,
+    origin,
+    () => getCurrentSemester(referenceDate),
+  );
+}
 
 export async function getAcademicMetadata() {
   const [

--- a/src/features/catalog/server/course-page-data.ts
+++ b/src/features/catalog/server/course-page-data.ts
@@ -2,7 +2,6 @@ import type { CourseDetailSection } from "@/features/catalog/components/catalog-
 import { localizedNameSelect } from "@/features/section-detail/server/section-page-name-selects";
 import { getPrisma } from "@/lib/db/prisma";
 import { toLoadData } from "@/lib/load-data-utils";
-import { resolveCourseIdByJwId } from "./course-jw-id";
 
 const coursePageSectionsSelect = {
   jwId: true,
@@ -28,10 +27,8 @@ export async function getCoursePage(
   options: { includeSections?: boolean } = {},
 ) {
   const prisma = getPrisma(locale);
-  const courseId = await resolveCourseIdByJwId(prisma, jwId);
-  if (courseId == null) return null;
   const course = await prisma.course.findUnique({
-    where: { id: courseId },
+    where: { jwId },
     select: {
       id: true,
       jwId: true,

--- a/src/features/catalog/server/course-section-read-queries.ts
+++ b/src/features/catalog/server/course-section-read-queries.ts
@@ -9,7 +9,6 @@ import type { AppLocale } from "@/i18n/config";
 import { DEFAULT_LOCALE } from "@/i18n/config";
 import { getPrisma } from "@/lib/db/prisma";
 import { serializeScheduleTimeFields } from "@/shared/lib/schedule-serialization";
-import { resolveCourseIdByJwId } from "./course-jw-id";
 
 const sectionDetailInclude = {
   ...sectionInclude,
@@ -40,11 +39,8 @@ export async function findCourseDetailByJwId(
   jwId: number,
   locale: AppLocale = DEFAULT_LOCALE,
 ) {
-  const prisma = getPrisma(locale);
-  const courseId = await resolveCourseIdByJwId(prisma, jwId);
-  if (courseId == null) return null;
-  return prisma.course.findUnique({
-    where: { id: courseId },
+  return getPrisma(locale).course.findUnique({
+    where: { jwId },
     include: courseDetailInclude,
   });
 }

--- a/src/lib/api/routes/academic-metadata-routes.ts
+++ b/src/lib/api/routes/academic-metadata-routes.ts
@@ -1,6 +1,6 @@
 import {
   getAcademicMetadata,
-  getCurrentSemester,
+  getCachedCurrentSemester,
   listSemesters,
 } from "@/features/catalog/server/academic-metadata-read-model";
 import {
@@ -11,7 +11,10 @@ import {
 } from "@/lib/api/helpers";
 import { semestersQuerySchema } from "@/lib/api/schemas/request-schemas";
 import { cachedCatalogRuntimeData } from "@/lib/catalog-runtime-cache";
-import { PUBLIC_CATALOG_HEADERS } from "@/lib/public-cache-control";
+import {
+  currentSemesterCacheHeaders,
+  PUBLIC_CATALOG_HEADERS,
+} from "@/lib/public-cache-control";
 import { getCanonicalOrigin } from "@/lib/site-url";
 
 export async function getMetadataRoute() {
@@ -61,15 +64,17 @@ export async function getSemestersRoute(request: Request) {
   }
 }
 
-export async function getCurrentSemesterRoute() {
+export async function getCurrentSemesterRoute(referenceDate = new Date()) {
   try {
-    const currentSemester = await getCurrentSemester(new Date());
+    const currentSemester = await getCachedCurrentSemester(referenceDate);
 
     if (!currentSemester) {
       return notFound("No current semester found");
     }
 
-    return jsonResponse(currentSemester);
+    return jsonResponse(currentSemester, {
+      headers: currentSemesterCacheHeaders(referenceDate),
+    });
   } catch (error) {
     return handleRouteError("Failed to fetch current semester", error);
   }

--- a/src/lib/graphql/schema.ts
+++ b/src/lib/graphql/schema.ts
@@ -4,7 +4,7 @@ import {
   listBusRoutes,
 } from "@/features/bus/server/bus-catalog";
 import {
-  getCurrentSemester,
+  getCachedCurrentSemester,
   listSemesters,
 } from "@/features/catalog/server/academic-metadata-read-model";
 import { listCourseSummaries } from "@/features/catalog/server/course-summary-read-model";
@@ -331,7 +331,7 @@ export const graphqlSchema = createSchema<
         return listSemesters(pagination);
       },
       currentSemester() {
-        return getCurrentSemester(new Date());
+        return getCachedCurrentSemester(new Date());
       },
       courses(
         _parent,

--- a/src/lib/mcp/tools/catalog/course-semester-tools.ts
+++ b/src/lib/mcp/tools/catalog/course-semester-tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod";
 import { CATALOG_MAX_PAGE } from "@/features/catalog/lib/catalog-list-query";
 import {
-  getCurrentSemester,
+  getCachedCurrentSemester,
   listSemesters,
 } from "@/features/catalog/server/academic-metadata-read-model";
 import {
@@ -42,7 +42,7 @@ export function registerCourseSemesterTools(server: McpServer) {
       },
     },
     async ({ mode }) => {
-      const semester = await getCurrentSemester(new Date());
+      const semester = await getCachedCurrentSemester(new Date());
 
       return jsonToolResult(
         {

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -78,6 +78,7 @@ type StorageOperationAnalyticsInput = {
 export type PublicRuntimeCacheAnalyticsNamespace =
   | "api:metadata"
   | "api:semesters"
+  | "catalog:current-semester"
   | "sitemap"
   | `page:section-detail:overview:${AppLocale}`
   | `search:catalog:${AppLocale}`

--- a/src/lib/public-cache-control.ts
+++ b/src/lib/public-cache-control.ts
@@ -1,4 +1,5 @@
 import { CATALOG_EDGE_CACHE_TAG } from "@/lib/catalog-runtime-cache";
+import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
 
 const HOUR_SECONDS = 3_600;
 
@@ -12,6 +13,19 @@ export const PUBLIC_CATALOG_HEADERS = {
   "Cache-Tag": CATALOG_EDGE_CACHE_TAG,
   "Cloudflare-CDN-Cache-Control": PUBLIC_CATALOG_CDN_CACHE_CONTROL,
 } as const;
+
+export function currentSemesterCacheHeaders(referenceDate: Date) {
+  const now = shanghaiDayjs(referenceDate);
+  const secondsUntilNextShanghaiDay = Math.max(
+    1,
+    now.add(1, "day").startOf("day").diff(now, "second"),
+  );
+  return {
+    "Cache-Control": "public, max-age=0",
+    "Cache-Tag": CATALOG_EDGE_CACHE_TAG,
+    "Cloudflare-CDN-Cache-Control": `public, max-age=${secondsUntilNextShanghaiDay}`,
+  } as const;
+}
 
 export const PUBLIC_SEARCH_CACHE_HEADERS = {
   "Cache-Control":

--- a/tests/unit/catalog-detail-page-data.test.ts
+++ b/tests/unit/catalog-detail-page-data.test.ts
@@ -46,7 +46,11 @@ describe("catalog detail page data", () => {
       sectionCount: 3,
       sections: [],
     });
-    const courseSelect = courseFindUniqueMock.mock.calls[1]?.[0]?.select;
+    expect(courseFindUniqueMock).toHaveBeenCalledTimes(1);
+    expect(courseFindUniqueMock).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { jwId: course.jwId } }),
+    );
+    const courseSelect = courseFindUniqueMock.mock.calls[0]?.[0]?.select;
     expect(courseSelect).not.toHaveProperty("description");
     expect(courseSelect?.sections).toBe(false);
     expect(result).not.toHaveProperty("commentCount");

--- a/tests/unit/course-detail-query.test.ts
+++ b/tests/unit/course-detail-query.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { courseFindUniqueMock } = vi.hoisted(() => ({
+  courseFindUniqueMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  getPrisma: () => ({
+    course: { findUnique: courseFindUniqueMock },
+  }),
+}));
+
+describe("course detail query", () => {
+  beforeEach(() => {
+    courseFindUniqueMock.mockReset();
+  });
+
+  it("loads REST and MCP course detail directly by the unique jwId", async () => {
+    const course = { id: 7, jwId: 683_001 };
+    courseFindUniqueMock.mockResolvedValue(course);
+    const { findCourseDetailByJwId } = await import(
+      "@/features/catalog/server/course-section-read-queries"
+    );
+
+    await expect(findCourseDetailByJwId(course.jwId, "en-us")).resolves.toBe(
+      course,
+    );
+    expect(courseFindUniqueMock).toHaveBeenCalledTimes(1);
+    expect(courseFindUniqueMock).toHaveBeenCalledWith({
+      where: { jwId: course.jwId },
+      include: expect.any(Object),
+    });
+  });
+});

--- a/tests/unit/current-semester-read-model.test.ts
+++ b/tests/unit/current-semester-read-model.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { cachedCatalogRuntimeDataMock, semesterFindFirstMock } = vi.hoisted(
+  () => ({
+    cachedCatalogRuntimeDataMock: vi.fn(
+      async (
+        _namespace: string,
+        _cacheKey: string,
+        _origin: string,
+        load: () => Promise<unknown>,
+      ) => load(),
+    ),
+    semesterFindFirstMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/catalog-runtime-cache", () => ({
+  cachedCatalogRuntimeData: cachedCatalogRuntimeDataMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    semester: { findFirst: semesterFindFirstMock },
+  },
+}));
+
+describe("current semester read model", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shares a revision-aware runtime cache key scoped to the Shanghai date", async () => {
+    const semester = { id: 1, jwId: 421 };
+    semesterFindFirstMock.mockResolvedValue(semester);
+    const { getCachedCurrentSemester } = await import(
+      "@/features/catalog/server/academic-metadata-read-model"
+    );
+
+    await expect(
+      getCachedCurrentSemester(
+        new Date("2026-08-14T15:59:59.000Z"),
+        "https://life.example",
+      ),
+    ).resolves.toBe(semester);
+
+    expect(cachedCatalogRuntimeDataMock).toHaveBeenCalledWith(
+      "catalog:current-semester",
+      "current-semester:2026-08-14",
+      "https://life.example",
+      expect.any(Function),
+    );
+    expect(semesterFindFirstMock).toHaveBeenCalledWith({
+      where: {
+        startDate: { lte: new Date("2026-08-14T00:00:00.000Z") },
+        endDate: { gte: new Date("2026-08-14T00:00:00.000Z") },
+      },
+      orderBy: [
+        { startDate: "desc" },
+        { endDate: "asc" },
+        { jwId: "desc" },
+        { id: "desc" },
+      ],
+    });
+  });
+
+  it("also caches a missing result without changing its null semantics", async () => {
+    semesterFindFirstMock.mockResolvedValue(null);
+    const { getCachedCurrentSemester } = await import(
+      "@/features/catalog/server/academic-metadata-read-model"
+    );
+
+    await expect(
+      getCachedCurrentSemester(
+        new Date("2026-08-15T00:00:00.000Z"),
+        "https://life.example",
+      ),
+    ).resolves.toBeNull();
+    expect(cachedCatalogRuntimeDataMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/current-semester-route.test.ts
+++ b/tests/unit/current-semester-route.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getCachedCurrentSemesterMock } = vi.hoisted(() => ({
+  getCachedCurrentSemesterMock: vi.fn(),
+}));
+
+vi.mock("@/features/catalog/server/academic-metadata-read-model", () => ({
+  getAcademicMetadata: vi.fn(),
+  getCachedCurrentSemester: getCachedCurrentSemesterMock,
+  listSemesters: vi.fn(),
+}));
+
+vi.mock("@/lib/catalog-runtime-cache", () => ({
+  CATALOG_EDGE_CACHE_TAG: "catalog",
+  cachedCatalogRuntimeData: vi.fn(),
+}));
+
+describe("current semester REST route", () => {
+  beforeEach(() => {
+    getCachedCurrentSemesterMock.mockReset();
+  });
+
+  it("adds public catalog CDN headers to a successful response", async () => {
+    getCachedCurrentSemesterMock.mockResolvedValue({ id: 1, jwId: 421 });
+    const { getCurrentSemesterRoute } = await import(
+      "@/lib/api/routes/academic-metadata-routes"
+    );
+
+    const response = await getCurrentSemesterRoute(
+      new Date("2026-08-14T04:00:00.000Z"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=0");
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
+      "public, max-age=43200",
+    );
+  });
+
+  it("keeps a missing semester as an uncached 404", async () => {
+    getCachedCurrentSemesterMock.mockResolvedValue(null);
+    const { getCurrentSemesterRoute } = await import(
+      "@/lib/api/routes/academic-metadata-routes"
+    );
+
+    const response = await getCurrentSemesterRoute();
+
+    expect(response.status).toBe(404);
+    expect(response.headers.has("Cloudflare-CDN-Cache-Control")).toBe(false);
+  });
+});

--- a/tests/unit/current-semester.test.ts
+++ b/tests/unit/current-semester.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCurrentSemesterWhere,
+  currentSemesterDateKey,
   selectCurrentSemesterFromList,
 } from "@/features/catalog/lib/current-semester";
 
@@ -17,6 +18,28 @@ describe("当前学期辅助函数", () => {
       startDate: { lte: now },
       endDate: { gte: now },
     });
+  });
+
+  it("按上海自然日归一化查询日期并生成缓存键", () => {
+    const lateOnEndDate = new Date("2026-08-14T15:59:59.000Z");
+    const dateOnly = new Date("2026-08-14T00:00:00.000Z");
+
+    expect(buildCurrentSemesterWhere(lateOnEndDate)).toEqual({
+      startDate: { lte: dateOnly },
+      endDate: { gte: dateOnly },
+    });
+    expect(currentSemesterDateKey(lateOnEndDate)).toBe("2026-08-14");
+  });
+
+  it("上海午夜后切换到新的查询日期和缓存键", () => {
+    const afterMidnight = new Date("2026-08-14T16:00:00.000Z");
+    const dateOnly = new Date("2026-08-15T00:00:00.000Z");
+
+    expect(buildCurrentSemesterWhere(afterMidnight)).toEqual({
+      startDate: { lte: dateOnly },
+      endDate: { gte: dateOnly },
+    });
+    expect(currentSemesterDateKey(afterMidnight)).toBe("2026-08-15");
   });
 
   it("优先选择第一个未结束学期", () => {

--- a/tests/unit/graphql-document-runner.test.ts
+++ b/tests/unit/graphql-document-runner.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
 
 const catalogService = vi.hoisted(() => ({
-  getCurrentSemester: vi.fn(),
+  getCachedCurrentSemester: vi.fn(),
 }));
 
 vi.mock(
@@ -14,7 +14,7 @@ vi.mock(
       >();
     return {
       ...original,
-      getCurrentSemester: catalogService.getCurrentSemester,
+      getCachedCurrentSemester: catalogService.getCachedCurrentSemester,
     };
   },
 );
@@ -61,7 +61,7 @@ function installAnalytics() {
 describe("arbitrary GraphQL document runner", () => {
   beforeEach(() => {
     vi.spyOn(console, "info").mockImplementation(() => {});
-    catalogService.getCurrentSemester.mockResolvedValue({
+    catalogService.getCachedCurrentSemester.mockResolvedValue({
       id: 1,
       jwId: 202601,
       code: "2026SP",
@@ -73,7 +73,7 @@ describe("arbitrary GraphQL document runner", () => {
 
   afterEach(() => {
     setCloudflareRuntimeEnv(undefined);
-    catalogService.getCurrentSemester.mockReset();
+    catalogService.getCachedCurrentSemester.mockReset();
     vi.restoreAllMocks();
   });
 

--- a/tests/unit/graphql-operation-runner.test.ts
+++ b/tests/unit/graphql-operation-runner.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../shared/deferred";
 
 const catalogService = vi.hoisted(() => ({
-  getCurrentSemester: vi.fn(),
+  getCachedCurrentSemester: vi.fn(),
 }));
 const todoService = vi.hoisted(() => ({
   createTodo: vi.fn(),
@@ -23,7 +23,7 @@ vi.mock(
       >();
     return {
       ...original,
-      getCurrentSemester: catalogService.getCurrentSemester,
+      getCachedCurrentSemester: catalogService.getCachedCurrentSemester,
     };
   },
 );
@@ -124,7 +124,7 @@ describe("registered GraphQL operation runner", () => {
   });
 
   afterEach(() => {
-    catalogService.getCurrentSemester.mockReset();
+    catalogService.getCachedCurrentSemester.mockReset();
     todoService.createTodo.mockReset();
     uploadService.completeOwnedUploadSession.mockReset();
     mutationRateLimit.checkUserMutationRateLimit.mockReset();
@@ -133,7 +133,7 @@ describe("registered GraphQL operation runner", () => {
   });
 
   it("executes a fixed pre-parsed operation without accepting a document", async () => {
-    catalogService.getCurrentSemester.mockResolvedValue(currentSemester);
+    catalogService.getCachedCurrentSemester.mockResolvedValue(currentSemester);
 
     await expect(run("catalog.semester.current.get.v1")).resolves.toMatchObject(
       {
@@ -240,7 +240,7 @@ describe("registered GraphQL operation runner", () => {
   });
 
   it("masks unexpected resolver failures", async () => {
-    catalogService.getCurrentSemester.mockRejectedValue(
+    catalogService.getCachedCurrentSemester.mockRejectedValue(
       new Error("private-current-semester-failure"),
     );
 
@@ -260,7 +260,7 @@ describe("registered GraphQL operation runner", () => {
     vi.useFakeTimers();
     const result = createDeferred<typeof currentSemester>();
     const started = createDeferred<void>();
-    catalogService.getCurrentSemester.mockImplementation(() => {
+    catalogService.getCachedCurrentSemester.mockImplementation(() => {
       started.resolve(undefined);
       return result.promise;
     });
@@ -305,7 +305,7 @@ describe("registered GraphQL operation runner", () => {
     const result = createDeferred<typeof currentSemester>();
     const started = createDeferred<void>();
     const controller = new AbortController();
-    catalogService.getCurrentSemester.mockImplementation(() => {
+    catalogService.getCachedCurrentSemester.mockImplementation(() => {
       started.resolve(undefined);
       return result.promise;
     });


### PR DESCRIPTION
## Summary\n- collapse course detail lookups from two serial database round trips to one unique lookup\n- share current-semester runtime caching across REST, GraphQL, and MCP\n- normalize current-semester comparisons to the Shanghai calendar date\n- cache successful REST responses only until the next Shanghai midnight\n\n## Validation\n- full unit suite: 335 files / 2019 tests\n- OpenAPI and GraphQL schema checks\n- Wrangler types, TypeScript, Svelte, and Biome checks\n\nDB-backed integration coverage is delegated to PR CI.