### PR TITLE
perf(catalog): bound public teacher payloads

### DIFF
--- a/docs/contracts/course.json
+++ b/docs/contracts/course.json
@@ -16,7 +16,8 @@
     "public-list-cache": "Course REST responses may use short shared CDN caching only when a supported locale is explicit in the locale URL query; responses localized from Cookie/Accept-Language fallback are private/no-store. Server-side list data may still use short locale-keyed runtime caching. Localized HTML pages must not use shared edge caching unless the cache key varies by locale.",
     "mobile-detail-hierarchy": "Course detail pages present the public course code before the localized display name on mobile, use a responsive title size, and use the Detail Two-Column Stream without a context-tab rail.",
     "detail-canonical-url": "The canonical course detail URL is `/catalog/courses/[jwId]`. Legacy path segments and `?tab=` deep links permanently redirect to the root; optional hash anchors scroll within the page.",
-    "static-classification-unsupported": "Static course snapshots do not currently provide CourseClassify source data, so static-loaded courses keep classifyId/classify null and static-loaded metadata may expose courseClassifies as an empty array."
+    "static-classification-unsupported": "Static course snapshots do not currently provide CourseClassify source data, so static-loaded courses keep classifyId/classify null and static-loaded metadata may expose courseClassifies as an empty array.",
+    "bounded-detail-history": "Course detail returns the 20 most recent Section offerings plus the total Section count. Nested teacher references contain only public identity and localized names; contact and private source columns are never embedded."
   },
   "capabilities": {
     "course-list": {
@@ -96,7 +97,10 @@
         "routes": [
           {
             "path": "/api/catalog/courses/[jwId]",
-            "returns": "CourseDetail"
+            "returns": "CourseDetail",
+            "notes": [
+              "sections is a newest-first preview capped at 20 records; _count.sections is the complete historical total."
+            ]
           }
         ]
       },

--- a/docs/contracts/section.json
+++ b/docs/contracts/section.json
@@ -16,7 +16,8 @@
     "student-identity-teachers": "Student-facing section identity is the course display name plus teachers. Section code is secondary (monospace in lists, search descriptions, and the Basic Info Card) and must not dominate search titles or the detail hero.",
     "public-list-cache": "Section REST responses may use short shared CDN caching only when a supported locale is explicit in the locale URL query; responses localized from Cookie/Accept-Language fallback are private/no-store. Server-side list data may still use short locale-keyed runtime caching. Localized HTML pages must not use shared edge caching unless the cache key varies by locale.",
     "mobile-detail-actions": "Section detail pages present concise metadata and teachers with a responsive course title, use the Detail Two-Column Stream (no context-tab rail), and keep the primary calendar and subscription actions available in a bottom sticky action bar that stays above the signed-in shell navigation.",
-    "detail-canonical-url": "The canonical section detail URL is `/catalog/sections/[jwId]`. Legacy path segments and `?tab=` deep links permanently redirect to the root; optional hash anchors scroll within the page."
+    "detail-canonical-url": "The canonical section detail URL is `/catalog/sections/[jwId]`. Legacy path segments and `?tab=` deep links permanently redirect to the root; optional hash anchors scroll within the page.",
+    "public-teacher-reference": "Teachers embedded in Section list/detail payloads contain only public identity and localized names, with department/title added only where the detail UI requests that context. TeacherAssignment links by teacherId and does not duplicate the nested Teacher object. Contact and private source columns are available only on the teacher's own public detail where explicitly permitted."
   },
   "capabilities": {
     "section-list": {

--- a/docs/contracts/teacher.json
+++ b/docs/contracts/teacher.json
@@ -11,7 +11,8 @@
     "section-code-auxiliary": "Section codes retain value on teacher pages but appear only as auxiliary fields in the teaching section list.",
     "public-list-cache": "Teacher REST responses may use short shared CDN caching only when a supported locale is explicit in the locale URL query; responses localized from Cookie/Accept-Language fallback are private/no-store. Server-side list data may still use short locale-keyed runtime caching. Localized HTML pages must not use shared edge caching unless the cache key varies by locale.",
     "mobile-detail-hierarchy": "Teacher detail pages use a responsive title size and the Detail Two-Column Stream without a context-tab rail on mobile.",
-    "detail-canonical-url": "The canonical teacher detail URL is `/catalog/teachers/[id]`. Legacy path segments and `?tab=` deep links permanently redirect to the root; optional hash anchors scroll within the page."
+    "detail-canonical-url": "The canonical teacher detail URL is `/catalog/teachers/[id]`. Legacy path segments and `?tab=` deep links permanently redirect to the root; optional hash anchors scroll within the page.",
+    "bounded-detail-history": "Teacher detail returns the 20 most recent Section offerings plus the total Section count. Public teacher payloads explicitly select allowed fields and never expose source-only columns such as age, postcode, QQ, or WeChat."
   },
   "capabilities": {
     "teacher-list": {
@@ -91,7 +92,10 @@
         "routes": [
           {
             "path": "/api/catalog/teachers/[id]",
-            "returns": "TeacherDetail"
+            "returns": "TeacherDetail",
+            "notes": [
+              "sections is a newest-first preview capped at 20 records; _count.sections is the complete historical total."
+            ]
           }
         ]
       },

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -22814,33 +22814,12 @@
                         "nullable": true,
                         "type": "string"
                       },
-                      "email": {
-                        "nullable": true,
+                      "namePrimary": {
                         "type": "string"
                       },
-                      "telephone": {
+                      "nameSecondary": {
                         "nullable": true,
                         "type": "string"
-                      },
-                      "mobile": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "address": {
-                        "nullable": true,
-                        "type": "string"
-                      },
-                      "departmentId": {
-                        "nullable": true,
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
-                      },
-                      "teacherTitleId": {
-                        "nullable": true,
-                        "type": "integer",
-                        "minimum": -9007199254740991,
-                        "maximum": 9007199254740991
                       }
                     },
                     "required": [
@@ -22850,12 +22829,8 @@
                       "code",
                       "nameCn",
                       "nameEn",
-                      "email",
-                      "telephone",
-                      "mobile",
-                      "address",
-                      "departmentId",
-                      "teacherTitleId"
+                      "namePrimary",
+                      "nameSecondary"
                     ],
                     "additionalProperties": false
                   }
@@ -22902,6 +22877,20 @@
               ],
               "additionalProperties": false
             }
+          },
+          "_count": {
+            "type": "object",
+            "properties": {
+              "sections": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": [
+              "sections"
+            ],
+            "additionalProperties": false
           }
         },
         "required": [
@@ -22922,7 +22911,8 @@
           "educationLevel",
           "gradation",
           "type",
-          "sections"
+          "sections",
+          "_count"
         ],
         "additionalProperties": false
       },
@@ -23671,33 +23661,12 @@
                   "nullable": true,
                   "type": "string"
                 },
-                "email": {
-                  "nullable": true,
+                "namePrimary": {
                   "type": "string"
                 },
-                "telephone": {
+                "nameSecondary": {
                   "nullable": true,
                   "type": "string"
-                },
-                "mobile": {
-                  "nullable": true,
-                  "type": "string"
-                },
-                "address": {
-                  "nullable": true,
-                  "type": "string"
-                },
-                "departmentId": {
-                  "nullable": true,
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
-                },
-                "teacherTitleId": {
-                  "nullable": true,
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
                 },
                 "department": {
                   "nullable": true,
@@ -23721,6 +23690,13 @@
                     "isCollege": {
                       "nullable": true,
                       "type": "boolean"
+                    },
+                    "namePrimary": {
+                      "type": "string"
+                    },
+                    "nameSecondary": {
+                      "nullable": true,
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23728,7 +23704,9 @@
                     "code",
                     "nameCn",
                     "nameEn",
-                    "isCollege"
+                    "isCollege",
+                    "namePrimary",
+                    "nameSecondary"
                   ],
                   "additionalProperties": false
                 },
@@ -23759,6 +23737,13 @@
                     "enabled": {
                       "nullable": true,
                       "type": "boolean"
+                    },
+                    "namePrimary": {
+                      "type": "string"
+                    },
+                    "nameSecondary": {
+                      "nullable": true,
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23767,7 +23752,9 @@
                     "nameCn",
                     "nameEn",
                     "code",
-                    "enabled"
+                    "enabled",
+                    "namePrimary",
+                    "nameSecondary"
                   ],
                   "additionalProperties": false
                 }
@@ -23779,12 +23766,8 @@
                 "code",
                 "nameCn",
                 "nameEn",
-                "email",
-                "telephone",
-                "mobile",
-                "address",
-                "departmentId",
-                "teacherTitleId",
+                "namePrimary",
+                "nameSecondary",
                 "department",
                 "teacherTitle"
               ],
@@ -23840,81 +23823,6 @@
                   "minimum": -9007199254740991,
                   "maximum": 9007199254740991
                 },
-                "teacher": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "jwId": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "personId": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "code": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "nameCn": {
-                      "type": "string"
-                    },
-                    "nameEn": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "email": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "telephone": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "mobile": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "address": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "departmentId": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "teacherTitleId": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "jwId",
-                    "personId",
-                    "code",
-                    "nameCn",
-                    "nameEn",
-                    "email",
-                    "telephone",
-                    "mobile",
-                    "address",
-                    "departmentId",
-                    "teacherTitleId"
-                  ],
-                  "additionalProperties": false
-                },
                 "teacherLessonType": {
                   "nullable": true,
                   "type": "object",
@@ -23969,7 +23877,6 @@
                 "weekIndices",
                 "weekIndicesMsg",
                 "teacherLessonTypeId",
-                "teacher",
                 "teacherLessonType"
               ],
               "additionalProperties": false

--- a/src/features/catalog/components/CourseDetailPageController.svelte
+++ b/src/features/catalog/components/CourseDetailPageController.svelte
@@ -136,6 +136,9 @@ $: displayName =
           <h2 class="mb-3 text-lg font-semibold tracking-tight">
             {copy.courseDetail.teachingSections}
           </h2>
+          <p class="mb-4 text-sm text-muted-foreground">
+            {copy.courseDetail.teachingSectionsDescription}
+          </p>
           <CourseDetailSections
             copy={detailCopy}
             course={data.course}

--- a/src/features/catalog/components/TeacherDetailPageController.svelte
+++ b/src/features/catalog/components/TeacherDetailPageController.svelte
@@ -125,6 +125,9 @@ $: displayName = catalogLocalizedDisplayName(data.teacher, data.locale);
           <h2 class="mb-3 text-lg font-semibold tracking-tight">
             {copy.teacherDetail.teachingSectionsTitle}
           </h2>
+          <p class="mb-4 text-sm text-muted-foreground">
+            {copy.teacherDetail.teachingSectionsDescription}
+          </p>
           <TeacherDetailSections
             copy={detailCopy}
             locale={data.locale}

--- a/src/features/catalog/server/academic-query-includes.ts
+++ b/src/features/catalog/server/academic-query-includes.ts
@@ -36,6 +36,50 @@ const teacherPublicScalarSelect = {
   teacherTitleId: true,
 } satisfies Prisma.TeacherSelect;
 
+/** Safe teacher identity for embedding in public course/section summaries. */
+export const teacherPublicIdentitySelect = {
+  id: true,
+  jwId: true,
+  personId: true,
+  code: true,
+  ...localizedNameSelect,
+} satisfies Prisma.TeacherSelect;
+
+/** Public teacher reference with the catalog context used by section detail. */
+export const teacherPublicReferenceSelect = {
+  ...teacherPublicIdentitySelect,
+  department: {
+    select: departmentSummarySelect,
+  },
+  teacherTitle: {
+    select: teacherTitleSummarySelect,
+  },
+} satisfies Prisma.TeacherSelect;
+
+export const PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT = 20;
+
+export const teacherAssignmentPublicSelect = {
+  id: true,
+  teacherId: true,
+  sectionId: true,
+  role: true,
+  period: true,
+  weekIndices: true,
+  weekIndicesMsg: true,
+  teacherLessonTypeId: true,
+  teacherLessonType: {
+    select: {
+      id: true,
+      jwId: true,
+      nameCn: true,
+      nameEn: true,
+      code: true,
+      role: true,
+      enabled: true,
+    },
+  },
+} satisfies Prisma.TeacherAssignmentSelect;
+
 /** Narrow teacher payload for schedule entries: names and department only. */
 export const scheduleTeacherSelect = {
   id: true,
@@ -116,13 +160,7 @@ export const sectionSummarySelect = {
     },
   },
   teachers: {
-    select: {
-      id: true,
-      jwId: true,
-      personId: true,
-      code: true,
-      ...localizedNameSelect,
-    },
+    select: teacherPublicIdentitySelect,
   },
 };
 
@@ -141,7 +179,7 @@ export const sectionCompactInclude = {
   semester: true,
   campus: true,
   openDepartment: true,
-  teachers: true,
+  teachers: { select: teacherPublicIdentitySelect },
 } satisfies Prisma.SectionInclude;
 
 /** Common include object for sections. */
@@ -161,7 +199,7 @@ export const sectionInclude = {
   openDepartment: true,
   examMode: true,
   teachLanguage: true,
-  teachers: true,
+  teachers: { select: teacherPublicIdentitySelect },
   adminClasses: true,
 } satisfies Prisma.SectionInclude;
 
@@ -195,6 +233,7 @@ export const teacherPublicDetailSelect = {
       { semester: { jwId: "desc" as const } },
       { course: { nameCn: "asc" as const } },
     ],
+    take: PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
   },
   _count: {
     select: {
@@ -221,10 +260,12 @@ export const courseDetailInclude = {
     include: {
       semester: true,
       campus: true,
-      teachers: true,
+      teachers: { select: teacherPublicIdentitySelect },
     },
     orderBy: [{ semester: { jwId: "desc" } }, { code: "asc" }],
+    take: PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
   },
+  _count: { select: { sections: true } },
 } satisfies Prisma.CourseInclude;
 
 /** @deprecated Use teacherPublicListSelect with select instead of include. */

--- a/src/features/catalog/server/course-page-data.ts
+++ b/src/features/catalog/server/course-page-data.ts
@@ -1,4 +1,5 @@
 import type { CourseDetailSection } from "@/features/catalog/components/catalog-detail-component-types";
+import { PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT } from "@/features/catalog/server/academic-query-includes";
 import { localizedNameSelect } from "@/features/section-detail/server/section-page-name-selects";
 import { getPrisma } from "@/lib/db/prisma";
 import { toLoadData } from "@/lib/load-data-utils";
@@ -60,6 +61,7 @@ export async function getCoursePage(
           ? false
           : {
               orderBy: [{ semester: { jwId: "desc" } }, { code: "asc" }],
+              take: PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
               select: coursePageSectionsSelect,
             },
     },

--- a/src/features/catalog/server/course-section-read-queries.ts
+++ b/src/features/catalog/server/course-section-read-queries.ts
@@ -4,6 +4,8 @@ import {
   sectionCatalogInclude,
   sectionCompactInclude,
   sectionInclude,
+  teacherAssignmentPublicSelect,
+  teacherPublicReferenceSelect,
 } from "@/features/catalog/server/academic-query-includes";
 import type { AppLocale } from "@/i18n/config";
 import { DEFAULT_LOCALE } from "@/i18n/config";
@@ -15,18 +17,8 @@ const sectionDetailInclude = {
   roomType: true,
   schedules: true,
   scheduleGroups: true,
-  teachers: {
-    include: {
-      department: true,
-      teacherTitle: true,
-    },
-  },
-  teacherAssignments: {
-    include: {
-      teacher: true,
-      teacherLessonType: true,
-    },
-  },
+  teachers: { select: teacherPublicReferenceSelect },
+  teacherAssignments: { select: teacherAssignmentPublicSelect },
   exams: {
     include: {
       examBatch: true,
@@ -121,22 +113,16 @@ function buildPartialSectionDetailInclude(options: {
 }) {
   const includeExams = options.includeExams === true;
   const includeSchedules = options.includeSchedules === true;
-  const includeTeacherDepartments = options.includeTeacherDepartments === true;
-
   return {
     ...sectionInclude,
     roomType: true,
     schedules: includeSchedules,
     scheduleGroups: includeSchedules,
-    teachers: includeTeacherDepartments
-      ? {
-          include: {
-            department: true,
-            teacherTitle: true,
-          },
-        }
-      : true,
-    teacherAssignments: includeTeacherDepartments,
+    teachers: { select: teacherPublicReferenceSelect },
+    teacherAssignments:
+      options.includeTeacherDepartments === true
+        ? { select: teacherAssignmentPublicSelect }
+        : false,
     exams: includeExams
       ? {
           include: {

--- a/src/features/catalog/server/teacher-page-data.ts
+++ b/src/features/catalog/server/teacher-page-data.ts
@@ -1,4 +1,5 @@
 import type { TeacherDetailSection } from "@/features/catalog/components/catalog-detail-component-types";
+import { PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT } from "@/features/catalog/server/academic-query-includes";
 import { localizedNameSelect } from "@/features/section-detail/server/section-page-name-selects";
 import { getPrisma } from "@/lib/db/prisma";
 import { toLoadData } from "@/lib/load-data-utils";
@@ -49,6 +50,7 @@ export async function getTeacherPage(
                 { semester: { jwId: "desc" } },
                 { course: { nameCn: "asc" } },
               ],
+              take: PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
               select: teacherPageSectionsSelect,
             },
     },

--- a/src/lib/api/schemas/academic-section-detail-response-schemas.ts
+++ b/src/lib/api/schemas/academic-section-detail-response-schemas.ts
@@ -15,7 +15,7 @@ import {
 } from "./academic-section-base-response-schemas";
 import {
   departmentSchema,
-  teacherWithDepartmentTitleSchema,
+  teacherPublicReferenceSchema,
 } from "./academic-teacher-response-schemas";
 
 export {
@@ -52,7 +52,7 @@ export const sectionDetailSchema = sectionBaseSchema.extend({
   roomType: roomTypeSchema.nullable(),
   schedules: z.array(scheduleBaseSchema),
   scheduleGroups: z.array(scheduleGroupSchema),
-  teachers: z.array(teacherWithDepartmentTitleSchema),
+  teachers: z.array(teacherPublicReferenceSchema),
   teacherAssignments: z.array(teacherAssignmentSchema),
   exams: z.array(examSchema),
   adminClasses: z.array(adminClassSchema),

--- a/src/lib/api/schemas/academic-section-list-response-schemas.ts
+++ b/src/lib/api/schemas/academic-section-list-response-schemas.ts
@@ -12,6 +12,7 @@ import {
 } from "./academic-section-base-response-schemas";
 import {
   departmentSchema,
+  teacherPublicIdentitySchema,
   teacherSchema,
   teacherWithDepartmentTitleSchema,
 } from "./academic-teacher-response-schemas";
@@ -90,18 +91,19 @@ export const sectionListSchema = sectionBaseSchema.extend({
   openDepartment: departmentSchema.nullable(),
   examMode: examModeSchema.nullable(),
   teachLanguage: teachLanguageSchema.nullable(),
-  teachers: z.array(teacherSchema),
+  teachers: z.array(teacherPublicIdentitySchema),
   adminClasses: z.array(adminClassSchema),
 });
 
 export const courseDetailSectionSchema = sectionBaseSchema.extend({
   semester: semesterSchema.nullable(),
   campus: campusSchema.nullable(),
-  teachers: z.array(teacherSchema),
+  teachers: z.array(teacherPublicIdentitySchema),
 });
 
 export const courseDetailSchema = courseSchema.extend({
   sections: z.array(courseDetailSectionSchema),
+  _count: z.object({ sections: z.number().int() }),
 });
 
 export const teacherDetailSectionSchema = sectionBaseSchema.extend({

--- a/src/lib/api/schemas/academic-teacher-assignment-response-schemas.ts
+++ b/src/lib/api/schemas/academic-teacher-assignment-response-schemas.ts
@@ -1,8 +1,5 @@
 import * as z from "zod";
-import {
-  teacherLessonTypeSchema,
-  teacherSchema,
-} from "./academic-teacher-response-schemas";
+import { teacherLessonTypeSchema } from "./academic-teacher-response-schemas";
 
 export const teacherAssignmentBaseSchema = z.object({
   id: z.number().int(),
@@ -16,6 +13,5 @@ export const teacherAssignmentBaseSchema = z.object({
 });
 
 export const teacherAssignmentSchema = teacherAssignmentBaseSchema.extend({
-  teacher: teacherSchema,
   teacherLessonType: teacherLessonTypeSchema.nullable(),
 });

--- a/src/lib/api/schemas/academic-teacher-response-schemas.ts
+++ b/src/lib/api/schemas/academic-teacher-response-schemas.ts
@@ -42,6 +42,32 @@ export const teacherSchema = z.object({
   teacherTitleId: z.number().int().nullable(),
 });
 
+export const teacherPublicIdentitySchema = z.object({
+  id: z.number().int(),
+  jwId: z.number().int(),
+  personId: z.number().int().nullable(),
+  code: z.string().nullable(),
+  nameCn: z.string(),
+  nameEn: z.string().nullable(),
+  namePrimary: z.string(),
+  nameSecondary: z.string().nullable(),
+});
+
+export const teacherPublicReferenceSchema = teacherPublicIdentitySchema.extend({
+  department: departmentSchema
+    .extend({
+      namePrimary: z.string(),
+      nameSecondary: z.string().nullable(),
+    })
+    .nullable(),
+  teacherTitle: teacherTitleSchema
+    .extend({
+      namePrimary: z.string(),
+      nameSecondary: z.string().nullable(),
+    })
+    .nullable(),
+});
+
 export const teacherWithDepartmentTitleSchema = teacherSchema.extend({
   department: departmentSchema.nullable(),
   teacherTitle: teacherTitleSchema.nullable(),

--- a/src/lib/mcp/tools/catalog/course-search-tools.ts
+++ b/src/lib/mcp/tools/catalog/course-search-tools.ts
@@ -46,7 +46,8 @@ export function registerCourseSearchTools(server: McpServer) {
   server.registerTool(
     "catalog_course_get",
     {
-      description: "Fetch one detailed course by USTC JW course ID.",
+      description:
+        "Fetch one detailed course by USTC JW course ID, with its 20 most recent sections and complete section count.",
       inputSchema: {
         jwId: z.number().int().positive(),
         locale: mcpLocaleInputSchema,

--- a/src/lib/mcp/tools/catalog/course-teacher-tools.ts
+++ b/src/lib/mcp/tools/catalog/course-teacher-tools.ts
@@ -41,7 +41,7 @@ export function registerCourseTeacherTools(server: McpServer) {
     "catalog_teacher_get",
     {
       description:
-        "Fetch one detailed teacher by numeric ID, including department and related sections.",
+        "Fetch one detailed teacher by numeric ID, including department, the 20 most recent sections, and complete section count.",
       inputSchema: {
         id: z.number().int().positive(),
         locale: mcpLocaleInputSchema,

--- a/tests/integration/mcp/catalog/search.test.ts
+++ b/tests/integration/mcp/catalog/search.test.ts
@@ -74,7 +74,7 @@ describe("课程与班级查找", () => {
           endTime?: unknown;
           startTime?: unknown;
         }>;
-        teacherAssignments?: unknown[];
+        teacherAssignments?: Array<Record<string, unknown>>;
         scheduleGroups?: unknown[];
         exams?: unknown[];
         roomType?: unknown;
@@ -90,6 +90,9 @@ describe("课程与班级查找", () => {
     expect(typeof result.section?.schedules?.[0]?.startTime).toBe("string");
     expect(typeof result.section?.schedules?.[0]?.endTime).toBe("string");
     expect((result.section?.teacherAssignments?.length ?? 0) > 0).toBe(true);
+    for (const assignment of result.section?.teacherAssignments ?? []) {
+      expect(assignment).not.toHaveProperty("teacher");
+    }
     expect(Array.isArray(result.section?.scheduleGroups)).toBe(true);
     expect((result.section?.exams?.length ?? 0) > 0).toBe(true);
     expect(Object.hasOwn(result.section ?? {}, "roomType")).toBe(true);
@@ -327,6 +330,7 @@ type GetCourseResult = {
     educationLevel?: { nameCn?: string | null; nameEn?: string | null } | null;
     category?: { nameCn?: string | null; nameEn?: string | null } | null;
     classType?: { nameCn?: string | null; nameEn?: string | null } | null;
+    _count?: { sections?: number };
     sections?: Array<{
       id?: number;
       jwId?: number;
@@ -463,6 +467,10 @@ describe("课程详情工具 catalog_course_get", () => {
     );
     expect(course?.classType?.nameCn).toBe(
       fixtures.DEV_SEED.course.classTypeNameCn,
+    );
+    expect(course?.sections?.length ?? 0).toBeLessThanOrEqual(20);
+    expect(course?._count?.sections ?? 0).toBeGreaterThanOrEqual(
+      course?.sections?.length ?? 0,
     );
 
     const seedSection = course?.sections?.find(

--- a/tests/integration/rest/courses/test.ts
+++ b/tests/integration/rest/courses/test.ts
@@ -193,6 +193,7 @@ test.describe("GET /api/catalog/courses 接口", () => {
       jwId?: number;
       code?: string;
       nameCn?: string;
+      _count?: { sections?: number };
       sections?: Array<{
         jwId?: number;
         code?: string;
@@ -206,6 +207,10 @@ test.describe("GET /api/catalog/courses 接口", () => {
     expect(body.jwId).toBe(DEV_SEED.course.jwId);
     expect(body.code).toBe(DEV_SEED.course.code);
     expect(body.nameCn).toBe(DEV_SEED.course.nameCn);
+    expect(body.sections?.length ?? 0).toBeLessThanOrEqual(20);
+    expect(body._count?.sections ?? 0).toBeGreaterThanOrEqual(
+      body.sections?.length ?? 0,
+    );
     expect(
       body.sections?.some((section) => section.jwId === DEV_SEED.section.jwId),
     ).toBe(true);
@@ -216,6 +221,14 @@ test.describe("GET /api/catalog/courses 接口", () => {
     expect(Object.hasOwn(seedSection as object, "semester")).toBe(true);
     expect(Object.hasOwn(seedSection as object, "campus")).toBe(true);
     expect(Array.isArray(seedSection?.teachers)).toBe(true);
+    for (const teacher of seedSection?.teachers ?? []) {
+      expect(teacher).not.toHaveProperty("age");
+      expect(teacher).not.toHaveProperty("postcode");
+      expect(teacher).not.toHaveProperty("qq");
+      expect(teacher).not.toHaveProperty("wechat");
+      expect(teacher).not.toHaveProperty("email");
+      expect(teacher).not.toHaveProperty("mobile");
+    }
     expect(typeof seedSection?.stdCount).toBe("number");
     expect(typeof seedSection?.limitCount).toBe("number");
   });

--- a/tests/integration/rest/sections/[jwId]/test.ts
+++ b/tests/integration/rest/sections/[jwId]/test.ts
@@ -16,12 +16,15 @@ test("/api/catalog/sections/[jwId] 返回 teacherAssignments 与 exams", async (
   );
   expect(response.status()).toBe(200);
   const body = (await response.json()) as {
-    teacherAssignments?: unknown[];
+    teacherAssignments?: Array<Record<string, unknown>>;
     exams?: unknown[];
     code?: string;
   };
   expect(body.code).toBe(DEV_SEED.section.code);
   expect((body.teacherAssignments?.length ?? 0) > 0).toBe(true);
+  for (const assignment of body.teacherAssignments ?? []) {
+    expect(assignment).not.toHaveProperty("teacher");
+  }
   expect((body.exams?.length ?? 0) > 0).toBe(true);
 });
 
@@ -45,6 +48,12 @@ test("班级详情包含全部 SectionDetail 字段", async ({ request }) => {
   if (firstTeacher) {
     expect(typeof firstTeacher.id).toBe("number");
     expect(typeof firstTeacher.nameCn).toBe("string");
+    expect(firstTeacher).not.toHaveProperty("age");
+    expect(firstTeacher).not.toHaveProperty("postcode");
+    expect(firstTeacher).not.toHaveProperty("qq");
+    expect(firstTeacher).not.toHaveProperty("wechat");
+    expect(firstTeacher).not.toHaveProperty("email");
+    expect(firstTeacher).not.toHaveProperty("mobile");
   }
   expect(Array.isArray(body.schedules)).toBe(true);
   expect(typeof body.schedules?.[0]?.startTime).toBe("string");

--- a/tests/integration/rest/teachers/test.ts
+++ b/tests/integration/rest/teachers/test.ts
@@ -158,6 +158,14 @@ test.describe("GET /api/catalog/teachers", () => {
       body.sections?.some((section) => section.code === DEV_SEED.section.code),
     ).toBe(true);
     expect((body._count?.sections ?? 0) > 0).toBe(true);
+    expect(body.sections?.length ?? 0).toBeLessThanOrEqual(20);
+    expect(body._count?.sections ?? 0).toBeGreaterThanOrEqual(
+      body.sections?.length ?? 0,
+    );
+    expect(body).not.toHaveProperty("age");
+    expect(body).not.toHaveProperty("postcode");
+    expect(body).not.toHaveProperty("qq");
+    expect(body).not.toHaveProperty("wechat");
     expect(Object.hasOwn(body, "nameEn")).toBe(true);
     expect(Object.hasOwn(body, "telephone")).toBe(true);
     expect(Object.hasOwn(body, "mobile")).toBe(true);

--- a/tests/unit/catalog-detail-page-data.test.ts
+++ b/tests/unit/catalog-detail-page-data.test.ts
@@ -115,6 +115,12 @@ describe("catalog detail page data", () => {
 
     expect(courseResult?.sections).toEqual(courseSections);
     expect(teacherResult?.sections).toEqual(teacherSections);
+    expect(
+      courseFindUniqueMock.mock.calls.at(-1)?.[0]?.select?.sections?.take,
+    ).toBe(20);
+    expect(
+      teacherFindUniqueMock.mock.calls.at(-1)?.[0]?.select?.sections?.take,
+    ).toBe(20);
     expect(Reflect.ownKeys(courseResult ?? {})).not.toContain(
       localizedNameSymbol,
     );

--- a/tests/unit/public-teacher-payload.test.ts
+++ b/tests/unit/public-teacher-payload.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  courseDetailInclude,
+  PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
+  sectionCompactInclude,
+  sectionInclude,
+  teacherAssignmentPublicSelect,
+  teacherPublicDetailSelect,
+  teacherPublicIdentitySelect,
+  teacherPublicListSelect,
+  teacherPublicReferenceSelect,
+} from "@/features/catalog/server/academic-query-includes";
+
+const sourceOnlyTeacherFields = ["age", "postcode", "qq", "wechat"];
+const teacherContactFields = ["email", "telephone", "mobile", "address"];
+
+describe("public teacher payloads", () => {
+  it("uses an explicit identity allowlist for nested teacher references", () => {
+    expect(Object.keys(teacherPublicIdentitySelect).sort()).toEqual(
+      [
+        "code",
+        "id",
+        "jwId",
+        "nameCn",
+        "nameEn",
+        "namePrimary",
+        "nameSecondary",
+        "personId",
+      ].sort(),
+    );
+    for (const field of [...sourceOnlyTeacherFields, ...teacherContactFields]) {
+      expect(teacherPublicIdentitySelect).not.toHaveProperty(field);
+      expect(teacherPublicReferenceSelect).not.toHaveProperty(field);
+    }
+  });
+
+  it("never exposes source-only teacher fields on list or detail", () => {
+    for (const select of [teacherPublicListSelect, teacherPublicDetailSelect]) {
+      for (const field of sourceOnlyTeacherFields) {
+        expect(select).not.toHaveProperty(field);
+      }
+    }
+  });
+
+  it("reuses narrow nested selects and bounds detail history", () => {
+    expect(sectionCompactInclude.teachers).toEqual({
+      select: teacherPublicIdentitySelect,
+    });
+    expect(sectionInclude.teachers).toEqual({
+      select: teacherPublicIdentitySelect,
+    });
+    expect(courseDetailInclude.sections.take).toBe(
+      PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
+    );
+    expect(courseDetailInclude.sections.include.teachers).toEqual({
+      select: teacherPublicIdentitySelect,
+    });
+    expect(teacherPublicDetailSelect.sections.take).toBe(
+      PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
+    );
+  });
+
+  it("links assignments by teacherId without duplicating teacher rows", () => {
+    expect(teacherAssignmentPublicSelect.teacherId).toBe(true);
+    expect(teacherAssignmentPublicSelect).not.toHaveProperty("teacher");
+    expect(teacherAssignmentPublicSelect).not.toHaveProperty("teacherTitle");
+  });
+});


### PR DESCRIPTION
## What changed

- replace broad nested Teacher includes with explicit public identity/reference selects
- remove the duplicate nested Teacher object from TeacherAssignment while retaining teacherId
- cap course and teacher detail histories at the 20 newest sections and return the complete total in _count.sections
- apply the same preview limit to SSR page loaders and explain the recent-history view in the UI
- synchronize product contracts, REST/OpenAPI schemas, MCP descriptions, and transport tests

## Why

Public course and section detail paths serialized entire Teacher database rows, including source-only fields, and large teacher/course histories grew without a bound. This increased database width, response size, serialization work, and accidental exposure risk.

## Validation

- bunx vitest run: 338 files, 2029 tests passed
- focused catalog/schema/MCP unit tests: 73 tests passed
- TypeScript app/tests/operational checks passed
- svelte-check: 0 errors (existing warnings only)
- Biome: no errors (existing warnings only)
- openapi:check passed
- Wrangler type check passed
- production build passed

## Local integration note

The source-level MCP integration harness hit the local Prisma 7 WASM query-compiler loader error before issuing affected queries. The draft PR CI PostgreSQL, REST, and MCP jobs are expected to provide the authoritative integration validation.