### PR TITLE
perf(workspace): bound overview calendar data

### DIFF
--- a/src/features/dashboard/components/OverviewTab.svelte
+++ b/src/features/dashboard/components/OverviewTab.svelte
@@ -9,6 +9,7 @@ import {
   dashboardReferenceTime,
 } from "@/features/dashboard/lib/dashboard-agenda";
 import type {
+  DashboardCalendarPreviewData,
   DashboardCommonCopy,
   DashboardDashboardCopy,
   DashboardLinkPinSubmit,
@@ -32,7 +33,6 @@ import {
 import { DASHBOARD_OVERVIEW_PREVIEW_LIMIT } from "@/features/dashboard/lib/overview-preview";
 import DashboardNoSubscriptionsState from "./DashboardNoSubscriptionsState.svelte";
 import type {
-  DashboardCalendarData,
   DashboardCalendarSession,
   DashboardCalendarTabHref,
 } from "./dashboard-calendar-component-types";
@@ -90,7 +90,7 @@ function dashboardOverviewWeekStart() {
   return buildDashboardOverviewWeekStart(signedData);
 }
 
-function overviewUpcomingExams(overviewCalendar: DashboardCalendarData) {
+function overviewUpcomingExams(overviewCalendar: DashboardCalendarPreviewData) {
   return buildOverviewUpcomingExams(overviewCalendar, signedData);
 }
 
@@ -99,7 +99,7 @@ function sessionHref(session: Pick<DashboardCalendarSession, "sectionJwId">) {
 }
 
 function overviewCalendarWeekDays(
-  overviewCalendar: DashboardCalendarData,
+  overviewCalendar: DashboardCalendarPreviewData,
   overviewWeekStart: string,
 ) {
   return buildOverviewCalendarWeekDays(
@@ -111,7 +111,7 @@ function overviewCalendarWeekDays(
 }
 
 function overviewAgendaDays(
-  overviewCalendar: DashboardCalendarData,
+  overviewCalendar: DashboardCalendarPreviewData,
 ): DashboardAgendaDay[] {
   return buildDashboardAgendaDays({
     calendar: overviewCalendar,
@@ -127,7 +127,7 @@ function overviewReference(value: unknown): Date | string | null {
 }
 
 function overviewFocus(
-  overviewCalendar: DashboardCalendarData,
+  overviewCalendar: DashboardCalendarPreviewData,
   days: DashboardAgendaDay[],
 ) {
   const currentTime = dashboardReferenceTime(

--- a/src/features/dashboard/components/overview-tab-navigation.ts
+++ b/src/features/dashboard/components/overview-tab-navigation.ts
@@ -2,9 +2,9 @@ import {
   dashboardOverviewWeekStart as buildDashboardOverviewWeekStart,
   overviewUpcomingExams as buildOverviewUpcomingExams,
 } from "@/features/dashboard/lib/calendar-display";
+import type { DashboardCalendarPreviewData } from "@/features/dashboard/lib/dashboard-controller-helpers";
 import { referenceDate } from "@/features/dashboard/lib/overview";
 import type {
-  DashboardCalendarData,
   DashboardCalendarSession,
   DashboardCalendarTabHref,
 } from "./dashboard-calendar-component-types";
@@ -18,7 +18,7 @@ export function dashboardOverviewWeekStart(signedData: OverviewSignedData) {
 }
 
 export function overviewUpcomingExams(
-  overviewCalendar: DashboardCalendarData,
+  overviewCalendar: DashboardCalendarPreviewData,
   signedData: OverviewSignedData,
 ) {
   return buildOverviewUpcomingExams(

--- a/src/features/dashboard/components/overview-tab-types.ts
+++ b/src/features/dashboard/components/overview-tab-types.ts
@@ -1,15 +1,13 @@
 import type { DashboardTimelineItem } from "@/features/dashboard/lib/dashboard-agenda";
 import type {
+  DashboardCalendarPreviewData,
   DashboardDashboardCopy,
   DashboardSectionCopy,
   DashboardTodoItem,
   SignedDashboardData,
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
 import type { CalendarGridDay } from "$lib/components/calendar/types";
-import type {
-  DashboardCalendarData,
-  DashboardCalendarEvents,
-} from "./dashboard-calendar-component-types";
+import type { DashboardCalendarEvents } from "./dashboard-calendar-component-types";
 
 export type OverviewTimelineItem = DashboardTimelineItem;
 
@@ -25,7 +23,7 @@ export type OverviewSignedData = SignedDashboardData & {
   overview?:
     | (NonNullable<SignedDashboardData["overview"]> & {
         calendar?:
-          | (DashboardCalendarData & {
+          | (DashboardCalendarPreviewData & {
               referenceDate?: string | null;
             })
           | null;

--- a/src/features/dashboard/components/overview-tab-week-days.ts
+++ b/src/features/dashboard/components/overview-tab-week-days.ts
@@ -3,16 +3,16 @@ import {
   weekDaysFor,
 } from "@/features/dashboard/lib/calendar";
 import { overviewDayLabel } from "@/features/dashboard/lib/calendar-display";
+import type { DashboardCalendarPreviewData } from "@/features/dashboard/lib/dashboard-controller-helpers";
 import { fmtTime } from "@/features/dashboard/lib/overview";
 import { formatCampusDate } from "@/lib/time/campus-date";
-import type { DashboardCalendarData } from "./dashboard-calendar-component-types";
 import type {
   OverviewCalendarTimelineItemsForDay,
   OverviewWeekDay,
 } from "./overview-tab-types";
 
 export function overviewCalendarWeekDays(
-  overviewCalendar: DashboardCalendarData,
+  overviewCalendar: DashboardCalendarPreviewData,
   overviewWeekStart: string,
   calendarTimelineItemsForDay: OverviewCalendarTimelineItemsForDay,
   locale: string,

--- a/src/features/dashboard/lib/dashboard-controller-helpers.ts
+++ b/src/features/dashboard/lib/dashboard-controller-helpers.ts
@@ -14,6 +14,7 @@ export type {
   DashboardActionData,
   DashboardCalendarControllerState,
   DashboardCalendarData,
+  DashboardCalendarPreviewData,
   DashboardCommonCopy,
   DashboardDashboardCopy,
   DashboardHomepageCopy,

--- a/src/features/dashboard/lib/dashboard-controller-types.ts
+++ b/src/features/dashboard/lib/dashboard-controller-types.ts
@@ -462,7 +462,7 @@ export type DashboardLinkPinSubmit = (
 ) => void;
 
 export type DashboardOverviewData = DashboardRecord & {
-  calendar?: DashboardCalendarData | null;
+  calendar?: DashboardCalendarData | DashboardCalendarPreviewData | null;
   dueToday: DashboardHomeworkItem[];
   hasAnySelection?: boolean;
   hasCurrentTermSelection: boolean;
@@ -471,17 +471,20 @@ export type DashboardOverviewData = DashboardRecord & {
   todaySessions: DashboardSessionItem[];
 };
 
-export type DashboardCalendarData = DashboardRecord & {
-  activeCalendarSemesterId: number | null;
-  activeCalendarSemesterName?: string | null;
+export type DashboardCalendarPreviewData = DashboardRecord & {
   allExams: DashboardOverviewExamItem[];
   allSessions: DashboardSessionItem[];
-  calendarSemesterNavList: Array<{ id: number; name?: string | null }>;
+  calendarSemesterPicker: Array<{ id: number; name?: string | null }>;
   semesterHomeworks: DashboardHomeworkItem[];
   semesterTodos: DashboardCalendarTodoItem[];
-  semesterWeeks: string[][];
-  calendarSemesterPicker: Array<{ id: number; name?: string | null }>;
   todayDate: string;
+};
+
+export type DashboardCalendarData = DashboardCalendarPreviewData & {
+  activeCalendarSemesterId: number | null;
+  activeCalendarSemesterName?: string | null;
+  calendarSemesterNavList: Array<{ id: number; name?: string | null }>;
+  semesterWeeks: string[][];
 };
 
 export type DashboardHomeworksData = DashboardRecord & {
@@ -594,9 +597,7 @@ export type TodoFilter = "incomplete" | "completed" | "all";
 export type TodoView = "cards" | "list";
 export type ExamView = "cards" | "list";
 export type LinkView = "grid" | "list";
-export type CalendarData = NonNullable<
-  NonNullable<SignedDashboardData["overview"]>["calendar"]
->;
+export type CalendarData = DashboardCalendarData;
 export type SubscriptionsData = NonNullable<
   SignedDashboardData["subscriptions"]
 >;

--- a/src/features/dashboard/server/dashboard-overview-calendar.ts
+++ b/src/features/dashboard/server/dashboard-overview-calendar.ts
@@ -1,5 +1,6 @@
 export { buildRollingCalendarPreview } from "./dashboard-overview-calendar-preview";
 export {
+  buildPreviewCalendarPayload,
   buildSemesterCalendarPayload,
   resolveGridSemesterBounds,
 } from "./dashboard-overview-semester-calendar";

--- a/src/features/dashboard/server/dashboard-overview-data.ts
+++ b/src/features/dashboard/server/dashboard-overview-data.ts
@@ -1,6 +1,8 @@
 import { listSubscribedHomeworks } from "@/features/subscriptions/server/subscription-read-model";
 import { formatSemesterName } from "@/lib/text/format-semester-name";
+import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
 import {
+  buildPreviewCalendarPayload,
   buildSemesterCalendarPayload,
   resolveGridSemesterBounds,
 } from "./dashboard-overview-calendar";
@@ -28,6 +30,20 @@ export type {
   OverviewDataOptions,
 } from "./dashboard-overview-types";
 
+function dayjsMin<T extends ReturnType<typeof shanghaiDayjs>>(
+  left: T,
+  right: T,
+) {
+  return left.isBefore(right) ? left : right;
+}
+
+function dayjsMax<T extends ReturnType<typeof shanghaiDayjs>>(
+  left: T,
+  right: T,
+) {
+  return left.isAfter(right) ? left : right;
+}
+
 export async function getDashboardOverviewData(
   userId: string,
   options: OverviewDataOptions = {},
@@ -45,6 +61,16 @@ export async function getDashboardOverviewData(
     scheduleDateStart,
   } = semesterContext;
 
+  const calendarMode = options.calendarMode ?? "semester";
+  const previewWeekStart = options.overviewWeek
+    ? shanghaiDayjs(options.overviewWeek).startOf("week")
+    : referenceNow.startOf("week");
+  const previewStart = dayjsMin(referenceNow.startOf("day"), previewWeekStart);
+  const previewEnd = dayjsMax(
+    referenceNow.startOf("day").add(6, "day"),
+    previewWeekStart.add(6, "day"),
+  ).endOf("day");
+
   const { semesterEnd, semesterStart } =
     resolveGridSemesterBounds(gridSemesterRow);
   const sectionScopePromise = resolveDashboardOverviewSectionScope({
@@ -54,8 +80,10 @@ export async function getDashboardOverviewData(
     isCalendarSemesterFromUrlValid: calendarSemesterFromUrlValid,
     locale,
     sectionIds: options.sectionIds,
-    scheduleDateEnd,
-    scheduleDateStart,
+    scheduleDateEnd:
+      calendarMode === "preview" ? previewEnd.toDate() : scheduleDateEnd,
+    scheduleDateStart:
+      calendarMode === "preview" ? previewStart.toDate() : scheduleDateStart,
     semesters,
     userId,
   });
@@ -63,11 +91,14 @@ export async function getDashboardOverviewData(
     locale,
     skipLinks: options.skipLinks,
   });
-  const semesterTodosPromise = listSemesterCalendarTodos({
-    semesterEnd,
-    semesterStart,
-    userId,
-  });
+  const calendarTodosPromise = options.calendarTodos
+    ? Promise.resolve(Array.from(options.calendarTodos))
+    : listSemesterCalendarTodos({
+        semesterEnd: calendarMode === "preview" ? previewEnd : semesterEnd,
+        semesterStart:
+          calendarMode === "preview" ? previewStart : semesterStart,
+        userId,
+      });
 
   const {
     calendarSemesterNavList,
@@ -84,7 +115,7 @@ export async function getDashboardOverviewData(
   const [
     overviewHomeworks,
     { dashboardLinks, recommendedLinks, pinnedLinks, overviewLinks },
-    semesterTodos,
+    calendarTodos,
   ] = await Promise.all([
     listSubscribedHomeworks(userId, {
       incompleteOrHasDueDate: true,
@@ -93,7 +124,7 @@ export async function getDashboardOverviewData(
       shape: "dashboard",
     }),
     linksPromise,
-    semesterTodosPromise,
+    calendarTodosPromise,
   ]);
   const homeworks = overviewHomeworks.filter(
     (homework) => homework.homeworkCompletions.length === 0,
@@ -109,19 +140,31 @@ export async function getDashboardOverviewData(
     locale,
     referenceNow: now,
   });
+  const calendarPayload =
+    calendarMode === "preview"
+      ? buildPreviewCalendarPayload({
+          calendarHomeworks,
+          referenceNow: now,
+          sections: sectionsForCalendarGrid,
+          todos: calendarTodos,
+          windowEnd: previewEnd,
+          windowStart: previewStart,
+        })
+      : buildSemesterCalendarPayload({
+          calendarHomeworks,
+          gridSemesterRow,
+          sectionsForCalendarGrid,
+          semesterTodos: calendarTodos,
+        });
   const {
     allExams,
     allSessions,
     semesterEnd: calendarSemesterEnd,
     semesterHomeworks,
     semesterStart: calendarSemesterStart,
-    semesterWeeks,
-  } = buildSemesterCalendarPayload({
-    calendarHomeworks,
-    gridSemesterRow,
-    sectionsForCalendarGrid,
     semesterTodos,
-  });
+    semesterWeeks,
+  } = calendarPayload;
 
   const defaultCalendarSemesterId = currentSemester?.id ?? null;
   const activeCalendarSemesterId = gridSemesterRow?.id ?? null;
@@ -130,6 +173,7 @@ export async function getDashboardOverviewData(
     : null;
 
   return {
+    calendarMode,
     user: {
       id: user.id,
       name: user.name,

--- a/src/features/dashboard/server/dashboard-overview-semester-calendar.ts
+++ b/src/features/dashboard/server/dashboard-overview-semester-calendar.ts
@@ -1,3 +1,5 @@
+import { overviewUpcomingExams } from "@/features/dashboard/lib/calendar-display";
+import { DASHBOARD_OVERVIEW_PREVIEW_LIMIT } from "@/features/dashboard/lib/overview-preview";
 import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
 import {
   buildExams,
@@ -69,5 +71,45 @@ export function buildSemesterCalendarPayload({
     semesterStart,
     semesterTodos,
     semesterWeeks,
+  };
+}
+
+export function buildPreviewCalendarPayload({
+  calendarHomeworks,
+  referenceNow,
+  sections,
+  todos,
+  windowEnd,
+  windowStart,
+}: {
+  calendarHomeworks: HomeworkWithSection[];
+  referenceNow: ReturnType<typeof shanghaiDayjs>;
+  sections: Parameters<typeof buildSessions>[0];
+  todos: CalendarTodoItem[];
+  windowEnd: ReturnType<typeof shanghaiDayjs>;
+  windowStart: ReturnType<typeof shanghaiDayjs>;
+}) {
+  const inWindow = (value: Date | string) => {
+    const date = shanghaiDayjs(value);
+    return (
+      !date.isBefore(windowStart, "day") && !date.isAfter(windowEnd, "day")
+    );
+  };
+  const allExams = overviewUpcomingExams(
+    { allExams: buildExams(sections) },
+    referenceNow.toDate(),
+  ).slice(0, DASHBOARD_OVERVIEW_PREVIEW_LIMIT + 1);
+
+  return {
+    allExams,
+    allSessions: sortSessionsByStart(buildSessions(sections)),
+    semesterEnd: null,
+    semesterHomeworks: calendarHomeworks.filter(
+      (homework) =>
+        homework.submissionDueAt && inWindow(homework.submissionDueAt),
+    ),
+    semesterStart: null,
+    semesterTodos: todos.filter((todo) => inWindow(todo.dueAt)),
+    semesterWeeks: [],
   };
 }

--- a/src/features/dashboard/server/dashboard-overview-serialization.ts
+++ b/src/features/dashboard/server/dashboard-overview-serialization.ts
@@ -13,6 +13,67 @@ export function serializeDashboardOverview(overview: OverviewData) {
     ].map((homework) => [homework.id, homework]),
   );
 
+  const calendarEvents = {
+    todayDate: overview.todayStart.format("YYYY-MM-DD"),
+    referenceDate: overview.referenceNow.format("YYYY-MM-DD"),
+    allSessions: overview.allSessions.map((session) => ({
+      id: session.id,
+      sectionJwId: session.sectionJwId,
+      courseName: session.courseName,
+      date: session.date,
+      dateKey: calendarDateKey(session.date),
+      startTime: session.startTime,
+      endTime: session.endTime,
+      location: session.location,
+      teacherDisplay: session.teacherDisplay,
+    })),
+    allExams: overview.allExams.map((exam) => ({
+      id: exam.id,
+      courseName: exam.courseName,
+      date: exam.date,
+      dateKey: calendarDateKey(exam.date),
+      startTime: exam.startTime,
+      endTime: exam.endTime,
+      examMode: exam.examMode,
+      rooms: exam.rooms,
+    })),
+    semesterHomeworks: overview.semesterHomeworks.map((homework) => ({
+      ...dashboardHomeworkItem(homework),
+      description: homework.description?.content ?? null,
+      dateKey: calendarDateKey(homework.submissionDueAt),
+    })),
+    semesterTodos: overview.semesterTodos.map((todo) => ({
+      ...todo,
+      dateKey: calendarDateKey(todo.dueAt),
+    })),
+    calendarSemesterPicker: overview.calendarSemesterPicker,
+  };
+  const calendar: typeof calendarEvents &
+    Partial<{
+      activeCalendarSemesterId: number | null;
+      activeCalendarSemesterName: string | null;
+      calendarSemesterNavList: OverviewData["calendarSemesterNavList"];
+      calendarSemesterPicker: OverviewData["calendarSemesterPicker"];
+      defaultCalendarSemesterId: number | null;
+      semesterEnd: string | null;
+      semesterStart: string | null;
+      semesterWeeks: string[][];
+    }> =
+    overview.calendarMode === "preview"
+      ? calendarEvents
+      : {
+          ...calendarEvents,
+          semesterStart: overview.semesterStart?.format("YYYY-MM-DD") ?? null,
+          semesterEnd: overview.semesterEnd?.format("YYYY-MM-DD") ?? null,
+          semesterWeeks: overview.semesterWeeks.map((week) =>
+            week.map((day) => day.format("YYYY-MM-DD")),
+          ),
+          calendarSemesterNavList: overview.calendarSemesterNavList,
+          activeCalendarSemesterId: overview.activeCalendarSemesterId,
+          defaultCalendarSemesterId: overview.defaultCalendarSemesterId,
+          activeCalendarSemesterName: overview.activeCalendarSemesterName,
+        };
+
   return {
     user: overview.user,
     currentTermName: overview.currentTermName,
@@ -25,50 +86,7 @@ export function serializeDashboardOverview(overview: OverviewData) {
     pendingHomeworks: Array.from(homeworkItems.values()).map(
       dashboardHomeworkItem,
     ),
-    calendar: {
-      todayDate: overview.todayStart.format("YYYY-MM-DD"),
-      referenceDate: overview.referenceNow.format("YYYY-MM-DD"),
-      semesterStart: overview.semesterStart?.format("YYYY-MM-DD") ?? null,
-      semesterEnd: overview.semesterEnd?.format("YYYY-MM-DD") ?? null,
-      semesterWeeks: overview.semesterWeeks.map((week) =>
-        week.map((day) => day.format("YYYY-MM-DD")),
-      ),
-      allSessions: overview.allSessions.map((session) => ({
-        id: session.id,
-        sectionJwId: session.sectionJwId,
-        courseName: session.courseName,
-        date: session.date,
-        dateKey: calendarDateKey(session.date),
-        startTime: session.startTime,
-        endTime: session.endTime,
-        location: session.location,
-        teacherDisplay: session.teacherDisplay,
-      })),
-      allExams: overview.allExams.map((exam) => ({
-        id: exam.id,
-        courseName: exam.courseName,
-        date: exam.date,
-        dateKey: calendarDateKey(exam.date),
-        startTime: exam.startTime,
-        endTime: exam.endTime,
-        examMode: exam.examMode,
-        rooms: exam.rooms,
-      })),
-      semesterHomeworks: overview.semesterHomeworks.map((homework) => ({
-        ...dashboardHomeworkItem(homework),
-        description: homework.description?.content ?? null,
-        dateKey: calendarDateKey(homework.submissionDueAt),
-      })),
-      semesterTodos: overview.semesterTodos.map((todo) => ({
-        ...todo,
-        dateKey: calendarDateKey(todo.dueAt),
-      })),
-      calendarSemesterPicker: overview.calendarSemesterPicker,
-      calendarSemesterNavList: overview.calendarSemesterNavList,
-      activeCalendarSemesterId: overview.activeCalendarSemesterId,
-      defaultCalendarSemesterId: overview.defaultCalendarSemesterId,
-      activeCalendarSemesterName: overview.activeCalendarSemesterName,
-    },
+    calendar,
     overviewLinks: overview.overviewLinks,
   };
 }

--- a/src/features/dashboard/server/dashboard-overview-types.ts
+++ b/src/features/dashboard/server/dashboard-overview-types.ts
@@ -24,6 +24,12 @@ export type OverviewDataOptions = {
   skipLinks?: boolean;
   /** Override the current time for deterministic snapshot and test views. */
   referenceNow?: Date;
+  /** Overview renders a bounded preview; calendar renders the full selected term. */
+  calendarMode?: "preview" | "semester";
+  /** Todo snapshot already loaded for the overview cards. */
+  calendarTodos?: readonly CalendarTodoItem[];
+  /** Week selected by the overview strip, if any. */
+  overviewWeek?: string | null;
   /** User row already loaded by the page shell. */
   user?: DashboardUserSummary;
   /** Subscription ids already loaded by the page shell. */
@@ -49,6 +55,7 @@ export type CalendarTodoItem = {
 };
 
 export type OverviewData = {
+  calendarMode: "preview" | "semester";
   user: { id: string; name: string | null; username: string | null };
   currentTermName: string;
   hasAnySelection: boolean;

--- a/src/features/dashboard/server/dashboard-page-load-signed.ts
+++ b/src/features/dashboard/server/dashboard-page-load-signed.ts
@@ -62,6 +62,7 @@ export async function loadSignedDashboardPageData(input: {
           calendarSemesterId: input.calendarSemesterId,
           context,
           locale: input.locale,
+          overviewWeek: input.overviewWeek,
           referenceNow: input.referenceNow ?? undefined,
           requestId: input.requestId,
           tab: input.tab,

--- a/src/features/dashboard/server/dashboard-page-tab-data.ts
+++ b/src/features/dashboard/server/dashboard-page-tab-data.ts
@@ -49,6 +49,7 @@ export async function loadSignedDashboardTabData(input: {
   calendarSemesterId: number | undefined;
   context: DashboardUserContext;
   locale: AppLocale;
+  overviewWeek?: string | null;
   referenceNow: Date | undefined;
   requestId: string | undefined;
   tab: string;
@@ -64,104 +65,137 @@ export async function loadSignedDashboardTabData(input: {
     subscribedSectionCount: input.context.sectionIds.length,
     tab: input.tab,
   };
-  const shouldLoadTodos = input.tab === "todos" || input.tab === "overview";
-  const semesters = await timeDashboardStage("semesters", stageContext, () =>
-    dashboard.getDashboardSemesters(),
-  );
-  const { navStats, todos } = await withUserDbContext(
-    input.userId,
-    async () => {
-      const todosPromise = shouldLoadTodos
-        ? timeDashboardStage("todos", stageContext, () =>
-            dashboardTabs.getTodosTabData(input.userId),
+  return withUserDbContext(input.userId, async () => {
+    const shouldLoadTodos = input.tab === "todos" || input.tab === "overview";
+    const semestersPromise = timeDashboardStage("semesters", stageContext, () =>
+      dashboard.getDashboardSemesters(),
+    );
+    const todosPromise = shouldLoadTodos
+      ? timeDashboardStage("todos", stageContext, () =>
+          dashboardTabs.getTodosTabData(input.userId),
+        )
+      : inactiveStage(null);
+    const pendingTodosCountPromise = shouldLoadTodos
+      ? todosPromise.then(
+          (items) => items?.filter((todo) => !todo.completed).length ?? 0,
+        )
+      : undefined;
+    const navStatsPromise = timeDashboardStage(
+      "nav-stats",
+      stageContext,
+      async () =>
+        dashboard.getDashboardNavStats(
+          input.context.user,
+          input.context.subscribedSections,
+          input.referenceNow,
+          pendingTodosCountPromise,
+          await semestersPromise,
+        ),
+    );
+    const overviewPromise =
+      input.tab === "overview" || input.tab === "calendar"
+        ? timeDashboardStage("overview", stageContext, async () => {
+            const [semesters, overviewTodos] = await Promise.all([
+              semestersPromise,
+              todosPromise,
+            ]);
+            return dashboard.getDashboardOverviewData(input.userId, {
+              calendarMode: input.tab === "calendar" ? "semester" : "preview",
+              calendarSemesterId: input.calendarSemesterId,
+              calendarTodos:
+                overviewTodos?.flatMap((todo) =>
+                  !todo.completed && todo.dueAt
+                    ? [
+                        {
+                          completed: false,
+                          content: todo.content,
+                          dueAt: todo.dueAt,
+                          id: todo.id,
+                          priority: todo.priority,
+                          title: todo.title,
+                        },
+                      ]
+                    : [],
+                ) ?? undefined,
+              locale: input.locale,
+              overviewWeek: input.overviewWeek,
+              referenceNow: input.referenceNow,
+              sectionIds: input.context.sectionIds,
+              semesters,
+              skipLinks: input.tab === "calendar",
+              user: input.context.user,
+            });
+          })
+        : inactiveStage(null);
+    const linksPromise =
+      input.tab === "links"
+        ? timeDashboardStage("links", stageContext, () =>
+            dashboardLinks.getLinksTabData(input.userId, input.locale),
           )
         : inactiveStage(null);
-      const pendingTodosCountPromise = shouldLoadTodos
-        ? todosPromise.then(
-            (items) => items?.filter((todo) => !todo.completed).length ?? 0,
+    const homeworksPromise =
+      input.tab === "homeworks"
+        ? timeDashboardStage("homeworks", stageContext, () =>
+            dashboardTabs.getHomeworksTabData(input.userId, input.locale, {
+              sectionIds: input.context.sectionIds,
+            }),
           )
-        : undefined;
-      const [resolvedNavStats, resolvedTodos] = await Promise.all([
-        timeDashboardStage("nav-stats", stageContext, () =>
-          dashboard.getDashboardNavStats(
-            input.context.user,
-            input.context.subscribedSections,
-            input.referenceNow,
-            pendingTodosCountPromise,
-            semesters,
-          ),
-        ),
-        todosPromise,
-      ]);
-      return { navStats: resolvedNavStats, todos: resolvedTodos };
-    },
-  );
+        : inactiveStage(null);
+    const subscriptionsPromise =
+      input.tab === "subscriptions" || input.tab === "exams"
+        ? timeDashboardStage("subscriptions", stageContext, () =>
+            dashboardTabs.getSubscriptionsTabData(input.userId, input.locale, {
+              calendarFeedToken: input.context.user.calendarFeedToken,
+              includeExams: input.tab === "exams",
+              sectionIds: input.context.sectionIds,
+            }),
+          )
+        : inactiveStage(null);
+    const calendarSubscriptionUrlPromise =
+      input.tab === "calendar"
+        ? timeDashboardStage("calendar-subscription", stageContext, () =>
+            dashboardTabs.getCalendarSubscriptionUrl(
+              input.userId,
+              input.context.user.calendarFeedToken,
+            ),
+          )
+        : inactiveStage(null);
+    const busPromise =
+      input.tab === "bus"
+        ? timeDashboardStage("bus", stageContext, () =>
+            dashboardTabs.getBusTabData(input.userId, input.locale),
+          )
+        : inactiveStage(null);
 
-  const [
-    overview,
-    links,
-    homeworks,
-    subscriptions,
-    calendarSubscriptionUrl,
-    bus,
-  ] = await Promise.all([
-    input.tab === "overview" || input.tab === "calendar"
-      ? timeDashboardStage("overview", stageContext, () =>
-          dashboard.getDashboardOverviewData(input.userId, {
-            locale: input.locale,
-            user: input.context.user,
-            sectionIds: input.context.sectionIds,
-            calendarSemesterId: input.calendarSemesterId,
-            referenceNow: input.referenceNow,
-            semesters,
-            skipLinks: input.tab === "calendar",
-          }),
-        )
-      : inactiveStage(null),
-    input.tab === "links"
-      ? timeDashboardStage("links", stageContext, () =>
-          dashboardLinks.getLinksTabData(input.userId, input.locale),
-        )
-      : inactiveStage(null),
-    input.tab === "homeworks"
-      ? timeDashboardStage("homeworks", stageContext, () =>
-          dashboardTabs.getHomeworksTabData(input.userId, input.locale, {
-            sectionIds: input.context.sectionIds,
-          }),
-        )
-      : inactiveStage(null),
-    input.tab === "subscriptions" || input.tab === "exams"
-      ? timeDashboardStage("subscriptions", stageContext, () =>
-          dashboardTabs.getSubscriptionsTabData(input.userId, input.locale, {
-            calendarFeedToken: input.context.user.calendarFeedToken,
-            includeExams: input.tab === "exams",
-            sectionIds: input.context.sectionIds,
-          }),
-        )
-      : inactiveStage(null),
-    input.tab === "calendar"
-      ? timeDashboardStage("calendar-subscription", stageContext, () =>
-          dashboardTabs.getCalendarSubscriptionUrl(
-            input.userId,
-            input.context.user.calendarFeedToken,
-          ),
-        )
-      : inactiveStage(null),
-    input.tab === "bus"
-      ? timeDashboardStage("bus", stageContext, () =>
-          dashboardTabs.getBusTabData(input.userId, input.locale),
-        )
-      : inactiveStage(null),
-  ]);
+    const [
+      navStats,
+      todos,
+      overview,
+      links,
+      homeworks,
+      subscriptions,
+      calendarSubscriptionUrl,
+      bus,
+    ] = await Promise.all([
+      navStatsPromise,
+      todosPromise,
+      overviewPromise,
+      linksPromise,
+      homeworksPromise,
+      subscriptionsPromise,
+      calendarSubscriptionUrlPromise,
+      busPromise,
+    ]);
 
-  return {
-    bus,
-    calendarSubscriptionUrl,
-    homeworks,
-    links,
-    navStats,
-    overview,
-    subscriptions,
-    todos,
-  };
+    return {
+      bus,
+      calendarSubscriptionUrl,
+      homeworks,
+      links,
+      navStats,
+      overview,
+      subscriptions,
+      todos,
+    };
+  });
 }

--- a/tests/integration/dashboard-page-rls-reuse.test.ts
+++ b/tests/integration/dashboard-page-rls-reuse.test.ts
@@ -42,5 +42,27 @@ describe("signed dashboard localized RLS context", () => {
     expect("userMissing" in data).toBe(false);
     expect(data.navStats).toBeDefined();
     expect(data.overview).toBeDefined();
+    expect(data.overview?.calendar).not.toHaveProperty("semesterWeeks");
+    expect(data.overview?.calendar).not.toHaveProperty("semesterStart");
+    expect(data.overview?.calendar).not.toHaveProperty(
+      "calendarSemesterNavList",
+    );
+
+    const calendarData = await loadSignedDashboardPageData({
+      calendarSemesterId: undefined,
+      locale: "en-us",
+      overviewWeek: null,
+      pageCopy: {} as never,
+      referenceNow: new Date("2026-04-29T08:00:00.000+08:00"),
+      requestId: "integration-dashboard-calendar-rls-reuse",
+      tab: "calendar",
+      userId: subscription.userId,
+    });
+
+    expect(calendarData.overview?.calendar).toHaveProperty("semesterWeeks");
+    expect(calendarData.overview?.calendar).toHaveProperty("semesterStart");
+    expect(calendarData.overview?.calendar).toHaveProperty(
+      "calendarSemesterNavList",
+    );
   });
 });

--- a/tests/unit/dashboard-overview-homework-read.test.ts
+++ b/tests/unit/dashboard-overview-homework-read.test.ts
@@ -3,6 +3,7 @@ import { shanghaiDayjs } from "@/lib/time/shanghai-dayjs";
 
 const {
   buildDashboardOverviewScheduleMock,
+  buildPreviewCalendarPayloadMock,
   buildSemesterCalendarPayloadMock,
   getDashboardOverviewLinksDataMock,
   listSemesterCalendarTodosMock,
@@ -11,6 +12,7 @@ const {
   resolveDashboardOverviewSectionScopeMock,
 } = vi.hoisted(() => ({
   buildDashboardOverviewScheduleMock: vi.fn(),
+  buildPreviewCalendarPayloadMock: vi.fn(),
   buildSemesterCalendarPayloadMock: vi.fn(),
   getDashboardOverviewLinksDataMock: vi.fn(),
   listSemesterCalendarTodosMock: vi.fn(),
@@ -29,6 +31,7 @@ vi.mock("@/features/dashboard/server/dashboard-overview-calendar", async () => {
   >("@/features/dashboard/server/dashboard-overview-calendar");
   return {
     ...actual,
+    buildPreviewCalendarPayload: buildPreviewCalendarPayloadMock,
     buildSemesterCalendarPayload: buildSemesterCalendarPayloadMock,
   };
 });
@@ -129,8 +132,70 @@ describe("dashboard overview homework read", () => {
       semesterEnd: null,
       semesterHomeworks: [],
       semesterStart: null,
+      semesterTodos: [],
       semesterWeeks: [],
     });
+    buildPreviewCalendarPayloadMock.mockReturnValue({
+      allExams: [],
+      allSessions: [],
+      semesterEnd: null,
+      semesterHomeworks: [],
+      semesterStart: null,
+      semesterTodos: [],
+      semesterWeeks: [],
+    });
+  });
+
+  it("bounds overview reads to preview dates and skips the semester payload", async () => {
+    listSubscribedHomeworksMock.mockResolvedValue([]);
+
+    await getDashboardOverviewData("user-1", {
+      calendarMode: "preview",
+      locale: "en-us",
+      overviewWeek: "2026-05-17",
+    });
+
+    expect(resolveDashboardOverviewSectionScopeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scheduleDateStart: new Date("2026-05-16T16:00:00.000Z"),
+        scheduleDateEnd: new Date("2026-05-28T15:59:59.999Z"),
+      }),
+    );
+    expect(listSemesterCalendarTodosMock).toHaveBeenCalledWith({
+      semesterStart: expect.objectContaining({}),
+      semesterEnd: expect.objectContaining({}),
+      userId: "user-1",
+    });
+    const todoRange = listSemesterCalendarTodosMock.mock.calls[0]?.[0];
+    expect(todoRange.semesterStart.format("YYYY-MM-DD")).toBe("2026-05-17");
+    expect(todoRange.semesterEnd.format("YYYY-MM-DD")).toBe("2026-05-28");
+    expect(buildPreviewCalendarPayloadMock).toHaveBeenCalledOnce();
+    expect(buildSemesterCalendarPayloadMock).not.toHaveBeenCalled();
+  });
+
+  it("reuses a provided todo snapshot instead of querying calendar todos", async () => {
+    listSubscribedHomeworksMock.mockResolvedValue([]);
+    const calendarTodos = [
+      {
+        completed: false,
+        content: null,
+        dueAt: "2026-05-23T10:00:00+08:00",
+        id: "todo-1",
+        priority: "medium" as const,
+        title: "Review",
+      },
+    ];
+
+    await getDashboardOverviewData("user-1", {
+      calendarMode: "preview",
+      calendarTodos,
+      locale: "en-us",
+    });
+
+    expect(listSemesterCalendarTodosMock).not.toHaveBeenCalled();
+    expect(buildPreviewCalendarPayloadMock).toHaveBeenCalledWith(
+      expect.objectContaining({ todos: calendarTodos }),
+    );
   });
 
   it("uses one union read and preserves all four completion/due-date quadrants", async () => {

--- a/tests/unit/dashboard-overview-serialization.test.ts
+++ b/tests/unit/dashboard-overview-serialization.test.ts
@@ -14,6 +14,7 @@ const today = shanghaiDayjs(DEV_SEED_ANCHOR.startOfDayAtTime);
 
 function buildOverviewData(partial: Partial<OverviewData> = {}): OverviewData {
   return {
+    calendarMode: "semester",
     user: { id: "user-1", name: "Test User", username: "testuser" },
     currentTermName: "2026春",
     hasAnySelection: true,
@@ -184,7 +185,7 @@ describe("仪表盘概览序列化", () => {
     expect(result.calendar.semesterStart).toBe("2026-03-30");
     expect(result.calendar.semesterEnd).toBe("2026-06-28");
     expect(result.calendar.semesterWeeks).toHaveLength(1);
-    expect(result.calendar.semesterWeeks[0]).toHaveLength(7);
+    expect(result.calendar.semesterWeeks?.[0]).toHaveLength(7);
 
     expect(result.calendar.allSessions).toHaveLength(1);
     const serializedSession = result.calendar.allSessions[0];
@@ -226,6 +227,40 @@ describe("仪表盘概览序列化", () => {
 
     expect(result.overviewLinks).toHaveLength(1);
     expect(result.overviewLinks[0].slug).toBe("library");
+  });
+
+  it("overview preview omits semester-wide calendar metadata", () => {
+    const result = serializeDashboardOverview(
+      buildOverviewData({
+        calendarMode: "preview",
+        allSessions: [buildSession()],
+        allExams: [buildExam()],
+        semesterHomeworks: [buildHomework()],
+        semesterTodos: [
+          {
+            id: "todo-1",
+            title: "复习",
+            dueAt: "2026-05-01T10:00:00+08:00",
+            priority: TodoPriority.medium,
+            content: null,
+            completed: false,
+          },
+        ],
+      }),
+    );
+
+    expect(result.calendar).toMatchObject({
+      allExams: expect.any(Array),
+      allSessions: expect.any(Array),
+      semesterHomeworks: expect.any(Array),
+      semesterTodos: expect.any(Array),
+      todayDate: "2026-04-29",
+    });
+    expect(result.calendar).not.toHaveProperty("semesterWeeks");
+    expect(result.calendar).not.toHaveProperty("semesterStart");
+    expect(result.calendar).not.toHaveProperty("semesterEnd");
+    expect(result.calendar.calendarSemesterPicker).toEqual([]);
+    expect(result.calendar).not.toHaveProperty("calendarSemesterNavList");
   });
 
   it("去重 pendingHomeworks 中的重复作业", () => {

--- a/tests/unit/dashboard-todo-nav-reuse.test.ts
+++ b/tests/unit/dashboard-todo-nav-reuse.test.ts
@@ -171,7 +171,45 @@ describe("dashboard todo count reuse", () => {
     );
     expect(getDashboardOverviewDataMock).toHaveBeenCalledWith(
       "user-1",
-      expect.objectContaining({ semesters }),
+      expect.objectContaining({
+        calendarMode: "preview",
+        calendarTodos: expect.any(Array),
+        semesters,
+      }),
+    );
+  });
+
+  it("starts overview work without waiting for navigation counts", async () => {
+    let releaseNav!: () => void;
+    const navGate = new Promise<void>((resolve) => {
+      releaseNav = resolve;
+    });
+    getTodosTabDataMock.mockResolvedValue([]);
+    getDashboardNavStatsMock.mockImplementation(async () => {
+      await navGate;
+      return { pendingTodosCount: 0 };
+    });
+    getDashboardOverviewDataMock.mockResolvedValue({ calendarMode: "preview" });
+
+    const pending = loadTab("overview");
+
+    await vi.waitFor(() => {
+      expect(getDashboardNavStatsMock).toHaveBeenCalledOnce();
+      expect(getDashboardOverviewDataMock).toHaveBeenCalledOnce();
+    });
+
+    releaseNav();
+    await pending;
+  });
+
+  it("keeps the calendar tab on the complete semester model", async () => {
+    getDashboardNavStatsMock.mockResolvedValue({ pendingTodosCount: 0 });
+
+    await loadTab("calendar");
+
+    expect(getDashboardOverviewDataMock).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ calendarMode: "semester", skipLinks: true }),
     );
   });
 });


### PR DESCRIPTION
## What changed

- split workspace calendar data into bounded overview preview and complete semester modes
- bound overview schedule and todo reads to the visible preview window
- cap serialized upcoming exam samples at five plus one overflow sentinel
- reuse the overview todo snapshot for navigation counts and calendar preview
- start navigation and active-tab reads concurrently inside the existing shared RLS context
- retain full semester calendar data and navigation for the calendar tab

## Why

The overview route used the same read and response model as the full calendar tab. It queried and serialized semester-wide sessions, exams, homeworks, todos, week grids, and navigation metadata even though the overview only renders a seven-day agenda, week strip, and small summary cards. Active-tab work also started only after navigation statistics completed.

## Impact

Typical overview schedule reads now cover 7 to 13 days instead of a whole semester. The response omits semester weeks, semester boundaries, and calendar navigation metadata; upcoming exam samples are bounded to six records. The existing todo read is reused, removing the second calendar-todo query. Calendar tab behavior remains complete and unchanged.

## Validation

- focused dashboard unit tests: 23 passed
- full unit suite: 337 files, 2031 tests passed
- TypeScript application, test, and operational checks passed
- Svelte check passed with existing warnings only
- Biome passed with existing repository warnings only
- OpenAPI generated diff check passed
- production build passed
- focused DB integration could not run locally because the available test database had no seeded subscription fixture; CI integration test now asserts preview omission and full calendar preservation