### PR TITLE
perf(community): collapse read query phases

### DIFF
--- a/src/features/comments/server/comment-read-model.ts
+++ b/src/features/comments/server/comment-read-model.ts
@@ -344,10 +344,10 @@ export async function loadCommentThread(input: {
       ],
     } satisfies Prisma.CommentWhereInput;
     const pagination = input.pagination;
-    const [total, rootComments, hiddenCount] = await withCommentDbContext(
+    const { comments, hiddenCount, total } = await withCommentDbContext(
       input.viewerUserId,
-      (client) =>
-        Promise.all([
+      async (client) => {
+        const [total, rootComments, hiddenCount] = await Promise.all([
           client.comment.count({ where: rootWhere }),
           client.comment.findMany({
             where: rootWhere,
@@ -359,26 +359,30 @@ export async function loadCommentThread(input: {
           viewer.isAuthenticated
             ? Promise.resolve(0)
             : countAnonymousHiddenRoots(input.target.whereTarget),
-        ]),
+        ]);
+        const rootIds = rootComments.map((comment) => comment.id);
+        const comments =
+          rootIds.length === 0
+            ? []
+            : await client.comment.findMany({
+                where: {
+                  AND: [
+                    input.target.whereTarget,
+                    {
+                      OR: [
+                        { id: { in: rootIds } },
+                        { rootId: { in: rootIds } },
+                      ],
+                    },
+                  ],
+                },
+                include: commentThreadInclude,
+                orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+              });
+
+        return { comments, hiddenCount, total };
+      },
     );
-    const rootIds = rootComments.map((comment) => comment.id);
-    const comments =
-      rootIds.length === 0
-        ? []
-        : await withCommentDbContext(input.viewerUserId, (client) =>
-            client.comment.findMany({
-              where: {
-                AND: [
-                  input.target.whereTarget,
-                  {
-                    OR: [{ id: { in: rootIds } }, { rootId: { in: rootIds } }],
-                  },
-                ],
-              },
-              include: commentThreadInclude,
-              orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-            }),
-          );
 
     const commentsWithMetadata = await withCommentReadMetadata(
       comments,

--- a/src/features/homeworks/server/homework-list-read-model.ts
+++ b/src/features/homeworks/server/homework-list-read-model.ts
@@ -1,11 +1,11 @@
 import type { AppLocale } from "@/i18n/config";
 import { DEFAULT_LOCALE } from "@/i18n/config";
 import { getViewerContext } from "@/lib/auth/viewer-context";
-import { getPrisma, prisma } from "@/lib/db/prisma";
+import { getPrisma, prisma, withUserDbContext } from "@/lib/db/prisma";
 import {
+  attachHomeworkCompletionsForViewer,
   homeworkItemInclude,
   homeworkItemResponse,
-  withHomeworkCompletionsForViewer,
 } from "./homework-read-model";
 
 type SectionHomeworkListInput = {
@@ -77,20 +77,42 @@ export async function listSectionHomeworkItems({
   sectionIds,
   viewerUserId,
 }: SectionHomeworkItemInput) {
-  const homeworks = await getPrisma(locale).homework.findMany({
-    where: {
-      ...homeworkSectionWhere(sectionIds),
-      ...(includeDeleted ? {} : { deletedAt: null }),
-    },
-    include: homeworkItemInclude(),
-    orderBy: [{ submissionDueAt: "asc" }, { createdAt: "desc" }],
-  });
+  const loadHomeworks = () =>
+    getPrisma(locale).homework.findMany({
+      where: {
+        ...homeworkSectionWhere(sectionIds),
+        ...(includeDeleted ? {} : { deletedAt: null }),
+      },
+      include: homeworkItemInclude(),
+      orderBy: [{ submissionDueAt: "asc" }, { createdAt: "desc" }],
+    });
 
-  const homeworksWithCompletions = await withHomeworkCompletionsForViewer(
-    homeworks,
-    viewerUserId,
+  if (!viewerUserId) {
+    const homeworks = await loadHomeworks();
+    return attachHomeworkCompletionsForViewer(homeworks, []).map(
+      homeworkItemResponse,
+    );
+  }
+
+  const [homeworks, completions] = await Promise.all([
+    loadHomeworks(),
+    withUserDbContext(viewerUserId, (tx) =>
+      tx.homeworkCompletion.findMany({
+        where: {
+          userId: viewerUserId,
+          homework: {
+            ...homeworkSectionWhere(sectionIds),
+            ...(includeDeleted ? {} : { deletedAt: null }),
+          },
+        },
+        select: { homeworkId: true, completedAt: true },
+      }),
+    ),
+  ]);
+
+  return attachHomeworkCompletionsForViewer(homeworks, completions).map(
+    homeworkItemResponse,
   );
-  return homeworksWithCompletions.map(homeworkItemResponse);
 }
 
 export function listSectionHomeworkAuditLogs(sectionIds: readonly number[]) {
@@ -108,17 +130,16 @@ export async function listSectionHomeworksWithAudit({
   sectionIds,
   userId,
 }: SectionHomeworkListWithAuditInput) {
-  const viewer = await getViewerContext({
-    includeAdmin: true,
-    userId: userId ?? null,
-  });
-
-  const [homeworks, auditLogs] = await Promise.all([
+  const [viewer, homeworks, auditLogs] = await Promise.all([
+    getViewerContext({
+      includeAdmin: true,
+      userId: userId ?? null,
+    }),
     listSectionHomeworkItems({
       includeDeleted,
       locale,
       sectionIds,
-      viewerUserId: viewer.userId,
+      viewerUserId: userId,
     }),
     listSectionHomeworkAuditLogs(sectionIds),
   ]);

--- a/tests/unit/comment-read-model-pagination.test.ts
+++ b/tests/unit/comment-read-model-pagination.test.ts
@@ -240,6 +240,7 @@ describe("loadCommentThread pagination", () => {
         },
       }),
     );
+    expect(withUserDbContextMock).toHaveBeenCalledTimes(3);
   });
 
   it("loads OIDC provider badges once for all comment authors", async () => {

--- a/tests/unit/homework-list-read-model-performance.test.ts
+++ b/tests/unit/homework-list-read-model-performance.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../shared/deferred";
+
+const {
+  auditFindManyMock,
+  completionFindManyMock,
+  getViewerContextMock,
+  homeworkFindManyMock,
+  withUserDbContextMock,
+} = vi.hoisted(() => ({
+  auditFindManyMock: vi.fn(),
+  completionFindManyMock: vi.fn(),
+  getViewerContextMock: vi.fn(),
+  homeworkFindManyMock: vi.fn(),
+  withUserDbContextMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/viewer-context", () => ({
+  getViewerContext: getViewerContextMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  getPrisma: vi.fn(() => ({
+    homework: { findMany: homeworkFindManyMock },
+  })),
+  prisma: {
+    homeworkAuditLog: { findMany: auditFindManyMock },
+  },
+  withUserDbContext: withUserDbContextMock,
+}));
+
+import {
+  listSectionHomeworkItems,
+  listSectionHomeworksWithAudit,
+} from "@/features/homeworks/server/homework-list-read-model";
+
+const viewer = {
+  image: null,
+  isAdmin: false,
+  isAuthenticated: true,
+  isSuspended: false,
+  name: "Viewer",
+  suspensionExpiresAt: null,
+  suspensionReason: null,
+  userId: "viewer-1",
+};
+
+describe("section homework list read phases", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    homeworkFindManyMock.mockResolvedValue([
+      { id: "homework-1", title: "Homework", _count: { comments: 2 } },
+    ]);
+    completionFindManyMock.mockResolvedValue([
+      {
+        completedAt: new Date("2026-08-01T00:00:00.000Z"),
+        homeworkId: "homework-1",
+      },
+    ]);
+    auditFindManyMock.mockResolvedValue([]);
+    getViewerContextMock.mockResolvedValue(viewer);
+    withUserDbContextMock.mockImplementation((_userId, action) =>
+      action({
+        homeworkCompletion: { findMany: completionFindManyMock },
+      }),
+    );
+  });
+
+  it("loads localized rows alongside completions in one RLS transaction", async () => {
+    const result = await listSectionHomeworkItems({
+      locale: "en-us",
+      sectionIds: [7],
+      viewerUserId: viewer.userId,
+    });
+
+    expect(withUserDbContextMock).toHaveBeenCalledOnce();
+    expect(withUserDbContextMock).toHaveBeenCalledWith(
+      viewer.userId,
+      expect.any(Function),
+    );
+    expect(homeworkFindManyMock).toHaveBeenCalledOnce();
+    expect(completionFindManyMock).toHaveBeenCalledOnce();
+    expect(completionFindManyMock).toHaveBeenCalledWith({
+      where: {
+        userId: viewer.userId,
+        homework: { sectionId: 7, deletedAt: null },
+      },
+      select: { homeworkId: true, completedAt: true },
+    });
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: "homework-1",
+        commentCount: 2,
+        completion: {
+          completedAt: new Date("2026-08-01T00:00:00.000Z"),
+        },
+      }),
+    ]);
+  });
+
+  it("starts viewer, homework, and audit reads in the same response phase", async () => {
+    const viewerDeferred = createDeferred<typeof viewer>();
+    getViewerContextMock.mockReturnValueOnce(viewerDeferred.promise);
+
+    const resultPromise = listSectionHomeworksWithAudit({
+      locale: "zh-cn",
+      sectionIds: [7],
+      userId: viewer.userId,
+    });
+    await Promise.resolve();
+
+    expect(getViewerContextMock).toHaveBeenCalledOnce();
+    expect(homeworkFindManyMock).toHaveBeenCalledOnce();
+    expect(completionFindManyMock).toHaveBeenCalledOnce();
+    expect(auditFindManyMock).toHaveBeenCalledOnce();
+
+    viewerDeferred.resolve(viewer);
+    await expect(resultPromise).resolves.toMatchObject({
+      viewer,
+      auditLogs: [],
+      homeworks: [expect.objectContaining({ id: "homework-1" })],
+    });
+  });
+
+  it("keeps anonymous lists outside an RLS transaction", async () => {
+    const result = await listSectionHomeworkItems({
+      sectionIds: [7],
+      viewerUserId: null,
+    });
+
+    expect(withUserDbContextMock).not.toHaveBeenCalled();
+    expect(completionFindManyMock).not.toHaveBeenCalled();
+    expect(result[0]).toMatchObject({ completion: null });
+  });
+});


### PR DESCRIPTION
## Summary\n\n- reuse one authenticated RLS context for paginated comment root selection and complete-thread loading\n- start section homework rows, viewer completions, viewer context, and audit reads in the same response phase\n- preserve comment visibility, full reply trees, ordering, pagination, optional metadata fallback, homework localization, completion ownership, audit freshness, and response shapes\n- add transaction-count and orchestration tests\n\n## Root cause and query phases\n\n### Comments\n\nBefore:\n1. viewer context\n2. RLS transaction: count roots + select paged root ids\n3. second RLS transaction: load selected complete reply trees\n4. parallel metadata phase: author provider query + separate reaction and attachment RLS transactions\n\nAfter:\n1. viewer context\n2. one RLS transaction: count/select roots, then load selected complete reply trees\n3. unchanged parallel metadata phase (kept separate so either optional summary RPC can still fail soft without aborting the core thread transaction)\n\nAuthenticated non-empty pagination drops from 4 to 3 RLS transactions without changing the five domain queries or visibility semantics.\n\n### Section homeworks\n\nBefore:\n1. viewer context\n2. homework rows and audit logs\n3. viewer completion RLS query, blocked on homework ids\n\nAfter:\n1. viewer context, localized homework rows, one viewer completion RLS query scoped by section, and audit logs all start together\n2. attach completion rows in memory\n\nThe endpoint keeps exactly one viewer RLS transaction, but removes two serial response phases and avoids any user-dependent/public cache.\n\n## Validation\n\n- 
 RUN  v4.1.10 /home/tiankaima/Source/Life-USTC/wt-hotspot-community


 Test Files  339 passed (339)
      Tests  2033 passed (2033)
   Start at  14:25:50
   Duration  8.20s (transform 24.39s, setup 0ms, import 50.80s, tests 42.97s, environment 22ms) — 339 files, 2033 tests passed\n- focused community tests — 5 files, 20 tests passed\n- app and test TypeScript checks passed\n- Wrangler type check passed\n- Biome passed with 7 pre-existing warnings\n- Svelte check passed with 0 errors and 13 pre-existing warnings\n- OpenAPI generated check passed\n- GraphQL schema snapshot passed\n- production build passed\n\nNo contract files changed because response shape and behavior are unchanged; this is read orchestration only.