### PR TITLE
perf(social-card): collapse upstream render waterfall

### DIFF
--- a/src/lib/server/social-card-renderer.ts
+++ b/src/lib/server/social-card-renderer.ts
@@ -1,5 +1,4 @@
 import { ImageResponse } from "@ethercorps/sveltekit-og";
-import { GoogleFont, resolveFonts } from "@ethercorps/sveltekit-og/fonts";
 import {
   normalizeSocialCardOptions,
   SOCIAL_CARD_HEIGHT,
@@ -9,14 +8,36 @@ import {
 import socialCardBackground from "$lib/assets/social-card-background.png?inline";
 
 const MAX_AVATAR_BYTES = 1_000_000;
+const MAX_FONT_BYTES = 5_000_000;
+const UPSTREAM_TIMEOUT_MS = 2_000;
+const SOCIAL_CARD_CACHE_CONTROL =
+  "public, max-age=3600, stale-while-revalidate=604800, stale-if-error=604800";
+const SOCIAL_CARD_CDN_CACHE_CONTROL =
+  "public, max-age=86400, stale-while-revalidate=604800, stale-if-error=604800";
+const SOCIAL_CARD_FALLBACK_CACHE_CONTROL =
+  "public, max-age=60, stale-while-revalidate=300";
+const SOCIAL_CARD_FALLBACK_CDN_CACHE_CONTROL =
+  "public, max-age=300, stale-while-revalidate=3600";
 const allowedAvatarContentTypes = new Set([
   "image/jpeg",
   "image/png",
   "image/svg+xml",
   "image/webp",
 ]);
-const MONO_FONT_FAMILY = "Life Mono";
 const SANS_FONT_FAMILY = "Life Sans";
+
+function fetchWithTimeout(
+  fetcher: typeof fetch,
+  input: string,
+  init?: RequestInit,
+) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+
+  return fetcher(input, { ...init, signal: controller.signal }).finally(() =>
+    clearTimeout(timeout),
+  );
+}
 
 function isAllowedAvatarUrl(value: string) {
   try {
@@ -52,7 +73,7 @@ async function loadAvatarDataUrl(
   if (!avatarUrl || !isAllowedAvatarUrl(avatarUrl)) return undefined;
 
   try {
-    const response = await fetcher(avatarUrl, {
+    const response = await fetchWithTimeout(fetcher, avatarUrl, {
       headers: {
         Accept: "image/avif,image/webp,image/png,image/jpeg,image/svg+xml",
       },
@@ -99,40 +120,107 @@ function usesMonoFont(character: string) {
   );
 }
 
-function fontCharacters(value: string, mono: boolean) {
+function mixedTextHtml(value: string) {
+  return escapeHtml(value);
+}
+
+function socialCardFontText(
+  options: ReturnType<typeof normalizeSocialCardOptions>,
+) {
   return uniqueCharacters(
-    Array.from(value)
-      .filter((character) => usesMonoFont(character) === mono)
-      .join(""),
+    `${options.title}${options.subtitle}${options.footer}${options.label}@${options.username ?? ""}Life @ USTC…科大`,
   );
 }
 
-function mixedTextHtml(value: string) {
-  const runs: Array<{ mono: boolean; space?: boolean; text: string }> = [];
+function googleFontStylesheetUrl(text: string) {
+  const url = new URL("https://fonts.googleapis.com/css2");
+  url.searchParams.set("family", "Noto Sans SC:wght@400;700");
+  url.searchParams.set("text", text);
+  return url.href;
+}
 
-  for (const character of Array.from(value)) {
-    if (character === " ") {
-      runs.push({ mono: true, space: true, text: "" });
-      continue;
+function googleFontUrls(css: string) {
+  const urls = new Map<400 | 700, string>();
+  const fontFacePattern =
+    /font-weight:\s*(400|700);[\s\S]*?src:\s*url\(([^)]+)\)\s*format\(['"](?:opentype|truetype)['"]\)/gu;
+
+  for (const match of css.matchAll(fontFacePattern)) {
+    const weight = Number(match[1]) as 400 | 700;
+    const url = new URL(match[2]);
+    if (url.protocol !== "https:" || url.hostname !== "fonts.gstatic.com") {
+      throw new Error("Unexpected Google Fonts asset URL");
     }
-    const mono = usesMonoFont(character);
-    const previous = runs.at(-1);
-    if (!previous?.space && previous?.mono === mono) {
-      previous.text += character;
-    } else {
-      runs.push({ mono, text: character });
-    }
+    urls.set(weight, url.href);
   }
 
-  return runs
-    .map(({ mono, space, text }) =>
-      space
-        ? '<span style="display:flex; width:0.55em;"></span>'
-        : `<span style="display:flex; font-family:'${
-            mono ? MONO_FONT_FAMILY : SANS_FONT_FAMILY
-          }';">${escapeHtml(text)}</span>`,
-    )
-    .join("");
+  if (!urls.has(400) || !urls.has(700)) {
+    throw new Error("Google Fonts stylesheet omitted a required weight");
+  }
+  return urls;
+}
+
+async function loadFontBuffer(fetcher: typeof fetch, url: string) {
+  const response = await fetchWithTimeout(fetcher, url);
+  if (!response.ok) throw new Error("Google Fonts asset request failed");
+
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > MAX_FONT_BYTES) {
+    throw new Error("Google Fonts asset exceeds the size limit");
+  }
+
+  const buffer = await response.arrayBuffer();
+  if (buffer.byteLength === 0 || buffer.byteLength > MAX_FONT_BYTES) {
+    throw new Error("Google Fonts asset has an invalid size");
+  }
+  return buffer;
+}
+
+async function loadSocialCardFonts(
+  options: ReturnType<typeof normalizeSocialCardOptions>,
+  fetcher: typeof fetch,
+) {
+  const stylesheetResponse = await fetchWithTimeout(
+    fetcher,
+    googleFontStylesheetUrl(socialCardFontText(options)),
+  );
+  if (!stylesheetResponse.ok) {
+    throw new Error("Google Fonts stylesheet request failed");
+  }
+
+  const urls = googleFontUrls(await stylesheetResponse.text());
+  const [regular, bold] = await Promise.all([
+    loadFontBuffer(fetcher, urls.get(400) as string),
+    loadFontBuffer(fetcher, urls.get(700) as string),
+  ]);
+
+  return [
+    {
+      data: regular,
+      name: SANS_FONT_FAMILY,
+      style: "normal" as const,
+      weight: 400 as const,
+    },
+    {
+      data: bold,
+      name: SANS_FONT_FAMILY,
+      style: "normal" as const,
+      weight: 700 as const,
+    },
+  ];
+}
+
+function fallbackSocialCardResponse() {
+  const [, encoded = ""] = socialCardBackground.split(",", 2);
+  const bytes = Uint8Array.from(atob(encoded), (character) =>
+    character.charCodeAt(0),
+  );
+  return new Response(bytes, {
+    headers: {
+      "Cache-Control": SOCIAL_CARD_FALLBACK_CACHE_CONTROL,
+      "Cloudflare-CDN-Cache-Control": SOCIAL_CARD_FALLBACK_CDN_CACHE_CONTROL,
+      "Content-Type": "image/png",
+    },
+  });
 }
 
 function textUnits(value: string) {
@@ -316,42 +404,24 @@ export async function renderSocialCard(
   fetcher: typeof fetch = fetch,
 ) {
   const options = normalizeSocialCardOptions(input);
-  const avatarDataUrl =
+  const avatarPromise =
     options.variant === "profile"
-      ? await loadAvatarDataUrl(options.avatarUrl, fetcher)
-      : undefined;
-  const regularText = `${options.subtitle}${options.footer}${options.label}…`;
-  const boldText = `${options.title}@${options.username ?? ""}Life @ USTC…`;
-  const fonts = await resolveFonts([
-    new GoogleFont("Noto Sans SC", {
-      name: SANS_FONT_FAMILY,
-      text: fontCharacters(regularText, false) || "科大",
-      weight: 400,
-    }),
-    new GoogleFont("Noto Sans SC", {
-      name: SANS_FONT_FAMILY,
-      text: fontCharacters(boldText, false) || "科大",
-      weight: 700,
-    }),
-    new GoogleFont("Fira Code", {
-      name: MONO_FONT_FAMILY,
-      text: fontCharacters(regularText, true) || "Life @ USTC",
-      weight: 400,
-    }),
-    new GoogleFont("Fira Code", {
-      name: MONO_FONT_FAMILY,
-      text: fontCharacters(boldText, true) || "Life @ USTC",
-      weight: 700,
-    }),
+      ? loadAvatarDataUrl(options.avatarUrl, fetcher)
+      : Promise.resolve(undefined);
+  const [avatarDataUrl, fonts] = await Promise.all([
+    avatarPromise,
+    loadSocialCardFonts(options, fetcher).catch(() => undefined),
   ]);
+
+  if (!fonts) return fallbackSocialCardResponse();
 
   return new ImageResponse(buildSocialCardHtml(options, avatarDataUrl), {
     fonts,
     height: SOCIAL_CARD_HEIGHT,
     width: SOCIAL_CARD_WIDTH,
     headers: {
-      "Cache-Control":
-        "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+      "Cache-Control": SOCIAL_CARD_CACHE_CONTROL,
+      "Cloudflare-CDN-Cache-Control": SOCIAL_CARD_CDN_CACHE_CONTROL,
       "Content-Type": "image/png",
     },
   });

--- a/tests/unit/social-card-renderer.test.ts
+++ b/tests/unit/social-card-renderer.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createDeferred } from "../shared/deferred";
+
+const { imageResponses } = vi.hoisted(() => ({
+  imageResponses: [] as Array<{
+    html: string;
+    options: { fonts: unknown[]; headers: Record<string, string> };
+  }>,
+}));
+
+vi.mock("@ethercorps/sveltekit-og", () => ({
+  ImageResponse: class extends Response {
+    constructor(
+      html: string,
+      options: { fonts: unknown[]; headers: Record<string, string> },
+    ) {
+      imageResponses.push({ html, options });
+      super(new Uint8Array([137, 80, 78, 71]), { headers: options.headers });
+    }
+  },
+}));
+
+vi.mock("$lib/assets/social-card-background.png?inline", () => ({
+  default: "data:image/png;base64,iVBORw0KGgo=",
+}));
+
+import { renderSocialCard } from "@/lib/server/social-card-renderer";
+
+const fontCss = `
+  @font-face {
+    font-family: 'Noto Sans SC';
+    font-style: normal;
+    font-weight: 400;
+    src: url(https://fonts.gstatic.com/regular.ttf) format('truetype');
+  }
+  @font-face {
+    font-family: 'Noto Sans SC';
+    font-style: normal;
+    font-weight: 700;
+    src: url(https://fonts.gstatic.com/bold.ttf) format('truetype');
+  }
+`;
+
+function responseWithUrl(
+  body: BodyInit | null,
+  url: string,
+  init?: ResponseInit,
+) {
+  const response = new Response(body, init);
+  Object.defineProperty(response, "url", { value: url });
+  return response;
+}
+
+describe("social card renderer", () => {
+  beforeEach(() => {
+    imageResponses.length = 0;
+  });
+
+  test("starts avatar and consolidated font loading concurrently", async () => {
+    const avatar = createDeferred<Response>();
+    const fetcher = vi.fn<typeof fetch>((input) => {
+      const url = String(input);
+      if (url.startsWith("https://avatars.githubusercontent.com/")) {
+        return avatar.promise;
+      }
+      if (url.startsWith("https://fonts.googleapis.com/")) {
+        return Promise.resolve(new Response(fontCss, { status: 200 }));
+      }
+      if (url === "https://fonts.gstatic.com/regular.ttf") {
+        return Promise.resolve(new Response(new Uint8Array([1, 2, 3])));
+      }
+      if (url === "https://fonts.gstatic.com/bold.ttf") {
+        return Promise.resolve(new Response(new Uint8Array([4, 5, 6])));
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    const rendering = renderSocialCard(
+      {
+        avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
+        subtitle: "中英 mixed text",
+        title: "科大喵",
+        username: "life_ustc",
+        variant: "profile",
+      },
+      fetcher,
+    );
+
+    await vi.waitFor(() => {
+      expect(fetcher).toHaveBeenCalledWith(
+        expect.stringMatching(/^https:\/\/fonts\.googleapis\.com\/css2\?/u),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+    expect(imageResponses).toHaveLength(0);
+
+    avatar.resolve(
+      responseWithUrl(
+        new Uint8Array([7, 8, 9]),
+        "https://avatars.githubusercontent.com/u/1?v=4",
+        { headers: { "content-type": "image/png" } },
+      ),
+    );
+
+    const response = await rendering;
+    expect(response.status).toBe(200);
+    expect(fetcher).toHaveBeenCalledTimes(4);
+    expect(
+      fetcher.mock.calls.filter(([input]) =>
+        String(input).startsWith("https://fonts."),
+      ),
+    ).toHaveLength(3);
+    expect(imageResponses[0]?.options.fonts).toEqual([
+      expect.objectContaining({ name: "Life Sans", weight: 400 }),
+      expect.objectContaining({ name: "Life Sans", weight: 700 }),
+    ]);
+    expect(imageResponses[0]?.html).toContain("科大喵");
+    expect(imageResponses[0]?.html).not.toContain("Life Mono");
+  });
+
+  test("falls back to initials when the avatar upstream fails", async () => {
+    const fetcher = vi.fn<typeof fetch>((input) => {
+      const url = String(input);
+      if (url.startsWith("https://avatars.githubusercontent.com/")) {
+        return Promise.resolve(new Response(null, { status: 503 }));
+      }
+      if (url.startsWith("https://fonts.googleapis.com/")) {
+        return Promise.resolve(new Response(fontCss, { status: 200 }));
+      }
+      return Promise.resolve(new Response(new Uint8Array([1, 2, 3])));
+    });
+
+    await renderSocialCard(
+      {
+        avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
+        title: "科大喵",
+        variant: "profile",
+      },
+      fetcher,
+    );
+
+    expect(imageResponses[0]?.html).toContain(">科</div>");
+    expect(imageResponses[0]?.html).not.toContain(
+      '<img src="data:image/png;base64,iVBORw0KGgo=" width="154"',
+    );
+  });
+
+  test("returns a short-lived deterministic PNG when fonts are unavailable", async () => {
+    const response = await renderSocialCard(
+      { title: "数据结构", variant: "course" },
+      vi.fn<typeof fetch>(() =>
+        Promise.resolve(new Response(null, { status: 503 })),
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(response.headers.get("cache-control")).toContain("max-age=60");
+    expect(response.headers.get("cloudflare-cdn-cache-control")).toContain(
+      "max-age=300",
+    );
+    expect(new Uint8Array(await response.arrayBuffer()).slice(0, 8)).toEqual(
+      new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),
+    );
+    expect(imageResponses).toHaveLength(0);
+  });
+
+  test("bounds a stalled font upstream before returning the fallback", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetcher = vi.fn<typeof fetch>(
+        (_input, init) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(new DOMException("Timed out", "AbortError")),
+            );
+          }),
+      );
+
+      const rendering = renderSocialCard(
+        { title: "网络超时", variant: "course" },
+        fetcher,
+      );
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(imageResponses).toHaveLength(0);
+      await vi.advanceTimersByTimeAsync(1);
+
+      const response = await rendering;
+      expect(response.status).toBe(200);
+      expect(response.headers.get("cache-control")).toContain("max-age=60");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("sets separate browser and edge cache policies on rendered cards", async () => {
+    const fetcher = vi.fn<typeof fetch>((input) => {
+      const url = String(input);
+      if (url.startsWith("https://fonts.googleapis.com/")) {
+        return Promise.resolve(new Response(fontCss, { status: 200 }));
+      }
+      return Promise.resolve(new Response(new Uint8Array([1, 2, 3])));
+    });
+
+    const response = await renderSocialCard(
+      { title: "Algorithms 算法", variant: "course" },
+      fetcher,
+    );
+
+    expect(response.headers.get("cache-control")).toContain("max-age=3600");
+    expect(response.headers.get("cloudflare-cdn-cache-control")).toContain(
+      "max-age=86400",
+    );
+  });
+});


### PR DESCRIPTION
## Summary\n- start profile avatar loading in parallel with the font dependency chain\n- replace four independently resolved Google font subsets with one Noto Sans SC stylesheet request and two parallel weight downloads, preserving Chinese and Latin glyph coverage\n- remove per-character font spans to reduce Satori layout work\n- bound avatar/font fetches to 2 seconds and return a short-lived deterministic PNG fallback if fonts are unavailable\n- send separate browser and Cloudflare CDN cache policies\n\n## Local performance\nCompared two local dev servers from the same machine using unique query strings and a DiceBear profile avatar:\n- before: 0.775–0.810s TTFB after warmup; app-observed 630–662ms\n- after: 0.574–0.588s TTFB after warmup; app-observed 425–441ms\n- reduction: about 26–33% on the profile path\n- font upstream requests: 8 potential requests (4 CSS + 4 binaries) to 3 (1 CSS + 2 binaries)\n\nThe first Vite request was excluded because it includes development module compilation.\n\n## Verification\n- wrangler type generation check\n- Biome check (7 pre-existing warnings)\n- Svelte check (0 errors, 13 pre-existing warnings)\n- app, test, and operational TypeScript checks\n- full Vitest suite (339 files, 2039 tests)\n- OpenAPI generated artifact check\n- GraphQL schema snapshot\n- production build\n- live local 1200×630 8-bit RGBA PNG render and cache-header inspection