### PR TITLE
fix(search): isolate public and workspace caching

### DIFF
--- a/src/features/search/lib/global-search-client.ts
+++ b/src/features/search/lib/global-search-client.ts
@@ -1,4 +1,5 @@
 import type { GlobalSearchResponse } from "@/features/search/server/global-search-types";
+import type { AppLocale } from "@/i18n/config";
 
 export const GLOBAL_SEARCH_MIN_QUERY_LENGTH = 2;
 export const GLOBAL_SEARCH_DEBOUNCE_MS = 200;
@@ -8,10 +9,20 @@ export const GLOBAL_SEARCH_PAGE_LIMIT = 20;
 export async function fetchGlobalSearch(
   query: string,
   limit: number,
+  options: {
+    includeWorkspace?: boolean;
+    locale: AppLocale;
+  },
 ): Promise<GlobalSearchResponse> {
-  const response = await fetch(
-    `/api/search?q=${encodeURIComponent(query)}&limit=${limit}`,
-  );
+  const searchParams = new URLSearchParams({
+    q: query,
+    limit: String(limit),
+    locale: options.locale,
+  });
+  if (options.includeWorkspace) {
+    searchParams.set("scope", "workspace");
+  }
+  const response = await fetch(`/api/search?${searchParams}`);
   if (!response.ok) {
     throw new Error("Search request failed");
   }

--- a/src/features/search/lib/global-search-controller.ts
+++ b/src/features/search/lib/global-search-controller.ts
@@ -13,6 +13,7 @@ import type {
   GlobalSearchResultGroup,
   GlobalSearchResultItem,
 } from "@/features/search/server/global-search-types";
+import { type AppLocale, DEFAULT_LOCALE } from "@/i18n/config";
 
 export type GlobalSearchUrlSyncOptions = {
   getPageUrl: () => URL;
@@ -28,6 +29,10 @@ export type GlobalSearchUrlSyncOptions = {
 
 export type GlobalSearchControllerOptions = {
   limit: number;
+  getRequestContext?: () => {
+    includeWorkspace?: boolean;
+    locale: AppLocale;
+  };
   urlSync?: GlobalSearchUrlSyncOptions;
   showInitialHintDeps?: Readable<unknown>;
   getShowInitialHint?: (state: {
@@ -167,7 +172,11 @@ export function createGlobalSearchController(
     hasSearched.set(true);
 
     try {
-      const body = await fetchGlobalSearch(trimmed, options.limit);
+      const body = await fetchGlobalSearch(
+        trimmed,
+        options.limit,
+        options.getRequestContext?.() ?? { locale: DEFAULT_LOCALE },
+      );
       if (generation !== searchGeneration) return;
       groups.set(body.groups ?? []);
     } catch {

--- a/src/features/search/server/global-search-service.ts
+++ b/src/features/search/server/global-search-service.ts
@@ -257,32 +257,30 @@ export async function searchGlobally(input: {
     return { query, groups: [] };
   }
 
-  const catalogGroups = await searchCachedCatalogGroups({
+  const catalogGroupsPromise = searchCachedCatalogGroups({
     limit,
     locale: input.locale,
     origin: input.origin,
     query,
   });
-
-  let workspaceGroups: GlobalSearchResultGroup[] = [];
-  if (input.userId) {
-    try {
-      workspaceGroups = await searchWorkspaceGroups(
-        query,
-        input.userId,
-        input.locale,
-        limit,
-      );
-    } catch (error) {
-      // Workspace results are optional; catalog results still stand on their own.
-      logAppEvent(
-        "warn",
-        "Global search workspace query failed",
-        { source: "global-search" },
-        error,
-      );
-    }
-  }
+  const workspaceGroupsPromise = input.userId
+    ? searchWorkspaceGroups(query, input.userId, input.locale, limit).catch(
+        (error): GlobalSearchResultGroup[] => {
+          // Workspace results are optional; catalog results still stand on their own.
+          logAppEvent(
+            "warn",
+            "Global search workspace query failed",
+            { source: "global-search" },
+            error,
+          );
+          return [];
+        },
+      )
+    : Promise.resolve([]);
+  const [catalogGroups, workspaceGroups] = await Promise.all([
+    catalogGroupsPromise,
+    workspaceGroupsPromise,
+  ]);
 
   return {
     query,

--- a/src/lib/api/routes/global-search.ts
+++ b/src/lib/api/routes/global-search.ts
@@ -1,6 +1,6 @@
 import { searchGlobally } from "@/features/search/server/global-search-service";
 import { handleRouteError, jsonResponse } from "@/lib/api/helpers";
-import { getRequestLocale } from "@/lib/api/routes/request-locale";
+import { resolvePublicCatalogLocale } from "@/lib/api/routes/request-locale";
 import { resolveApiUserId } from "@/lib/auth/api-auth";
 import {
   PRIVATE_LOCALE_CATALOG_HEADERS,
@@ -8,41 +8,50 @@ import {
 } from "@/lib/public-cache-control";
 
 const MAX_LIMIT = 25;
+const SEARCH_SCOPES = new Set(["catalog", "workspace"]);
 
 function parseSearchQuery(request: Request) {
   const searchParams = new URL(request.url).searchParams;
   const query = searchParams.get("q") ?? searchParams.get("query") ?? "";
   const limitParam = searchParams.get("limit");
   const limit = limitParam ? Number(limitParam) : undefined;
+  const scope = searchParams.get("scope") ?? "catalog";
   if (
     limit !== undefined &&
     (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT)
   ) {
     return jsonResponse({ error: "Invalid limit" }, { status: 400 });
   }
-  return { query, limit };
+  if (!SEARCH_SCOPES.has(scope)) {
+    return jsonResponse({ error: "Invalid search scope" }, { status: 400 });
+  }
+  return { query, limit, scope: scope as "catalog" | "workspace" };
 }
 
 export async function getGlobalSearchRoute(request: Request) {
   const parsed = parseSearchQuery(request);
   if (parsed instanceof Response) return parsed;
 
-  const locale = getRequestLocale(request);
-  const userId = await resolveApiUserId(request);
+  const localeResolution = resolvePublicCatalogLocale(request);
+  if (localeResolution instanceof Response) return localeResolution;
+
+  const includeWorkspace = parsed.scope === "workspace";
+  const userId = includeWorkspace ? await resolveApiUserId(request) : null;
   const origin = new URL(request.url).origin;
 
   try {
     const result = await searchGlobally({
       query: parsed.query,
       limit: parsed.limit,
-      locale,
+      locale: localeResolution.locale,
       origin,
       userId,
     });
     return jsonResponse(result, {
-      headers: userId
-        ? PRIVATE_LOCALE_CATALOG_HEADERS
-        : PUBLIC_SEARCH_CACHE_HEADERS,
+      headers:
+        includeWorkspace || !new URL(request.url).searchParams.has("locale")
+          ? PRIVATE_LOCALE_CATALOG_HEADERS
+          : PUBLIC_SEARCH_CACHE_HEADERS,
     });
   } catch (error) {
     return handleRouteError("Failed to search", error);

--- a/src/lib/components/shell/AppShell.svelte
+++ b/src/lib/components/shell/AppShell.svelte
@@ -766,6 +766,7 @@ afterNavigate(({ from, to }) => {
   <svelte:component
     this={GlobalSearchDialog}
     copy={data.copy.globalSearch}
+    locale={data.locale}
     bind:open={globalSearchOpen}
     signedIn={Boolean(viewerUser)}
     on:openChange={(event) => {

--- a/src/lib/components/shell/GlobalSearchDialog.svelte
+++ b/src/lib/components/shell/GlobalSearchDialog.svelte
@@ -13,6 +13,7 @@ import {
   globalSearchItemDomId,
 } from "@/features/search/lib/global-search-keyboard";
 import type { GlobalSearchResultItem } from "@/features/search/server/global-search-types";
+import type { AppLocale } from "@/i18n/config";
 import { goto } from "$app/navigation";
 import GlobalSearchResults from "$lib/components/shell/GlobalSearchResults.svelte";
 import { Button } from "$lib/components/ui/button/index.js";
@@ -22,6 +23,7 @@ import type { LayoutCopy } from "$lib/shell/layout-server-data";
 import { cn } from "$lib/utils.js";
 
 export let copy: LayoutCopy["globalSearch"];
+export let locale: AppLocale;
 export let open = false;
 export let signedIn = false;
 
@@ -34,6 +36,10 @@ const dialogOpen = writable(false);
 $: dialogOpen.set(open);
 
 const search = createGlobalSearchController({
+  getRequestContext: () => ({
+    includeWorkspace: signedIn,
+    locale,
+  }),
   limit: GLOBAL_SEARCH_DIALOG_LIMIT,
   showInitialHintDeps: dialogOpen,
   getShowInitialHint: ({ hasSearched, query }) =>

--- a/src/lib/public-cache-control.ts
+++ b/src/lib/public-cache-control.ts
@@ -33,7 +33,6 @@ export const PUBLIC_SEARCH_CACHE_HEADERS = {
   "Cache-Tag": CATALOG_EDGE_CACHE_TAG,
   "Cloudflare-CDN-Cache-Control":
     "public, max-age=120, stale-while-revalidate=300",
-  Vary: "Accept-Language",
 } as const;
 
 // Bus schedule responses are purged with the catalog revision tag. Keep the

--- a/src/routes/api/search/+server.ts
+++ b/src/routes/api/search/+server.ts
@@ -4,7 +4,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
 
 /**
  * Global search across catalog and workspace entities.
- * @params q, limit
+ * @params q, limit, locale, scope
  * @response globalSearchResponse
  * @response 400:openApiErrorSchema
  */

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -22,6 +22,10 @@ export let data: PageData;
 let inputElement: HTMLInputElement | null = null;
 
 const search = createGlobalSearchController({
+  getRequestContext: () => ({
+    includeWorkspace: Boolean(data.user),
+    locale: data.locale,
+  }),
   limit: GLOBAL_SEARCH_PAGE_LIMIT,
   urlSync: {
     getPageUrl: () => $page.url,

--- a/tests/e2e/src/app/global-search/test.ts
+++ b/tests/e2e/src/app/global-search/test.ts
@@ -11,7 +11,10 @@ test("global search shortcut returns catalog results", async ({ page }) => {
 
   const searchResponse = page.waitForResponse(
     (response) =>
-      response.url().includes("/api/search?q=math") && response.ok(),
+      response.url().includes("/api/search?q=math") &&
+      response.url().includes("locale=") &&
+      !response.url().includes("scope=workspace") &&
+      response.ok(),
   );
 
   const input = dialog.locator("input").first();
@@ -34,7 +37,10 @@ test("global search returns Chinese catalog matches", async ({ page }) => {
 
   const searchResponse = page.waitForResponse(
     (response) =>
-      response.url().includes(encodeURIComponent("线性代数")) && response.ok(),
+      response.url().includes(encodeURIComponent("线性代数")) &&
+      response.url().includes("locale=") &&
+      !response.url().includes("scope=workspace") &&
+      response.ok(),
   );
 
   const input = dialog.locator("input").first();
@@ -121,6 +127,8 @@ test("signed-in global search returns catalog results", async ({ page }) => {
     (response) =>
       response.url().includes("/api/search") &&
       response.url().includes(encodeURIComponent("线性代数")) &&
+      response.url().includes("locale=") &&
+      response.url().includes("scope=workspace") &&
       response.ok(),
   );
 
@@ -128,7 +136,8 @@ test("signed-in global search returns catalog results", async ({ page }) => {
   const dialog = page.locator('[data-slot="dialog-content"]');
   await expect(dialog).toBeVisible();
   await dialog.locator("input").first().fill("线性代数");
-  await searchResponse;
+  const response = await searchResponse;
+  expect(response.headers()["cache-control"]).toBe("private, no-store");
 
   await expect(
     dialog

--- a/tests/e2e/src/app/search/test.ts
+++ b/tests/e2e/src/app/search/test.ts
@@ -7,6 +7,7 @@ test("search page returns catalog and link results", async ({ page }) => {
     (response) =>
       response.url().includes("/api/search") &&
       response.url().includes("email") &&
+      response.url().includes("locale=") &&
       response.ok(),
   );
 

--- a/tests/integration/global-search.test.ts
+++ b/tests/integration/global-search.test.ts
@@ -99,4 +99,31 @@ describe("global search integration", () => {
       courseSearchSpy.mockRestore();
     }
   });
+
+  it("keeps runtime search results isolated by locale", async () => {
+    clearPublicRuntimeCache();
+    const courseSearchSpy = vi.spyOn(catalogQueries, "searchCoursesForGlobal");
+
+    try {
+      await searchGlobally({
+        locale: "zh-cn",
+        origin: ORIGIN,
+        query: "线性代数",
+      });
+      const callsAfterChinese = courseSearchSpy.mock.calls.length;
+
+      await searchGlobally({
+        locale: "en-us",
+        origin: ORIGIN,
+        query: "线性代数",
+      });
+
+      expect(callsAfterChinese).toBeGreaterThan(0);
+      expect(courseSearchSpy.mock.calls.length).toBeGreaterThan(
+        callsAfterChinese,
+      );
+    } finally {
+      courseSearchSpy.mockRestore();
+    }
+  });
 });

--- a/tests/unit/global-search-controller.test.ts
+++ b/tests/unit/global-search-controller.test.ts
@@ -49,11 +49,36 @@ describe("createGlobalSearchController", () => {
 
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(fetchMock).toHaveBeenCalledWith(
-      `/api/search?q=${encodeURIComponent("math")}&limit=5`,
+      `/api/search?q=${encodeURIComponent("math")}&limit=5&locale=zh-cn`,
     );
     expect(get(controller.groups)).toHaveLength(1);
     expect(get(controller.isSearching)).toBe(false);
     expect(get(controller.hasSearched)).toBe(true);
+
+    vi.useRealTimers();
+  });
+
+  it("uses an explicit locale and isolated workspace scope", async () => {
+    vi.useFakeTimers();
+    const fetchMock = mockSearchFetch({ groups: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const controller = createGlobalSearchController({
+      getRequestContext: () => ({
+        includeWorkspace: true,
+        locale: "en-us",
+      }),
+      limit: 5,
+    });
+    controller.query.set("math");
+    controller.scheduleSearch();
+
+    await vi.advanceTimersByTimeAsync(GLOBAL_SEARCH_DEBOUNCE_MS);
+    await vi.runAllTimersAsync();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/search?q=math&limit=5&locale=en-us&scope=workspace",
+    );
 
     vi.useRealTimers();
   });

--- a/tests/unit/global-search-route.test.ts
+++ b/tests/unit/global-search-route.test.ts
@@ -22,7 +22,7 @@ function clearPublicRuntimeCache() {
 
 describe("global search route", () => {
   afterEach(() => {
-    searchGloballyMock.mockReset();
+    vi.clearAllMocks();
     clearPublicRuntimeCache();
     vi.resetModules();
   });
@@ -47,8 +47,11 @@ describe("global search route", () => {
       "public, max-age=120, stale-while-revalidate=300",
     );
     expect(response.headers.get("Cache-Tag")).toBe("catalog");
+    expect(response.headers.get("Vary")).toBeNull();
+    expect(resolveApiUserId).not.toHaveBeenCalled();
     expect(searchGloballyMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        locale: "en-us",
         origin: "https://life.example",
         query: "math",
         userId: null,
@@ -65,7 +68,9 @@ describe("global search route", () => {
       "@/lib/api/routes/global-search"
     );
     const response = await getGlobalSearchRoute(
-      new Request("https://life.example/api/search?q=math&locale=en-us"),
+      new Request(
+        "https://life.example/api/search?q=math&locale=en-us&scope=workspace",
+      ),
     );
 
     expect(response.status).toBe(200);
@@ -75,5 +80,85 @@ describe("global search route", () => {
         userId: "user-1",
       }),
     );
+  });
+
+  it("keeps workspace scope private when authentication is stale", async () => {
+    const { resolveApiUserId } = await import("@/lib/auth/api-auth");
+    vi.mocked(resolveApiUserId).mockResolvedValue(null);
+    searchGloballyMock.mockResolvedValue({ query: "math", groups: [] });
+
+    const { getGlobalSearchRoute } = await import(
+      "@/lib/api/routes/global-search"
+    );
+    const response = await getGlobalSearchRoute(
+      new Request(
+        "https://life.example/api/search?q=math&locale=en-us&scope=workspace",
+      ),
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(searchGloballyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: null }),
+    );
+  });
+
+  it("never authenticates or personalizes the public catalog scope", async () => {
+    const { resolveApiUserId } = await import("@/lib/auth/api-auth");
+    vi.mocked(resolveApiUserId).mockResolvedValue("user-1");
+    searchGloballyMock.mockResolvedValue({ query: "math", groups: [] });
+
+    const { getGlobalSearchRoute } = await import(
+      "@/lib/api/routes/global-search"
+    );
+    const response = await getGlobalSearchRoute(
+      new Request("https://life.example/api/search?q=math&locale=zh-cn"),
+    );
+
+    expect(response.headers.get("Cache-Control")).toContain("public");
+    expect(resolveApiUserId).not.toHaveBeenCalled();
+    expect(searchGloballyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: "zh-cn", userId: null }),
+    );
+  });
+
+  it("keeps implicit cookie-negotiated locale responses private", async () => {
+    const { resolveApiUserId } = await import("@/lib/auth/api-auth");
+    searchGloballyMock.mockResolvedValue({ query: "math", groups: [] });
+
+    const { getGlobalSearchRoute } = await import(
+      "@/lib/api/routes/global-search"
+    );
+    const response = await getGlobalSearchRoute(
+      new Request("https://life.example/api/search?q=math", {
+        headers: { Cookie: "NEXT_LOCALE=en-us" },
+      }),
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(resolveApiUserId).not.toHaveBeenCalled();
+    expect(searchGloballyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: "en-us", userId: null }),
+    );
+  });
+
+  it("rejects invalid locale and scope before searching", async () => {
+    const { resolveApiUserId } = await import("@/lib/auth/api-auth");
+    const { getGlobalSearchRoute } = await import(
+      "@/lib/api/routes/global-search"
+    );
+
+    const invalidScope = await getGlobalSearchRoute(
+      new Request(
+        "https://life.example/api/search?q=math&locale=zh-cn&scope=all",
+      ),
+    );
+    const invalidLocale = await getGlobalSearchRoute(
+      new Request("https://life.example/api/search?q=math&locale=fr-fr"),
+    );
+
+    expect(invalidScope.status).toBe(400);
+    expect(invalidLocale.status).toBe(400);
+    expect(resolveApiUserId).not.toHaveBeenCalled();
+    expect(searchGloballyMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/global-search-service.test.ts
+++ b/tests/unit/global-search-service.test.ts
@@ -38,6 +38,7 @@ import {
   hasGlobalSearchQuery,
   searchGlobally,
 } from "@/features/search/server/global-search-service";
+import type { GlobalSearchResultGroup } from "@/features/search/server/global-search-types";
 
 const ORIGIN = "https://life.example";
 
@@ -192,6 +193,33 @@ describe("global search service", () => {
         ],
       },
     ]);
+  });
+
+  it("starts workspace search without waiting for the catalog cache", async () => {
+    let resolveCatalog:
+      | ((groups: GlobalSearchResultGroup[]) => void)
+      | undefined;
+    cachedCatalogRuntimeDataMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCatalog = resolve;
+      }),
+    );
+
+    const resultPromise = searchGlobally({
+      locale: "zh-cn",
+      origin: ORIGIN,
+      query: "数据",
+      userId: "user-1",
+    });
+    await Promise.resolve();
+
+    expect(withUserDbContextMock).toHaveBeenCalledWith(
+      "user-1",
+      expect.any(Function),
+    );
+
+    resolveCatalog?.([]);
+    await expect(resultPromise).resolves.toEqual({ query: "数据", groups: [] });
   });
 
   it("reuses cached catalog results without hitting catalog queries again", async () => {


### PR DESCRIPTION
## What changed

- make locale an explicit `/api/search` query parameter so public CDN cache keys are locale-safe
- split catalog and workspace requests with an explicit `scope=workspace` discriminator
- keep workspace and implicit-locale responses `private, no-store`; public catalog requests no longer run authentication
- start catalog and workspace searches concurrently for signed-in requests
- cover route caching, client URLs, locale cache isolation, concurrency, and browser requests

## Root cause

The endpoint varied its response by locale cookies / `Accept-Language` and by authentication, but Cloudflare cached the public response by URL. `Vary: Accept-Language` did not isolate Worker cache variants, and an authenticated request could therefore receive a previously cached anonymous response before reaching the Worker. The route also awaited catalog search before starting workspace search.

## Impact

Public search responses now have complete cache identity in the URL. Personalized requests are isolated from public caching, avoid unnecessary auth work for catalog-only calls, and execute their independent catalog/workspace work in parallel.

## Validation

- `bun run test:unit` — 2041 passed
- focused unit suite — 26 passed
- `bunx vitest run --config vitest.integration.config.ts tests/integration/global-search.test.ts` — 4 passed
- `bunx tsc --noEmit`
- `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors (13 existing warnings)
- `bun run build`
- `bun run openapi:check`
- focused Playwright — 7/8 passed; all anonymous search cases passed. The signed-in case was blocked during local auth setup by a pre-existing BetterAuth JWKS/secret mismatch before the search request was issued.