### PR TITLE
perf(search): bound queries and abort stale requests

### DIFF
--- a/src/features/search/lib/global-search-client.ts
+++ b/src/features/search/lib/global-search-client.ts
@@ -1,7 +1,9 @@
+import { CATALOG_SEARCH_MAX_LENGTH } from "@/features/catalog/lib/catalog-list-query";
 import type { GlobalSearchResponse } from "@/features/search/server/global-search-types";
 import type { AppLocale } from "@/i18n/config";
 
 export const GLOBAL_SEARCH_MIN_QUERY_LENGTH = 2;
+export const GLOBAL_SEARCH_MAX_QUERY_LENGTH = CATALOG_SEARCH_MAX_LENGTH;
 export const GLOBAL_SEARCH_DEBOUNCE_MS = 200;
 export const GLOBAL_SEARCH_DIALOG_LIMIT = 5;
 export const GLOBAL_SEARCH_PAGE_LIMIT = 20;
@@ -12,6 +14,7 @@ export async function fetchGlobalSearch(
   options: {
     includeWorkspace?: boolean;
     locale: AppLocale;
+    signal?: AbortSignal;
   },
 ): Promise<GlobalSearchResponse> {
   const searchParams = new URLSearchParams({
@@ -22,7 +25,9 @@ export async function fetchGlobalSearch(
   if (options.includeWorkspace) {
     searchParams.set("scope", "workspace");
   }
-  const response = await fetch(`/api/search?${searchParams}`);
+  const response = await fetch(`/api/search?${searchParams}`, {
+    signal: options.signal,
+  });
   if (!response.ok) {
     throw new Error("Search request failed");
   }

--- a/src/features/search/lib/global-search-controller.ts
+++ b/src/features/search/lib/global-search-controller.ts
@@ -83,6 +83,7 @@ export function createGlobalSearchController(
 
   let searchGeneration = 0;
   let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+  let activeSearchController: AbortController | undefined;
 
   const flatItems = derived(groups, ($groups) => flattenSearchGroups($groups));
 
@@ -126,8 +127,14 @@ export function createGlobalSearchController(
     clearTimeout(searchDebounceTimer);
   }
 
+  function abortActiveSearch() {
+    activeSearchController?.abort();
+    activeSearchController = undefined;
+  }
+
   function reset() {
     clearSearchDebounce();
+    abortActiveSearch();
     searchGeneration += 1;
     query.set("");
     groups.set([]);
@@ -167,16 +174,18 @@ export function createGlobalSearchController(
       return;
     }
 
+    abortActiveSearch();
+    const requestController = new AbortController();
+    activeSearchController = requestController;
     const generation = ++searchGeneration;
     isSearching.set(true);
     hasSearched.set(true);
 
     try {
-      const body = await fetchGlobalSearch(
-        trimmed,
-        options.limit,
-        options.getRequestContext?.() ?? { locale: DEFAULT_LOCALE },
-      );
+      const body = await fetchGlobalSearch(trimmed, options.limit, {
+        ...(options.getRequestContext?.() ?? { locale: DEFAULT_LOCALE }),
+        signal: requestController.signal,
+      });
       if (generation !== searchGeneration) return;
       groups.set(body.groups ?? []);
     } catch {
@@ -184,6 +193,7 @@ export function createGlobalSearchController(
       groups.set([]);
     } finally {
       if (generation === searchGeneration) {
+        activeSearchController = undefined;
         isSearching.set(false);
       }
     }
@@ -191,11 +201,12 @@ export function createGlobalSearchController(
 
   function scheduleSearch() {
     clearSearchDebounce();
+    abortActiveSearch();
+    searchGeneration += 1;
     updateUrlQuery(get(query));
 
     const trimmed = get(query).trim();
     if (trimmed.length < GLOBAL_SEARCH_MIN_QUERY_LENGTH) {
-      searchGeneration += 1;
       groups.set([]);
       hasSearched.set(false);
       isSearching.set(false);

--- a/src/lib/api/routes/global-search.ts
+++ b/src/lib/api/routes/global-search.ts
@@ -1,3 +1,4 @@
+import { CATALOG_SEARCH_MAX_LENGTH } from "@/features/catalog/lib/catalog-list-query";
 import { searchGlobally } from "@/features/search/server/global-search-service";
 import { handleRouteError, jsonResponse } from "@/lib/api/helpers";
 import { resolvePublicCatalogLocale } from "@/lib/api/routes/request-locale";
@@ -16,6 +17,14 @@ function parseSearchQuery(request: Request) {
   const limitParam = searchParams.get("limit");
   const limit = limitParam ? Number(limitParam) : undefined;
   const scope = searchParams.get("scope") ?? "catalog";
+  if (query.trim().length > CATALOG_SEARCH_MAX_LENGTH) {
+    return jsonResponse(
+      {
+        error: `Search query must not exceed ${CATALOG_SEARCH_MAX_LENGTH} characters`,
+      },
+      { status: 400 },
+    );
+  }
   if (
     limit !== undefined &&
     (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT)

--- a/src/lib/components/shell/GlobalSearchDialog.svelte
+++ b/src/lib/components/shell/GlobalSearchDialog.svelte
@@ -5,6 +5,7 @@ import { createEventDispatcher } from "svelte";
 import { writable } from "svelte/store";
 import {
   GLOBAL_SEARCH_DIALOG_LIMIT,
+  GLOBAL_SEARCH_MAX_QUERY_LENGTH,
   GLOBAL_SEARCH_MIN_QUERY_LENGTH,
 } from "@/features/search/lib/global-search-client";
 import { createGlobalSearchController } from "@/features/search/lib/global-search-controller";
@@ -118,6 +119,7 @@ $: if (open) {
           oninput={handleQueryInput}
           onkeydown={(event) => handleInputKeydown(event, inputElement)}
           placeholder={placeholder}
+          maxlength={GLOBAL_SEARCH_MAX_QUERY_LENGTH}
           role="combobox"
           type="text"
         />

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 import SearchIcon from "@lucide/svelte/icons/search";
 import { onMount } from "svelte";
-import { GLOBAL_SEARCH_PAGE_LIMIT } from "@/features/search/lib/global-search-client";
+import {
+  GLOBAL_SEARCH_MAX_QUERY_LENGTH,
+  GLOBAL_SEARCH_PAGE_LIMIT,
+} from "@/features/search/lib/global-search-client";
 import {
   createGlobalSearchController,
   mountGlobalSearchUrlSync,
@@ -92,6 +95,7 @@ afterNavigate(({ to }) => {
       oninput={handleQueryInput}
       onkeydown={(event) => handleInputKeydown(event, inputElement)}
       placeholder={data.copy.placeholderSignedIn}
+      maxlength={GLOBAL_SEARCH_MAX_QUERY_LENGTH}
       role="combobox"
       type="search"
     />

--- a/tests/integration/rest/search/test.ts
+++ b/tests/integration/rest/search/test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("GET /api/search", () => {
+  test("accepts the catalog search bound and rejects longer queries", async ({
+    request,
+  }) => {
+    const accepted = await request.get(
+      `/api/search?q=${"a".repeat(200)}&locale=zh-cn`,
+    );
+    expect(accepted.status()).toBe(200);
+
+    const rejected = await request.get(
+      `/api/search?q=${"a".repeat(201)}&locale=zh-cn`,
+    );
+    expect(rejected.status()).toBe(400);
+    await expect(rejected.json()).resolves.toEqual({
+      error: "Search query must not exceed 200 characters",
+    });
+  });
+});

--- a/tests/unit/global-search-controller.test.ts
+++ b/tests/unit/global-search-controller.test.ts
@@ -50,6 +50,7 @@ describe("createGlobalSearchController", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(fetchMock).toHaveBeenCalledWith(
       `/api/search?q=${encodeURIComponent("math")}&limit=5&locale=zh-cn`,
+      { signal: expect.any(AbortSignal) },
     );
     expect(get(controller.groups)).toHaveLength(1);
     expect(get(controller.isSearching)).toBe(false);
@@ -78,6 +79,7 @@ describe("createGlobalSearchController", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/search?q=math&limit=5&locale=en-us&scope=workspace",
+      { signal: expect.any(AbortSignal) },
     );
 
     vi.useRealTimers();
@@ -211,6 +213,48 @@ describe("createGlobalSearchController", () => {
     await vi.runAllTimersAsync();
 
     expect(get(controller.groups)[0]?.items[0]?.id).toBe("course:new");
+
+    vi.useRealTimers();
+  });
+
+  it("aborts superseded workspace requests as soon as the query changes", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce((_url: string, init: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        });
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ groups: [] }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const controller = createGlobalSearchController({
+      getRequestContext: () => ({
+        includeWorkspace: true,
+        locale: "zh-cn",
+      }),
+      limit: 5,
+    });
+    controller.query.set("old query");
+    controller.scheduleSearch();
+    await vi.advanceTimersByTimeAsync(GLOBAL_SEARCH_DEBOUNCE_MS);
+
+    const firstSignal = fetchMock.mock.calls[0]?.[1]?.signal as AbortSignal;
+    expect(firstSignal.aborted).toBe(false);
+
+    controller.query.set("new query");
+    controller.scheduleSearch();
+
+    expect(firstSignal.aborted).toBe(true);
+    await vi.advanceTimersByTimeAsync(GLOBAL_SEARCH_DEBOUNCE_MS);
+    await vi.runAllTimersAsync();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
 
     vi.useRealTimers();
   });

--- a/tests/unit/global-search-route.test.ts
+++ b/tests/unit/global-search-route.test.ts
@@ -161,4 +161,24 @@ describe("global search route", () => {
     expect(resolveApiUserId).not.toHaveBeenCalled();
     expect(searchGloballyMock).not.toHaveBeenCalled();
   });
+
+  it("rejects search queries longer than the catalog search bound", async () => {
+    const { resolveApiUserId } = await import("@/lib/auth/api-auth");
+    const { getGlobalSearchRoute } = await import(
+      "@/lib/api/routes/global-search"
+    );
+
+    const response = await getGlobalSearchRoute(
+      new Request(
+        `https://life.example/api/search?q=${"a".repeat(201)}&locale=zh-cn`,
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Search query must not exceed 200 characters",
+    });
+    expect(resolveApiUserId).not.toHaveBeenCalled();
+    expect(searchGloballyMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Summary:
- reject global search queries above the existing 200-character catalog bound
- expose the same bound in both search inputs
- abort superseded in-flight search requests immediately while retaining stale-response guards

Validation:
- focused controller and route unit tests
- focused REST integration test
- TypeScript and Svelte checks
- production build