### PR TITLE
fix(search): keep source links out of catalog cache

### DIFF
--- a/src/features/search/server/global-search-service.ts
+++ b/src/features/search/server/global-search-service.ts
@@ -95,16 +95,14 @@ async function searchCatalogGroups(
   locale: AppLocale,
   limit: number,
 ): Promise<GlobalSearchResultGroup[]> {
-  const [courses, teachers, sections, links] = await Promise.all([
+  const [courses, teachers, sections] = await Promise.all([
     searchCoursesForGlobal(query, locale, limit),
     searchTeachersForGlobal(query, locale, limit),
     searchSectionsForGlobal(query, locale, limit),
-    Promise.resolve(searchLinksForGlobal(query, locale, limit)),
   ]);
 
-  const groupItems: Record<
-    GlobalSearchResultGroupType,
-    GlobalSearchResultItem[]
+  const groupItems: Partial<
+    Record<GlobalSearchResultGroupType, GlobalSearchResultItem[]>
   > = {
     courses: courses.map(toCourseItem),
     teachers: teachers.map((teacher) => ({
@@ -114,19 +112,44 @@ async function searchCatalogGroups(
       href: `/catalog/teachers/${teacher.id}`,
     })),
     sections: sections.map((section) => toSectionItem(section, locale)),
-    links: links.map((link) => ({
-      id: `link:${link.slug}`,
-      title: link.title,
-      description: link.description,
-      href: link.url,
-      external: true,
-    })),
-    homeworks: [],
-    todos: [],
   };
 
   return GLOBAL_SEARCH_GROUP_ORDER.flatMap((type) => {
-    const items = groupItems[type];
+    const items = groupItems[type] ?? [];
+    return items.length > 0 ? [{ type, items }] : [];
+  });
+}
+
+function searchLinkGroups(
+  query: string,
+  locale: AppLocale,
+  limit: number,
+): GlobalSearchResultGroup[] {
+  const items = searchLinksForGlobal(query, locale, limit).map((link) => ({
+    id: `link:${link.slug}`,
+    title: link.title,
+    description: link.description,
+    href: link.url,
+    external: true,
+  }));
+  return items.length > 0 ? [{ type: "links", items }] : [];
+}
+
+function orderSearchGroups(
+  groups: GlobalSearchResultGroup[],
+): GlobalSearchResultGroup[] {
+  const itemsByType = new Map<
+    GlobalSearchResultGroupType,
+    GlobalSearchResultItem[]
+  >();
+  for (const group of groups) {
+    const items = itemsByType.get(group.type) ?? [];
+    items.push(...group.items);
+    itemsByType.set(group.type, items);
+  }
+
+  return GLOBAL_SEARCH_GROUP_ORDER.flatMap((type) => {
+    const items = itemsByType.get(type) ?? [];
     return items.length > 0 ? [{ type, items }] : [];
   });
 }
@@ -281,10 +304,15 @@ export async function searchGlobally(input: {
     catalogGroupsPromise,
     workspaceGroupsPromise,
   ]);
+  const linkGroups = searchLinkGroups(query, input.locale, limit);
 
   return {
     query,
-    groups: [...catalogGroups, ...workspaceGroups],
+    groups: orderSearchGroups([
+      ...catalogGroups,
+      ...linkGroups,
+      ...workspaceGroups,
+    ]),
   };
 }
 

--- a/tests/unit/global-search-route.test.ts
+++ b/tests/unit/global-search-route.test.ts
@@ -121,7 +121,7 @@ describe("global search route", () => {
     );
   });
 
-  it("keeps implicit cookie-negotiated locale responses private", async () => {
+  it("uses the deterministic default locale for implicit private responses", async () => {
     const { resolveApiUserId } = await import("@/lib/auth/api-auth");
     searchGloballyMock.mockResolvedValue({ query: "math", groups: [] });
 
@@ -137,7 +137,7 @@ describe("global search route", () => {
     expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(resolveApiUserId).not.toHaveBeenCalled();
     expect(searchGloballyMock).toHaveBeenCalledWith(
-      expect.objectContaining({ locale: "en-us", userId: null }),
+      expect.objectContaining({ locale: "zh-cn", userId: null }),
     );
   });
 

--- a/tests/unit/global-search-service.test.ts
+++ b/tests/unit/global-search-service.test.ts
@@ -48,7 +48,7 @@ describe("global search service", () => {
     searchCoursesForGlobalMock.mockResolvedValue([]);
     searchSectionsForGlobalMock.mockResolvedValue([]);
     searchTeachersForGlobalMock.mockResolvedValue([]);
-    searchLinksForGlobalMock.mockResolvedValue([]);
+    searchLinksForGlobalMock.mockReturnValue([]);
     cachedCatalogRuntimeDataMock.mockImplementation(
       async (
         _namespace: string,
@@ -246,6 +246,53 @@ describe("global search service", () => {
 
     expect(result.groups).toHaveLength(1);
     expect(searchCoursesForGlobalMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes source-backed links when database catalog results are cached", async () => {
+    let cachedGroups: GlobalSearchResultGroup[] | undefined;
+    cachedCatalogRuntimeDataMock.mockImplementation(
+      async (
+        _namespace: string,
+        _cacheKey: string,
+        _origin: string,
+        load: () => Promise<GlobalSearchResultGroup[]>,
+      ) => {
+        cachedGroups ??= await load();
+        return cachedGroups;
+      },
+    );
+    searchLinksForGlobalMock.mockReturnValue([
+      {
+        slug: "mail",
+        title: "Old mail title",
+        description: "Old mail description",
+        url: "https://old.example/",
+      },
+    ]);
+
+    const first = await searchGlobally({
+      locale: "en-us",
+      origin: ORIGIN,
+      query: "mail",
+    });
+    searchLinksForGlobalMock.mockReturnValue([
+      {
+        slug: "mail",
+        title: "New mail title",
+        description: "New mail description",
+        url: "https://new.example/",
+      },
+    ]);
+    const second = await searchGlobally({
+      locale: "en-us",
+      origin: ORIGIN,
+      query: "mail",
+    });
+
+    expect(searchCoursesForGlobalMock).toHaveBeenCalledTimes(1);
+    expect(searchLinksForGlobalMock).toHaveBeenCalledTimes(2);
+    expect(first.groups[0]?.items[0]?.href).toBe("https://old.example/");
+    expect(second.groups[0]?.items[0]?.href).toBe("https://new.example/");
   });
 
   it("includes link matches in catalog results", async () => {


### PR DESCRIPTION
## What changed

- cache only database-backed course, teacher, and section search groups
- resolve source-controlled dashboard links after every catalog cache read
- restore canonical group ordering when catalog, link, and workspace results are combined
- correct the adjacent implicit-locale unit expectation left stale by the merged deterministic-default contract

## Why

Search catalog KV entries live for 24 hours and are revisioned by the database static-import snapshot. Dashboard links are source-controlled, so link URL or copy changes did not change that revision and could remain stale for nearly a day after deployment.

## Impact

Catalog query caching and response shapes remain unchanged. Link matching stays bounded by the requested search limit and now reflects the deployed source immediately, including on a catalog KV hit.

## Validation

- 339 unit files / 2052 tests
- TypeScript no-emit
- Biome on changed files
- svelte-check: 0 errors (13 pre-existing warnings)
- OpenAPI check
- production build