### PR TITLE
perf(calendar): bound multi-section exports

### DIFF
--- a/docs/contracts/ical.json
+++ b/docs/contracts/ical.json
@@ -10,6 +10,7 @@
     "copyable-links": "iCal links should be presented as copyable links rather than requiring users to manually construct them.",
     "no-second-model": "iCal is an export / subscription capability and should not carry a second business model.",
     "rfc5545-dtstamp-utc": "Every VEVENT in section, multi-section, and personal feeds serializes DTSTAMP as a UTC DATE-TIME with a Z suffix while retaining Asia/Shanghai TZID values for event start and end times.",
+    "bounded-multi-section-export": "A multi-section iCal export accepts at most 50 unique positive Section IDs. IDs are deduplicated and sorted into one canonical URL before the expanded Section graph is loaded, so one cold request can expand no more than 50 Sections and equivalent ID sets share the same CDN cache key.",
     "personal-feed-cache": "Personal feeds may use a private Workers KV cache (30m fresh / 24h stale). Fresh hits serve immediately; stale hits serve cached ICS and enqueue CALENDAR_EXPORT_REBUILD. True misses rebuild on the request path (KV put may defer). Write-time invalidation enqueues rebuilds instead of waitUntil deletes. Include ETag/304. Check the current feed token before any cache read; revoked tokens for an existing user return 410 with short Cache-Control. Never put user IDs or feed tokens in cache telemetry.",
     "static-json-resilient": "Calendar location and building image enhancements only read static JSON published at https://static.life-ustc.tiankaima.dev; when loading fails or data is corrupted, diagnostic information should be logged and a valid iCal should still be returned."
   },
@@ -99,7 +100,9 @@
             "path": "/api/catalog/sections/calendar.ics",
             "returns": "text/calendar",
             "notes": [
-              "Generates a multi-section iCal based on sectionIds query parameter."
+              "Generates a multi-section iCal based on a comma-separated sectionIds query parameter.",
+              "Accepts at most 50 unique positive Section IDs. Malformed or empty input returns 400.",
+              "IDs are deduplicated and sorted; non-canonical requests permanently redirect to the canonical cache URL before loading calendar relations."
             ]
           }
         ]

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -5226,9 +5226,11 @@
             "name": "sectionIds",
             "schema": {
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "description": "Comma-separated positive Section database IDs; at most 50 unique IDs."
             },
-            "required": true
+            "required": true,
+            "description": "Comma-separated positive Section database IDs; at most 50 unique IDs."
           }
         ],
         "responses": {
@@ -5241,6 +5243,9 @@
                 }
               }
             }
+          },
+          "308": {
+            "description": "Response 308"
           },
           "400": {
             "description": "Error response",

--- a/src/lib/api/routes/calendar-route-request.ts
+++ b/src/lib/api/routes/calendar-route-request.ts
@@ -2,7 +2,6 @@ import {
   badRequest,
   invalidParamResponse,
   parseInteger,
-  parseIntegerList,
   parseRouteInput,
   parseRouteSearchParams,
 } from "@/lib/api/helpers";
@@ -11,6 +10,8 @@ import {
   sectionsCalendarQuerySchema,
   userCalendarPathParamsSchema,
 } from "@/lib/api/schemas/request-schemas";
+
+export const MAX_MULTI_SECTION_CALENDAR_IDS = 50;
 
 export function parseSectionsCalendarIds(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -24,13 +25,44 @@ export function parseSectionsCalendarIds(request: Request) {
     return parsedQuery;
   }
 
-  const sectionIds = parseIntegerList(parsedQuery.sectionIds);
+  const rawSectionIds = parsedQuery.sectionIds.split(",");
+  const parsedSectionIds: number[] = [];
+  for (const value of rawSectionIds) {
+    const sectionId = parseInteger(value);
+    if (sectionId === null || sectionId <= 0) {
+      return badRequest("Invalid sectionIds parameter");
+    }
+    parsedSectionIds.push(sectionId);
+  }
 
-  if (sectionIds.length === 0) {
-    return badRequest("No valid section IDs provided");
+  const sectionIds = Array.from(new Set(parsedSectionIds)).sort(
+    (left, right) => left - right,
+  );
+  if (sectionIds.length > MAX_MULTI_SECTION_CALENDAR_IDS) {
+    return badRequest(
+      `sectionIds must contain at most ${MAX_MULTI_SECTION_CALENDAR_IDS} unique IDs`,
+    );
   }
 
   return sectionIds;
+}
+
+export function canonicalSectionsCalendarUrl(
+  request: Request,
+  sectionIds: readonly number[],
+) {
+  const url = new URL(request.url);
+  const canonicalIds = sectionIds.join(",");
+  if (
+    url.searchParams.size === 1 &&
+    url.searchParams.get("sectionIds") === canonicalIds
+  ) {
+    return null;
+  }
+
+  url.search = "";
+  url.searchParams.set("sectionIds", canonicalIds);
+  return url;
 }
 
 export function parseSectionCalendarJwId(params: { jwId: string }) {

--- a/src/lib/api/routes/calendars.ts
+++ b/src/lib/api/routes/calendars.ts
@@ -5,6 +5,7 @@ import {
   generateUserCalendarAction,
 } from "./calendar-route-actions";
 import {
+  canonicalSectionsCalendarUrl,
   parseSectionCalendarJwId,
   parseSectionsCalendarIds,
   parseUserCalendarRawUserId,
@@ -16,6 +17,11 @@ export async function getSectionsCalendarRoute(request: Request) {
     const sectionIds = parseSectionsCalendarIds(request);
     if (sectionIds instanceof Response) {
       return sectionIds;
+    }
+
+    const canonicalUrl = canonicalSectionsCalendarUrl(request, sectionIds);
+    if (canonicalUrl) {
+      return Response.redirect(canonicalUrl, 308);
     }
 
     return await generateSectionsCalendarAction(sectionIds);

--- a/src/lib/api/schemas/content-query-schemas.ts
+++ b/src/lib/api/schemas/content-query-schemas.ts
@@ -44,7 +44,13 @@ export const homeworksQuerySchema = z.object({
 });
 
 export const sectionsCalendarQuerySchema = z.object({
-  sectionIds: z.string().trim().min(1),
+  sectionIds: z
+    .string()
+    .trim()
+    .min(1)
+    .describe(
+      "Comma-separated positive Section database IDs; at most 50 unique IDs.",
+    ),
 });
 
 export const userCalendarQuerySchema = z.object({

--- a/src/routes/api/catalog/sections/calendar.ics/+server.ts
+++ b/src/routes/api/catalog/sections/calendar.ics/+server.ts
@@ -6,6 +6,7 @@ import { observedApiRoute } from "@/lib/log/api-observability";
  * Generate sections calendar.
  * @params sectionsCalendarQuerySchema
  * @response 200:calendar
+ * @response 308
  * @response 400:openApiErrorSchema
  */
 export const GET = svelteRequestHandler(

--- a/tests/integration/rest/sections/calendar.ics/test.ts
+++ b/tests/integration/rest/sections/calendar.ics/test.ts
@@ -1,14 +1,8 @@
-import { expect, test } from "@playwright/test";
+import { type APIRequestContext, expect, test } from "@playwright/test";
 import { DEV_SEED } from "../../../../e2e/utils/dev-seed";
 import { assertApiContract } from "../../_shared/api-contract";
 
-test("/api/catalog/sections/calendar.ics 契约", async ({ request }) => {
-  await assertApiContract(request, {
-    routePath: "/api/catalog/sections/calendar.ics",
-  });
-});
-
-test("/api/catalog/sections/calendar.ics 返回日历文本", async ({ request }) => {
+async function getSeedSectionId(request: APIRequestContext) {
   const matchResponse = await request.post(
     "/api/catalog/sections/match-codes",
     {
@@ -21,6 +15,17 @@ test("/api/catalog/sections/calendar.ics 返回日历文本", async ({ request }
   };
   const sectionId = matchBody.sections?.[0]?.id;
   expect(sectionId).toBeDefined();
+  return sectionId as number;
+}
+
+test("/api/catalog/sections/calendar.ics 契约", async ({ request }) => {
+  await assertApiContract(request, {
+    routePath: "/api/catalog/sections/calendar.ics",
+  });
+});
+
+test("/api/catalog/sections/calendar.ics 返回日历文本", async ({ request }) => {
+  const sectionId = await getSeedSectionId(request);
 
   const response = await request.get(
     `/api/catalog/sections/calendar.ics?sectionIds=${sectionId}`,
@@ -29,4 +34,63 @@ test("/api/catalog/sections/calendar.ics 返回日历文本", async ({ request }
   const content = await response.text();
   expect(content).toContain("BEGIN:VCALENDAR");
   expect(content).toContain("END:VCALENDAR");
+});
+
+test("/api/catalog/sections/calendar.ics accepts exactly 50 unique IDs", async ({
+  request,
+}) => {
+  const sectionId = await getSeedSectionId(request);
+  const unusedIds = Array.from(
+    { length: 49 },
+    (_, index) => 2_000_000_000 + index,
+  );
+  const ids = [sectionId, ...unusedIds].sort((left, right) => left - right);
+
+  const response = await request.get(
+    `/api/catalog/sections/calendar.ics?sectionIds=${ids.join(",")}`,
+  );
+
+  expect(response.status()).toBe(200);
+  expect(await response.text()).toContain("BEGIN:VCALENDAR");
+});
+
+test("/api/catalog/sections/calendar.ics rejects 51 unique IDs", async ({
+  request,
+}) => {
+  const ids = Array.from({ length: 51 }, (_, index) => index + 1);
+  const response = await request.get(
+    `/api/catalog/sections/calendar.ics?sectionIds=${ids.join(",")}`,
+  );
+
+  expect(response.status()).toBe(400);
+  await expect(response.json()).resolves.toEqual({
+    error: "sectionIds must contain at most 50 unique IDs",
+  });
+});
+
+test("/api/catalog/sections/calendar.ics canonicalizes duplicate IDs", async ({
+  request,
+}) => {
+  const response = await request.get(
+    "/api/catalog/sections/calendar.ics?sectionIds=3,1,3",
+    { maxRedirects: 0 },
+  );
+
+  expect(response.status()).toBe(308);
+  expect(response.headers().location).toBe(
+    "http://localhost:3000/api/catalog/sections/calendar.ics?sectionIds=1%2C3",
+  );
+});
+
+test("/api/catalog/sections/calendar.ics rejects malformed IDs", async ({
+  request,
+}) => {
+  const response = await request.get(
+    "/api/catalog/sections/calendar.ics?sectionIds=1,invalid,2",
+  );
+
+  expect(response.status()).toBe(400);
+  await expect(response.json()).resolves.toEqual({
+    error: "Invalid sectionIds parameter",
+  });
 });

--- a/tests/unit/sections-calendar-request.test.ts
+++ b/tests/unit/sections-calendar-request.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalSectionsCalendarUrl,
+  MAX_MULTI_SECTION_CALENDAR_IDS,
+  parseSectionsCalendarIds,
+} from "@/lib/api/routes/calendar-route-request";
+
+function calendarRequest(sectionIds?: string) {
+  const url = new URL("https://life.example/api/catalog/sections/calendar.ics");
+  if (sectionIds !== undefined) url.searchParams.set("sectionIds", sectionIds);
+  return new Request(url);
+}
+
+describe("multi-section calendar request", () => {
+  it("accepts exactly 50 unique IDs", () => {
+    const ids = Array.from(
+      { length: MAX_MULTI_SECTION_CALENDAR_IDS },
+      (_, index) => index + 1,
+    );
+
+    expect(parseSectionsCalendarIds(calendarRequest(ids.join(",")))).toEqual(
+      ids,
+    );
+  });
+
+  it("rejects 51 unique IDs", async () => {
+    const ids = Array.from(
+      { length: MAX_MULTI_SECTION_CALENDAR_IDS + 1 },
+      (_, index) => index + 1,
+    );
+    const response = parseSectionsCalendarIds(calendarRequest(ids.join(",")));
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(400);
+    await expect((response as Response).json()).resolves.toEqual({
+      error: "sectionIds must contain at most 50 unique IDs",
+    });
+  });
+
+  it("deduplicates before enforcing the limit and sorts the canonical IDs", () => {
+    const fiftyIds = Array.from(
+      { length: MAX_MULTI_SECTION_CALENDAR_IDS },
+      (_, index) => index + 1,
+    );
+    const input = [...fiftyIds.reverse(), 50, 1, 50];
+
+    expect(parseSectionsCalendarIds(calendarRequest(input.join(",")))).toEqual(
+      Array.from(
+        { length: MAX_MULTI_SECTION_CALENDAR_IDS },
+        (_, index) => index + 1,
+      ),
+    );
+  });
+
+  it.each([undefined, "", " "])("rejects empty input %s", async (input) => {
+    const response = parseSectionsCalendarIds(calendarRequest(input));
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(400);
+  });
+
+  it.each([
+    "1,foo,2",
+    "1,,2",
+    "0",
+    "-1",
+    "1.5",
+    "9007199254740992",
+  ])("rejects malformed input %s", async (input) => {
+    const response = parseSectionsCalendarIds(calendarRequest(input));
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(400);
+    await expect((response as Response).json()).resolves.toEqual({
+      error: "Invalid sectionIds parameter",
+    });
+  });
+
+  it("canonicalizes equivalent ID sets to one URL", () => {
+    const request = new Request(
+      "https://life.example/api/catalog/sections/calendar.ics?sectionIds=3,1,3&ignored=1",
+    );
+    const sectionIds = parseSectionsCalendarIds(request);
+    expect(sectionIds).toEqual([1, 3]);
+
+    const canonicalUrl = canonicalSectionsCalendarUrl(
+      request,
+      sectionIds as number[],
+    );
+    expect(canonicalUrl?.href).toBe(
+      "https://life.example/api/catalog/sections/calendar.ics?sectionIds=1%2C3",
+    );
+    expect(
+      canonicalSectionsCalendarUrl(
+        new Request(canonicalUrl as URL),
+        sectionIds as number[],
+      ),
+    ).toBeNull();
+  });
+});

--- a/tests/unit/sections-calendar-route.test.ts
+++ b/tests/unit/sections-calendar-route.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { generateSectionsCalendarActionMock } = vi.hoisted(() => ({
+  generateSectionsCalendarActionMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api/routes/calendar-route-actions", () => ({
+  generateSectionCalendarAction: vi.fn(),
+  generateSectionsCalendarAction: generateSectionsCalendarActionMock,
+  generateUserCalendarAction: vi.fn(),
+}));
+
+describe("multi-section calendar route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirects equivalent ID sets before loading expanded calendar data", async () => {
+    const { getSectionsCalendarRoute } = await import(
+      "@/lib/api/routes/calendars"
+    );
+    const response = await getSectionsCalendarRoute(
+      new Request(
+        "https://life.example/api/catalog/sections/calendar.ics?sectionIds=3,1,3",
+      ),
+    );
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("Location")).toBe(
+      "https://life.example/api/catalog/sections/calendar.ics?sectionIds=1%2C3",
+    );
+    expect(generateSectionsCalendarActionMock).not.toHaveBeenCalled();
+  });
+
+  it("loads only a canonical bounded ID list", async () => {
+    const calendarResponse = new Response("BEGIN:VCALENDAR", { status: 200 });
+    generateSectionsCalendarActionMock.mockResolvedValue(calendarResponse);
+    const { getSectionsCalendarRoute } = await import(
+      "@/lib/api/routes/calendars"
+    );
+    const response = await getSectionsCalendarRoute(
+      new Request(
+        "https://life.example/api/catalog/sections/calendar.ics?sectionIds=1%2C3",
+      ),
+    );
+
+    expect(response).toBe(calendarResponse);
+    expect(generateSectionsCalendarActionMock).toHaveBeenCalledWith([1, 3]);
+  });
+});


### PR DESCRIPTION
## Summary
- cap public multi-section iCal exports at 50 unique positive section IDs before any expanded relation query
- deduplicate and sort IDs, redirecting equivalent requests to one canonical CDN cache URL
- reject missing, malformed, or over-limit input with 400 and document the public contract

## Resource bound
A cold request can now expand at most 50 Section graphs (course, schedules/rooms/buildings/campuses/teachers, exams) before synchronous ICS generation. Equivalent permutations and duplicates converge on one canonical one-hour cache key.

## Validation
- focused Vitest: 24 passed
- focused REST Playwright: 6 passed
- TypeScript app/tests/operational
- full Biome (only existing warnings)
- svelte-check (0 errors; existing warnings)
- OpenAPI generation
- production build
