### PR TITLE
perf(todos): bound and fuse summary reads

### DIFF
--- a/docs/contracts/todo.json
+++ b/docs/contracts/todo.json
@@ -10,6 +10,7 @@
     "purely-personal": "Todo is a purely personal object and is not bound to any section.",
     "due-date-calendar": "Only incomplete todos with a due date appear in the calendar.",
     "completed-retained": "Completed todos retain history but no longer occupy urgent information areas.",
+    "bounded-summary-read": "REST todo summaries default to 100 items and accept at most 200. The complete incomplete/completed/overdue counts are fused into one RLS-scoped aggregate statement and remain independent of list filters; the bounded list is loaded in one additional statement.",
     "mobile-toolbar-priority": "At mobile widths, completion-status filters stay directly available, card/list display mode moves into an accessible overflow menu, and the create action remains a minimum 44 by 44 CSS pixel target. Desktop toolbar behavior remains unchanged."
   },
   "capabilities": {
@@ -109,7 +110,8 @@
             "notes": [
               "Returns the same count summary as workspace_todo_list plus todos[]; each item contains id, title, content, completed, priority, dueAt, createdAt, and updatedAt.",
               "Supports completed, priority, dueBefore, dueAfter, and limit query parameters.",
-              "REST and MCP share the same limit bounds: 1-200."
+              "REST defaults limit to 100. REST and MCP share the same explicit limit bounds: 1-200.",
+              "Summary counts cover all of the current user's todos regardless of list filters and are computed in one aggregate statement."
             ]
           }
         ]

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -3546,7 +3546,8 @@
               "type": "integer",
               "format": "int64",
               "minimum": 1,
-              "maximum": 200
+              "maximum": 200,
+              "default": 100
             }
           }
         ],

--- a/src/features/todos/lib/todo-list-limits.ts
+++ b/src/features/todos/lib/todo-list-limits.ts
@@ -1,0 +1,2 @@
+export const TODO_LIST_DEFAULT_LIMIT = 100;
+export const TODO_LIST_MAX_LIMIT = 200;

--- a/src/features/todos/server/todo-service.ts
+++ b/src/features/todos/server/todo-service.ts
@@ -1,4 +1,5 @@
 import { scheduleInvalidateUserCalendarExportCache } from "@/features/calendar/server/calendar-export-invalidation";
+import { TODO_LIST_DEFAULT_LIMIT } from "@/features/todos/lib/todo-list-limits";
 import type { Prisma, TodoPriority } from "@/generated/prisma/client";
 import { buildPaginatedResponse, normalizePagination } from "@/lib/api/helpers";
 import { withUserDbContext } from "@/lib/db/prisma";
@@ -260,7 +261,7 @@ export type OverviewTodoBundleCounts = {
   overdue: number;
 };
 
-export async function countOverviewTodoBundleInTransaction(
+async function countTodoBundleInTransaction(
   tx: Prisma.TransactionClient,
   input: {
     homeworkWindowEnd: Date;
@@ -303,6 +304,17 @@ export async function countOverviewTodoBundleInTransaction(
   };
 }
 
+export function countOverviewTodoBundleInTransaction(
+  tx: Prisma.TransactionClient,
+  input: {
+    homeworkWindowEnd: Date;
+    now: Date;
+    userId: string;
+  },
+) {
+  return countTodoBundleInTransaction(tx, input);
+}
+
 async function loadOverviewTodoBundleInTransaction(
   tx: Prisma.TransactionClient,
   input: {
@@ -314,7 +326,7 @@ async function loadOverviewTodoBundleInTransaction(
   },
 ) {
   const userId = normalizeTodoUserId(input.userId);
-  const fusedCountsPromise = countOverviewTodoBundleInTransaction(tx, {
+  const fusedCountsPromise = countTodoBundleInTransaction(tx, {
     userId,
     now: input.now,
     homeworkWindowEnd: input.homeworkWindowEnd,
@@ -393,32 +405,25 @@ async function loadTodoSummaryInTransaction(
 ) {
   const userId = normalizeTodoUserId(input.userId);
   const where = buildTodoListWhere(userId, input.filters);
-  const [incompleteCount, completedCount, overdueCount, todos] =
-    await Promise.all([
-      countIncompleteTodosInTransaction(tx, userId),
-      tx.todo.count({
-        where: { userId, completed: true },
-      }),
-      tx.todo.count({
-        where: {
-          userId,
-          completed: false,
-          dueAt: { lt: input.now },
-        },
-      }),
-      input.take === 0
-        ? Promise.resolve([])
-        : findTodoSnapshots(tx, {
-            where,
-            take: input.take,
-          }),
-    ]);
+  const [counts, todos] = await Promise.all([
+    countTodoBundleInTransaction(tx, {
+      userId,
+      now: input.now,
+      homeworkWindowEnd: input.now,
+    }),
+    input.take === 0
+      ? Promise.resolve([])
+      : findTodoSnapshots(tx, {
+          where,
+          take: input.take,
+        }),
+  ]);
 
   return {
     counts: {
-      incomplete: incompleteCount,
-      completed: completedCount,
-      overdue: overdueCount,
+      incomplete: counts.incomplete,
+      completed: counts.completed,
+      overdue: counts.overdue,
     },
     todos,
   };
@@ -477,7 +482,7 @@ export async function listTodoSummary(input: {
       userId,
       now: input.now ?? new Date(),
       filters: input.filters,
-      take: input.take,
+      take: input.take ?? TODO_LIST_DEFAULT_LIMIT,
     }),
   );
 }

--- a/src/lib/api/schemas/misc-query-schemas.ts
+++ b/src/lib/api/schemas/misc-query-schemas.ts
@@ -1,6 +1,10 @@
 import * as z from "zod";
 import { busVersionKeySchema } from "@/features/bus/lib/bus-version-key";
 import { CATALOG_MAX_PAGE } from "@/features/catalog/lib/catalog-list-query";
+import {
+  TODO_LIST_DEFAULT_LIMIT,
+  TODO_LIST_MAX_LIMIT,
+} from "@/features/todos/lib/todo-list-limits";
 import { APP_LOCALES } from "@/i18n/config";
 import {
   booleanQuerySchema,
@@ -49,8 +53,16 @@ const subscribedSchedulesLimitSchema = integerQueryRangeSchema({
 
 const todoLimitSchema = integerQueryRangeSchema({
   minimum: 1,
-  maximum: 200,
-  message: "limit must be between 1 and 200",
+  maximum: TODO_LIST_MAX_LIMIT,
+  message: `limit must be between 1 and ${TODO_LIST_MAX_LIMIT}`,
+}).meta({
+  override: {
+    type: "integer",
+    format: "int64",
+    minimum: 1,
+    maximum: TODO_LIST_MAX_LIMIT,
+    default: TODO_LIST_DEFAULT_LIMIT,
+  },
 });
 
 const overviewHomeworkWindowDaysSchema = integerQueryRangeSchema({
@@ -152,7 +164,7 @@ export const todosQuerySchema = z.object({
   priority: todoPrioritySchema.optional(),
   dueBefore: dateQuerySchema().optional(),
   dueAfter: dateQuerySchema().optional(),
-  limit: todoLimitSchema.optional(),
+  limit: todoLimitSchema.default(TODO_LIST_DEFAULT_LIMIT),
 });
 
 export const uploadObjectQuerySchema = z.object({

--- a/tests/integration/todo-overview-counts.test.ts
+++ b/tests/integration/todo-overview-counts.test.ts
@@ -3,6 +3,7 @@ import {
   countDueTodos,
   countIncompleteTodos,
   countOverviewTodoBundleInTransaction,
+  listTodoSummary,
 } from "@/features/todos/server/todo-service";
 import { prisma, withUserDbContext } from "@/lib/db/prisma";
 
@@ -115,5 +116,22 @@ describe("overview todo bundle counts", () => {
     expect(fusedCounts.completed).toBe(completed);
     expect(fusedCounts.overdue).toBe(overdue);
     expect(fusedCounts.dueSoon).toBe(dueSoon);
+  });
+
+  it("keeps complete summary counts independent from the bounded list filters", async () => {
+    const summary = await listTodoSummary({
+      filters: { completed: true },
+      now,
+      take: 1,
+      userId,
+    });
+
+    expect(summary.counts).toEqual({
+      incomplete: 4,
+      completed: 1,
+      overdue: 1,
+    });
+    expect(summary.todos).toHaveLength(1);
+    expect(summary.todos[0]?.completed).toBe(true);
   });
 });

--- a/tests/unit/api-route-query-validation.test.ts
+++ b/tests/unit/api-route-query-validation.test.ts
@@ -66,4 +66,10 @@ describe("API 路由查询校验", () => {
       "Invalid todo query",
     );
   });
+
+  it("待办查询在省略 limit 时使用有界默认值", () => {
+    expect(
+      parseTodosQuery(new Request("https://example.test/api/workspace/todos")),
+    ).toMatchObject({ limit: 100 });
+  });
 });

--- a/tests/unit/api-schemas.test.ts
+++ b/tests/unit/api-schemas.test.ts
@@ -622,6 +622,7 @@ describe("其他请求 schema", () => {
     });
     expect(todos).toMatchObject({ completed: true, limit: 20 });
     expect(todos.dueBefore).toEqual(new Date("2026-03-01T00:00:00.000Z"));
+    expect(todosQuerySchema.parse({}).limit).toBe(100);
 
     expect(homeworksQuerySchema.parse({ includeDeleted: "true" })).toEqual({
       includeDeleted: true,

--- a/tests/unit/todo-summary-read-model-performance.test.ts
+++ b/tests/unit/todo-summary-read-model-performance.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { queryRawMock, todoCountMock, todoFindManyMock, withUserDbContextMock } =
+  vi.hoisted(() => {
+    const queryRaw = vi.fn();
+    const todoCount = vi.fn();
+    const todoFindMany = vi.fn();
+    const tx = {
+      $queryRaw: queryRaw,
+      todo: { count: todoCount, findMany: todoFindMany },
+    };
+    return {
+      queryRawMock: queryRaw,
+      todoCountMock: todoCount,
+      todoFindManyMock: todoFindMany,
+      withUserDbContextMock: vi.fn(
+        async (_userId: string, action: (transaction: typeof tx) => unknown) =>
+          action(tx),
+      ),
+    };
+  });
+
+vi.mock("@/lib/db/prisma", () => ({
+  withUserDbContext: withUserDbContextMock,
+}));
+
+describe("todo summary read model performance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryRawMock.mockResolvedValue([
+      {
+        completed: 3n,
+        due_soon: 0n,
+        incomplete: 5n,
+        overdue: 2n,
+      },
+    ]);
+    todoFindManyMock.mockResolvedValue([{ id: "todo-1" }]);
+  });
+
+  it("collapses three counts plus the list from four statements to two", async () => {
+    const { listTodoSummary } = await import(
+      "@/features/todos/server/todo-service"
+    );
+    const now = new Date("2026-08-14T08:00:00.000Z");
+
+    const result = await listTodoSummary({
+      filters: {
+        completed: false,
+        dueAfter: new Date("2026-08-01T00:00:00.000Z"),
+        priority: "high",
+      },
+      now,
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      counts: { completed: 3, incomplete: 5, overdue: 2 },
+      todos: [{ id: "todo-1" }],
+    });
+    expect(withUserDbContextMock).toHaveBeenCalledOnce();
+    expect(withUserDbContextMock).toHaveBeenCalledWith(
+      "user-1",
+      expect.any(Function),
+    );
+    expect(queryRawMock).toHaveBeenCalledOnce();
+    expect(todoFindManyMock).toHaveBeenCalledOnce();
+    expect(todoCountMock).not.toHaveBeenCalled();
+    expect(queryRawMock.mock.invocationCallOrder[0]).toBeLessThan(
+      todoFindManyMock.mock.invocationCallOrder[0],
+    );
+    expect(todoFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 100,
+        where: {
+          completed: false,
+          dueAt: { gte: new Date("2026-08-01T00:00:00.000Z") },
+          priority: "high",
+          userId: "user-1",
+        },
+      }),
+    );
+  });
+
+  it("preserves an explicit smaller list limit", async () => {
+    const { listTodoSummary } = await import(
+      "@/features/todos/server/todo-service"
+    );
+
+    await listTodoSummary({ take: 25, userId: "user-1" });
+
+    expect(todoFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 25 }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- default omitted `/api/workspace/todos` limits to 100 items while retaining the explicit 1–200 contract
- reuse the RLS-scoped aggregate bundle so todo summaries issue one count aggregate plus one bounded list query
- document and regression-test the response semantics, OpenAPI default, bounds, and 4-to-2 statement reduction

## Query impact
- before: 3 count statements + 1 unbounded/bounded list statement = 4 business statements
- after: 1 aggregate statement + 1 list statement capped at 100 by default = 2 business statements
- summary counts remain global to the authenticated user and independent of list filters

## Validation
- focused unit suite: 51 passed
- todo overview DB integration: 2 passed
- all three TypeScript configs passed
- focused Biome passed
- svelte-check: 0 errors (13 existing warnings)
- OpenAPI generation passed
- production build passed
- authenticated local REST Playwright could not complete because the existing local BetterAuth JWKS row was encrypted with a different secret; CI covers this path