### PR TITLE
fix(search): match tokenized catalog queries

### DIFF
--- a/src/features/catalog/server/section-search-where.ts
+++ b/src/features/catalog/server/section-search-where.ts
@@ -14,6 +14,18 @@ function localizedNameCondition(value: string) {
   };
 }
 
+function generalSearchCondition(value: string): Prisma.SectionWhereInput {
+  return {
+    OR: [
+      { course: { nameCn: ilike(value) } },
+      { course: { nameEn: ilike(value) } },
+      { course: { code: ilike(value) } },
+      { code: ilike(value) },
+      { teachers: { some: localizedNameCondition(value) } },
+    ],
+  };
+}
+
 const SECTION_SEARCH_CONDITIONS: Array<{
   key: SectionSearchConditionKey;
   build: (value: string) => Prisma.SectionWhereInput | undefined;
@@ -120,33 +132,9 @@ export function buildSectionSearchWhere(
   });
 
   if (parsed.general) {
-    conditions.push({
-      OR: [
-        {
-          course: {
-            nameCn: ilike(parsed.general),
-          },
-        },
-        {
-          course: {
-            nameEn: ilike(parsed.general),
-          },
-        },
-        {
-          course: {
-            code: ilike(parsed.general),
-          },
-        },
-        {
-          code: ilike(parsed.general),
-        },
-        {
-          teachers: {
-            some: localizedNameCondition(parsed.general),
-          },
-        },
-      ],
-    });
+    conditions.push(
+      ...[...new Set(parsed.general.split(/\s+/u))].map(generalSearchCondition),
+    );
   }
 
   return {

--- a/src/features/search/server/global-search-catalog-queries.ts
+++ b/src/features/search/server/global-search-catalog-queries.ts
@@ -1,23 +1,72 @@
-import { buildCourseListWhere } from "@/features/catalog/server/course-query-filters";
 import { SECTION_SUMMARY_DEFAULT_ORDER_BY } from "@/features/catalog/server/section-summary-read-model";
-import { buildTeacherWhere } from "@/features/catalog/server/teacher-query";
 import type { Prisma } from "@/generated/prisma/client";
 import type { AppLocale } from "@/i18n/config";
 import { getPrisma } from "@/lib/db/prisma";
 import { ilike } from "@/lib/query-filter-helpers";
+
+function searchTerms(query: string) {
+  return [...new Set(query.trim().split(/\s+/u).filter(Boolean))];
+}
+
+function buildGlobalCourseSearchWhere(
+  query: string,
+): Prisma.CourseWhereInput | undefined {
+  const terms = searchTerms(query);
+  return terms.length > 0
+    ? {
+        AND: terms.map((term) => ({
+          OR: [
+            { nameCn: ilike(term) },
+            { nameEn: ilike(term) },
+            { code: ilike(term) },
+          ],
+        })),
+      }
+    : undefined;
+}
 
 function buildGlobalSectionSearchWhere(
   query: string,
 ): Prisma.SectionWhereInput {
   return {
     retiredAt: null,
-    OR: [
-      { course: { nameCn: ilike(query) } },
-      { course: { nameEn: ilike(query) } },
-      { course: { code: ilike(query) } },
-      { code: ilike(query) },
-    ],
+    AND: searchTerms(query).map((term) => ({
+      OR: [
+        { course: { nameCn: ilike(term) } },
+        { course: { nameEn: ilike(term) } },
+        { course: { code: ilike(term) } },
+        { code: ilike(term) },
+        {
+          teachers: {
+            some: {
+              OR: [
+                { nameCn: ilike(term) },
+                { nameEn: ilike(term) },
+                { code: ilike(term) },
+              ],
+            },
+          },
+        },
+      ],
+    })),
   };
+}
+
+function buildGlobalTeacherSearchWhere(
+  query: string,
+): Prisma.TeacherWhereInput | undefined {
+  const terms = searchTerms(query);
+  return terms.length > 0
+    ? {
+        AND: terms.map((term) => ({
+          OR: [
+            { nameCn: ilike(term) },
+            { nameEn: ilike(term) },
+            { code: ilike(term) },
+          ],
+        })),
+      }
+    : undefined;
 }
 
 export async function searchCoursesForGlobal(
@@ -26,7 +75,7 @@ export async function searchCoursesForGlobal(
   limit: number,
 ) {
   return getPrisma(locale).course.findMany({
-    where: buildCourseListWhere({ search: query }),
+    where: buildGlobalCourseSearchWhere(query),
     orderBy: [{ code: "asc" }, { jwId: "asc" }],
     select: {
       code: true,
@@ -86,7 +135,7 @@ export async function searchTeachersForGlobal(
   limit: number,
 ) {
   return getPrisma(locale).teacher.findMany({
-    where: buildTeacherWhere({ search: query }),
+    where: buildGlobalTeacherSearchWhere(query),
     orderBy: { nameCn: "asc" },
     select: {
       code: true,

--- a/src/features/search/server/global-search-service.ts
+++ b/src/features/search/server/global-search-service.ts
@@ -165,7 +165,7 @@ async function searchCachedCatalogGroups(input: {
   origin: string;
   query: string;
 }): Promise<GlobalSearchResultGroup[]> {
-  const namespace: PublicRuntimeCacheAnalyticsNamespace = `search:catalog:v3:${input.locale}`;
+  const namespace: PublicRuntimeCacheAnalyticsNamespace = `search:catalog:v4:${input.locale}`;
   return cachedCatalogRuntimeData(
     namespace,
     catalogSearchCacheKey(input.query, input.limit),

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -82,7 +82,7 @@ export type PublicRuntimeCacheAnalyticsNamespace =
   | "sitemap"
   | `page:section-detail:overview:${AppLocale}`
   | `search:catalog:${AppLocale}`
-  | `search:catalog:v3:${AppLocale}`
+  | `search:catalog:v4:${AppLocale}`
   | `bus:timetable:${AppLocale}`
   | `catalog:${
       | "courses"

--- a/tests/e2e/src/app/search/test.ts
+++ b/tests/e2e/src/app/search/test.ts
@@ -41,6 +41,39 @@ test("search page supports keyboard navigation into results", async ({
   await expect(page.getByRole("option").first()).toBeFocused();
 });
 
+test("search page matches course and teacher terms in one section", async ({
+  page,
+}) => {
+  const query = "线性代数 林璟锵";
+  const runtimeErrors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") runtimeErrors.push(message.text());
+  });
+  page.on("pageerror", (error) => runtimeErrors.push(error.message));
+  await gotoAndWaitForReady(page, "/search");
+
+  const searchResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/search") &&
+      new URL(response.url()).searchParams.get("q") === query &&
+      response.ok(),
+  );
+  await page.getByRole("combobox").fill(query);
+  await searchResponse;
+
+  await expect(page).toHaveURL(/\/search\?q=/);
+  await expect(page).toHaveTitle(/^(搜索|Search) - Life@USTC$/);
+  await expect(page.locator("vite-error-overlay")).toHaveCount(0);
+  await expect(
+    page
+      .getByRole("option", {
+        name: /线性代数进阶.*林璟锵|Advanced Linear Algebra.*Lin Jingqiang/i,
+      })
+      .first(),
+  ).toBeVisible();
+  expect(runtimeErrors).toEqual([]);
+});
+
 test("页面契约", async ({ page }, testInfo) => {
   await assertPageContract(page, { routePath: "/search", testInfo });
 });

--- a/tests/integration/global-search.test.ts
+++ b/tests/integration/global-search.test.ts
@@ -51,6 +51,55 @@ describe("global search integration", () => {
     ).toBe(true);
   });
 
+  it("matches section terms across course and teacher fields", async () => {
+    clearPublicRuntimeCache();
+    const uniqueBase = -1_500_000_000 - Number.parseInt(marker.slice(0, 6), 16);
+    const course = await prisma.course.create({
+      data: {
+        jwId: uniqueBase,
+        code: `SEARCH-${marker}`,
+        nameCn: "数学分析",
+      },
+      select: { id: true },
+    });
+    const teacher = await prisma.teacher.create({
+      data: {
+        jwId: uniqueBase + 1,
+        code: `TEACHER-${marker}`,
+        nameCn: "程艺",
+      },
+      select: { id: true },
+    });
+
+    try {
+      const section = await prisma.section.create({
+        data: {
+          jwId: uniqueBase + 2,
+          code: "000-SEARCH-INTEGRATION",
+          courseId: course.id,
+          teachers: { connect: { id: teacher.id } },
+        },
+        select: { jwId: true },
+      });
+
+      const result = await searchGlobally({
+        locale: "zh-cn",
+        origin: ORIGIN,
+        query: "数学分析 程艺",
+      });
+
+      expect(
+        result.groups
+          .find((group) => group.type === "sections")
+          ?.items.some((item) => item.id === `section:${section.jwId}`),
+      ).toBe(true);
+    } finally {
+      await prisma.section.deleteMany({ where: { courseId: course.id } });
+      await prisma.teacher.deleteMany({ where: { id: teacher.id } });
+      await prisma.course.deleteMany({ where: { id: course.id } });
+    }
+  });
+
   it("returns catalog results for signed-in users and can include workspace groups", async () => {
     clearPublicRuntimeCache();
 

--- a/tests/unit/catalog-section-search.test.ts
+++ b/tests/unit/catalog-section-search.test.ts
@@ -13,6 +13,18 @@ function localized(value: string) {
   };
 }
 
+function general(value: string) {
+  return {
+    OR: [
+      { course: { nameCn: contains(value) } },
+      { course: { nameEn: contains(value) } },
+      { course: { code: contains(value) } },
+      { code: contains(value) },
+      { teachers: { some: localized(value) } },
+    ],
+  };
+}
+
 describe("课段搜索语法解析器", () => {
   it("识别所有标签并保留普通搜索词", () => {
     const result = parseSectionSearchQuery(
@@ -213,6 +225,14 @@ describe("课段搜索条件构造器", () => {
           ],
         },
       ],
+    });
+  });
+
+  it("普通搜索词按空白拆分并跨课程与教师字段组合为 AND", () => {
+    const result = buildSectionSearchWhere("数学分析  程艺");
+
+    expect(result.where).toEqual({
+      AND: [general("数学分析"), general("程艺")],
     });
   });
 

--- a/tests/unit/course-section-queries.test.ts
+++ b/tests/unit/course-section-queries.test.ts
@@ -30,6 +30,18 @@ function localized(value: string) {
   };
 }
 
+function general(value: string) {
+  return {
+    OR: [
+      { course: { nameCn: contains(value) } },
+      { course: { nameEn: contains(value) } },
+      { course: { code: contains(value) } },
+      { code: contains(value) },
+      { teachers: { some: localized(value) } },
+    ],
+  };
+}
+
 describe("课程与开课查询辅助函数", () => {
   it("根据搜索和数字 ID 构建课程筛选条件", () => {
     expect(
@@ -92,45 +104,8 @@ describe("课程与开课查询辅助函数", () => {
             some: localized("smith"),
           },
         },
-        {
-          OR: [
-            {
-              course: {
-                nameCn: {
-                  contains: "linear algebra",
-                  mode: "insensitive",
-                },
-              },
-            },
-            {
-              course: {
-                nameEn: {
-                  contains: "linear algebra",
-                  mode: "insensitive",
-                },
-              },
-            },
-            {
-              course: {
-                code: {
-                  contains: "linear algebra",
-                  mode: "insensitive",
-                },
-              },
-            },
-            {
-              code: {
-                contains: "linear algebra",
-                mode: "insensitive",
-              },
-            },
-            {
-              teachers: {
-                some: localized("linear algebra"),
-              },
-            },
-          ],
-        },
+        general("linear"),
+        general("algebra"),
       ]),
     );
     expect(result.orderBy).toEqual({ semester: { jwId: "desc" } });

--- a/tests/unit/global-search-catalog-queries.test.ts
+++ b/tests/unit/global-search-catalog-queries.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { courseFindManyMock, getPrismaMock, sectionFindManyMock } = vi.hoisted(
+  () => ({
+    courseFindManyMock: vi.fn(),
+    getPrismaMock: vi.fn(),
+    sectionFindManyMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/db/prisma", () => ({
+  getPrisma: getPrismaMock,
+}));
+
+import {
+  searchCoursesForGlobal,
+  searchSectionsForGlobal,
+} from "@/features/search/server/global-search-catalog-queries";
+
+function contains(value: string) {
+  return { contains: value, mode: "insensitive" as const };
+}
+
+function sectionTerm(value: string) {
+  return {
+    OR: [
+      { course: { nameCn: contains(value) } },
+      { course: { nameEn: contains(value) } },
+      { course: { code: contains(value) } },
+      { code: contains(value) },
+      {
+        teachers: {
+          some: {
+            OR: [
+              { nameCn: contains(value) },
+              { nameEn: contains(value) },
+              { code: contains(value) },
+            ],
+          },
+        },
+      },
+    ],
+  };
+}
+
+describe("global catalog search queries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    courseFindManyMock.mockResolvedValue([]);
+    sectionFindManyMock.mockResolvedValue([]);
+    getPrismaMock.mockReturnValue({
+      course: { findMany: courseFindManyMock },
+      section: { findMany: sectionFindManyMock },
+    });
+  });
+
+  it("matches every whitespace-delimited course term", async () => {
+    await searchCoursesForGlobal("  数学   分析  ", "zh-cn", 5);
+
+    expect(courseFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          AND: [
+            {
+              OR: [
+                { nameCn: contains("数学") },
+                { nameEn: contains("数学") },
+                { code: contains("数学") },
+              ],
+            },
+            {
+              OR: [
+                { nameCn: contains("分析") },
+                { nameEn: contains("分析") },
+                { code: contains("分析") },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+  });
+
+  it("matches section terms across course and teacher fields", async () => {
+    await searchSectionsForGlobal("数学分析 程艺", "zh-cn", 5);
+
+    expect(sectionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          retiredAt: null,
+          AND: [sectionTerm("数学分析"), sectionTerm("程艺")],
+        },
+      }),
+    );
+  });
+});

--- a/tests/unit/global-search-service.test.ts
+++ b/tests/unit/global-search-service.test.ts
@@ -109,7 +109,7 @@ describe("global search service", () => {
     });
 
     expect(cachedCatalogRuntimeDataMock).toHaveBeenCalledWith(
-      "search:catalog:v3:zh-cn",
+      "search:catalog:v4:zh-cn",
       "5:数据",
       ORIGIN,
       expect.any(Function),

--- a/tests/unit/public-runtime-cache.test.ts
+++ b/tests/unit/public-runtime-cache.test.ts
@@ -448,7 +448,7 @@ describe("public runtime cache", () => {
 
     await expect(
       cachedPublicRuntimeData(
-        "search:catalog:v3:zh-cn",
+        "search:catalog:v4:zh-cn",
         "5:calculus",
         60_000,
         chineseLoad,
@@ -456,7 +456,7 @@ describe("public runtime cache", () => {
     ).resolves.toEqual({ locale: "zh-cn" });
     await expect(
       cachedPublicRuntimeData(
-        "search:catalog:v3:en-us",
+        "search:catalog:v4:en-us",
         "5:calculus",
         60_000,
         englishLoad,


### PR DESCRIPTION
## What changed

- split catalog search queries on whitespace and require every term to match
- allow section terms to match across course and teacher fields
- apply the same behavior to the section catalog filter
- rotate the catalog search cache namespace to avoid stale empty results

## Why

Global and section searches treated `数学分析 程艺` as one literal value. The section query also omitted teacher fields, so a course-name plus teacher-name query could not return the intended section.

## Validation

- `bunx biome check` on changed files
- TypeScript application and test typechecks
- 72 focused unit tests
- 5 PostgreSQL global-search integration tests, including `数学分析 程艺`
- focused Chromium Playwright search interaction
- production build