### PR TITLE
feat(observability): attribute public cache phases

### DIFF
--- a/src/lib/adapters/cloudflare-runtime.ts
+++ b/src/lib/adapters/cloudflare-runtime.ts
@@ -60,12 +60,12 @@ type CloudflareCacheStorage = {
 
 type CloudflareTaskScheduler = (promise: Promise<unknown>) => void;
 
-type CloudflareSpan = {
+export type CloudflareTraceSpan = {
   setAttribute(key: string, value?: boolean | number | string): void;
 };
 
 type CloudflareTracing = {
-  enterSpan<T>(name: string, callback: (span: CloudflareSpan) => T): T;
+  enterSpan<T>(name: string, callback: (span: CloudflareTraceSpan) => T): T;
 };
 
 export type CloudflareQueueSendOptions = {
@@ -211,16 +211,16 @@ export function runWithCloudflareRuntimeEnv<T>(
 export function runCloudflareTraceSpan<T>(
   name: string,
   attributes: Record<string, boolean | number | string | undefined>,
-  callback: () => T,
+  callback: (span?: CloudflareTraceSpan) => T,
 ): T {
   const tracing = cloudflareRuntimeStorage.getStore()?.tracing;
-  if (!tracing) return callback();
+  if (!tracing) return callback(undefined);
 
   return tracing.enterSpan(name, (span) => {
     for (const [key, value] of Object.entries(attributes)) {
       if (value !== undefined) span.setAttribute(key, value);
     }
-    return callback();
+    return callback(span);
   });
 }
 

--- a/src/lib/catalog-detail-cache-revision.ts
+++ b/src/lib/catalog-detail-cache-revision.ts
@@ -1,3 +1,4 @@
+import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import { prisma } from "@/lib/db/prisma";
 
 const REVISION_CACHE_TTL_MS = 60_000;
@@ -15,10 +16,26 @@ export async function getCatalogDetailCacheRevision() {
     return cachedRevision.value;
   }
 
-  const state = await prisma.staticImportState.findUnique({
-    where: { id: "global" },
-    select: { snapshotSha256: true },
-  });
+  const state = await runCloudflareTraceSpan(
+    "cache.catalog_revision.read",
+    {
+      "cache.layer": "origin",
+      "cache.namespace": "catalog:revision",
+    },
+    async (span) => {
+      try {
+        const state = await prisma.staticImportState.findUnique({
+          where: { id: "global" },
+          select: { snapshotSha256: true },
+        });
+        span?.setAttribute("cache.outcome", "success");
+        return state;
+      } catch (error) {
+        span?.setAttribute("cache.outcome", "error");
+        throw error;
+      }
+    },
+  );
   const value = state?.snapshotSha256?.slice(0, 16) ?? BOOTSTRAP_REVISION;
   cachedRevision = { expiresAt: now + REVISION_CACHE_TTL_MS, value };
   return value;

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -81,7 +81,6 @@ export type PublicRuntimeCacheAnalyticsNamespace =
   | "catalog:current-semester"
   | "sitemap"
   | `page:section-detail:overview:${AppLocale}`
-  | `search:catalog:${AppLocale}`
   | `search:catalog:v4:${AppLocale}`
   | `bus:timetable:${AppLocale}`
   | `catalog:${
@@ -386,7 +385,7 @@ export function writeCacheEventAnalytics(input: CacheEventAnalyticsInput) {
   writeAnalyticsDataPoint({
     indexes: [`cache:${boundedValue(input.namespace)}`],
     blobs: [
-      "public_runtime_cache_v2",
+      "public_runtime_cache_v3",
       input.event,
       input.namespace,
       input.reason ?? "none",

--- a/src/lib/public-runtime-cache.ts
+++ b/src/lib/public-runtime-cache.ts
@@ -4,6 +4,7 @@ import {
   getCloudflareCatalogDetailCoreNamespace,
   getCloudflareNamedCache,
   getCloudflareRuntimeTaskScheduler,
+  runCloudflareTraceSpan,
 } from "@/lib/adapters/cloudflare-runtime";
 import {
   type PublicRuntimeCacheAnalyticsNamespace,
@@ -31,12 +32,17 @@ type RuntimeCacheEnvelope = {
 };
 
 type RuntimeCacheRead<T> =
-  | { expiresAt: number; hit: true; value: T }
-  | { hit: false };
+  | { expiresAt: number; hit: true; outcome: "hit"; value: T }
+  | { hit: false; outcome: "error" | "invalid" | "miss" | "unavailable" };
 
 type ColoCacheRead<T> =
-  | { expiresAt: number; hit: true; value: T }
-  | { cache?: CloudflareCache; hit: false; request?: Request };
+  | { expiresAt: number; hit: true; outcome: "hit"; value: T }
+  | {
+      cache?: CloudflareCache;
+      hit: false;
+      outcome: "error" | "invalid" | "miss";
+      request?: Request;
+    };
 
 type RuntimeCacheEvent =
   | "colo_hit"
@@ -167,13 +173,14 @@ async function readKvCache<T>(
   cacheKey: string,
   ttlMs: number,
   namespace: PublicRuntimeCacheAnalyticsNamespace,
-  start: number,
   storeSize: number,
   validateColoCacheResult?: (result: unknown) => boolean,
 ): Promise<RuntimeCacheRead<T>> {
   const kv = getCloudflareCatalogDetailCoreNamespace();
-  if (!kv) return { hit: false };
+  if (!kv) return { hit: false, outcome: "unavailable" };
 
+  const start = Date.now();
+  let failureOutcome: "error" | "invalid" = "error";
   const cacheTtlSeconds = Math.ceil(ttlMs / 1_000);
   try {
     const parsed = await kv.get<RuntimeCacheEnvelope>(cacheKey, {
@@ -183,17 +190,18 @@ async function readKvCache<T>(
     const now = Date.now();
     if (!parsed || !validRuntimeCacheEnvelope(parsed, now, ttlMs)) {
       writeRuntimeCacheEvent("kv_miss", namespace, start, storeSize, ttlMs);
-      return { hit: false };
+      return { hit: false, outcome: "miss" };
     }
     if (!validRuntimeCacheResult(parsed.value, validateColoCacheResult)) {
+      failureOutcome = "invalid";
       throw new TypeError("Invalid cached result");
     }
     const value = parsed.value as T;
     writeRuntimeCacheEvent("kv_hit", namespace, start, storeSize, ttlMs);
-    return { expiresAt: parsed.expiresAt, hit: true, value };
+    return { expiresAt: parsed.expiresAt, hit: true, outcome: "hit", value };
   } catch {
     writeRuntimeCacheEvent("kv_read_error", namespace, start, storeSize, ttlMs);
-    return { hit: false };
+    return { hit: false, outcome: failureOutcome };
   }
 }
 
@@ -203,10 +211,10 @@ function scheduleKvCacheWrite<T>(
   expiresAt: number,
   ttlMs: number,
   namespace: PublicRuntimeCacheAnalyticsNamespace,
-  start: number,
   storeSize: number,
   validateColoCacheResult?: (result: unknown) => boolean,
 ) {
+  const start = Date.now();
   const kv = getCloudflareCatalogDetailCoreNamespace();
   const scheduleTask = getCloudflareRuntimeTaskScheduler();
   const remainingTtlMs = expiresAt - Date.now();
@@ -319,10 +327,11 @@ async function readColoCache<T>(
   cacheKey: string,
   ttlMs: number,
   namespace: PublicRuntimeCacheAnalyticsNamespace,
-  start: number,
   storeSize: number,
   validateColoCacheResult?: (result: unknown) => boolean,
 ): Promise<ColoCacheRead<T>> {
+  const start = Date.now();
+  let failureOutcome: "error" | "invalid" = "error";
   let cache: CloudflareCache | undefined;
   let request: Request | undefined;
   try {
@@ -333,7 +342,7 @@ async function readColoCache<T>(
     const response = await cache.match(request);
     if (!response) {
       writeRuntimeCacheEvent("colo_miss", namespace, start, storeSize, ttlMs);
-      return { cache, hit: false, request };
+      return { cache, hit: false, outcome: "miss", request };
     }
 
     const parsed: unknown = await response.json();
@@ -342,14 +351,16 @@ async function readColoCache<T>(
       response.status !== 200 ||
       !validRuntimeCacheEnvelope(parsed, now, ttlMs)
     ) {
+      failureOutcome = "invalid";
       throw new TypeError("Invalid cache envelope");
     }
     if (!validRuntimeCacheResult(parsed.value, validateColoCacheResult)) {
+      failureOutcome = "invalid";
       throw new TypeError("Invalid cached result");
     }
     const value = parsed.value as T;
     writeRuntimeCacheEvent("colo_hit", namespace, start, storeSize, ttlMs);
-    return { expiresAt: parsed.expiresAt, hit: true, value };
+    return { expiresAt: parsed.expiresAt, hit: true, outcome: "hit", value };
   } catch {
     writeRuntimeCacheEvent(
       "colo_read_error",
@@ -358,7 +369,7 @@ async function readColoCache<T>(
       storeSize,
       ttlMs,
     );
-    return { cache, hit: false, request };
+    return { cache, hit: false, outcome: failureOutcome, request };
   }
 }
 
@@ -369,9 +380,9 @@ function scheduleColoCacheWrite<T>(
   expiresAt: number,
   ttlMs: number,
   namespace: PublicRuntimeCacheAnalyticsNamespace,
-  start: number,
   storeSize: number,
 ) {
+  const start = Date.now();
   const scheduleTask = getCloudflareRuntimeTaskScheduler();
   const remainingTtlMs = expiresAt - Date.now();
   if (!scheduleTask || remainingTtlMs <= 0) {
@@ -569,13 +580,23 @@ export function cachedPublicRuntimeData<T>(
       options.kvCacheKey ?? resolvePublicDetailKvCacheKey(options);
     const kvTtlMs = options.kvTtlMs ?? ttlMs;
     const kvRead = kvCacheKey
-      ? await readKvCache<T>(
-          kvCacheKey,
-          kvTtlMs,
-          analyticsNamespace,
-          start,
-          initialStoreSize,
-          options.validateColoCacheResult,
+      ? await runCloudflareTraceSpan(
+          "cache.kv.read",
+          {
+            "cache.layer": "kv",
+            "cache.namespace": analyticsNamespace,
+          },
+          async (span) => {
+            const result = await readKvCache<T>(
+              kvCacheKey,
+              kvTtlMs,
+              analyticsNamespace,
+              initialStoreSize,
+              options.validateColoCacheResult,
+            );
+            span?.setAttribute("cache.outcome", result.outcome);
+            return result;
+          },
         )
       : undefined;
     if (kvRead?.hit) {
@@ -585,14 +606,25 @@ export function cachedPublicRuntimeData<T>(
       return kvRead.value;
     }
 
-    const coloRead = options.coloCacheKey
-      ? await readColoCache<T>(
-          options.coloCacheKey,
-          ttlMs,
-          analyticsNamespace,
-          start,
-          initialStoreSize,
-          options.validateColoCacheResult,
+    const coloCacheKey = options.coloCacheKey;
+    const coloRead = coloCacheKey
+      ? await runCloudflareTraceSpan(
+          "cache.colo.read",
+          {
+            "cache.layer": "colo",
+            "cache.namespace": analyticsNamespace,
+          },
+          async (span) => {
+            const result = await readColoCache<T>(
+              coloCacheKey,
+              ttlMs,
+              analyticsNamespace,
+              initialStoreSize,
+              options.validateColoCacheResult,
+            );
+            span?.setAttribute("cache.outcome", result.outcome);
+            return result;
+          },
         )
       : undefined;
     if (coloRead?.hit) {
@@ -602,7 +634,43 @@ export function cachedPublicRuntimeData<T>(
       return coloRead.value;
     }
 
-    const result = await load();
+    const loadStart = Date.now();
+    let result: T;
+    try {
+      result = await runCloudflareTraceSpan(
+        "cache.origin_load",
+        {
+          "cache.layer": "origin",
+          "cache.namespace": analyticsNamespace,
+        },
+        async (span) => {
+          try {
+            const loaded = await load();
+            span?.setAttribute("cache.outcome", "success");
+            return loaded;
+          } catch (error) {
+            span?.setAttribute("cache.outcome", "error");
+            throw error;
+          }
+        },
+      );
+      writeCacheEventAnalytics({
+        event: "load_success",
+        ioObservedDurationMs: Date.now() - loadStart,
+        namespace: analyticsNamespace,
+        storeSize: store.size,
+        ttlMs,
+      });
+    } catch (error) {
+      writeCacheEventAnalytics({
+        event: "load_error",
+        ioObservedDurationMs: Date.now() - loadStart,
+        namespace: analyticsNamespace,
+        storeSize: store.size,
+        ttlMs,
+      });
+      throw error;
+    }
     const retain = options.shouldCacheResult?.(result) ?? true;
     if (!retain) {
       if (value) deleteCurrentEntry(store, storeKey, value);
@@ -620,7 +688,6 @@ export function cachedPublicRuntimeData<T>(
             Date.now() + kvTtlMs,
             kvTtlMs,
             analyticsNamespace,
-            start,
             initialStoreSize,
             options.validateColoCacheResult,
           );
@@ -633,7 +700,6 @@ export function cachedPublicRuntimeData<T>(
             expiresAt,
             ttlMs,
             analyticsNamespace,
-            start,
             initialStoreSize,
           );
         }
@@ -660,23 +726,9 @@ export function cachedPublicRuntimeData<T>(
         }
       }
     }
-    writeCacheEventAnalytics({
-      event: "load_success",
-      ioObservedDurationMs: Date.now() - start,
-      namespace: analyticsNamespace,
-      storeSize: store.size,
-      ttlMs,
-    });
     return result;
   })().catch((error) => {
     if (value) deleteCurrentEntry(store, storeKey, value);
-    writeCacheEventAnalytics({
-      event: "load_error",
-      ioObservedDurationMs: Date.now() - start,
-      namespace: analyticsNamespace,
-      storeSize: store.size,
-      ttlMs,
-    });
     throw error;
   });
   store.set(storeKey, { expiresAt, value });

--- a/tests/unit/analytics-engine-runtime-events.test.ts
+++ b/tests/unit/analytics-engine-runtime-events.test.ts
@@ -383,12 +383,12 @@ describe("Cloudflare Analytics Engine runtime events", () => {
     expect(load).toHaveBeenCalledTimes(1);
     expect(writeDataPoint).toHaveBeenCalledWith({
       indexes: [`cache:${namespace}`],
-      blobs: ["public_runtime_cache_v2", "miss", namespace, "none"],
+      blobs: ["public_runtime_cache_v3", "miss", namespace, "none"],
       doubles: [expect.any(Number), 60_000, 0],
     });
     expect(writeDataPoint).toHaveBeenCalledWith({
       indexes: [`cache:${namespace}`],
-      blobs: ["public_runtime_cache_v2", "hit", namespace, "none"],
+      blobs: ["public_runtime_cache_v3", "hit", namespace, "none"],
       doubles: [expect.any(Number), 60_000, 1],
     });
     expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain(
@@ -457,7 +457,7 @@ describe("Cloudflare Analytics Engine runtime events", () => {
       expect(writeDataPoint).toHaveBeenCalledWith({
         indexes: ["cache:page:course-detail:en-us"],
         blobs: [
-          "public_runtime_cache_v2",
+          "public_runtime_cache_v3",
           event,
           "page:course-detail:en-us",
           "none",

--- a/tests/unit/catalog-detail-cache-revision.test.ts
+++ b/tests/unit/catalog-detail-cache-revision.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { runWithCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
 import {
   getCatalogDetailCacheRevision,
   resetCatalogDetailCacheRevisionForTest,
@@ -41,5 +42,35 @@ describe("catalog detail cache revision", () => {
     findUniqueMock.mockResolvedValue(null);
 
     await expect(getCatalogDetailCacheRevision()).resolves.toBe("bootstrap");
+  });
+
+  it("traces only the revision origin read with fixed cache attributes", async () => {
+    findUniqueMock.mockResolvedValue({ snapshotSha256: "abcdef0123456789" });
+    const setAttribute = vi.fn();
+    const enterSpan = vi.fn(
+      <T>(
+        name: string,
+        callback: (span: { setAttribute: typeof setAttribute }) => T,
+      ) => {
+        expect(name).toBe("cache.catalog_revision.read");
+        return callback({ setAttribute });
+      },
+    );
+
+    await runWithCloudflareRuntimeEnv(
+      {},
+      async () => {
+        await getCatalogDetailCacheRevision();
+        await getCatalogDetailCacheRevision();
+      },
+      { tracing: { enterSpan } },
+    );
+
+    expect(enterSpan).toHaveBeenCalledOnce();
+    expect(setAttribute.mock.calls).toEqual([
+      ["cache.layer", "origin"],
+      ["cache.namespace", "catalog:revision"],
+      ["cache.outcome", "success"],
+    ]);
   });
 });

--- a/tests/unit/catalog-runtime-cache.test.ts
+++ b/tests/unit/catalog-runtime-cache.test.ts
@@ -12,16 +12,20 @@ import {
 describe("catalog runtime cache keys", () => {
   it("builds revision-scoped KV and colo keys", () => {
     expect(
-      publicCatalogKvCacheKey("rev123", "search:catalog:zh-cn", "5:数学分析"),
-    ).toBe("list:v1:rev123:search:catalog:zh-cn:5:数学分析");
+      publicCatalogKvCacheKey(
+        "rev123",
+        "search:catalog:v4:zh-cn",
+        "5:数学分析",
+      ),
+    ).toBe("list:v1:rev123:search:catalog:v4:zh-cn:5:数学分析");
     expect(
       publicCatalogColoCacheKey(
         "https://life.example",
-        "search:catalog:zh-cn",
+        "search:catalog:v4:zh-cn",
         "5:数学分析",
       ),
     ).toBe(
-      "https://life.example/_life-ustc-internal-cache/catalog-runtime/v1/search%3Acatalog%3Azh-cn/5%3A%E6%95%B0%E5%AD%A6%E5%88%86%E6%9E%90",
+      "https://life.example/_life-ustc-internal-cache/catalog-runtime/v1/search%3Acatalog%3Av4%3Azh-cn/5%3A%E6%95%B0%E5%AD%A6%E5%88%86%E6%9E%90",
     );
   });
 

--- a/tests/unit/public-runtime-cache.test.ts
+++ b/tests/unit/public-runtime-cache.test.ts
@@ -98,7 +98,7 @@ function expectCacheEvent(
   expect(writeDataPoint).toHaveBeenCalledWith({
     indexes: ["cache:page:course-detail:en-us"],
     blobs: [
-      "public_runtime_cache_v2",
+      "public_runtime_cache_v3",
       event,
       "page:course-detail:en-us",
       reason,
@@ -413,6 +413,150 @@ describe("public runtime cache", () => {
     expectCacheEvent(writeDataPoint, "kv_read_error", "none");
     expect(put).toHaveBeenCalledOnce();
     expect(namespace.put).toHaveBeenCalledOnce();
+  });
+
+  it("records phase-local cache durations and fixed low-cardinality spans", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const writeDataPoint = vi.fn();
+    const setAttribute = vi.fn();
+    const enterSpan = vi.fn(
+      <T>(
+        name: string,
+        callback: (span: { setAttribute: typeof setAttribute }) => T,
+      ) => {
+        void name;
+        return callback({ setAttribute });
+      },
+    );
+    const namespace = {
+      get: vi.fn(async () => {
+        vi.setSystemTime(Date.now() + 11);
+        return null;
+      }),
+      put: vi.fn(async () => undefined),
+    };
+    const { match } = installNamedCache({
+      match: async () => {
+        vi.setSystemTime(Date.now() + 23);
+        return undefined;
+      },
+    });
+    const scheduled: Promise<unknown>[] = [];
+    const context = {
+      tracing: { enterSpan },
+      waitUntil(promise: Promise<unknown>) {
+        scheduled.push(promise);
+      },
+    };
+    const sensitiveKey = "search=sensitive-marker-683011";
+
+    await runWithCloudflareRuntimeEnv(
+      { ANALYTICS: { writeDataPoint }, CATALOG_DETAIL_CORE: namespace },
+      async () => {
+        await cachedPublicRuntimeData(
+          "page:course-detail:en-us",
+          sensitiveKey,
+          60_000,
+          async () => {
+            vi.setSystemTime(Date.now() + 37);
+            return { source: "database" };
+          },
+          {
+            coloCacheKey: publicDetailColoCacheKey(
+              "https://example.test",
+              "course",
+              "en-us",
+              683011,
+            ),
+            kvCacheKey: publicDetailKvCacheKey(
+              "rev",
+              "course",
+              "en-us",
+              683011,
+              "core-without-sections",
+            ),
+            validateColoCacheResult: validatesSource,
+          },
+        );
+        await Promise.all(scheduled);
+      },
+      context,
+    );
+
+    const durationFor = (event: string) =>
+      writeDataPoint.mock.calls.find(
+        ([dataPoint]) => dataPoint.blobs?.[1] === event,
+      )?.[0].doubles?.[0];
+    expect(durationFor("kv_miss")).toBe(11);
+    expect(durationFor("colo_miss")).toBe(23);
+    expect(durationFor("load_success")).toBe(37);
+    expect(match).toHaveBeenCalledOnce();
+    expect(enterSpan.mock.calls.map(([name]) => name)).toEqual([
+      "cache.kv.read",
+      "cache.colo.read",
+      "cache.origin_load",
+    ]);
+    expect(setAttribute.mock.calls).toEqual([
+      ["cache.layer", "kv"],
+      ["cache.namespace", "page:course-detail:en-us"],
+      ["cache.outcome", "miss"],
+      ["cache.layer", "colo"],
+      ["cache.namespace", "page:course-detail:en-us"],
+      ["cache.outcome", "miss"],
+      ["cache.layer", "origin"],
+      ["cache.namespace", "page:course-detail:en-us"],
+      ["cache.outcome", "success"],
+    ]);
+    expect(JSON.stringify(setAttribute.mock.calls)).not.toContain(sensitiveKey);
+  });
+
+  it("records one phase-local origin error without retaining the failed load", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(20_000);
+    const writeDataPoint = vi.fn();
+    const setAttribute = vi.fn();
+    const enterSpan = vi.fn(
+      <T>(
+        _name: string,
+        callback: (span: { setAttribute: typeof setAttribute }) => T,
+      ) => callback({ setAttribute }),
+    );
+    const load = vi.fn(async () => {
+      vi.setSystemTime(Date.now() + 41);
+      throw new Error("origin failed");
+    });
+
+    await runWithCloudflareRuntimeEnv(
+      { ANALYTICS: { writeDataPoint } },
+      async () => {
+        await expect(
+          cachedPublicRuntimeData(
+            "api:metadata",
+            "private-cache-key",
+            60_000,
+            load,
+          ),
+        ).rejects.toThrow("origin failed");
+      },
+      { tracing: { enterSpan } },
+    );
+
+    const loadErrors = writeDataPoint.mock.calls.filter(
+      ([dataPoint]) => dataPoint.blobs?.[1] === "load_error",
+    );
+    expect(loadErrors).toHaveLength(1);
+    expect(loadErrors[0]?.[0].doubles?.[0]).toBe(41);
+    expect(setAttribute).toHaveBeenCalledWith("cache.outcome", "error");
+    await expect(
+      cachedPublicRuntimeData(
+        "api:metadata",
+        "private-cache-key",
+        60_000,
+        async () => ({ source: "retry" }),
+      ),
+    ).resolves.toEqual({ source: "retry" });
+    expect(load).toHaveBeenCalledOnce();
   });
 
   it("returns one in-flight promise for concurrent callers of the same key", async () => {


### PR DESCRIPTION
## What changed

- add fixed low-cardinality custom spans for KV reads, colo Cache API reads, origin loads, and catalog revision origin reads
- expose `cache.outcome` as `hit`, `miss`, `invalid`, `error`, `unavailable`, or `success` without recording cache keys, queries, users, or entity IDs
- make Analytics Engine cache durations phase-local instead of cumulative across prior cache layers
- measure KV and colo write events from the start of their own write phase
- remove the obsolete unversioned global-search cache namespace

## Why

Cold cache misses previously reused one request-level start timestamp for KV, colo, origin load, and background write events. A 1.1–1.3s miss therefore could not be attributed reliably to one cache layer or to the canonical database-backed loader.

## Analytics schema impact

`public_runtime_cache_v2` becomes `public_runtime_cache_v3`. Blob and double positions are unchanged, but `double1` now represents the duration of the event's own phase. Consumers should switch their schema discriminator to v3 and must not combine v2 and v3 duration percentiles.

## Behavior

Cache keys, TTLs, read order, fail-open behavior, in-flight coalescing, validation, background scheduling, and response values are unchanged. A loader rejection writes exactly one phase-local `load_error`, removes the failed in-flight entry, and remains retryable.

## Validation

- Wrangler binding types check
- Biome full repository check (7 existing warnings)
- Svelte check (0 errors, 13 existing warnings)
- application, test, and operational TypeScript checks
- Vitest: 346 files / 2093 tests
- OpenAPI parity
- GraphQL schema snapshot
- production build