### PR TITLE
fix(observability): redact worker operational logs

### DIFF
--- a/src/features/calendar/server/calendar-export-rebuild.ts
+++ b/src/features/calendar/server/calendar-export-rebuild.ts
@@ -6,6 +6,7 @@ import {
 } from "@/features/calendar/server/calendar-export-queue";
 import { buildUserCalendarExport } from "@/features/calendar/server/calendar-export-service";
 import { prisma } from "@/lib/db/prisma";
+import { logAppEvent } from "@/lib/log/app-logger";
 import { writeCalendarExportRebuildAnalytics } from "@/lib/metrics/analytics-engine";
 
 export async function rebuildUserCalendarExport(userId: string) {
@@ -60,9 +61,9 @@ export async function processCalendarExportRebuildMessages(
     try {
       await rebuildUserCalendarExport(userId);
       writeCalendarExportRebuildAnalytics({ status: "ok" });
-    } catch {
+    } catch (error) {
       writeCalendarExportRebuildAnalytics({ status: "error" });
-      throw new Error("calendar_export_rebuild_failed");
+      throw error;
     }
   }
 }
@@ -103,7 +104,20 @@ export async function handleCalendarExportRebuildBatch(
     for (const message of validMessages) {
       message.ack();
     }
-  } catch {
+  } catch (error) {
+    logAppEvent(
+      "error",
+      "calendar-export-rebuild.retry",
+      {
+        batchMessageCount: batch.messages.length,
+        event: "calendar-export-rebuild.retry",
+        messageType: "calendar-export-rebuild",
+        retryCount: validMessages.length,
+        source: "calendar-export-rebuild",
+        validMessageCount: validMessages.length,
+      },
+      error,
+    );
     for (const message of validMessages) {
       message.retry();
     }

--- a/src/features/uploads/server/upload-pending-cleanup.ts
+++ b/src/features/uploads/server/upload-pending-cleanup.ts
@@ -12,7 +12,6 @@ type ClaimedUploadPendingCleanupRow = {
   attemptId: string;
   id: string;
   key: string;
-  userId: string;
 };
 
 export type UploadPendingCleanupReport = {
@@ -60,16 +59,16 @@ export async function cleanupStaleUploadPendingStorage(
 
       if (await finalizeUploadPendingCleanupClaim(prisma, row)) {
         report.completed += 1;
-        logAppEvent("info", "Upload pending storage cleanup completed", {
-          source: "upload-pending-cleanup",
-          key: row.key,
-          userId: row.userId,
-        });
       } else {
         report.skipped += 1;
       }
     } catch (error) {
-      if (await releaseUploadPendingCleanupClaim(prisma, row, now)) {
+      const retryScheduled = await releaseUploadPendingCleanupClaim(
+        prisma,
+        row,
+        now,
+      );
+      if (retryScheduled) {
         report.retried += 1;
       } else {
         report.failed += 1;
@@ -78,9 +77,9 @@ export async function cleanupStaleUploadPendingStorage(
         "error",
         "Upload pending storage cleanup failed",
         {
+          event: "upload-pending-cleanup.failed",
+          outcome: retryScheduled ? "retry" : "failed",
           source: "upload-pending-cleanup",
-          key: row.key,
-          userId: row.userId,
         },
         error,
       );
@@ -132,8 +131,9 @@ async function deleteUploadPendingStorageObject(key: string) {
       "warn",
       "Upload pending storage cleanup could not delete object",
       {
+        event: "upload-pending-cleanup.storage-delete-failed",
+        outcome: "retry",
         source: "upload-pending-cleanup",
-        key,
       },
       error,
     );

--- a/src/lib/log/worker-entrypoint-observability.ts
+++ b/src/lib/log/worker-entrypoint-observability.ts
@@ -1,0 +1,105 @@
+import { logAppEvent } from "@/lib/log/app-logger";
+
+export type EdgeRequestClass =
+  | "catalog-redirect"
+  | "public-not-found"
+  | "public-ssr-cache";
+
+export type EdgeCacheOutcome =
+  | "bypass"
+  | "dynamic"
+  | "hit"
+  | "miss"
+  | "revalidated"
+  | "stale"
+  | "unknown"
+  | "updating";
+
+const SAFE_STATIC_PUBLIC_ROUTES = new Set([
+  "/api-docs",
+  "/guides/markdown-support",
+  "/privacy",
+  "/terms",
+  "/usage/bot",
+  "/usage/cli",
+  "/usage/mcp",
+  "/usage/mobile",
+]);
+
+const CATALOG_DETAIL_ROUTE = /^\/catalog\/(courses|sections|teachers)\/[^/]+$/;
+const CATALOG_LIST_ROUTE = /^\/catalog\/(courses|sections|teachers)$/;
+const SAFE_CACHE_OUTCOMES = new Set<EdgeCacheOutcome>([
+  "bypass",
+  "dynamic",
+  "hit",
+  "miss",
+  "revalidated",
+  "stale",
+  "updating",
+]);
+
+export function normalizePublicSsrObservedRoute(pathname: string) {
+  const detail = CATALOG_DETAIL_ROUTE.exec(pathname);
+  if (detail) return `/catalog/${detail[1]}/:id`;
+  if (CATALOG_LIST_ROUTE.test(pathname)) return pathname;
+  if (pathname === "/api/docs" || pathname.startsWith("/api/docs/")) {
+    return "/api/docs/:page";
+  }
+  if (SAFE_STATIC_PUBLIC_ROUTES.has(pathname)) return pathname;
+  return "public-page";
+}
+
+export function resolveEdgeCacheOutcome(response: Response): EdgeCacheOutcome {
+  const outcome = response.headers.get("cf-cache-status")?.toLowerCase();
+  return outcome && SAFE_CACHE_OUTCOMES.has(outcome as EdgeCacheOutcome)
+    ? (outcome as EdgeCacheOutcome)
+    : "unknown";
+}
+
+export function observedEdgeResponse(input: {
+  cacheOutcome: EdgeCacheOutcome;
+  request: Request;
+  requestClass: EdgeRequestClass;
+  requestId: string;
+  response: Response;
+  route: string;
+  startMs: number;
+}) {
+  const response = new Response(input.response.body, input.response);
+  response.headers.set("x-request-id", input.requestId);
+  logAppEvent(
+    response.status >= 500 ? "error" : "info",
+    "edge.request.finish",
+    {
+      cacheOutcome: input.cacheOutcome,
+      event: "edge.request.finish",
+      ioObservedDurationMs: Date.now() - input.startMs,
+      method: input.request.method,
+      requestClass: input.requestClass,
+      requestId: input.requestId,
+      route: input.route,
+      source: "worker-entrypoint",
+      status: response.status,
+    },
+  );
+  return response;
+}
+
+export function logScheduledTaskFinish(
+  task: "auth-record-cleanup" | "upload-pending-cleanup",
+  counts: Record<string, number>,
+) {
+  logAppEvent("info", "scheduled.task.finish", {
+    ...counts,
+    event: "scheduled.task.finish",
+    source: "worker-entrypoint",
+    task,
+  });
+}
+
+export function logUnknownScheduledTask() {
+  logAppEvent("warn", "scheduled.task.unknown", {
+    event: "scheduled.task.unknown",
+    source: "worker-entrypoint",
+  });
+}

--- a/src/worker.js
+++ b/src/worker.js
@@ -34,6 +34,13 @@ import {
 } from "./lib/cloudflare/public-ssr-gateway";
 import { maintenancePrisma } from "./lib/db/maintenance-prisma";
 import { prisma } from "./lib/db/prisma";
+import {
+  logScheduledTaskFinish,
+  logUnknownScheduledTask,
+  normalizePublicSsrObservedRoute,
+  observedEdgeResponse,
+  resolveEdgeCacheOutcome,
+} from "./lib/log/worker-entrypoint-observability";
 import { buildContentSecurityPolicy } from "./lib/security/csp";
 import { CONTENT_SIGNAL } from "./lib/seo/content-signal";
 
@@ -90,7 +97,6 @@ function publicNotFoundResponse(locale, headRequest) {
       Vary: "Accept-Language, Cookie",
       "X-Content-Type-Options": "nosniff",
       "X-Frame-Options": "SAMEORIGIN",
-      "x-request-id": crypto.randomUUID(),
     },
   });
 }
@@ -121,7 +127,6 @@ function personalizeCachedResponse(response) {
   headers.set("Cache-Control", "private, no-store");
   headers.set("Cloudflare-CDN-Cache-Control", "no-store");
   headers.set("Vary", "Accept-Language, Cookie");
-  headers.set("x-request-id", crypto.randomUUID());
 
   const rewritten = new Response(response.body, {
     headers,
@@ -197,97 +202,152 @@ export class PublicSsr extends WorkerEntrypoint {
   }
 }
 
-export default {
-  async fetch(request, env, context) {
-    const legacyRedirect = resolveLegacyCatalogRedirect(request);
-    if (legacyRedirect) {
-      return new Response(null, {
+async function handleFetch(request, env, context) {
+  const startMs = Date.now();
+  const finish = (response, requestClass, route, cacheOutcome = "bypass") =>
+    observedEdgeResponse({
+      cacheOutcome,
+      request,
+      requestClass,
+      requestId: crypto.randomUUID(),
+      response,
+      route,
+      startMs,
+    });
+
+  const legacyRedirect = resolveLegacyCatalogRedirect(request);
+  if (legacyRedirect) {
+    return finish(
+      new Response(null, {
         status: 301,
         headers: {
           "Cache-Control": "public, max-age=86400",
           Location: legacyRedirect,
         },
-      });
-    }
-    const sectionTabRedirect = resolveSectionDetailTabRedirect(request);
-    if (sectionTabRedirect) {
-      return new Response(null, {
+      }),
+      "catalog-redirect",
+      "/:legacy-catalog-route",
+    );
+  }
+  const sectionTabRedirect = resolveSectionDetailTabRedirect(request);
+  if (sectionTabRedirect) {
+    return finish(
+      new Response(null, {
         status: 308,
         headers: {
           "Cache-Control": "public, max-age=86400",
           Location: sectionTabRedirect,
         },
-      });
-    }
-    const sectionTabQueryRedirect =
-      resolveSectionDetailTabQueryRedirect(request);
-    if (sectionTabQueryRedirect) {
-      return new Response(null, {
+      }),
+      "catalog-redirect",
+      "/catalog/sections/:id/:legacy-tab",
+    );
+  }
+  const sectionTabQueryRedirect = resolveSectionDetailTabQueryRedirect(request);
+  if (sectionTabQueryRedirect) {
+    return finish(
+      new Response(null, {
         status: 308,
         headers: {
           "Cache-Control": "public, max-age=86400",
           Location: sectionTabQueryRedirect,
         },
-      });
-    }
-    const courseTabRedirect = resolveCourseDetailTabRedirect(request);
-    if (courseTabRedirect) {
-      return new Response(null, {
+      }),
+      "catalog-redirect",
+      "/catalog/sections/:id",
+    );
+  }
+  const courseTabRedirect = resolveCourseDetailTabRedirect(request);
+  if (courseTabRedirect) {
+    return finish(
+      new Response(null, {
         status: 308,
         headers: {
           "Cache-Control": "public, max-age=86400",
           Location: courseTabRedirect,
         },
-      });
-    }
-    const courseTabQueryRedirect = resolveCourseDetailTabQueryRedirect(request);
-    if (courseTabQueryRedirect) {
-      return new Response(null, {
+      }),
+      "catalog-redirect",
+      "/catalog/courses/:id/:legacy-tab",
+    );
+  }
+  const courseTabQueryRedirect = resolveCourseDetailTabQueryRedirect(request);
+  if (courseTabQueryRedirect) {
+    return finish(
+      new Response(null, {
         status: 308,
         headers: {
           "Cache-Control": "public, max-age=86400",
           Location: courseTabQueryRedirect,
         },
-      });
-    }
-    const teacherTabRedirect = resolveTeacherDetailTabRedirect(request);
-    if (teacherTabRedirect) {
-      return new Response(null, {
+      }),
+      "catalog-redirect",
+      "/catalog/courses/:id",
+    );
+  }
+  const teacherTabRedirect = resolveTeacherDetailTabRedirect(request);
+  if (teacherTabRedirect) {
+    return finish(
+      new Response(null, {
         status: 308,
         headers: {
           "Cache-Control": "public, max-age=86400",
           Location: teacherTabRedirect,
         },
-      });
-    }
-    const teacherTabQueryRedirect =
-      resolveTeacherDetailTabQueryRedirect(request);
-    if (teacherTabQueryRedirect) {
-      return new Response(null, {
+      }),
+      "catalog-redirect",
+      "/catalog/teachers/:id/:legacy-tab",
+    );
+  }
+  const teacherTabQueryRedirect = resolveTeacherDetailTabQueryRedirect(request);
+  if (teacherTabQueryRedirect) {
+    return finish(
+      new Response(null, {
         status: 308,
         headers: {
           "Cache-Control": "public, max-age=86400",
           Location: teacherTabQueryRedirect,
         },
-      });
-    }
-    const mode = resolvePublicSsrMode(request, resolveCatalogListPublicSsrMode);
-    if (!shouldRoutePublicSsrCache(request, mode)) {
-      return app.fetch(directRequest(request), env, context);
-    }
+      }),
+      "catalog-redirect",
+      "/catalog/teachers/:id",
+    );
+  }
+  const mode = resolvePublicSsrMode(request, resolveCatalogListPublicSsrMode);
+  if (!shouldRoutePublicSsrCache(request, mode)) {
+    return app.fetch(directRequest(request), env, context);
+  }
 
-    const locale = resolvePublicSsrLocale(request);
-    if (mode === "not-found") {
-      return publicNotFoundResponse(locale, request.method === "HEAD");
-    }
-    const cachedRequest = publicSsrRequest(request, mode, locale);
-    const cacheUrl = new URL(cachedRequest.url);
-    const response = await context.exports
-      .PublicSsr({ props: { locale, mode } })
-      .fetch(cachedRequest, {
-        cf: { cacheKey: cacheUrl.pathname + cacheUrl.search },
-      });
-    return personalizeCachedResponse(response);
+  const locale = resolvePublicSsrLocale(request);
+  if (mode === "not-found") {
+    return finish(
+      publicNotFoundResponse(locale, request.method === "HEAD"),
+      "public-not-found",
+      "public-not-found",
+    );
+  }
+  const cachedRequest = publicSsrRequest(request, mode, locale);
+  const cacheUrl = new URL(cachedRequest.url);
+  const response = await context.exports
+    .PublicSsr({ props: { locale, mode } })
+    .fetch(cachedRequest, {
+      cf: { cacheKey: cacheUrl.pathname + cacheUrl.search },
+    });
+  return finish(
+    personalizeCachedResponse(response),
+    "public-ssr-cache",
+    normalizePublicSsrObservedRoute(new URL(request.url).pathname),
+    resolveEdgeCacheOutcome(response),
+  );
+}
+
+export default {
+  async fetch(request, env, context) {
+    return runWithCloudflareRuntimeEnv(
+      env,
+      () => handleFetch(request, env, context),
+      context,
+    );
   },
   async queue(batch, env, context) {
     await runWithCloudflareRuntimeEnv(
@@ -302,19 +362,17 @@ export default {
       async () => {
         if (controller.cron === UPLOAD_PENDING_CLEANUP_CRON) {
           const report = await cleanupStaleUploadPendingStorage(prisma);
-          console.log(
-            `Upload pending storage cleanup completed: ${JSON.stringify(report)}`,
-          );
+          logScheduledTaskFinish("upload-pending-cleanup", report);
           return;
         }
 
         if (controller.cron === AUTH_RECORD_CLEANUP_CRON) {
-          await cleanupExpiredAuthRecords(maintenancePrisma);
-          console.log("Expired auth record cleanup completed");
+          const report = await cleanupExpiredAuthRecords(maintenancePrisma);
+          logScheduledTaskFinish("auth-record-cleanup", report);
           return;
         }
 
-        console.log(`Ignoring unknown scheduled cron: ${controller.cron}`);
+        logUnknownScheduledTask();
       },
       context,
     );

--- a/tests/unit/calendar-export-rebuild.test.ts
+++ b/tests/unit/calendar-export-rebuild.test.ts
@@ -4,11 +4,13 @@ const {
   findManyMock,
   getUserCalendarRecordMock,
   buildUserCalendarExportMock,
+  logAppEventMock,
   storeBuiltUserCalendarExportMock,
 } = vi.hoisted(() => ({
   findManyMock: vi.fn(),
   getUserCalendarRecordMock: vi.fn(),
   buildUserCalendarExportMock: vi.fn(),
+  logAppEventMock: vi.fn(),
   storeBuiltUserCalendarExportMock: vi.fn(),
 }));
 
@@ -30,6 +32,10 @@ vi.mock("@/features/calendar/server/calendar-export-service", () => ({
 
 vi.mock("@/features/calendar/server/calendar-export-cache", () => ({
   storeBuiltUserCalendarExport: storeBuiltUserCalendarExportMock,
+}));
+
+vi.mock("@/lib/log/app-logger", () => ({
+  logAppEvent: logAppEventMock,
 }));
 
 import {
@@ -121,5 +127,47 @@ describe("calendar export rebuild fan-out", () => {
     expect(invalid.retry).not.toHaveBeenCalled();
     expect(valid.ack).toHaveBeenCalledOnce();
     expect(valid.retry).not.toHaveBeenCalled();
+  });
+
+  it("logs safe batch context before retrying a failed batch", async () => {
+    findManyMock.mockResolvedValue([{ userId: "subscriber-secret" }]);
+    getUserCalendarRecordMock.mockRejectedValue(
+      new Error("failure for user-secret"),
+    );
+    const userMessage = {
+      ack: vi.fn(),
+      body: { type: "user", userId: "user-secret" },
+      retry: vi.fn(),
+    };
+    const sectionMessage = {
+      ack: vi.fn(),
+      body: { type: "section", sectionId: 987654 },
+      retry: vi.fn(),
+    };
+
+    await handleCalendarExportRebuildBatch({
+      messages: [userMessage, sectionMessage],
+    });
+
+    expect(userMessage.ack).not.toHaveBeenCalled();
+    expect(sectionMessage.ack).not.toHaveBeenCalled();
+    expect(userMessage.retry).toHaveBeenCalledOnce();
+    expect(sectionMessage.retry).toHaveBeenCalledOnce();
+    expect(logAppEventMock).toHaveBeenCalledOnce();
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "error",
+      "calendar-export-rebuild.retry",
+      {
+        batchMessageCount: 2,
+        event: "calendar-export-rebuild.retry",
+        messageType: "calendar-export-rebuild",
+        retryCount: 2,
+        source: "calendar-export-rebuild",
+        validMessageCount: 2,
+      },
+      expect.any(Error),
+    );
+    expect(logAppEventMock.mock.calls[0]?.[2]).not.toHaveProperty("userId");
+    expect(logAppEventMock.mock.calls[0]?.[2]).not.toHaveProperty("sectionId");
   });
 });

--- a/tests/unit/upload-pending-cleanup.test.ts
+++ b/tests/unit/upload-pending-cleanup.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   cleanupStaleUploadPendingStorage,
   UPLOAD_PENDING_CLEANUP_BATCH_SIZE,
@@ -19,6 +19,10 @@ vi.mock("@/lib/log/app-logger", () => ({
 }));
 
 describe("upload pending storage cleanup", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("claims rows through the security-definer function and finalizes after R2 delete", async () => {
     const now = new Date("2026-07-30T12:00:00.000Z");
     const queryRaw = vi
@@ -59,6 +63,7 @@ describe("upload pending storage cleanup", () => {
       UPLOAD_PENDING_CLEANUP_BATCH_SIZE,
       UPLOAD_PENDING_CLEANUP_LEASE_SECONDS,
     ]);
+    expect(logAppEventMock).not.toHaveBeenCalled();
   });
 
   it("extends the cleanup lease when R2 deletion fails", async () => {
@@ -85,5 +90,59 @@ describe("upload pending storage cleanup", () => {
       retried: 1,
       skipped: 0,
     });
+
+    expect(logAppEventMock).toHaveBeenCalledOnce();
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "warn",
+      "Upload pending storage cleanup could not delete object",
+      {
+        event: "upload-pending-cleanup.storage-delete-failed",
+        outcome: "retry",
+        source: "upload-pending-cleanup",
+      },
+      expect.any(Error),
+    );
+    expect(logAppEventMock.mock.calls[0]?.[2]).not.toHaveProperty("key");
+    expect(logAppEventMock.mock.calls[0]?.[2]).not.toHaveProperty("userId");
+  });
+
+  it("logs safe context when cleanup finalization fails", async () => {
+    const now = new Date("2026-07-30T12:00:00.000Z");
+    const queryRaw = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          attemptId: "attempt-1",
+          id: "pending-1",
+          key: "uploads/user-secret/file.txt",
+          userId: "user-secret",
+        },
+      ])
+      .mockRejectedValueOnce(new Error("database unavailable"))
+      .mockResolvedValueOnce([{ released: true }]);
+    deleteStorageObjectMock.mockResolvedValue(undefined);
+
+    await expect(
+      cleanupStaleUploadPendingStorage({ $queryRaw: queryRaw } as never, now),
+    ).resolves.toEqual({
+      claimed: 1,
+      completed: 0,
+      failed: 0,
+      retried: 1,
+      skipped: 0,
+    });
+
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "error",
+      "Upload pending storage cleanup failed",
+      {
+        event: "upload-pending-cleanup.failed",
+        outcome: "retry",
+        source: "upload-pending-cleanup",
+      },
+      expect.any(Error),
+    );
+    expect(logAppEventMock.mock.calls[0]?.[2]).not.toHaveProperty("key");
+    expect(logAppEventMock.mock.calls[0]?.[2]).not.toHaveProperty("userId");
   });
 });

--- a/tests/unit/worker-entrypoint-observability.test.ts
+++ b/tests/unit/worker-entrypoint-observability.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { logAppEventMock } = vi.hoisted(() => ({
+  logAppEventMock: vi.fn(),
+}));
+
+vi.mock("@/lib/log/app-logger", () => ({
+  logAppEvent: logAppEventMock,
+}));
+
+import {
+  logScheduledTaskFinish,
+  logUnknownScheduledTask,
+  normalizePublicSsrObservedRoute,
+  observedEdgeResponse,
+  resolveEdgeCacheOutcome,
+} from "@/lib/log/worker-entrypoint-observability";
+
+describe("worker entrypoint observability", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("normalizes public SSR routes without retaining entity identifiers", () => {
+    expect(
+      normalizePublicSsrObservedRoute("/catalog/courses/course-secret"),
+    ).toBe("/catalog/courses/:id");
+    expect(normalizePublicSsrObservedRoute("/catalog/sections/12345")).toBe(
+      "/catalog/sections/:id",
+    );
+    expect(normalizePublicSsrObservedRoute("/api/docs/rest/catalog")).toBe(
+      "/api/docs/:page",
+    );
+    expect(normalizePublicSsrObservedRoute("/privacy")).toBe("/privacy");
+    expect(normalizePublicSsrObservedRoute("/users/user-secret")).toBe(
+      "public-page",
+    );
+  });
+
+  it("only emits allowlisted cache outcomes", () => {
+    expect(
+      resolveEdgeCacheOutcome(
+        new Response(null, { headers: { "CF-Cache-Status": "HIT" } }),
+      ),
+    ).toBe("hit");
+    expect(
+      resolveEdgeCacheOutcome(
+        new Response(null, {
+          headers: { "CF-Cache-Status": "tenant-secret" },
+        }),
+      ),
+    ).toBe("unknown");
+  });
+
+  it("adds the request id and logs a safe finish record", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-14T10:00:00.250Z"));
+    const response = observedEdgeResponse({
+      cacheOutcome: "hit",
+      request: new Request(
+        "https://life-ustc.tiankaima.dev/catalog/courses/course-secret?token=secret",
+      ),
+      requestClass: "public-ssr-cache",
+      requestId: "request-1",
+      response: new Response("ok", { status: 200 }),
+      route: "/catalog/courses/:id",
+      startMs: new Date("2026-08-14T10:00:00.000Z").getTime(),
+    });
+
+    expect(response.headers.get("x-request-id")).toBe("request-1");
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "info",
+      "edge.request.finish",
+      {
+        cacheOutcome: "hit",
+        event: "edge.request.finish",
+        ioObservedDurationMs: 250,
+        method: "GET",
+        requestClass: "public-ssr-cache",
+        requestId: "request-1",
+        route: "/catalog/courses/:id",
+        source: "worker-entrypoint",
+        status: 200,
+      },
+    );
+    expect(JSON.stringify(logAppEventMock.mock.calls)).not.toContain(
+      "course-secret",
+    );
+    expect(JSON.stringify(logAppEventMock.mock.calls)).not.toContain("token");
+  });
+
+  it("logs scheduled outcomes without exposing cron expressions", () => {
+    logScheduledTaskFinish("upload-pending-cleanup", {
+      completed: 2,
+      failed: 0,
+    });
+    logUnknownScheduledTask();
+
+    expect(logAppEventMock).toHaveBeenNthCalledWith(
+      1,
+      "info",
+      "scheduled.task.finish",
+      {
+        completed: 2,
+        event: "scheduled.task.finish",
+        failed: 0,
+        source: "worker-entrypoint",
+        task: "upload-pending-cleanup",
+      },
+    );
+    expect(logAppEventMock).toHaveBeenNthCalledWith(
+      2,
+      "warn",
+      "scheduled.task.unknown",
+      {
+        event: "scheduled.task.unknown",
+        source: "worker-entrypoint",
+      },
+    );
+  });
+});

--- a/tests/unit/wrangler-rate-limit-config.test.ts
+++ b/tests/unit/wrangler-rate-limit-config.test.ts
@@ -38,7 +38,7 @@ describe("Wrangler mutation rate-limit bindings", () => {
     ]);
   });
 
-  it("keeps public workers.dev disabled and enables invocation logs for CPU diagnosis", async () => {
+  it("keeps raw invocation logs disabled while retaining complete safe custom logs", async () => {
     const source = await readFile(
       new URL("../../wrangler.jsonc", import.meta.url),
       "utf8",
@@ -57,8 +57,8 @@ describe("Wrangler mutation rate-limit bindings", () => {
 
     expect(config.preview_urls).toBe(false);
     expect(config.workers_dev).toBe(false);
-    expect(config.observability?.logs?.invocation_logs).toBe(true);
-    expect(config.observability?.logs?.head_sampling_rate).toBe(0.5);
+    expect(config.observability?.logs?.invocation_logs).toBe(false);
+    expect(config.observability?.logs?.head_sampling_rate).toBe(1);
     expect(config.observability?.traces?.head_sampling_rate).toBe(0.1);
   });
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -37,8 +37,8 @@
     "enabled": true,
     "logs": {
       "enabled": true,
-      "head_sampling_rate": 0.5,
-      "invocation_logs": true,
+      "head_sampling_rate": 1,
+      "invocation_logs": false,
       "persist": true
     },
     "traces": {


### PR DESCRIPTION
## Summary
- replace upload cleanup and scheduled raw logs with structured, low-cardinality events
- emit one redacted calendar rebuild batch failure before retrying the batch
- add sanitized edge finish telemetry for direct redirects, not-found responses, and the public SSR cache gateway without duplicating SvelteKit finish logs
- retain 100% custom/error logs, disable raw invocation logs that expose request headers/query strings, and keep trace sampling at 10%

## Validation
- bunx vitest run tests/unit (347 files, 2095 tests)
- bunx tsc -p tsconfig.typecheck.json --noEmit
- bunx tsc -p tsconfig.typecheck.tests.json --noEmit
- bunx tsc -p tsconfig.typecheck.operational.json --noEmit
- bunx biome check (changed files)
- bunx wrangler types --include-runtime=false --check
- DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run build

## Operational note
Disabling invocation_logs removes Cloudflare-generated request metadata from persisted logs, including the currently exposed Authorization header and raw search parameters. Custom application logs are sampled at 100% and traces remain at 10%. Cache outcome depends on CF-Cache-Status and falls back to unknown when unavailable.