### PR TITLE
perf(observability): trace detail and response phases

### DIFF
--- a/src/features/catalog/server/catalog-detail-page-server.ts
+++ b/src/features/catalog/server/catalog-detail-page-server.ts
@@ -11,6 +11,7 @@ import {
 } from "@/features/catalog/lib/catalog-structured-data";
 import { getCoursePage } from "@/features/catalog/server/course-page-data";
 import { getTeacherPage } from "@/features/catalog/server/teacher-page-data";
+import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import { getViewerContext } from "@/lib/auth/viewer-context";
 import {
   buildSocialMetadata,
@@ -25,17 +26,26 @@ import {
 export type CourseDetailRouteSection = CatalogDetailTab;
 export type TeacherDetailRouteSection = CatalogDetailTab;
 
-export async function loadCourseDetailPage({
-  locals,
-  params,
-  request,
-  url,
-}: {
+type CourseDetailPageInput = {
   locals: App.Locals;
   params: { jwId: string; section?: string };
   request: Request;
   url: URL;
-}) {
+};
+
+type TeacherDetailPageInput = {
+  locals: App.Locals;
+  params: { id: string; section?: string };
+  request: Request;
+  url: URL;
+};
+
+async function loadCourseDetailPageData({
+  locals,
+  params,
+  request,
+  url,
+}: CourseDetailPageInput) {
   const tabQueryRedirect = resolveCatalogDetailTabQueryRedirect(
     request,
     "courses",
@@ -49,8 +59,19 @@ export async function loadCourseDetailPage({
   if (!Number.isInteger(jwId)) error(404, copy.notFound.description);
   // Stream layout always shows the sections table; include on first load.
   const [course, viewer] = await Promise.all([
-    getCoursePage(jwId, locals.locale, { includeSections: true }),
-    getViewerContext({ userId: locals.authUser?.id ?? null }),
+    runCloudflareTraceSpan(
+      "catalog.detail.core",
+      { "catalog.detail.kind": "course" },
+      () => getCoursePage(jwId, locals.locale, { includeSections: true }),
+    ),
+    runCloudflareTraceSpan(
+      "catalog.detail.viewer",
+      {
+        "catalog.detail.kind": "course",
+        "user.authenticated": Boolean(locals.authUser?.id),
+      },
+      () => getViewerContext({ userId: locals.authUser?.id ?? null }),
+    ),
   ]);
   if (!course) error(404, copy.notFound.description);
   if (course.jwId !== jwId) {
@@ -62,14 +83,17 @@ export async function loadCourseDetailPage({
     redirect(308, `${redirectUrl.pathname}${redirectUrl.search}`);
   }
   const displayName = catalogPrimaryName(course) || course.code;
-  const { commentsData, descriptionData } = await loadCatalogDetailCommentsData(
-    {
-      includeDescription: true,
-      includeDescriptionHistory: false,
-      targetId: course.id,
-      type: "course",
-      viewer,
-    },
+  const { commentsData, descriptionData } = await runCloudflareTraceSpan(
+    "catalog.detail.comments",
+    { "catalog.detail.kind": "course" },
+    () =>
+      loadCatalogDetailCommentsData({
+        includeDescription: true,
+        includeDescriptionHistory: false,
+        targetId: course.id,
+        type: "course",
+        viewer,
+      }),
   );
   const socialMetadata = buildSocialMetadata({
     card: {
@@ -112,17 +136,20 @@ export async function loadCourseDetailPage({
   };
 }
 
-export async function loadTeacherDetailPage({
+export function loadCourseDetailPage(input: CourseDetailPageInput) {
+  return runCloudflareTraceSpan(
+    "catalog.detail.data_load",
+    { "catalog.detail.kind": "course" },
+    () => loadCourseDetailPageData(input),
+  );
+}
+
+async function loadTeacherDetailPageData({
   locals,
   params,
   request,
   url,
-}: {
-  locals: App.Locals;
-  params: { id: string; section?: string };
-  request: Request;
-  url: URL;
-}) {
+}: TeacherDetailPageInput) {
   const tabQueryRedirect = resolveCatalogDetailTabQueryRedirect(
     request,
     "teachers",
@@ -136,19 +163,33 @@ export async function loadTeacherDetailPage({
   if (!Number.isInteger(id)) error(404, copy.notFound.description);
   // Stream layout always shows teaching sections; include on first load.
   const [teacher, viewer] = await Promise.all([
-    getTeacherPage(id, locals.locale, { includeSections: true }),
-    getViewerContext({ userId: locals.authUser?.id ?? null }),
+    runCloudflareTraceSpan(
+      "catalog.detail.core",
+      { "catalog.detail.kind": "teacher" },
+      () => getTeacherPage(id, locals.locale, { includeSections: true }),
+    ),
+    runCloudflareTraceSpan(
+      "catalog.detail.viewer",
+      {
+        "catalog.detail.kind": "teacher",
+        "user.authenticated": Boolean(locals.authUser?.id),
+      },
+      () => getViewerContext({ userId: locals.authUser?.id ?? null }),
+    ),
   ]);
   if (!teacher) error(404, copy.notFound.description);
   const displayName = catalogPrimaryName(teacher);
-  const { commentsData, descriptionData } = await loadCatalogDetailCommentsData(
-    {
-      includeDescription: true,
-      includeDescriptionHistory: false,
-      targetId: teacher.id,
-      type: "teacher",
-      viewer,
-    },
+  const { commentsData, descriptionData } = await runCloudflareTraceSpan(
+    "catalog.detail.comments",
+    { "catalog.detail.kind": "teacher" },
+    () =>
+      loadCatalogDetailCommentsData({
+        includeDescription: true,
+        includeDescriptionHistory: false,
+        targetId: teacher.id,
+        type: "teacher",
+        viewer,
+      }),
   );
   const socialMetadata = buildSocialMetadata({
     card: {
@@ -192,4 +233,12 @@ export async function loadTeacherDetailPage({
       }),
     ),
   };
+}
+
+export function loadTeacherDetailPage(input: TeacherDetailPageInput) {
+  return runCloudflareTraceSpan(
+    "catalog.detail.data_load",
+    { "catalog.detail.kind": "teacher" },
+    () => loadTeacherDetailPageData(input),
+  );
 }

--- a/src/features/section-detail/server/section-detail-page-server.ts
+++ b/src/features/section-detail/server/section-detail-page-server.ts
@@ -9,6 +9,7 @@ import {
 } from "@/features/section-detail/lib/display";
 import { resolveSectionDetailTabQueryRedirect } from "@/features/section-detail/lib/section-detail-tab";
 import { getSectionPage } from "@/features/section-detail/server/section-page-data";
+import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import { getViewerContext } from "@/lib/auth/viewer-context";
 import {
   buildSocialMetadata,
@@ -23,17 +24,19 @@ export {
   unsubscribeSectionAction,
 } from "./section-detail-subscription-actions";
 
-export async function loadSectionDetailPage({
-  locals,
-  params,
-  request,
-  url,
-}: {
+type SectionDetailPageInput = {
   locals: App.Locals;
   params: { jwId: string; section?: string };
   request: Request;
   url: URL;
-}) {
+};
+
+async function loadSectionDetailPageData({
+  locals,
+  params,
+  request,
+  url,
+}: SectionDetailPageInput) {
   const tabQueryRedirect = resolveSectionDetailTabQueryRedirect(request);
   if (tabQueryRedirect) {
     redirect(308, tabQueryRedirect);
@@ -53,13 +56,25 @@ export async function loadSectionDetailPage({
       )
     : Promise.resolve(null);
   const [pageData, viewer, subscriptionState] = await Promise.all([
-    getSectionPage(jwId, locals.locale, {
-      includeExams: true,
-      includeRelated: true,
-      includeSchedules: true,
-      includeTeacherDepartments: true,
-    }),
-    getViewerContext({ userId }),
+    runCloudflareTraceSpan(
+      "catalog.detail.core",
+      { "catalog.detail.kind": "section" },
+      () =>
+        getSectionPage(jwId, locals.locale, {
+          includeExams: true,
+          includeRelated: true,
+          includeSchedules: true,
+          includeTeacherDepartments: true,
+        }),
+    ),
+    runCloudflareTraceSpan(
+      "catalog.detail.viewer",
+      {
+        "catalog.detail.kind": "section",
+        "user.authenticated": Boolean(userId),
+      },
+      () => getViewerContext({ userId }),
+    ),
     subscriptionStatePromise,
   ]);
   if (!pageData) error(404, "Section not found");
@@ -148,4 +163,12 @@ export async function loadSectionDetailPage({
       subscriptionIcsUrl: subscriptionState?.subscriptionIcsUrl ?? null,
     },
   };
+}
+
+export function loadSectionDetailPage(input: SectionDetailPageInput) {
+  return runCloudflareTraceSpan(
+    "catalog.detail.data_load",
+    { "catalog.detail.kind": "section" },
+    () => loadSectionDetailPageData(input),
+  );
 }

--- a/src/lib/adapters/cloudflare-runtime.ts
+++ b/src/lib/adapters/cloudflare-runtime.ts
@@ -61,6 +61,7 @@ type CloudflareCacheStorage = {
 type CloudflareTaskScheduler = (promise: Promise<unknown>) => void;
 
 export type CloudflareTraceSpan = {
+  readonly isTraced: boolean;
   setAttribute(key: string, value?: boolean | number | string): void;
 };
 

--- a/src/lib/api/responses.ts
+++ b/src/lib/api/responses.ts
@@ -26,7 +26,7 @@ export function jsonResponse(body: unknown, init?: ResponseInit) {
     { "response.format": "json" },
     (span) => {
       const serialized = JSON.stringify(serializeDatesDeep(body));
-      if (span) {
+      if (span?.isTraced) {
         span.setAttribute(
           "http.response.body.size",
           new TextEncoder().encode(serialized).byteLength,

--- a/src/lib/api/responses.ts
+++ b/src/lib/api/responses.ts
@@ -1,3 +1,4 @@
+import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import { logRouteFailure } from "@/lib/log/app-logger";
 import { serializeDatesDeep } from "@/lib/time/serialize-date-output";
 
@@ -20,10 +21,23 @@ export function jsonResponse(body: unknown, init?: ResponseInit) {
     headers.set("Content-Type", "application/json; charset=utf-8");
   }
 
-  return new Response(JSON.stringify(serializeDatesDeep(body)), {
-    ...init,
-    headers,
-  });
+  return runCloudflareTraceSpan(
+    "response.serialize",
+    { "response.format": "json" },
+    (span) => {
+      const serialized = JSON.stringify(serializeDatesDeep(body));
+      if (span) {
+        span.setAttribute(
+          "http.response.body.size",
+          new TextEncoder().encode(serialized).byteLength,
+        );
+      }
+      return new Response(serialized, {
+        ...init,
+        headers,
+      });
+    },
+  );
 }
 
 export function createdJsonResponse(body: unknown, location: string) {

--- a/tests/unit/api-helpers.test.ts
+++ b/tests/unit/api-helpers.test.ts
@@ -28,10 +28,12 @@ describe("API 辅助函数", () => {
     const enterSpan = <T>(
       _name: string,
       callback: (span: {
+        readonly isTraced: boolean;
         setAttribute(key: string, value?: boolean | number | string): void;
       }) => T,
     ) =>
       callback({
+        isTraced: true,
         setAttribute(key, value) {
           attributes.set(key, value);
         },
@@ -60,11 +62,40 @@ describe("API 辅助函数", () => {
     expect(encode).not.toHaveBeenCalled();
   });
 
+  it("skips the UTF-8 size traversal for an unsampled trace span", async () => {
+    const encode = vi.spyOn(TextEncoder.prototype, "encode");
+    const setAttribute = vi.fn();
+    const enterSpan = <T>(
+      _name: string,
+      callback: (span: {
+        readonly isTraced: boolean;
+        setAttribute(key: string, value?: boolean | number | string): void;
+      }) => T,
+    ) => callback({ isTraced: false, setAttribute });
+
+    const response = await runWithCloudflareRuntimeEnv(
+      {},
+      () => jsonResponse({ label: "科" }),
+      { tracing: { enterSpan } },
+    );
+
+    expect(response).toBeInstanceOf(Response);
+    expect(encode).not.toHaveBeenCalled();
+    expect(setAttribute).toHaveBeenCalledWith("response.format", "json");
+    expect(setAttribute).not.toHaveBeenCalledWith(
+      "http.response.body.size",
+      expect.anything(),
+    );
+  });
+
   it("propagates JSON serialization failures from the traced callback", async () => {
     const enterSpan = <T>(
       _name: string,
-      callback: (span: { setAttribute(): void }) => T,
-    ) => callback({ setAttribute() {} });
+      callback: (span: {
+        readonly isTraced: boolean;
+        setAttribute(): void;
+      }) => T,
+    ) => callback({ isTraced: true, setAttribute() {} });
 
     await expect(
       runWithCloudflareRuntimeEnv({}, () => jsonResponse({ unsupported: 1n }), {

--- a/tests/unit/api-helpers.test.ts
+++ b/tests/unit/api-helpers.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import * as z from "zod";
+import { runWithCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
 import {
   getRequestSearchParams,
   jsonResponse,
@@ -12,10 +13,64 @@ import {
 } from "@/lib/api/helpers";
 
 describe("API 辅助函数", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("不覆盖代理提供的请求 ID 标头", () => {
     const response = jsonResponse({ ok: true });
 
     expect(response.headers.has("x-request-id")).toBe(false);
+  });
+
+  it("records the UTF-8 response size on JSON serialization spans", async () => {
+    const attributes = new Map<string, boolean | number | string | undefined>();
+    const enterSpan = <T>(
+      _name: string,
+      callback: (span: {
+        setAttribute(key: string, value?: boolean | number | string): void;
+      }) => T,
+    ) =>
+      callback({
+        setAttribute(key, value) {
+          attributes.set(key, value);
+        },
+      });
+
+    const response = await runWithCloudflareRuntimeEnv(
+      {},
+      () => jsonResponse({ label: "科" }),
+      { tracing: { enterSpan } },
+    );
+    const body = await response.text();
+
+    expect(body).toBe('{"label":"科"}');
+    expect(attributes.get("response.format")).toBe("json");
+    expect(attributes.get("http.response.body.size")).toBe(
+      new TextEncoder().encode(body).byteLength,
+    );
+  });
+
+  it("skips the UTF-8 size traversal when no trace span is sampled", () => {
+    const encode = vi.spyOn(TextEncoder.prototype, "encode");
+
+    const response = jsonResponse({ label: "科" });
+
+    expect(response).toBeInstanceOf(Response);
+    expect(encode).not.toHaveBeenCalled();
+  });
+
+  it("propagates JSON serialization failures from the traced callback", async () => {
+    const enterSpan = <T>(
+      _name: string,
+      callback: (span: { setAttribute(): void }) => T,
+    ) => callback({ setAttribute() {} });
+
+    await expect(
+      runWithCloudflareRuntimeEnv({}, () => jsonResponse({ unsupported: 1n }), {
+        tracing: { enterSpan },
+      }),
+    ).rejects.toThrow(TypeError);
   });
 
   it.each([

--- a/tests/unit/cloudflare-runtime-tracing.test.ts
+++ b/tests/unit/cloudflare-runtime-tracing.test.ts
@@ -49,6 +49,64 @@ describe("Cloudflare runtime tracing", () => {
     expect(runCloudflareTraceSpan("app.test", {}, () => 42)).toBe(42);
   });
 
+  it("lets traced callbacks attach result attributes", async () => {
+    const setAttribute = vi.fn();
+    const enterSpan = vi.fn(
+      <T>(
+        _name: string,
+        callback: (span: { setAttribute: typeof setAttribute }) => T,
+      ) => callback({ setAttribute }),
+    );
+
+    const result = await runWithCloudflareRuntimeEnv(
+      {},
+      () =>
+        runCloudflareTraceSpan(
+          "response.serialize",
+          { "response.format": "json" },
+          (span) => {
+            span?.setAttribute("http.response.body.size", 17);
+            return "serialized";
+          },
+        ),
+      { tracing: { enterSpan } },
+    );
+
+    expect(result).toBe("serialized");
+    expect(setAttribute).toHaveBeenCalledWith("response.format", "json");
+    expect(setAttribute).toHaveBeenCalledWith("http.response.body.size", 17);
+  });
+
+  it("passes no span when tracing is unavailable", () => {
+    let callbackSpan: unknown = "not-called";
+    expect(
+      runCloudflareTraceSpan("app.test", {}, (span) => {
+        callbackSpan = span;
+        return 42;
+      }),
+    ).toBe(42);
+    expect(callbackSpan).toBeUndefined();
+  });
+
+  it("propagates errors from callbacks that attach attributes", async () => {
+    const enterSpan = vi.fn(
+      <T>(_name: string, callback: (span: { setAttribute(): void }) => T) =>
+        callback({ setAttribute() {} }),
+    );
+    const failure = new Error("serialize failed");
+
+    await expect(
+      runWithCloudflareRuntimeEnv(
+        {},
+        () =>
+          runCloudflareTraceSpan("response.serialize", {}, () => {
+            throw failure;
+          }),
+        { tracing: { enterSpan } },
+      ),
+    ).rejects.toBe(failure);
+  });
+
   it("keeps named caches request-scoped and preserves the waitUntil receiver", async () => {
     const cache = { match: vi.fn(), put: vi.fn() };
     const open = vi.fn(async () => cache);

--- a/tests/unit/cloudflare-runtime-tracing.test.ts
+++ b/tests/unit/cloudflare-runtime-tracing.test.ts
@@ -16,8 +16,11 @@ describe("Cloudflare runtime tracing", () => {
     const enterSpan = vi.fn(
       <T>(
         _name: string,
-        callback: (span: { setAttribute: typeof setAttribute }) => T,
-      ) => callback({ setAttribute }),
+        callback: (span: {
+          readonly isTraced: boolean;
+          setAttribute: typeof setAttribute;
+        }) => T,
+      ) => callback({ isTraced: true, setAttribute }),
     );
 
     const result = await runWithCloudflareRuntimeEnv(
@@ -54,8 +57,11 @@ describe("Cloudflare runtime tracing", () => {
     const enterSpan = vi.fn(
       <T>(
         _name: string,
-        callback: (span: { setAttribute: typeof setAttribute }) => T,
-      ) => callback({ setAttribute }),
+        callback: (span: {
+          readonly isTraced: boolean;
+          setAttribute: typeof setAttribute;
+        }) => T,
+      ) => callback({ isTraced: true, setAttribute }),
     );
 
     const result = await runWithCloudflareRuntimeEnv(
@@ -90,8 +96,13 @@ describe("Cloudflare runtime tracing", () => {
 
   it("propagates errors from callbacks that attach attributes", async () => {
     const enterSpan = vi.fn(
-      <T>(_name: string, callback: (span: { setAttribute(): void }) => T) =>
-        callback({ setAttribute() {} }),
+      <T>(
+        _name: string,
+        callback: (span: {
+          readonly isTraced: boolean;
+          setAttribute(): void;
+        }) => T,
+      ) => callback({ isTraced: true, setAttribute() {} }),
     );
     const failure = new Error("serialize failed");
 

--- a/tests/unit/detail-page-loader-critical-path.test.ts
+++ b/tests/unit/detail-page-loader-critical-path.test.ts
@@ -207,6 +207,67 @@ afterEach(() => {
 });
 
 describe("catalog detail loader critical path", () => {
+  it("traces bounded course data-load phases without entity identifiers", async () => {
+    const spans: Array<{
+      attributes: Record<string, boolean | number | string | undefined>;
+      name: string;
+    }> = [];
+    const enterSpan = <T>(
+      name: string,
+      callback: (span: {
+        setAttribute(key: string, value?: boolean | number | string): void;
+      }) => T,
+    ) => {
+      const attributes: Record<string, boolean | number | string | undefined> =
+        {};
+      spans.push({ attributes, name });
+      return callback({
+        setAttribute(key, value) {
+          attributes[key] = value;
+        },
+      });
+    };
+    const { loadCourseDetailPage } = await import(
+      "@/features/catalog/server/catalog-detail-page-server"
+    );
+
+    await runWithCloudflareRuntimeEnv(
+      {},
+      () =>
+        loadCourseDetailPage({
+          locals: locals(),
+          params: { jwId: String(course.jwId) },
+          request: request(`/catalog/courses/${course.jwId}`),
+          url: new URL(`https://example.test/catalog/courses/${course.jwId}`),
+        }),
+      { tracing: { enterSpan } },
+    );
+
+    expect(spans).toEqual([
+      {
+        attributes: { "catalog.detail.kind": "course" },
+        name: "catalog.detail.data_load",
+      },
+      {
+        attributes: { "catalog.detail.kind": "course" },
+        name: "catalog.detail.core",
+      },
+      {
+        attributes: {
+          "catalog.detail.kind": "course",
+          "user.authenticated": false,
+        },
+        name: "catalog.detail.viewer",
+      },
+      {
+        attributes: { "catalog.detail.kind": "course" },
+        name: "catalog.detail.comments",
+      },
+    ]);
+    expect(JSON.stringify(spans)).not.toContain(String(course.jwId));
+    expect(JSON.stringify(spans)).not.toContain(String(course.id));
+  });
+
   it("starts course and viewer work together and skips comments outside the comments section", async () => {
     let resolveCourse: ((value: typeof course) => void) | undefined;
     getCoursePageMock.mockReturnValue(

--- a/tests/unit/workspace-route-tracing.test.ts
+++ b/tests/unit/workspace-route-tracing.test.ts
@@ -81,6 +81,7 @@ describe("workspace route tracing", () => {
     ).toEqual([
       ["workspace.homeworks.auth", {}],
       ["workspace.homeworks.read", {}],
+      ["response.serialize", { "response.format": "json" }],
     ]);
   });
 
@@ -105,6 +106,7 @@ describe("workspace route tracing", () => {
     ).toEqual([
       ["workspace.subscriptions.current.auth", {}],
       ["workspace.subscriptions.current.read", {}],
+      ["response.serialize", { "response.format": "json" }],
     ]);
   });
 
@@ -129,6 +131,7 @@ describe("workspace route tracing", () => {
     ).toEqual([
       ["workspace.overview.auth", {}],
       ["workspace.overview.read", {}],
+      ["response.serialize", { "response.format": "json" }],
     ]);
   });
 });


### PR DESCRIPTION
## What changed

- add fixed, low-cardinality `catalog.detail.data_load`, `catalog.detail.core`, `catalog.detail.viewer`, and `catalog.detail.comments` spans for course, teacher, and section detail loaders
- add a shared `response.serialize` span around date normalization and JSON serialization
- record exact UTF-8 response bytes only when a Cloudflare trace span is actually sampled, so untraced requests do not pay the `TextEncoder` traversal
- cover traced/untraced serialization, byte accuracy, error propagation, detail phase boundaries, and existing route span expectations

## Why

Production cold detail requests still had a large residual inside `app.sveltekit.resolve`. These spans separate page data loading from the remaining framework/render work and split the main catalog, viewer, and description/comment phases without logging entity IDs, users, SQL, parameters, or search values.

The current PrismaPg 7.9.1 adapter owns its internal `pg.Pool`; its public factory `connect()` creates the Pool but does not acquire a physical connection. A `pool.acquire` span would therefore be inaccurate. `catalog.detail.core` intentionally measures the hotspot data-read round trip as a whole; Hyperdrive checkout versus database execution remains a platform/adapter boundary.

## Validation

- `bunx vitest run` — 351 files / 2118 tests passed
- focused observability/detail tests — 45 tests passed
- `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors (13 existing warnings)
- all three TypeScript typecheck configs passed
- `bunx wrangler types --include-runtime=false --check` passed
- `bunx biome check` passed (7 existing warnings)
- production `bun run build` passed
