### PR TITLE
perf(catalog): refine detail core phases

### DIFF
--- a/src/features/catalog/components/CourseDetailPageController.svelte
+++ b/src/features/catalog/components/CourseDetailPageController.svelte
@@ -27,7 +27,6 @@ type CourseDetailData = CatalogNamed & {
   educationLevel?: CatalogNamed | null;
   id: number | string;
   jwId: number | string;
-  sectionCount: number;
   sections: CourseDetailSection[];
   type?: CatalogNamed | null;
 };

--- a/src/features/catalog/components/TeacherDetailPageController.svelte
+++ b/src/features/catalog/components/TeacherDetailPageController.svelte
@@ -26,7 +26,6 @@ type TeacherDetailData = CatalogNamed & {
   email?: string | null;
   id: number | string;
   mobile?: string | null;
-  sectionCount: number;
   sections: TeacherDetailSection[];
   teacherTitle?: CatalogNamed | null;
   telephone?: string | null;

--- a/src/features/catalog/server/catalog-detail-page-server.ts
+++ b/src/features/catalog/server/catalog-detail-page-server.ts
@@ -62,7 +62,7 @@ async function loadCourseDetailPageData({
     runCloudflareTraceSpan(
       "catalog.detail.core",
       { "catalog.detail.kind": "course" },
-      () => getCoursePage(jwId, locals.locale, { includeSections: true }),
+      () => getCoursePage(jwId, locals.locale),
     ),
     runCloudflareTraceSpan(
       "catalog.detail.viewer",
@@ -166,7 +166,7 @@ async function loadTeacherDetailPageData({
     runCloudflareTraceSpan(
       "catalog.detail.core",
       { "catalog.detail.kind": "teacher" },
-      () => getTeacherPage(id, locals.locale, { includeSections: true }),
+      () => getTeacherPage(id, locals.locale),
     ),
     runCloudflareTraceSpan(
       "catalog.detail.viewer",

--- a/src/features/catalog/server/course-page-data.ts
+++ b/src/features/catalog/server/course-page-data.ts
@@ -1,6 +1,7 @@
 import type { CourseDetailSection } from "@/features/catalog/components/catalog-detail-component-types";
 import { PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT } from "@/features/catalog/server/academic-query-includes";
 import { localizedNameSelect } from "@/features/section-detail/server/section-page-name-selects";
+import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import { getPrisma } from "@/lib/db/prisma";
 import { toLoadData } from "@/lib/load-data-utils";
 
@@ -22,59 +23,59 @@ const coursePageSectionsSelect = {
   },
 } as const;
 
-export async function getCoursePage(
-  jwId: number,
-  locale = "zh-cn",
-  options: { includeSections?: boolean } = {},
-) {
+export async function getCoursePage(jwId: number, locale = "zh-cn") {
   const prisma = getPrisma(locale);
-  const course = await prisma.course.findUnique({
-    where: { jwId },
-    select: {
-      id: true,
-      jwId: true,
-      code: true,
-      ...localizedNameSelect,
-      educationLevel: {
+  const course = await runCloudflareTraceSpan(
+    "catalog.detail.course.query",
+    { "catalog.detail.kind": "course" },
+    () =>
+      prisma.course.findUnique({
+        where: { jwId },
         select: {
+          id: true,
+          jwId: true,
+          code: true,
           ...localizedNameSelect,
-        },
-      },
-      category: {
-        select: {
-          ...localizedNameSelect,
-        },
-      },
-      classType: {
-        select: {
-          ...localizedNameSelect,
-        },
-      },
-      type: {
-        select: {
-          ...localizedNameSelect,
-        },
-      },
-      _count: { select: { sections: true } },
-      sections:
-        options.includeSections === false
-          ? false
-          : {
-              orderBy: [{ semester: { jwId: "desc" } }, { code: "asc" }],
-              take: PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
-              select: coursePageSectionsSelect,
+          educationLevel: {
+            select: {
+              ...localizedNameSelect,
             },
-    },
-  });
+          },
+          category: {
+            select: {
+              ...localizedNameSelect,
+            },
+          },
+          classType: {
+            select: {
+              ...localizedNameSelect,
+            },
+          },
+          type: {
+            select: {
+              ...localizedNameSelect,
+            },
+          },
+          sections: {
+            orderBy: [{ semester: { jwId: "desc" } }, { code: "asc" }],
+            take: PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
+            select: coursePageSectionsSelect,
+          },
+        },
+      }),
+  );
 
   if (!course) return null;
 
-  const { _count, sections, ...data } = course;
-  return toLoadData({
-    ...data,
-    sectionCount: _count.sections,
-    sections: (options.includeSections === false
-      ? []
-      : sections) as unknown as CourseDetailSection[],
-  });
+  return runCloudflareTraceSpan(
+    "catalog.detail.course.transform",
+    { "catalog.detail.kind": "course" },
+    () => {
+      const { sections, ...data } = course;
+      return toLoadData({
+        ...data,
+        sections: sections as unknown as CourseDetailSection[],
+      });
+    },
+  );
 }

--- a/src/features/catalog/server/teacher-page-data.ts
+++ b/src/features/catalog/server/teacher-page-data.ts
@@ -1,6 +1,7 @@
 import type { TeacherDetailSection } from "@/features/catalog/components/catalog-detail-component-types";
 import { PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT } from "@/features/catalog/server/academic-query-includes";
 import { localizedNameSelect } from "@/features/section-detail/server/section-page-name-selects";
+import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import { getPrisma } from "@/lib/db/prisma";
 import { toLoadData } from "@/lib/load-data-utils";
 
@@ -16,54 +17,54 @@ const teacherPageSectionsSelect = {
   semester: { select: { nameCn: true } },
 } as const;
 
-export async function getTeacherPage(
-  id: number,
-  locale = "zh-cn",
-  options: { includeSections?: boolean } = {},
-) {
+export async function getTeacherPage(id: number, locale = "zh-cn") {
   const prisma = getPrisma(locale);
-  const teacher = await prisma.teacher.findUnique({
-    where: { id },
-    select: {
-      id: true,
-      ...localizedNameSelect,
-      email: true,
-      telephone: true,
-      mobile: true,
-      address: true,
-      department: {
+  const teacher = await runCloudflareTraceSpan(
+    "catalog.detail.teacher.query",
+    { "catalog.detail.kind": "teacher" },
+    () =>
+      prisma.teacher.findUnique({
+        where: { id },
         select: {
+          id: true,
           ...localizedNameSelect,
-        },
-      },
-      teacherTitle: {
-        select: {
-          ...localizedNameSelect,
-        },
-      },
-      _count: { select: { sections: true } },
-      sections:
-        options.includeSections === false
-          ? false
-          : {
-              orderBy: [
-                { semester: { jwId: "desc" } },
-                { course: { nameCn: "asc" } },
-              ],
-              take: PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
-              select: teacherPageSectionsSelect,
+          email: true,
+          telephone: true,
+          mobile: true,
+          address: true,
+          department: {
+            select: {
+              ...localizedNameSelect,
             },
-    },
-  });
+          },
+          teacherTitle: {
+            select: {
+              ...localizedNameSelect,
+            },
+          },
+          sections: {
+            orderBy: [
+              { semester: { jwId: "desc" } },
+              { course: { nameCn: "asc" } },
+            ],
+            take: PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
+            select: teacherPageSectionsSelect,
+          },
+        },
+      }),
+  );
 
   if (!teacher) return null;
 
-  const { _count, sections, ...data } = teacher;
-  return toLoadData({
-    ...data,
-    sectionCount: _count.sections,
-    sections: (options.includeSections === false
-      ? []
-      : sections) as unknown as TeacherDetailSection[],
-  });
+  return runCloudflareTraceSpan(
+    "catalog.detail.teacher.transform",
+    { "catalog.detail.kind": "teacher" },
+    () => {
+      const { sections, ...data } = teacher;
+      return toLoadData({
+        ...data,
+        sections: sections as unknown as TeacherDetailSection[],
+      });
+    },
+  );
 }

--- a/src/features/section-detail/server/section-detail-page-server.ts
+++ b/src/features/section-detail/server/section-detail-page-server.ts
@@ -50,22 +50,23 @@ async function loadSectionDetailPageData({
   const focusedHomeworkId = url.searchParams.get("homeworkId");
   const shouldLoadHomework = Boolean(userId) || focusedHomeworkId != null;
   const subscriptionStatePromise = userId
-    ? import("@/features/subscriptions/server/subscriptions").then(
-        ({ getUserSectionSubscriptionState }) =>
-          getUserSectionSubscriptionState(userId),
+    ? runCloudflareTraceSpan(
+        "catalog.detail.section.subscription",
+        {
+          "catalog.detail.kind": "section",
+          "user.authenticated": true,
+        },
+        async () =>
+          (
+            await import("@/features/subscriptions/server/subscriptions")
+          ).getUserSectionSubscriptionStateForSection(userId, jwId),
       )
     : Promise.resolve(null);
   const [pageData, viewer, subscriptionState] = await Promise.all([
     runCloudflareTraceSpan(
       "catalog.detail.core",
       { "catalog.detail.kind": "section" },
-      () =>
-        getSectionPage(jwId, locals.locale, {
-          includeExams: true,
-          includeRelated: true,
-          includeSchedules: true,
-          includeTeacherDepartments: true,
-        }),
+      () => getSectionPage(jwId, locals.locale),
     ),
     runCloudflareTraceSpan(
       "catalog.detail.viewer",
@@ -73,7 +74,7 @@ async function loadSectionDetailPageData({
         "catalog.detail.kind": "section",
         "user.authenticated": Boolean(userId),
       },
-      () => getViewerContext({ userId }),
+      () => getViewerContext({ includeAdmin: true, userId }),
     ),
     subscriptionStatePromise,
   ]);
@@ -82,9 +83,17 @@ async function loadSectionDetailPageData({
   const copy = getSectionDetailPageCopy(locals.locale);
   const courseName = primaryName(section.course) || section.code;
   const homeworkData = shouldLoadHomework
-    ? await (
-        await import("./section-detail-homework-data")
-      ).getSectionHomeworkData(section.id, userId)
+    ? await runCloudflareTraceSpan(
+        "catalog.detail.section.homework",
+        {
+          "catalog.detail.kind": "section",
+          "user.authenticated": Boolean(userId),
+        },
+        async () =>
+          (
+            await import("./section-detail-homework-data")
+          ).getSectionHomeworkData(section.id, userId),
+      )
     : {
         auditLogs: [],
         homeworks: [],
@@ -157,9 +166,7 @@ async function loadSectionDetailPageData({
     ),
     viewer: {
       signedIn: Boolean(userId),
-      isSubscribed: Boolean(
-        subscriptionState?.subscribedSections.includes(section.id),
-      ),
+      isSubscribed: subscriptionState?.isSubscribed ?? false,
       subscriptionIcsUrl: subscriptionState?.subscriptionIcsUrl ?? null,
     },
   };

--- a/src/features/section-detail/server/section-page-data.ts
+++ b/src/features/section-detail/server/section-page-data.ts
@@ -5,108 +5,90 @@ import {
   sectionPageDescriptionSelect,
   sectionPageRelatedSectionSelect,
   sectionPageSelect,
-  sectionPageTeachersSelect,
   sectionPageTeachersWithDepartmentSelect,
 } from "@/features/section-detail/server/section-page-shape";
 import type { Prisma } from "@/generated/prisma/client";
+import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import { getPrisma } from "@/lib/db/prisma";
 
 type SectionPageRecord = Prisma.SectionGetPayload<{
   select: typeof sectionPageSelect;
 }>;
 
-type RelatedSectionRecord = Prisma.SectionGetPayload<{
-  select: typeof sectionPageRelatedSectionSelect;
-}>;
-
-export async function getSectionPage(
-  jwId: number,
-  locale = "zh-cn",
-  options: {
-    includeExams?: boolean;
-    includeRelated?: boolean;
-    includeSchedules?: boolean;
-    includeTeacherDepartments?: boolean;
-  } = {},
-) {
+export async function getSectionPage(jwId: number, locale = "zh-cn") {
   const prisma = getPrisma(locale);
-  const teachersSelect =
-    options.includeTeacherDepartments === true
-      ? sectionPageTeachersWithDepartmentSelect
-      : sectionPageTeachersSelect;
   const relatedWhere = {
     jwId: { not: jwId },
     retiredAt: null,
   } as const;
-  const section = await prisma.section.findUnique({
-    where: { jwId },
-    select: {
-      ...sectionPageSelect,
-      course: {
+  const section = await runCloudflareTraceSpan(
+    "catalog.detail.section.query",
+    { "catalog.detail.kind": "section" },
+    () =>
+      prisma.section.findUnique({
+        where: { jwId },
         select: {
-          ...sectionPageSelect.course.select,
-          ...(options.includeRelated === false
-            ? {}
-            : {
-                _count: { select: { sections: { where: relatedWhere } } },
-                sections: {
-                  where: relatedWhere,
-                  orderBy: [
-                    { semester: { jwId: "desc" as const } },
-                    { code: "asc" as const },
-                  ],
-                  take: SECTION_RELATED_PREVIEW_LIMIT,
-                  select: sectionPageRelatedSectionSelect,
-                },
-              }),
+          ...sectionPageSelect,
+          course: {
+            select: {
+              ...sectionPageSelect.course.select,
+              _count: { select: { sections: { where: relatedWhere } } },
+              sections: {
+                where: relatedWhere,
+                orderBy: [
+                  { semester: { jwId: "desc" as const } },
+                  { code: "asc" as const },
+                ],
+                take: SECTION_RELATED_PREVIEW_LIMIT,
+                select: sectionPageRelatedSectionSelect,
+              },
+            },
+          },
+          description: { select: sectionPageDescriptionSelect },
+          teachers: sectionPageTeachersWithDepartmentSelect,
+          exams: sectionPageSelect.exams,
+          schedules: sectionPageSelect.schedules,
         },
-      },
-      description: { select: sectionPageDescriptionSelect },
-      teachers: teachersSelect,
-      _count: { select: { exams: true, schedules: true } },
-      exams: options.includeExams === false ? false : sectionPageSelect.exams,
-      schedules:
-        options.includeSchedules === false
-          ? false
-          : sectionPageSelect.schedules,
-    },
-  });
+      }),
+  );
 
   if (!section) return null;
 
-  const {
-    _count,
-    course: courseRecord,
-    description,
-    exams,
-    schedules,
-    ...data
-  } = section;
-  const {
-    _count: relatedCount,
-    sections: relatedSections,
-    ...course
-  } = courseRecord as typeof courseRecord & {
-    _count?: { sections: number };
-    sections?: RelatedSectionRecord[];
-  };
-  const normalizedSection = {
-    ...data,
-    course,
-    examCount: _count.exams,
-    exams: options.includeExams === false ? [] : exams,
-    scheduleCount: _count.schedules,
-    schedules: options.includeSchedules === false ? [] : schedules,
-  } as unknown as SectionPageRecord & {
-    examCount: number;
-    scheduleCount: number;
-  };
+  return runCloudflareTraceSpan(
+    "catalog.detail.section.transform",
+    { "catalog.detail.kind": "section" },
+    () => {
+      const {
+        course: courseRecord,
+        description,
+        exams,
+        schedules,
+        ...data
+      } = section;
+      const {
+        _count: relatedCount,
+        sections: relatedSections,
+        ...course
+      } = courseRecord;
+      const normalizedSection = {
+        ...data,
+        course,
+        examCount: exams.length,
+        exams,
+        scheduleCount: schedules.length,
+        schedules,
+      } as unknown as SectionPageRecord & {
+        examCount: number;
+        scheduleCount: number;
+      };
 
-  return {
-    description: serializeDescriptionRecord(description),
-    section: buildSectionPageLoadData(normalizedSection, {
-      otherCourseSectionCount: relatedCount?.sections ?? 0,
-      otherCourseSections: relatedSections ?? [],
-    }),
-  };
+      return {
+        description: serializeDescriptionRecord(description),
+        section: buildSectionPageLoadData(normalizedSection, {
+          otherCourseSectionCount: relatedCount.sections,
+          otherCourseSections: relatedSections,
+        }),
+      };
+    },
+  );
 }

--- a/src/features/section-detail/server/section-page-select.ts
+++ b/src/features/section-detail/server/section-page-select.ts
@@ -64,7 +64,6 @@ export const sectionPageSelect = {
   periodsPerWeek: true,
   stdCount: true,
   limitCount: true,
-  dateTimePlaceText: true,
   scheduleRemark: true,
   remark: true,
   courseId: true,

--- a/src/features/subscriptions/server/subscription-calendar-read-model.ts
+++ b/src/features/subscriptions/server/subscription-calendar-read-model.ts
@@ -34,6 +34,36 @@ export async function getUserSectionSubscriptionState(
   };
 }
 
+export async function getUserSectionSubscriptionStateForSection(
+  userId: string,
+  sectionJwId: number,
+) {
+  const user = await withUserDbContext(userId, (tx) =>
+    tx.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        calendarFeedToken: true,
+        sectionSubscriptions: {
+          where: { section: { jwId: sectionJwId } },
+          select: { sectionId: true },
+          take: 1,
+        },
+      },
+    }),
+  );
+  if (!user) return null;
+
+  return {
+    userId: user.id,
+    subscriptionIcsUrl: await buildCalendarFeedPath(
+      user.id,
+      user.calendarFeedToken,
+    ),
+    isSubscribed: user.sectionSubscriptions.length > 0,
+  };
+}
+
 export async function getUserCalendarSubscription(
   userId: string,
   locale: AppLocale = DEFAULT_LOCALE,

--- a/src/features/subscriptions/server/subscription-read-model.ts
+++ b/src/features/subscriptions/server/subscription-read-model.ts
@@ -2,6 +2,7 @@ export {
   getCalendarSubscriptionUrl,
   getUserCalendarSubscription,
   getUserSectionSubscriptionState,
+  getUserSectionSubscriptionStateForSection,
 } from "./subscription-calendar-read-model";
 export { listSubscribedDashboardSections } from "./subscription-dashboard-section-read-model";
 export { listSubscribedHomeworkPage } from "./subscription-homework-page";

--- a/src/features/subscriptions/server/subscriptions.ts
+++ b/src/features/subscriptions/server/subscriptions.ts
@@ -1,6 +1,7 @@
 export {
   getUserCalendarSubscription,
   getUserSectionSubscriptionState,
+  getUserSectionSubscriptionStateForSection,
 } from "./subscription-read-model";
 export { resolveCalendarSubscriptionSections } from "./subscription-section-resolver";
 export {

--- a/tests/unit/catalog-detail-page-data.test.ts
+++ b/tests/unit/catalog-detail-page-data.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runWithCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
 
 const { courseFindManyMock, courseFindUniqueMock, teacherFindUniqueMock } =
   vi.hoisted(() => ({
@@ -24,7 +25,6 @@ describe("catalog detail page data", () => {
 
   it("loads a course without unused comment queries", async () => {
     const course = {
-      _count: { sections: 3 },
       code: "MATH1001",
       id: 11,
       jwId: 101,
@@ -35,15 +35,12 @@ describe("catalog detail page data", () => {
     const { getCoursePage } = await import(
       "@/features/catalog/server/course-page-data"
     );
-    const result = await getCoursePage(course.jwId, "zh-cn", {
-      includeSections: false,
-    });
+    const result = await getCoursePage(course.jwId, "zh-cn");
 
     expect(result).toEqual({
       code: course.code,
       id: course.id,
       jwId: course.jwId,
-      sectionCount: 3,
       sections: [],
     });
     expect(courseFindUniqueMock).toHaveBeenCalledTimes(1);
@@ -52,14 +49,14 @@ describe("catalog detail page data", () => {
     );
     const courseSelect = courseFindUniqueMock.mock.calls[0]?.[0]?.select;
     expect(courseSelect).not.toHaveProperty("description");
-    expect(courseSelect?.sections).toBe(false);
+    expect(courseSelect).not.toHaveProperty("_count");
+    expect(courseSelect?.sections?.take).toBe(20);
     expect(result).not.toHaveProperty("commentCount");
     expect(result).not.toHaveProperty("latestComments");
   });
 
   it("loads a teacher without unused comment queries", async () => {
     const teacher = {
-      _count: { sections: 2 },
       id: 21,
       namePrimary: "Ada",
       sections: [],
@@ -69,19 +66,17 @@ describe("catalog detail page data", () => {
     const { getTeacherPage } = await import(
       "@/features/catalog/server/teacher-page-data"
     );
-    const result = await getTeacherPage(teacher.id, "zh-cn", {
-      includeSections: false,
-    });
+    const result = await getTeacherPage(teacher.id, "zh-cn");
 
     expect(result).toEqual({
       id: teacher.id,
       namePrimary: teacher.namePrimary,
-      sectionCount: 2,
       sections: [],
     });
     const teacherSelect = teacherFindUniqueMock.mock.calls[0]?.[0]?.select;
     expect(teacherSelect).not.toHaveProperty("description");
-    expect(teacherSelect?.sections).toBe(false);
+    expect(teacherSelect).not.toHaveProperty("_count");
+    expect(teacherSelect?.sections?.take).toBe(20);
     expect(result).not.toHaveProperty("commentCount");
     expect(result).not.toHaveProperty("latestComments");
   });
@@ -90,7 +85,6 @@ describe("catalog detail page data", () => {
     const localizedNameSymbol = Symbol("localizedName");
     const courseSections = [{ code: "001", jwId: 301 }];
     courseFindUniqueMock.mockResolvedValue({
-      _count: { sections: 1 },
       id: 11,
       jwId: 101,
       [localizedNameSymbol]: "course",
@@ -98,7 +92,6 @@ describe("catalog detail page data", () => {
     });
     const teacherSections = [{ code: "002", jwId: 302 }];
     teacherFindUniqueMock.mockResolvedValue({
-      _count: { sections: 1 },
       id: 21,
       [localizedNameSymbol]: "teacher",
       sections: teacherSections,
@@ -127,5 +120,77 @@ describe("catalog detail page data", () => {
     expect(Reflect.ownKeys(teacherResult ?? {})).not.toContain(
       localizedNameSymbol,
     );
+  });
+
+  it("traces bounded course and teacher query phases", async () => {
+    courseFindUniqueMock.mockResolvedValue({
+      id: 11,
+      jwId: 101,
+      sections: [],
+    });
+    teacherFindUniqueMock.mockResolvedValue({ id: 21, sections: [] });
+    const [{ getCoursePage }, { getTeacherPage }] = await Promise.all([
+      import("@/features/catalog/server/course-page-data"),
+      import("@/features/catalog/server/teacher-page-data"),
+    ]);
+    const spans: Array<{
+      attributes: Record<string, boolean | number | string | undefined>;
+      name: string;
+    }> = [];
+
+    await runWithCloudflareRuntimeEnv(
+      {},
+      async () => {
+        await getCoursePage(101);
+        await getTeacherPage(21);
+      },
+      {
+        tracing: {
+          enterSpan<T>(
+            name: string,
+            callback: (span: {
+              isTraced: boolean;
+              setAttribute(
+                key: string,
+                value?: boolean | number | string,
+              ): void;
+            }) => T,
+          ) {
+            const attributes: Record<
+              string,
+              boolean | number | string | undefined
+            > = {};
+            spans.push({ attributes, name });
+            return callback({
+              isTraced: true,
+              setAttribute(key, value) {
+                attributes[key] = value;
+              },
+            });
+          },
+        },
+      },
+    );
+
+    expect(spans).toEqual([
+      {
+        attributes: { "catalog.detail.kind": "course" },
+        name: "catalog.detail.course.query",
+      },
+      {
+        attributes: { "catalog.detail.kind": "course" },
+        name: "catalog.detail.course.transform",
+      },
+      {
+        attributes: { "catalog.detail.kind": "teacher" },
+        name: "catalog.detail.teacher.query",
+      },
+      {
+        attributes: { "catalog.detail.kind": "teacher" },
+        name: "catalog.detail.teacher.transform",
+      },
+    ]);
+    expect(JSON.stringify(spans)).not.toContain("101");
+    expect(JSON.stringify(spans)).not.toContain("21");
   });
 });

--- a/tests/unit/detail-page-loader-critical-path.test.ts
+++ b/tests/unit/detail-page-loader-critical-path.test.ts
@@ -11,7 +11,7 @@ const {
   getSectionHomeworkDataMock,
   getSectionPageMock,
   getTeacherPageMock,
-  getUserSectionSubscriptionStateMock,
+  getUserSectionSubscriptionStateForSectionMock,
   getViewerContextMock,
   withSectionPageRelatedDataMock,
 } = vi.hoisted(() => ({
@@ -22,7 +22,7 @@ const {
   getSectionHomeworkDataMock: vi.fn(),
   getSectionPageMock: vi.fn(),
   getTeacherPageMock: vi.fn(),
-  getUserSectionSubscriptionStateMock: vi.fn(),
+  getUserSectionSubscriptionStateForSectionMock: vi.fn(),
   getViewerContextMock: vi.fn(),
   withSectionPageRelatedDataMock: vi.fn(),
 }));
@@ -66,7 +66,8 @@ vi.mock(
 );
 
 vi.mock("@/features/subscriptions/server/subscriptions", () => ({
-  getUserSectionSubscriptionState: getUserSectionSubscriptionStateMock,
+  getUserSectionSubscriptionStateForSection:
+    getUserSectionSubscriptionStateForSectionMock,
 }));
 
 vi.mock("@/lib/auth/viewer-context", () => ({
@@ -192,8 +193,8 @@ beforeEach(() => {
     section,
   });
   getTeacherPageMock.mockResolvedValue(teacher);
-  getUserSectionSubscriptionStateMock.mockResolvedValue({
-    subscribedSections: [],
+  getUserSectionSubscriptionStateForSectionMock.mockResolvedValue({
+    isSubscribed: false,
     subscriptionIcsUrl: null,
   });
   getViewerContextMock.mockResolvedValue(anonymousViewer);
@@ -362,9 +363,7 @@ describe("catalog detail loader critical path", () => {
     });
 
     expect(getCoursePageMock).toHaveBeenCalledTimes(2);
-    expect(getCoursePageMock).toHaveBeenCalledWith(course.jwId, "en-us", {
-      includeSections: true,
-    });
+    expect(getCoursePageMock).toHaveBeenCalledWith(course.jwId, "en-us");
   });
 
   it("separates public detail core entries by locale and entity", async () => {
@@ -419,9 +418,7 @@ describe("catalog detail loader critical path", () => {
     await loadSignedInWithSections();
 
     expect(getTeacherPageMock).toHaveBeenCalledTimes(4);
-    expect(getTeacherPageMock).toHaveBeenCalledWith(teacher.id, "en-us", {
-      includeSections: true,
-    });
+    expect(getTeacherPageMock).toHaveBeenCalledWith(teacher.id, "en-us");
   });
 
   it("bypasses public detail core caching for default dynamic and authenticated SSR", async () => {
@@ -602,13 +599,71 @@ describe("detail request session resolution", () => {
 
     expect(getSessionFromHeadersMock).not.toHaveBeenCalled();
     expect(getCoursePageMock).toHaveBeenCalledTimes(2);
-    expect(getCoursePageMock).toHaveBeenCalledWith(course.jwId, "en-us", {
-      includeSections: true,
-    });
+    expect(getCoursePageMock).toHaveBeenCalledWith(course.jwId, "en-us");
   });
 });
 
 describe("section detail loader critical path", () => {
+  it("traces bounded section subscription and homework phases", async () => {
+    const spans: Array<{
+      attributes: Record<string, boolean | number | string | undefined>;
+      name: string;
+    }> = [];
+    const enterSpan = <T>(
+      name: string,
+      callback: (span: {
+        isTraced: boolean;
+        setAttribute(key: string, value?: boolean | number | string): void;
+      }) => T,
+    ) => {
+      const attributes: Record<string, boolean | number | string | undefined> =
+        {};
+      spans.push({ attributes, name });
+      return callback({
+        isTraced: true,
+        setAttribute(key, value) {
+          attributes[key] = value;
+        },
+      });
+    };
+    const { loadSectionDetailPage } = await import(
+      "@/features/section-detail/server/section-detail-page-server"
+    );
+
+    await runWithCloudflareRuntimeEnv(
+      {},
+      () =>
+        loadSectionDetailPage({
+          locals: locals(signedInUser),
+          params: { jwId: String(section.jwId) },
+          request: request(`/catalog/sections/${section.jwId}`),
+          url: new URL(`https://example.test/catalog/sections/${section.jwId}`),
+        }),
+      { tracing: { enterSpan } },
+    );
+
+    expect(spans).toEqual(
+      expect.arrayContaining([
+        {
+          attributes: {
+            "catalog.detail.kind": "section",
+            "user.authenticated": true,
+          },
+          name: "catalog.detail.section.subscription",
+        },
+        {
+          attributes: {
+            "catalog.detail.kind": "section",
+            "user.authenticated": true,
+          },
+          name: "catalog.detail.section.homework",
+        },
+      ]),
+    );
+    expect(JSON.stringify(spans)).not.toContain(String(section.jwId));
+    expect(JSON.stringify(spans)).not.toContain(String(section.id));
+  });
+
   it("loads section detail without public overview colo cache on stream pages", async () => {
     const match = vi.fn(async () => undefined);
     const put = vi.fn(async () => undefined);
@@ -682,7 +737,9 @@ describe("section detail loader critical path", () => {
     expect(getDescriptionPayloadMock).not.toHaveBeenCalled();
     expect(getCommentsPayloadMock).not.toHaveBeenCalled();
     expect(getSectionHomeworkDataMock).not.toHaveBeenCalled();
-    expect(getUserSectionSubscriptionStateMock).not.toHaveBeenCalled();
+    expect(
+      getUserSectionSubscriptionStateForSectionMock,
+    ).not.toHaveBeenCalled();
   });
 
   it("redirects legacy tab query params to canonical hash URLs", async () => {
@@ -729,8 +786,8 @@ describe("section detail loader critical path", () => {
   });
 
   it("retains subscription state on signed-in sections because the fixed header consumes it", async () => {
-    getUserSectionSubscriptionStateMock.mockResolvedValue({
-      subscribedSections: [section.id],
+    getUserSectionSubscriptionStateForSectionMock.mockResolvedValue({
+      isSubscribed: true,
       subscriptionIcsUrl: "/api/calendar-feeds/user-1.ics",
     });
     const { loadSectionDetailPage } = await import(
@@ -744,7 +801,10 @@ describe("section detail loader critical path", () => {
       url: new URL(`https://example.test/catalog/sections/${section.jwId}`),
     });
 
-    expect(getUserSectionSubscriptionStateMock).toHaveBeenCalledWith("user-1");
+    expect(getUserSectionSubscriptionStateForSectionMock).toHaveBeenCalledWith(
+      "user-1",
+      section.jwId,
+    );
     expect(result.viewer).toMatchObject({
       isSubscribed: true,
       signedIn: true,
@@ -756,6 +816,10 @@ describe("section detail loader critical path", () => {
       section.id,
       signedInUser.id,
     );
+    expect(getViewerContextMock).toHaveBeenCalledWith({
+      includeAdmin: true,
+      userId: signedInUser.id,
+    });
   });
 
   it("loads full stream section data for anonymous PublicSsr requests", async () => {
@@ -781,12 +845,7 @@ describe("section detail loader critical path", () => {
     const [first, second] = await Promise.all([load(), load()]);
 
     expect(getSectionPageMock).toHaveBeenCalledTimes(2);
-    expect(getSectionPageMock).toHaveBeenCalledWith(section.jwId, "en-us", {
-      includeExams: true,
-      includeRelated: true,
-      includeSchedules: true,
-      includeTeacherDepartments: true,
-    });
+    expect(getSectionPageMock).toHaveBeenCalledWith(section.jwId, "en-us");
     expect(withSectionPageRelatedDataMock).not.toHaveBeenCalled();
     expect(first.section).toBe(relatedSection);
     expect(second.section).toBe(relatedSection);
@@ -811,11 +870,6 @@ describe("section detail loader critical path", () => {
     });
 
     expect(getSectionPageMock).toHaveBeenCalledTimes(2);
-    expect(getSectionPageMock).toHaveBeenCalledWith(section.jwId, "en-us", {
-      includeExams: true,
-      includeRelated: true,
-      includeSchedules: true,
-      includeTeacherDepartments: true,
-    });
+    expect(getSectionPageMock).toHaveBeenCalledWith(section.jwId, "en-us");
   });
 });

--- a/tests/unit/section-page-data-selection.test.ts
+++ b/tests/unit/section-page-data-selection.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runWithCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
 
 const { sectionFindUnique } = vi.hoisted(() => ({
   sectionFindUnique: vi.fn(),
@@ -12,7 +13,6 @@ vi.mock("@/lib/db/prisma", () => ({
 
 function sectionRecord() {
   return {
-    _count: { exams: 4, schedules: 18 },
     course: {
       _count: { sections: 42 },
       id: 10,
@@ -59,12 +59,40 @@ describe("section page data selection", () => {
       "@/features/section-detail/server/section-page-data"
     );
 
-    const result = await getSectionPage(30, "zh-cn", {
-      includeExams: true,
-      includeRelated: true,
-      includeSchedules: true,
-      includeTeacherDepartments: true,
-    });
+    const spans: Array<{
+      attributes: Record<string, boolean | number | string | undefined>;
+      name: string;
+    }> = [];
+    const result = await runWithCloudflareRuntimeEnv(
+      {},
+      () => getSectionPage(30, "zh-cn"),
+      {
+        tracing: {
+          enterSpan<T>(
+            name: string,
+            callback: (span: {
+              isTraced: boolean;
+              setAttribute(
+                key: string,
+                value?: boolean | number | string,
+              ): void;
+            }) => T,
+          ) {
+            const attributes: Record<
+              string,
+              boolean | number | string | undefined
+            > = {};
+            spans.push({ attributes, name });
+            return callback({
+              isTraced: true,
+              setAttribute(key, value) {
+                attributes[key] = value;
+              },
+            });
+          },
+        },
+      },
+    );
 
     expect(sectionFindUnique).toHaveBeenCalledOnce();
     const select = sectionFindUnique.mock.calls[0]?.[0]?.select;
@@ -82,15 +110,29 @@ describe("section page data selection", () => {
         },
       },
     });
+    expect(select).not.toHaveProperty("_count");
+    expect(select).not.toHaveProperty("dateTimePlaceText");
+    expect(select.teachers.select.department).toBeDefined();
+    expect(spans).toEqual([
+      {
+        attributes: { "catalog.detail.kind": "section" },
+        name: "catalog.detail.section.query",
+      },
+      {
+        attributes: { "catalog.detail.kind": "section" },
+        name: "catalog.detail.section.transform",
+      },
+    ]);
+    expect(JSON.stringify(spans)).not.toContain("30");
     expect(result).toMatchObject({
       description: {
         content: "Section description",
         id: "description-1",
       },
       section: {
-        examCount: 4,
+        examCount: 0,
         otherCourseSectionCount: 42,
-        scheduleCount: 18,
+        scheduleCount: 0,
       },
     });
     expect(result?.section.otherCourseSections).toEqual([
@@ -120,7 +162,7 @@ describe("section page data selection", () => {
             "namePrimary": "Calculus",
           },
           "courseId": 10,
-          "examCount": 4,
+          "examCount": 0,
           "exams": [],
           "id": 20,
           "otherCourseSectionCount": 42,
@@ -138,83 +180,12 @@ describe("section page data selection", () => {
               "teachers": [],
             },
           ],
-          "scheduleCount": 18,
+          "scheduleCount": 0,
           "schedules": [],
           "teachers": [],
         },
       }
     `);
-  });
-
-  it("skips tab-only relations while preserving navigation counts", async () => {
-    sectionFindUnique.mockResolvedValue({
-      ...sectionRecord(),
-      course: { id: 10, jwId: 100, namePrimary: "Calculus" },
-    });
-    const { getSectionPage } = await import(
-      "@/features/section-detail/server/section-page-data"
-    );
-
-    const result = await getSectionPage(30, "zh-cn", {
-      includeExams: false,
-      includeRelated: false,
-      includeSchedules: false,
-    });
-
-    const select = sectionFindUnique.mock.calls[0]?.[0]?.select;
-    expect(select.exams).toBe(false);
-    expect(select.schedules).toBe(false);
-    expect(select.course.select).not.toHaveProperty("sections");
-    expect(select.teachers).toEqual({
-      select: {
-        id: true,
-        nameCn: true,
-        nameEn: true,
-        namePrimary: true,
-        nameSecondary: true,
-      },
-    });
-    expect(result?.section).toMatchObject({
-      examCount: 4,
-      exams: [],
-      otherCourseSectionCount: 0,
-      otherCourseSections: [],
-      scheduleCount: 18,
-      schedules: [],
-    });
-  });
-
-  it("loads teacher departments only when requested", async () => {
-    sectionFindUnique.mockResolvedValue({
-      ...sectionRecord(),
-      course: { id: 10, jwId: 100, namePrimary: "Calculus" },
-    });
-    const { getSectionPage } = await import(
-      "@/features/section-detail/server/section-page-data"
-    );
-
-    await getSectionPage(30, "zh-cn", {
-      includeRelated: false,
-      includeTeacherDepartments: true,
-    });
-
-    expect(sectionFindUnique.mock.calls[0]?.[0]?.select.teachers).toEqual({
-      select: {
-        id: true,
-        nameCn: true,
-        nameEn: true,
-        namePrimary: true,
-        nameSecondary: true,
-        department: {
-          select: {
-            nameCn: true,
-            nameEn: true,
-            namePrimary: true,
-            nameSecondary: true,
-          },
-        },
-      },
-    });
   });
 
   it("returns JSON-clean page data", async () => {

--- a/tests/unit/section-subscription-state.test.ts
+++ b/tests/unit/section-subscription-state.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { userFindUniqueMock, withUserDbContextMock } = vi.hoisted(() => {
+  const userFindUnique = vi.fn();
+  return {
+    userFindUniqueMock: userFindUnique,
+    withUserDbContextMock: vi.fn(async (_userId, action) =>
+      action({ user: { findUnique: userFindUnique } }),
+    ),
+  };
+});
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {},
+  withUserDbContext: withUserDbContextMock,
+}));
+
+describe("section subscription state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    userFindUniqueMock.mockResolvedValue({
+      calendarFeedToken: "calendar-token",
+      id: "user-1",
+      sectionSubscriptions: [{ sectionId: 42 }],
+    });
+  });
+
+  it("loads only the current section subscription", async () => {
+    const { getUserSectionSubscriptionStateForSection } = await import(
+      "@/features/subscriptions/server/subscription-calendar-read-model"
+    );
+
+    const result = await getUserSectionSubscriptionStateForSection(
+      "user-1",
+      301,
+    );
+
+    expect(withUserDbContextMock).toHaveBeenCalledWith(
+      "user-1",
+      expect.any(Function),
+    );
+    expect(userFindUniqueMock).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      select: {
+        id: true,
+        calendarFeedToken: true,
+        sectionSubscriptions: {
+          where: { section: { jwId: 301 } },
+          select: { sectionId: true },
+          take: 1,
+        },
+      },
+    });
+    expect(result).toEqual({
+      isSubscribed: true,
+      subscriptionIcsUrl: "/api/calendar-feeds/user-1:calendar-token.ics",
+      userId: "user-1",
+    });
+  });
+
+  it("returns an unsubscribed state when the current section is absent", async () => {
+    userFindUniqueMock.mockResolvedValue({
+      calendarFeedToken: "calendar-token",
+      id: "user-1",
+      sectionSubscriptions: [],
+    });
+    const { getUserSectionSubscriptionStateForSection } = await import(
+      "@/features/subscriptions/server/subscription-calendar-read-model"
+    );
+
+    await expect(
+      getUserSectionSubscriptionStateForSection("user-1", 301),
+    ).resolves.toMatchObject({ isSubscribed: false });
+  });
+
+  it("returns null when the user no longer exists", async () => {
+    userFindUniqueMock.mockResolvedValue(null);
+    const { getUserSectionSubscriptionStateForSection } = await import(
+      "@/features/subscriptions/server/subscription-calendar-read-model"
+    );
+
+    await expect(
+      getUserSectionSubscriptionStateForSection("user-1", 301),
+    ).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add low-cardinality query/transform spans for course, teacher, and section detail cores plus section subscription/homework spans
- remove unused course/teacher section aggregations and redundant section exam/schedule counts
- narrow section subscription state to the current section and reuse the admin-aware viewer context for homework
- remove the unused section dateTimePlaceText payload

## Validation
- bunx wrangler types --include-runtime=false --check
- bunx biome check (repository has 7 pre-existing warnings)
- bunx svelte-check --tsconfig ./tsconfig.json (0 errors; 13 pre-existing warnings)
- bunx tsc --noEmit -p tsconfig.typecheck.json
- bunx tsc --noEmit -p tsconfig.typecheck.tests.json
- bunx tsc --noEmit -p tsconfig.typecheck.operational.json
- bunx vitest run (354 files, 2125 tests)
- bun run openapi:check
- bunx vitest run tests/unit/graphql-schema-snapshot.test.ts
- bun run build

No active prewarming is added.