### PR TITLE
fix(observability): await catalog detail query spans

### DIFF
--- a/src/features/catalog/server/course-page-data.ts
+++ b/src/features/catalog/server/course-page-data.ts
@@ -28,8 +28,8 @@ export async function getCoursePage(jwId: number, locale = "zh-cn") {
   const course = await runCloudflareTraceSpan(
     "catalog.detail.course.query",
     { "catalog.detail.kind": "course" },
-    () =>
-      prisma.course.findUnique({
+    async () =>
+      await prisma.course.findUnique({
         where: { jwId },
         select: {
           id: true,

--- a/src/features/catalog/server/teacher-page-data.ts
+++ b/src/features/catalog/server/teacher-page-data.ts
@@ -22,8 +22,8 @@ export async function getTeacherPage(id: number, locale = "zh-cn") {
   const teacher = await runCloudflareTraceSpan(
     "catalog.detail.teacher.query",
     { "catalog.detail.kind": "teacher" },
-    () =>
-      prisma.teacher.findUnique({
+    async () =>
+      await prisma.teacher.findUnique({
         where: { id },
         select: {
           id: true,

--- a/src/features/section-detail/server/section-page-data.ts
+++ b/src/features/section-detail/server/section-page-data.ts
@@ -24,8 +24,8 @@ export async function getSectionPage(jwId: number, locale = "zh-cn") {
   const section = await runCloudflareTraceSpan(
     "catalog.detail.section.query",
     { "catalog.detail.kind": "section" },
-    () =>
-      prisma.section.findUnique({
+    async () =>
+      await prisma.section.findUnique({
         where: { jwId },
         select: {
           ...sectionPageSelect,

--- a/tests/unit/catalog-detail-page-data.test.ts
+++ b/tests/unit/catalog-detail-page-data.test.ts
@@ -18,6 +18,15 @@ vi.mock("@/lib/db/prisma", () => ({
   }),
 }));
 
+function prismaThenable<T>(value: T): PromiseLike<T> {
+  return {
+    // biome-ignore lint/suspicious/noThenProperty: Prisma queries intentionally return thenables.
+    then(onfulfilled, onrejected) {
+      return Promise.resolve(value).then(onfulfilled, onrejected);
+    },
+  };
+}
+
 describe("catalog detail page data", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -123,12 +132,16 @@ describe("catalog detail page data", () => {
   });
 
   it("traces bounded course and teacher query phases", async () => {
-    courseFindUniqueMock.mockResolvedValue({
-      id: 11,
-      jwId: 101,
-      sections: [],
-    });
-    teacherFindUniqueMock.mockResolvedValue({ id: 21, sections: [] });
+    courseFindUniqueMock.mockReturnValue(
+      prismaThenable({
+        id: 11,
+        jwId: 101,
+        sections: [],
+      }),
+    );
+    teacherFindUniqueMock.mockReturnValue(
+      prismaThenable({ id: 21, sections: [] }),
+    );
     const [{ getCoursePage }, { getTeacherPage }] = await Promise.all([
       import("@/features/catalog/server/course-page-data"),
       import("@/features/catalog/server/teacher-page-data"),
@@ -137,6 +150,7 @@ describe("catalog detail page data", () => {
       attributes: Record<string, boolean | number | string | undefined>;
       name: string;
     }> = [];
+    const nativePromiseSpans: string[] = [];
 
     await runWithCloudflareRuntimeEnv(
       {},
@@ -161,12 +175,14 @@ describe("catalog detail page data", () => {
               boolean | number | string | undefined
             > = {};
             spans.push({ attributes, name });
-            return callback({
+            const result = callback({
               isTraced: true,
               setAttribute(key, value) {
                 attributes[key] = value;
               },
             });
+            if (result instanceof Promise) nativePromiseSpans.push(name);
+            return result;
           },
         },
       },
@@ -192,5 +208,9 @@ describe("catalog detail page data", () => {
     ]);
     expect(JSON.stringify(spans)).not.toContain("101");
     expect(JSON.stringify(spans)).not.toContain("21");
+    expect(nativePromiseSpans).toEqual([
+      "catalog.detail.course.query",
+      "catalog.detail.teacher.query",
+    ]);
   });
 });

--- a/tests/unit/section-page-data-selection.test.ts
+++ b/tests/unit/section-page-data-selection.test.ts
@@ -11,6 +11,15 @@ vi.mock("@/lib/db/prisma", () => ({
   }),
 }));
 
+function prismaThenable<T>(value: T): PromiseLike<T> {
+  return {
+    // biome-ignore lint/suspicious/noThenProperty: Prisma queries intentionally return thenables.
+    then(onfulfilled, onrejected) {
+      return Promise.resolve(value).then(onfulfilled, onrejected);
+    },
+  };
+}
+
 function sectionRecord() {
   return {
     course: {
@@ -55,6 +64,7 @@ describe("section page data selection", () => {
   });
 
   it("loads the stream page in one Prisma call with bounded related rows and description", async () => {
+    sectionFindUnique.mockReturnValue(prismaThenable(sectionRecord()));
     const { getSectionPage } = await import(
       "@/features/section-detail/server/section-page-data"
     );
@@ -63,6 +73,7 @@ describe("section page data selection", () => {
       attributes: Record<string, boolean | number | string | undefined>;
       name: string;
     }> = [];
+    const nativePromiseSpans: string[] = [];
     const result = await runWithCloudflareRuntimeEnv(
       {},
       () => getSectionPage(30, "zh-cn"),
@@ -83,12 +94,14 @@ describe("section page data selection", () => {
               boolean | number | string | undefined
             > = {};
             spans.push({ attributes, name });
-            return callback({
+            const spanResult = callback({
               isTraced: true,
               setAttribute(key, value) {
                 attributes[key] = value;
               },
             });
+            if (spanResult instanceof Promise) nativePromiseSpans.push(name);
+            return spanResult;
           },
         },
       },
@@ -124,6 +137,7 @@ describe("section page data selection", () => {
       },
     ]);
     expect(JSON.stringify(spans)).not.toContain("30");
+    expect(nativePromiseSpans).toEqual(["catalog.detail.section.query"]);
     expect(result).toMatchObject({
       description: {
         content: "Section description",


### PR DESCRIPTION
## Summary
- await Prisma thenables inside catalog detail query spans so Cloudflare receives a native Promise
- keep query spans open until database work actually settles
- add regression coverage using non-native PromiseLike Prisma mocks

## Production evidence
After #842 deployed, the new child-span query showed the query spans but reported 0 ms durations. Prisma returns PrismaPromise thenables, while the tracing callback lifecycle requires an actual asynchronous callback result. This patch explicitly assimilates each thenable through `async`/`await`.

## Validation
- `bunx vitest run` (354 files, 2128 tests)
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/life_ustc_dev bun run build`
- Biome on changed files
- `git diff --check`

No active or periodic prewarming is introduced.