### PR TITLE
fix(auth): adapt CIMD redirects for Workers

### DIFF
--- a/src/lib/auth/cimd-fetch-policy.ts
+++ b/src/lib/auth/cimd-fetch-policy.ts
@@ -52,9 +52,15 @@ export async function allowCimdMetadataFetch(url: string) {
  * Cloudflare's `global_fetch_strictly_public` compatibility flag enforces the
  * resolve-once, public-address-only network boundary required by CIMD. Keeping
  * the transport in application code also prevents the auth package from
- * selecting a non-Worker fetch implementation.
+ * selecting a non-Worker fetch implementation. Workers do not implement
+ * `redirect: "error"`, so use `manual`; CIMD still rejects every non-200
+ * response before reading metadata.
  */
 export const fetchCimdMetadataResource: ClientMetadataResourceFetch = (
   url,
   init,
-) => fetch(url, init);
+) =>
+  fetch(
+    url,
+    init?.redirect === "error" ? { ...init, redirect: "manual" } : init,
+  );

--- a/tests/unit/cimd-fetch-policy.test.ts
+++ b/tests/unit/cimd-fetch-policy.test.ts
@@ -1,6 +1,9 @@
 import { resolve4, resolve6 } from "node:dns/promises";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { allowCimdMetadataFetch } from "@/lib/auth/cimd-fetch-policy";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  allowCimdMetadataFetch,
+  fetchCimdMetadataResource,
+} from "@/lib/auth/cimd-fetch-policy";
 
 vi.mock("node:dns/promises", () => ({
   resolve4: vi.fn(),
@@ -14,6 +17,34 @@ describe("CIMD metadata fetch policy", () => {
   beforeEach(() => {
     resolve4Mock.mockReset();
     resolve6Mock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("adapts redirect rejection to the mode supported by Workers", async () => {
+    const response = new Response(null, { status: 200 });
+    const fetchMock = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchMock);
+    const signal = new AbortController().signal;
+
+    await expect(
+      fetchCimdMetadataResource("https://client.example/oauth.json", {
+        headers: { accept: "application/json" },
+        redirect: "error",
+        signal,
+      }),
+    ).resolves.toBe(response);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://client.example/oauth.json",
+      {
+        headers: { accept: "application/json" },
+        redirect: "manual",
+        signal,
+      },
+    );
   });
 
   it("accepts hostnames only when every resolved address is public", async () => {


### PR DESCRIPTION
## Summary

- translate Better Auth CIMD redirect:error requests to Workers-supported redirect:manual
- preserve fail-closed redirect handling because CIMD accepts only status 200
- add a transport regression test that preserves headers and abort signals

## Validation

- bunx vitest run tests/unit/cimd-fetch-policy.test.ts tests/unit/oauth-cimd-plugin.test.ts tests/unit/wrangler-rate-limit-config.test.ts
- bunx biome check src/lib/auth/cimd-fetch-policy.ts tests/unit/cimd-fetch-policy.test.ts
- bunx tsc --noEmit -p tsconfig.typecheck.json
- bunx tsc --noEmit -p tsconfig.typecheck.tests.json
- bunx wrangler types --include-runtime=false --check
- bun run build