### PR TITLE
fix(oauth): stabilize incremental scope grants

### DIFF
--- a/src/lib/api/routes/auth-token-grant-binding.ts
+++ b/src/lib/api/routes/auth-token-grant-binding.ts
@@ -1,12 +1,14 @@
 import { decodeJwt } from "jose";
 import { jsonResponse } from "@/lib/api/helpers";
 import { authPrisma as prisma } from "@/lib/db/auth-prisma";
+import { logAppEvent } from "@/lib/log/app-logger";
 import { resolveActiveOAuthUserGrant } from "@/lib/oauth/active-user-grant";
 import { OAUTH_GRANT_ID_CLAIM } from "@/lib/oauth/constants";
 import { hashOAuthClientSecretForDbStorage } from "@/lib/oauth/utils";
 
 type UserTokenEvidence = {
   clientId: string;
+  format: "jwt" | "opaque";
   grantId?: string;
   opaqueTokenHash?: string;
   scopes: string[];
@@ -40,7 +42,25 @@ function scopesAreSubset(
   return scopes.every((scope) => allowedScopes.includes(scope));
 }
 
-function inactiveGrantResponse() {
+type GrantBindingFailureReason =
+  | "access-token-evidence-invalid"
+  | "active-grant-missing"
+  | "grant-lineage-mismatch"
+  | "jwt-grant-claim-missing"
+  | "opaque-grant-binding-missing"
+  | "opaque-grant-persistence-failed"
+  | "refresh-token-identity-mismatch"
+  | "scope-outcome-mismatch"
+  | "token-response-invalid";
+
+function inactiveGrantResponse(reason: GrantBindingFailureReason) {
+  logAppEvent("warn", "oauth.token.grant-binding-rejected", {
+    event: "oauth.token.grant-binding-rejected",
+    phase: "bind-access-token-consent",
+    reason,
+    source: "oauth",
+    status: 400,
+  });
   return jsonResponse(
     {
       error: "invalid_grant",
@@ -68,6 +88,7 @@ async function resolveAccessTokenEvidence(
       if (!clientId) return null;
       return {
         clientId,
+        format: "jwt",
         ...(typeof payload[OAUTH_GRANT_ID_CLAIM] === "string"
           ? { grantId: payload[OAUTH_GRANT_ID_CLAIM] }
           : {}),
@@ -94,6 +115,7 @@ async function resolveAccessTokenEvidence(
   if (!row.userId) return "machine";
   return {
     clientId: row.clientId,
+    format: "opaque",
     ...((row.grantId ?? row.referenceId)
       ? { grantId: row.grantId ?? row.referenceId ?? undefined }
       : {}),
@@ -123,8 +145,9 @@ async function deleteReturnedTokenRows(input: {
 
 /**
  * Require every delegated user token returned by Better Auth to inherit one
- * immutable grant generation. The inherited reference is persisted on opaque
- * rows, but an unbound response is never attached to the latest consent.
+ * immutable grant generation. JWTs carry that signed reference and are checked
+ * directly against the active grant; opaque rows persist the same reference.
+ * An unbound response is never attached to the latest consent.
  */
 export async function bindOAuthAccessTokenToConsent(
   response: Response,
@@ -135,17 +158,61 @@ export async function bindOAuthAccessTokenToConsent(
   const body = await getTokenBody(response);
   const accessToken =
     typeof body?.access_token === "string" ? body.access_token : null;
-  if (!body || !accessToken) return inactiveGrantResponse();
+  if (!body || !accessToken) {
+    return inactiveGrantResponse("token-response-invalid");
+  }
 
   const evidence = await resolveAccessTokenEvidence(accessToken);
   if (evidence === "machine") return response;
-  if (!evidence) return inactiveGrantResponse();
+  if (!evidence) {
+    return inactiveGrantResponse("access-token-evidence-invalid");
+  }
 
   const refreshToken =
     typeof body.refresh_token === "string" ? body.refresh_token : null;
   const refreshTokenHash = refreshToken
     ? await hashOAuthClientSecretForDbStorage(refreshToken)
     : undefined;
+
+  const responseScopes =
+    typeof body.scope === "string" ? tokenScopes(body.scope) : undefined;
+  if (
+    (requestedRefreshScopes &&
+      !scopesAreSubset(evidence.scopes, requestedRefreshScopes)) ||
+    (responseScopes && !scopesAreSubset(evidence.scopes, responseScopes))
+  ) {
+    await deleteReturnedTokenRows({
+      accessTokenHash: evidence.opaqueTokenHash,
+      refreshTokenHash,
+    });
+    return inactiveGrantResponse("scope-outcome-mismatch");
+  }
+
+  if (evidence.format === "jwt") {
+    if (!evidence.grantId) {
+      await deleteReturnedTokenRows({ refreshTokenHash });
+      return inactiveGrantResponse("jwt-grant-claim-missing");
+    }
+
+    const grant = await resolveActiveOAuthUserGrant({
+      clientId: evidence.clientId,
+      grantId: evidence.grantId,
+      requireGrantBinding: true,
+      scopes: evidence.scopes,
+      userId: evidence.userId,
+    });
+    if (grant) return response;
+    await deleteReturnedTokenRows({ refreshTokenHash });
+    return inactiveGrantResponse("active-grant-missing");
+  }
+
+  if (!evidence.grantId) {
+    await deleteReturnedTokenRows({
+      accessTokenHash: evidence.opaqueTokenHash,
+    });
+    return inactiveGrantResponse("opaque-grant-binding-missing");
+  }
+
   const refreshRow = refreshTokenHash
     ? await prisma.oAuthRefreshToken.findUnique({
         where: { token: refreshTokenHash },
@@ -168,49 +235,39 @@ export async function bindOAuthAccessTokenToConsent(
       accessTokenHash: evidence.opaqueTokenHash,
       refreshTokenHash,
     });
-    return inactiveGrantResponse();
+    return inactiveGrantResponse("refresh-token-identity-mismatch");
   }
 
   const refreshGrantId = refreshRow?.grantId ?? refreshRow?.referenceId;
+  if (refreshRow && (!refreshGrantId || evidence.grantId !== refreshGrantId)) {
+    await deleteReturnedTokenRows({
+      accessTokenHash: evidence.opaqueTokenHash,
+      refreshTokenHash,
+    });
+    return inactiveGrantResponse("grant-lineage-mismatch");
+  }
+
   if (
-    evidence.grantId &&
-    refreshGrantId &&
-    evidence.grantId !== refreshGrantId
+    refreshRow &&
+    (!scopesAreSubset(evidence.scopes, refreshRow.scopes) ||
+      (requestedRefreshScopes &&
+        !scopesAreSubset(refreshRow.scopes, requestedRefreshScopes)) ||
+      (responseScopes && !scopesAreSubset(refreshRow.scopes, responseScopes)))
   ) {
     await deleteReturnedTokenRows({
       accessTokenHash: evidence.opaqueTokenHash,
       refreshTokenHash,
     });
-    return inactiveGrantResponse();
+    return inactiveGrantResponse("scope-outcome-mismatch");
   }
 
-  const responseScopes =
-    typeof body.scope === "string" ? tokenScopes(body.scope) : undefined;
-  if (
-    (requestedRefreshScopes &&
-      !scopesAreSubset(evidence.scopes, requestedRefreshScopes)) ||
-    (responseScopes && !scopesAreSubset(evidence.scopes, responseScopes)) ||
-    (refreshRow &&
-      (!scopesAreSubset(evidence.scopes, refreshRow.scopes) ||
-        (requestedRefreshScopes &&
-          !scopesAreSubset(refreshRow.scopes, requestedRefreshScopes)) ||
-        (responseScopes &&
-          !scopesAreSubset(refreshRow.scopes, responseScopes))))
-  ) {
-    await deleteReturnedTokenRows({
-      accessTokenHash: evidence.opaqueTokenHash,
-      refreshTokenHash,
-    });
-    return inactiveGrantResponse();
-  }
-
-  const expectedGrantId = evidence.grantId ?? refreshGrantId ?? undefined;
+  const grantId = evidence.grantId;
   const grantedScopes = [
     ...new Set([...evidence.scopes, ...(refreshRow?.scopes ?? [])]),
   ];
   const grant = await resolveActiveOAuthUserGrant({
     clientId: evidence.clientId,
-    grantId: expectedGrantId,
+    grantId,
     requireGrantBinding: true,
     scopes: grantedScopes,
     userId: evidence.userId,
@@ -220,19 +277,9 @@ export async function bindOAuthAccessTokenToConsent(
       accessTokenHash: evidence.opaqueTokenHash,
       refreshTokenHash,
     });
-    return inactiveGrantResponse();
+    return inactiveGrantResponse("active-grant-missing");
   }
   if (grant.kind === "trusted") return response;
-
-  if (!expectedGrantId) {
-    await deleteReturnedTokenRows({
-      accessTokenHash: evidence.opaqueTokenHash,
-      refreshTokenHash,
-    });
-    return inactiveGrantResponse();
-  }
-
-  const grantId = expectedGrantId;
   const updates = await Promise.all([
     evidence.opaqueTokenHash
       ? prisma.oAuthAccessToken.updateMany({
@@ -270,7 +317,7 @@ export async function bindOAuthAccessTokenToConsent(
       accessTokenHash: evidence.opaqueTokenHash,
       refreshTokenHash,
     });
-    return inactiveGrantResponse();
+    return inactiveGrantResponse("opaque-grant-persistence-failed");
   }
 
   return response;

--- a/src/lib/auth/better-auth-oauth-provider-plugin.ts
+++ b/src/lib/auth/better-auth-oauth-provider-plugin.ts
@@ -71,7 +71,19 @@ export function buildOAuthProviderPlugin(input: { authPublicOrigin: string }) {
       scopes_supported: [...PUBLIC_OAUTH_SCOPES],
       claims_supported: [...OAUTH_PROVIDER_CLAIMS_SUPPORTED],
     },
-    customAccessTokenClaims({ referenceId }: { referenceId?: string }) {
+    customAccessTokenClaims({
+      referenceId,
+      user,
+    }: {
+      referenceId?: string;
+      user?: Record<string, unknown> | null;
+    }) {
+      if (user && !referenceId) {
+        throw new APIError("BAD_REQUEST", {
+          error: "invalid_grant",
+          error_description: "OAuth authorization is no longer active",
+        });
+      }
       return referenceId ? { [OAUTH_GRANT_ID_CLAIM]: referenceId } : {};
     },
     async customUserInfoClaims({

--- a/src/lib/mcp/auth.ts
+++ b/src/lib/mcp/auth.ts
@@ -111,6 +111,9 @@ export function authorizeMcpToolScopes(
       hasRequiredFeatureScope(authInfo.scopes, scope),
     );
   if (!hasRequiredScope) {
+    const challengeScopes = [
+      ...new Set([...authInfo.scopes, ...requiredScopes]),
+    ];
     const diagnostics: McpAuthFailureDiagnostics = {
       authFailureKind: "missing_required_tool_scope",
       authHeaderKind: "bearer",
@@ -130,7 +133,7 @@ export function authorizeMcpToolScopes(
           status: 403,
           description: "Access token does not include the required tool scope",
         },
-        requiredScopes,
+        challengeScopes,
       ),
     };
   }

--- a/tests/e2e/src/app/api/mcp/helpers.ts
+++ b/tests/e2e/src/app/api/mcp/helpers.ts
@@ -76,7 +76,10 @@ async function resumeConsentIfSignInPage(page: Page) {
   await expectConsentDestination();
 }
 
-async function registerPublicClient(request: Page["request"], scope: string) {
+export async function registerPublicClient(
+  request: Page["request"],
+  scope: string,
+) {
   const response = await request.post("/api/auth/oauth2/register", {
     data: {
       application_type: "native",
@@ -141,6 +144,47 @@ async function authorizeAndGetCode(
   return code as string;
 }
 
+export async function issueAccessTokenForClient(
+  page: Page,
+  request: Page["request"],
+  options: {
+    clientId: string;
+    scope: string;
+    resource?: string;
+    /** Whether to repeat the authorization request's `resource` at token exchange. */
+    includeResourceInTokenExchange?: boolean;
+  },
+) {
+  const codeVerifier =
+    "mcp-public-client-verifier-012345678901234567890123456789";
+  const codeChallenge = await generateCodeChallenge(codeVerifier);
+
+  const code = await authorizeAndGetCode(page, options.clientId, {
+    scope: options.scope,
+    codeChallenge,
+    resource: options.resource,
+  });
+
+  const includeResourceInToken =
+    options.includeResourceInTokenExchange !== false && options.resource;
+  const tokenResponse = await request.post("/api/auth/oauth2/token", {
+    form: {
+      grant_type: OAUTH_AUTHORIZATION_CODE_GRANT_TYPE,
+      client_id: options.clientId,
+      code,
+      code_verifier: codeVerifier,
+      redirect_uri: REDIRECT_URI,
+      ...(includeResourceInToken ? { resource: options.resource } : {}),
+    },
+  });
+
+  const tokenBody = (await tokenResponse.json()) as {
+    access_token?: string;
+    refresh_token?: string;
+  };
+  return { response: tokenResponse, tokenBody };
+}
+
 export async function issueAccessToken(
   page: Page,
   request: Page["request"],
@@ -157,35 +201,15 @@ export async function issueAccessToken(
     options.clientScopes.join(" "),
   );
 
-  const codeVerifier =
-    "mcp-public-client-verifier-012345678901234567890123456789";
-  const codeChallenge = await generateCodeChallenge(codeVerifier);
-
-  const code = await authorizeAndGetCode(page, clientId, {
-    scope: options.scope,
-    codeChallenge,
-    resource: options.resource,
-  });
-
-  const includeResourceInToken =
-    options.includeResourceInTokenExchange !== false && options.resource;
-
-  const tokenResponse = await request.post("/api/auth/oauth2/token", {
-    form: {
-      grant_type: OAUTH_AUTHORIZATION_CODE_GRANT_TYPE,
-      client_id: clientId,
-      code,
-      code_verifier: codeVerifier,
-      redirect_uri: REDIRECT_URI,
-      ...(includeResourceInToken ? { resource: options.resource } : {}),
-    },
-  });
+  const { response: tokenResponse, tokenBody } =
+    await issueAccessTokenForClient(page, request, {
+      clientId,
+      scope: options.scope,
+      resource: options.resource,
+      includeResourceInTokenExchange: options.includeResourceInTokenExchange,
+    });
 
   expect(tokenResponse.status()).toBe(200);
-  const tokenBody = (await tokenResponse.json()) as {
-    access_token?: string;
-    refresh_token?: string;
-  };
   expect(typeof tokenBody.access_token).toBe("string");
 
   return {

--- a/tests/e2e/src/app/api/mcp/oauth-tokens.test.ts
+++ b/tests/e2e/src/app/api/mcp/oauth-tokens.test.ts
@@ -1,6 +1,10 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { expect, test } from "@playwright/test";
+import { decodeJwt } from "jose";
 import {
   DEFAULT_OAUTH_CLIENT_SCOPES,
+  OAUTH_GRANT_ID_CLAIM,
   OAUTH_OFFLINE_ACCESS_SCOPE,
   OAUTH_REFRESH_TOKEN_GRANT_TYPE,
   restReadScope,
@@ -10,8 +14,10 @@ import { PLAYWRIGHT_BASE_URL } from "../../../../utils/e2e-db";
 import {
   expectAccessTokenCannotInitializeMcp,
   issueAccessToken,
+  issueAccessTokenForClient,
   MCP_CLIENT_SCOPE,
   MCP_CLIENT_SCOPES,
+  registerPublicClient,
 } from "./helpers";
 
 test.describe("/api/mcp - OAuth token 资源绑定", () => {
@@ -55,6 +61,60 @@ test.describe("/api/mcp - OAuth token 资源绑定", () => {
     });
 
     expect(response.status()).toBe(200);
+  });
+
+  test("同一客户端增权后签发精确绑定且包含累计 scope 的 MCP token", async ({
+    page,
+    request,
+  }) => {
+    const resource = `${PLAYWRIGHT_BASE_URL}/api/mcp`;
+    const baselineScopes = [
+      restReadScope("account.profile"),
+      OAUTH_OFFLINE_ACCESS_SCOPE,
+    ];
+    const expandedScopes = [...baselineScopes, restReadScope("workspace.todo")];
+    await signInAsDebugUser(page, "/");
+    const clientId = await registerPublicClient(
+      request,
+      expandedScopes.join(" "),
+    );
+
+    const baseline = await issueAccessTokenForClient(page, request, {
+      clientId,
+      resource,
+      scope: baselineScopes.join(" "),
+    });
+    expect(baseline.response.status()).toBe(200);
+
+    const expanded = await issueAccessTokenForClient(page, request, {
+      clientId,
+      resource,
+      scope: expandedScopes.join(" "),
+    });
+    expect(expanded.response.status()).toBe(200);
+    expect(typeof expanded.tokenBody.access_token).toBe("string");
+    const accessToken = expanded.tokenBody.access_token as string;
+    const claims = decodeJwt(accessToken);
+    expect(claims[OAUTH_GRANT_ID_CLAIM]).toEqual(expect.any(String));
+    expect(new Set(String(claims.scope).split(" "))).toEqual(
+      new Set(expandedScopes),
+    );
+
+    const transport = new StreamableHTTPClientTransport(new URL(resource), {
+      requestInit: { headers: { Authorization: `Bearer ${accessToken}` } },
+    });
+    const client = new Client({
+      name: "incremental-scope-e2e-client",
+      version: "1.0.0",
+    });
+    await client.connect(transport);
+    try {
+      await expect(
+        client.callTool({ name: "workspace_todo_list", arguments: {} }),
+      ).resolves.toMatchObject({ structuredContent: { success: true } });
+    } finally {
+      await transport.close();
+    }
   });
 
   test("MCP resource JWT 被受保护 REST 路由拒绝", async ({ page, request }) => {

--- a/tests/unit/mcp-auth.test.ts
+++ b/tests/unit/mcp-auth.test.ts
@@ -337,8 +337,24 @@ describe("MCP per-tool scope enforcement", () => {
       response: expect.objectContaining({ status: 403 }),
     });
     if ("response" in result) {
-      expect(result.response.headers.get("WWW-Authenticate")).toContain(
-        restWriteScope("workspace.upload"),
+      const challenge = result.response.headers.get("WWW-Authenticate") ?? "";
+      expect(challenge).toContain(TODO_WRITE_SCOPE);
+      expect(challenge).toContain(restWriteScope("workspace.upload"));
+    }
+  });
+
+  it("retains already granted scopes in a step-up challenge", async () => {
+    const profileScope = restReadScope("account.profile");
+    const result = await authenticate(
+      [profileScope, TODO_READ_SCOPE],
+      "workspace_todo_create",
+    );
+
+    expect("response" in result).toBe(true);
+    if ("response" in result) {
+      const challenge = result.response.headers.get("WWW-Authenticate") ?? "";
+      expect(challenge).toContain(
+        `scope="${profileScope} ${TODO_READ_SCOPE} ${TODO_WRITE_SCOPE}"`,
       );
     }
   });

--- a/tests/unit/oauth-provider-plugin.test.ts
+++ b/tests/unit/oauth-provider-plugin.test.ts
@@ -229,6 +229,26 @@ describe("buildOAuthProviderPlugin", () => {
     });
   });
 
+  it("rejects delegated access-token issuance without an immutable grant reference", async () => {
+    const { buildOAuthProviderPlugin } = await import(
+      "@/lib/auth/better-auth-oauth-provider-plugin"
+    );
+    buildOAuthProviderPlugin({
+      authPublicOrigin: "https://life.example",
+    });
+    const options = mcpMock.mock.calls.at(-1)?.[0];
+
+    expect(() =>
+      options.customAccessTokenClaims({
+        scopes: ["profile"],
+        user: { id: "user-1" },
+      }),
+    ).toThrow();
+    expect(options.customAccessTokenClaims({ scopes: ["profile"] })).toEqual(
+      {},
+    );
+  });
+
   it("returns verified GitHub/Google email when available without clearing placeholders", async () => {
     const { buildOAuthProviderPlugin } = await import(
       "@/lib/auth/better-auth-oauth-provider-plugin"

--- a/tests/unit/oauth-token-grant-binding.test.ts
+++ b/tests/unit/oauth-token-grant-binding.test.ts
@@ -6,6 +6,7 @@ const {
   accessFindUniqueMock,
   accessUpdateManyMock,
   decodeJwtMock,
+  logAppEventMock,
   refreshDeleteManyMock,
   refreshFindUniqueMock,
   refreshUpdateManyMock,
@@ -15,6 +16,7 @@ const {
   accessFindUniqueMock: vi.fn(),
   accessUpdateManyMock: vi.fn(),
   decodeJwtMock: vi.fn(),
+  logAppEventMock: vi.fn(),
   refreshDeleteManyMock: vi.fn(),
   refreshFindUniqueMock: vi.fn(),
   refreshUpdateManyMock: vi.fn(),
@@ -23,6 +25,10 @@ const {
 
 vi.mock("jose", () => ({
   decodeJwt: decodeJwtMock,
+}));
+
+vi.mock("@/lib/log/app-logger", () => ({
+  logAppEvent: logAppEventMock,
 }));
 
 vi.mock("@/lib/db/auth-prisma", () => ({
@@ -50,6 +56,7 @@ describe("OAuth access-token grant binding", () => {
     accessFindUniqueMock.mockReset();
     accessUpdateManyMock.mockReset();
     decodeJwtMock.mockReset();
+    logAppEventMock.mockReset();
     refreshDeleteManyMock.mockReset();
     refreshFindUniqueMock.mockReset();
     refreshUpdateManyMock.mockReset();
@@ -89,17 +96,16 @@ describe("OAuth access-token grant binding", () => {
       ),
     );
 
-    expect(resolveActiveOAuthUserGrantMock).toHaveBeenNthCalledWith(1, {
-      clientId: "client-1",
-      grantId: undefined,
-      requireGrantBinding: true,
-      scopes: ["workspace.todo:read", "profile"],
-      userId: "user-1",
-    });
+    expect(resolveActiveOAuthUserGrantMock).not.toHaveBeenCalled();
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toMatchObject({
       error: "invalid_grant",
     });
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "warn",
+      "oauth.token.grant-binding-rejected",
+      expect.objectContaining({ reason: "jwt-grant-claim-missing" }),
+    );
   });
 
   it("keeps a JWT bound to the exact active grant generation", async () => {
@@ -232,7 +238,7 @@ describe("OAuth access-token grant binding", () => {
     expect(resolveActiveOAuthUserGrantMock).not.toHaveBeenCalled();
   });
 
-  it("uses the rotated refresh row as the scope outcome when scope is omitted", async () => {
+  it("validates a bound JWT without joining its refresh row", async () => {
     decodeJwtMock.mockReturnValue({
       azp: "client-1",
       [OAUTH_GRANT_ID_CLAIM]: "grant-1",
@@ -246,20 +252,29 @@ describe("OAuth access-token grant binding", () => {
       scopes: ["profile"],
       userId: "user-1",
     });
+    resolveActiveOAuthUserGrantMock.mockResolvedValue({
+      consentId: "consent-1",
+      grantId: "grant-1",
+      kind: "consent",
+    });
     const { bindOAuthAccessTokenToConsent } = await import(
       "@/lib/api/routes/auth-token-grant-binding"
     );
 
-    const response = await bindOAuthAccessTokenToConsent(
-      Response.json({
-        access_token: "header.payload.signature",
-        refresh_token: "rotated-refresh",
-      }),
-    );
+    const response = Response.json({
+      access_token: "header.payload.signature",
+      refresh_token: "rotated-refresh",
+    });
 
-    expect(response.status).toBe(400);
-    expect(refreshDeleteManyMock).toHaveBeenCalled();
-    expect(resolveActiveOAuthUserGrantMock).not.toHaveBeenCalled();
+    expect(await bindOAuthAccessTokenToConsent(response)).toBe(response);
+    expect(refreshFindUniqueMock).not.toHaveBeenCalled();
+    expect(resolveActiveOAuthUserGrantMock).toHaveBeenCalledWith({
+      clientId: "client-1",
+      grantId: "grant-1",
+      requireGrantBinding: true,
+      scopes: ["profile", "workspace.todo:write"],
+      userId: "user-1",
+    });
   });
 
   it("enforces an explicit refresh downscope when the response scope is omitted", async () => {
@@ -293,7 +308,7 @@ describe("OAuth access-token grant binding", () => {
     expect(resolveActiveOAuthUserGrantMock).not.toHaveBeenCalled();
   });
 
-  it("validates both access and refresh scopes against the active grant", async () => {
+  it("validates JWT access scopes against the exact active grant", async () => {
     decodeJwtMock.mockReturnValue({
       azp: "client-1",
       [OAUTH_GRANT_ID_CLAIM]: "grant-1",
@@ -326,9 +341,10 @@ describe("OAuth access-token grant binding", () => {
       clientId: "client-1",
       grantId: "grant-1",
       requireGrantBinding: true,
-      scopes: ["profile", "offline_access"],
+      scopes: ["profile"],
       userId: "user-1",
     });
+    expect(refreshFindUniqueMock).not.toHaveBeenCalled();
   });
 
   it("does not issue a JWT when its consent disappeared during exchange", async () => {
@@ -356,6 +372,7 @@ describe("OAuth access-token grant binding", () => {
   it("leaves an explicitly trusted client JWT unchanged", async () => {
     decodeJwtMock.mockReturnValue({
       azp: "trusted-client",
+      [OAUTH_GRANT_ID_CLAIM]: "trusted-generation",
       scope: "profile",
       sub: "user-1",
     });


### PR DESCRIPTION
## Summary

- Treat the signed OAuth grant-generation claim as the canonical binding for delegated JWT access tokens, while retaining strict row binding for opaque tokens.
- Fail delegated JWT issuance when Better Auth does not provide an immutable authorization reference.
- Preserve already granted scopes in MCP step-up challenges so clients such as Claude request the union instead of replacing OIDC scopes.
- Add safe structured rejection reasons and an end-to-end incremental-authorization regression test.

## Production evidence

Cloudflare Worker logs showed Claude first receiving a token with only two baseline scopes, then requesting `account.profile:read workspace.todo:read offline_access`. Better Auth returned HTTP 200 from the token endpoint, but the local grant-binding postprocessor converted that response to `invalid_grant`. Claude then retried with baseline scopes and remained unable to call the tool. A separate trace showed the same exchange pattern ending in `inactive_oauth_grant`.

The previous postprocessor rejoined a freshly issued signed JWT to the mutable refresh-token row. That join is redundant for JWT access tokens and can reject an otherwise valid incremental authorization. The JWT now carries and validates the exact active grant generation directly; refresh tokens continue to be validated on their own refresh path.

## Validation

- `bunx biome check .`
- `bunx wrangler types --include-runtime=false --check`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- Source, test, and operational TypeScript checks
- `bun run openapi:check`
- `bunx vitest run` — 355 files, 2141 tests
- Focused OAuth integration tests — 2 files, 12 tests
- `playwright test tests/e2e/src/app/api/mcp/oauth-tokens.test.ts` — 6 tests, including baseline-to-expanded scope authorization and a real MCP tool call
