### PR TITLE
fix(oauth): preserve grants across consent retries

### DIFF
--- a/src/features/oauth/components/OAuthAuthorizeConsentPanel.svelte
+++ b/src/features/oauth/components/OAuthAuthorizeConsentPanel.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 import CheckCircle from "@lucide/svelte/icons/check-circle";
+import type { SubmitFunction } from "@sveltejs/kit";
 import { oauthScopeCountLabel } from "@/features/admin/lib/oauth-controller";
 import OAuthScopesPicker from "@/features/oauth/components/OAuthScopesPicker.svelte";
 import { buildOAuthScopesPickerCopy } from "@/features/oauth/lib/oauth-scopes-picker-copy";
+import { enhance } from "$app/forms";
 import { Button } from "$lib/components/ui/button/index.js";
+import { Spinner } from "$lib/components/ui/spinner/index.js";
 
 export let copy: Record<string, string>;
 export let locale: string = "zh-cn";
@@ -13,6 +16,20 @@ export let scopes: Array<{ label: string; value: string }>;
 
 let scopeKey = "";
 let selectedScopes: string[] = [];
+let pendingDecision: "allow" | "deny" | null = null;
+
+function consentAction(decision: "allow" | "deny"): SubmitFunction {
+  return () => {
+    pendingDecision = decision;
+    return async ({ update }) => {
+      try {
+        await update({ reset: false });
+      } finally {
+        pendingDecision = null;
+      }
+    };
+  };
+}
 
 $: {
   const nextScopeKey = scopes.map((scopeItem) => scopeItem.value).join(" ");
@@ -46,15 +63,16 @@ $: canAllow = scopes.length === 0 || selectedScopes.length > 0;
 {/if}
 
 <div class="grid gap-3 sm:grid-cols-2">
-  <form method="POST" action="?/consent">
+  <form method="POST" action="?/consent" use:enhance={consentAction("deny")}>
     <input type="hidden" name="accept" value="false" />
     <input type="hidden" name="scope" value={scope} />
     <input type="hidden" name="oauthQuery" value={oauthQuery} />
-    <Button class="w-full" type="submit" variant="outline">
+    <Button class="w-full" disabled={Boolean(pendingDecision)} type="submit" variant="outline">
+      {#if pendingDecision === "deny"}<Spinner data-icon="inline-start" />{/if}
       {copy.deny}
     </Button>
   </form>
-  <form method="POST" action="?/consent">
+  <form method="POST" action="?/consent" use:enhance={consentAction("allow")}>
     <input type="hidden" name="accept" value="true" />
     <input type="hidden" name="scope" value={selectedScopeValue || scope} />
     <input type="hidden" name="scopeSelectionEnabled" value="true" />
@@ -62,8 +80,12 @@ $: canAllow = scopes.length === 0 || selectedScopes.length > 0;
       <input type="hidden" name="scopes" value={selectedScope} />
     {/each}
     <input type="hidden" name="oauthQuery" value={oauthQuery} />
-    <Button class="w-full" disabled={!canAllow} type="submit">
-      <CheckCircle data-icon="inline-start" />
+    <Button class="w-full" disabled={!canAllow || Boolean(pendingDecision)} type="submit">
+      {#if pendingDecision === "allow"}
+        <Spinner data-icon="inline-start" />
+      {:else}
+        <CheckCircle data-icon="inline-start" />
+      {/if}
       {copy.allow}
     </Button>
   </form>

--- a/src/features/oauth/server/oauth-consent-action.ts
+++ b/src/features/oauth/server/oauth-consent-action.ts
@@ -3,6 +3,7 @@ import { bindOAuthAuthorizationCodeRedirectToActiveGrant } from "@/features/oaut
 import { verifyOAuthProviderSignedQueryState } from "@/features/oauth/server/signed-oauth-query.server";
 import { isTrustedAuthOrigin } from "@/lib/auth/auth-origins";
 import { authPrisma as prisma } from "@/lib/db/auth-prisma";
+import { runSerializableTransaction } from "@/lib/db/serializable-transaction";
 import { getCanonicalOAuthIssuer } from "@/lib/mcp/urls";
 import { OAUTH_PROVIDER_CLAIMS_SUPPORTED } from "@/lib/oauth/constants";
 import { hashOAuthClientSecretForDbStorage } from "@/lib/oauth/utils";
@@ -121,6 +122,13 @@ function uniqueScopes(value: string | null) {
   return [...new Set((value ?? "").split(/\s+/).filter(Boolean))];
 }
 
+function mergeUniqueValues(
+  current: readonly string[],
+  additions: readonly string[],
+) {
+  return [...new Set([...current, ...additions])];
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -167,6 +175,7 @@ async function validateConsentRequest(
 ): Promise<
   | (ValidatedConsentRequest & {
       client: {
+        scopes: string[];
         skipConsent: boolean | null;
       };
     })
@@ -218,7 +227,7 @@ async function validateConsentRequest(
 
   return {
     authorizeQuery,
-    client: { skipConsent: client.skipConsent },
+    client: { scopes: client.scopes, skipConsent: client.skipConsent },
     clientId,
     redirectUri,
     requestedScopes,
@@ -298,85 +307,104 @@ export async function createAcceptedOAuthAuthorization(input: {
   session: OAuthSession;
 }) {
   const normalizedAcceptedScopes = [...new Set(input.acceptedScopes)];
-  return prisma.$transaction(async (tx) => {
-    const request = await validateConsentRequest(tx, input.authorizeQuery);
-    if (
-      !request ||
-      !normalizedAcceptedScopes.every((scope) =>
-        request.requestedScopes.includes(scope),
-      )
-    ) {
-      return null;
-    }
+  return runSerializableTransaction(
+    async (tx) => {
+      const request = await validateConsentRequest(tx, input.authorizeQuery);
+      if (
+        !request ||
+        !normalizedAcceptedScopes.every((scope) =>
+          request.requestedScopes.includes(scope),
+        )
+      ) {
+        return null;
+      }
 
-    const identity = {
-      clientId: request.clientId,
-      userId: input.session.user.id,
-    };
-    const grantId = crypto.randomUUID();
-    const resources = request.authorizeQuery.getAll("resource");
-    const userInfoClaims = requestedUserInfoClaims(
-      request.authorizeQuery.get("claims"),
-    );
-    if (request.client.skipConsent === true) {
-      await tx.oAuthConsent.deleteMany({ where: identity });
-    } else {
-      await tx.oAuthAccessToken.deleteMany({ where: identity });
-      await tx.oAuthRefreshToken.deleteMany({ where: identity });
-      await tx.deviceCode.deleteMany({ where: identity });
-      await tx.oAuthConsent.upsert({
-        where: { clientId_userId: identity },
-        create: {
-          ...identity,
-          grantId,
-          resources,
-          requestedUserInfoClaims: userInfoClaims,
-          scopes: normalizedAcceptedScopes,
-        },
-        update: {
-          grantId,
-          ...(resources.length > 0 ? { resources } : {}),
-          requestedUserInfoClaims: userInfoClaims,
-          scopes: normalizedAcceptedScopes,
+      const identity = {
+        clientId: request.clientId,
+        userId: input.session.user.id,
+      };
+      const resources = request.authorizeQuery.getAll("resource");
+      const userInfoClaims = requestedUserInfoClaims(
+        request.authorizeQuery.get("claims"),
+      );
+      let grantId: string;
+      if (request.client.skipConsent === true) {
+        grantId = crypto.randomUUID();
+        await tx.oAuthConsent.deleteMany({ where: identity });
+      } else {
+        const consent = await tx.oAuthConsent.upsert({
+          where: { clientId_userId: identity },
+          create: {
+            ...identity,
+            resources,
+            requestedUserInfoClaims: userInfoClaims,
+            scopes: normalizedAcceptedScopes,
+          },
+          update: {},
+          select: {
+            grantId: true,
+            requestedUserInfoClaims: true,
+            resources: true,
+            scopes: true,
+          },
+        });
+        grantId = consent.grantId;
+        await tx.oAuthConsent.update({
+          where: { clientId_userId: identity },
+          data: {
+            requestedUserInfoClaims: mergeUniqueValues(
+              consent.requestedUserInfoClaims,
+              userInfoClaims,
+            ),
+            resources: mergeUniqueValues(consent.resources, resources),
+            scopes: mergeUniqueValues(
+              consent.scopes.filter((scope) =>
+                request.client.scopes.includes(scope),
+              ),
+              normalizedAcceptedScopes,
+            ),
+          },
+        });
+      }
+
+      const code = randomOAuthCode();
+      const iat = Math.floor(Date.now() / 1000);
+      const issuedAt = new Date(iat * 1000);
+      const query = new URLSearchParams(request.authorizeQuery);
+      query.set("scope", normalizedAcceptedScopes.join(" "));
+      removePrompt(query, "consent");
+      const queryObject = searchParamsToQuery(query);
+      const authTime = sessionCreatedAtMillis(input.session.session.createdAt);
+      await tx.verificationToken.create({
+        data: {
+          identifier: await hashOAuthClientSecretForDbStorage(code),
+          token: JSON.stringify({
+            type: "authorization_code",
+            query: queryObject,
+            userId: input.session.user.id,
+            sessionId: input.session.session.id,
+            referenceId: grantId,
+            ...(authTime !== null ? { authTime } : {}),
+          }),
+          expires: new Date((iat + OAUTH_CODE_EXPIRES_IN_SECONDS) * 1000),
+          createdAt: issuedAt,
+          updatedAt: issuedAt,
         },
       });
-    }
 
-    const code = randomOAuthCode();
-    const iat = Math.floor(Date.now() / 1000);
-    const issuedAt = new Date(iat * 1000);
-    const query = new URLSearchParams(request.authorizeQuery);
-    query.set("scope", normalizedAcceptedScopes.join(" "));
-    removePrompt(query, "consent");
-    const queryObject = searchParamsToQuery(query);
-    const authTime = sessionCreatedAtMillis(input.session.session.createdAt);
-    await tx.verificationToken.create({
-      data: {
-        identifier: await hashOAuthClientSecretForDbStorage(code),
-        token: JSON.stringify({
-          type: "authorization_code",
-          query: queryObject,
-          userId: input.session.user.id,
-          sessionId: input.session.session.id,
-          referenceId: grantId,
-          ...(authTime !== null ? { authTime } : {}),
+      return {
+        clientId: request.clientId,
+        expectedGrantId: grantId,
+        redirectTarget: buildOAuthCallbackUrl({
+          code,
+          query,
+          redirectUri: request.redirectUri,
         }),
-        expires: new Date((iat + OAUTH_CODE_EXPIRES_IN_SECONDS) * 1000),
-        createdAt: issuedAt,
-        updatedAt: issuedAt,
-      },
-    });
-
-    return {
-      clientId: request.clientId,
-      expectedGrantId: grantId,
-      redirectTarget: buildOAuthCallbackUrl({
-        code,
-        query,
-        redirectUri: request.redirectUri,
-      }),
-    };
-  });
+      };
+    },
+    "Failed to create OAuth authorization",
+    prisma,
+  );
 }
 
 async function createDeniedOAuthAuthorization(authorizeQuery: URLSearchParams) {

--- a/tests/e2e/src/app/oauth/authorize/test.ts
+++ b/tests/e2e/src/app/oauth/authorize/test.ts
@@ -201,7 +201,24 @@ test("/oauth/authorize 允许授权时带 code 回跳", async ({ page }, testInf
   await gotoAndWaitForReady(page, consentLocation, { waitUntil: "load" });
   await resumeConsentIfSignInPage(page);
 
-  await page.getByRole("button", { name: /允许|Allow/i }).click();
+  let releaseConsentRequest = () => {};
+  const consentRequestGate = new Promise<void>((resolve) => {
+    releaseConsentRequest = resolve;
+  });
+  await page.route(
+    (url) => url.pathname === "/oauth/authorize" && url.search === "?/consent",
+    async (route) => {
+      await consentRequestGate;
+      await route.continue();
+    },
+  );
+  const allowButton = page.getByRole("button", { name: /允许|Allow/i });
+  const denyButton = page.getByRole("button", { name: /拒绝|Deny/i });
+  const allowClick = allowButton.click();
+  await expect(allowButton).toBeDisabled();
+  await expect(denyButton).toBeDisabled();
+  releaseConsentRequest();
+  await allowClick;
   await expect(page).toHaveURL(/\/e2e\/oauth\/callback\?/);
 
   const redirected = new URL(page.url());

--- a/tests/integration/oauth-consent-transaction.test.ts
+++ b/tests/integration/oauth-consent-transaction.test.ts
@@ -30,7 +30,7 @@ describe.sequential("OAuth consent transaction", () => {
         requirePKCE: true,
         redirectUris: ["https://client.example/callback"],
         responseTypes: ["code"],
-        scopes: ["openid", "profile"],
+        scopes: ["openid", "profile", "workspace.todo:read"],
         skipConsent,
         tokenEndpointAuthMethod: "none",
       },
@@ -187,7 +187,7 @@ describe.sequential("OAuth consent transaction", () => {
     await prisma.$disconnect();
   });
 
-  it("原子轮换 consent、清理旧凭据并创建 exact-bound code", async () => {
+  it("原子扩展 consent、保留旧凭据并创建 exact-bound code", async () => {
     const fixture = await createFixture("success");
     const query = authorizeQuery(fixture.clientId);
     const resource = getOAuthMcpResourceUrl();
@@ -247,11 +247,11 @@ describe.sequential("OAuth consent transaction", () => {
       ]),
     ]);
 
-    expect(consent.grantId).not.toBe(fixture.consent.grantId);
+    expect(consent.grantId).toBe(fixture.consent.grantId);
     expect(consent.requestedUserInfoClaims).toEqual(["preferred_username"]);
     expect(consent.resources).toEqual([resource]);
-    expect(consent.scopes).toEqual(["openid", "profile"]);
-    expect(counts).toEqual([0, 0, 0]);
+    expect(consent.scopes).toEqual(["profile", "openid"]);
+    expect(counts).toEqual([1, 1, 1]);
     expect(JSON.parse(codeRow.token)).toMatchObject({
       query: {
         resource,
@@ -300,6 +300,20 @@ describe.sequential("OAuth consent transaction", () => {
       }),
     ).resolves.toEqual({ resources: [resource] });
 
+    await expect(
+      Promise.all([
+        prisma.oAuthAccessToken.count({
+          where: { clientId: fixture.clientId, userId: fixture.userId },
+        }),
+        prisma.oAuthRefreshToken.count({
+          where: { clientId: fixture.clientId, userId: fixture.userId },
+        }),
+        prisma.deviceCode.count({
+          where: { clientId: fixture.clientId, userId: fixture.userId },
+        }),
+      ]),
+    ).resolves.toEqual([1, 1, 1]);
+
     const reuseQuery = new URLSearchParams(query);
     reuseQuery.set("prompt", "none");
     reuseQuery.set("state", `reuse-${marker}`);
@@ -322,37 +336,65 @@ describe.sequential("OAuth consent transaction", () => {
     }
   });
 
-  it("grantId rotation 冲突时回滚 consent 与旧凭据清理", async () => {
-    const fixture = await createFixture("rotation-rollback");
-    const collision = await createFixture("rotation-collision");
+  it("重复 consent 不生成新 grant 或撤销旧凭据", async () => {
+    const fixture = await createFixture("grant-reuse");
+    await prisma.oAuthConsent.update({
+      where: { id: fixture.consent.id },
+      data: { scopes: ["profile", "workspace.todo:read"] },
+    });
     const randomUuid = vi
       .spyOn(crypto, "randomUUID")
-      .mockReturnValue(
-        collision.consent
-          .grantId as `${string}-${string}-${string}-${string}-${string}`,
-      );
+      .mockReturnValue("11111111-1111-4111-8111-111111111111");
 
     try {
-      await expect(
-        createAcceptedOAuthAuthorization({
-          acceptedScopes: ["openid", "profile"],
-          authorizeQuery: authorizeQuery(fixture.clientId),
-          session: session(fixture.userId),
-        }),
-      ).rejects.toMatchObject({ code: "P2002" });
+      const authorization = await createAcceptedOAuthAuthorization({
+        acceptedScopes: ["openid", "profile"],
+        authorizeQuery: authorizeQuery(fixture.clientId),
+        session: session(fixture.userId),
+      });
+      expect(authorization?.expectedGrantId).toBe(fixture.consent.grantId);
+      const code = authorization
+        ? new URL(authorization.redirectTarget).searchParams.get("code")
+        : null;
+      if (code) {
+        verificationIdentifiers.push(
+          await hashOAuthClientSecretForDbStorage(code),
+        );
+      }
     } finally {
       randomUuid.mockRestore();
     }
-    await expectFixtureUnchanged({
-      clientId: fixture.clientId,
+    const [consent, counts] = await Promise.all([
+      prisma.oAuthConsent.findUniqueOrThrow({
+        where: {
+          clientId_userId: {
+            clientId: fixture.clientId,
+            userId: fixture.userId,
+          },
+        },
+        select: { grantId: true, scopes: true },
+      }),
+      Promise.all([
+        prisma.oAuthAccessToken.count({
+          where: { clientId: fixture.clientId, userId: fixture.userId },
+        }),
+        prisma.oAuthRefreshToken.count({
+          where: { clientId: fixture.clientId, userId: fixture.userId },
+        }),
+        prisma.deviceCode.count({
+          where: { clientId: fixture.clientId, userId: fixture.userId },
+        }),
+      ]),
+    ]);
+    expect(consent).toEqual({
       grantId: fixture.consent.grantId,
-      userId: fixture.userId,
+      scopes: ["profile", "workspace.todo:read", "openid"],
     });
+    expect(counts).toEqual([1, 1, 1]);
   });
 
-  it("authorization code 写入失败时回滚已完成的 rotation 与 cleanup", async () => {
+  it("authorization code 写入失败时回滚 consent 扩展", async () => {
     const fixture = await createFixture("code-rollback");
-    const fixedGrantId = "11111111-1111-4111-8111-111111111111";
     const fixedNow = Date.parse("2026-07-20T01:00:00.000Z");
     const code = "a".repeat(32);
     const identifier = await hashOAuthClientSecretForDbStorage(code);
@@ -365,7 +407,7 @@ describe.sequential("OAuth consent transaction", () => {
       query: Object.fromEntries(query.entries()),
       userId: fixture.userId,
       sessionId: `session-${marker}`,
-      referenceId: fixedGrantId,
+      referenceId: fixture.consent.grantId,
       authTime: Date.parse("2026-07-20T00:00:00.000Z"),
     });
     await prisma.verificationToken.create({
@@ -376,9 +418,6 @@ describe.sequential("OAuth consent transaction", () => {
       },
     });
 
-    const randomUuid = vi
-      .spyOn(crypto, "randomUUID")
-      .mockReturnValue(fixedGrantId);
     const randomValues = vi
       .spyOn(crypto, "getRandomValues")
       .mockImplementation(((array: Uint8Array) => {
@@ -396,7 +435,6 @@ describe.sequential("OAuth consent transaction", () => {
         }),
       ).rejects.toMatchObject({ code: "P2002" });
     } finally {
-      randomUuid.mockRestore();
       randomValues.mockRestore();
       now.mockRestore();
     }

--- a/tests/unit/oauth-consent-action.test.ts
+++ b/tests/unit/oauth-consent-action.test.ts
@@ -7,6 +7,7 @@ const AUTH_SECRET = "oauth-consent-test-secret-at-least-32-bytes";
 const {
   bindCodeMock,
   consentDeleteMock,
+  consentUpdateMock,
   consentUpsertMock,
   deviceDeleteMock,
   getSessionMock,
@@ -18,6 +19,7 @@ const {
 } = vi.hoisted(() => ({
   bindCodeMock: vi.fn(),
   consentDeleteMock: vi.fn(),
+  consentUpdateMock: vi.fn(),
   consentUpsertMock: vi.fn(),
   deviceDeleteMock: vi.fn(),
   getSessionMock: vi.fn(),
@@ -50,6 +52,7 @@ const transactionClient = {
   oAuthClient: { findUnique: txReadClientMock },
   oAuthConsent: {
     deleteMany: consentDeleteMock,
+    update: consentUpdateMock,
     upsert: consentUpsertMock,
   },
   oAuthRefreshToken: { deleteMany: tokenDeleteMock },
@@ -102,6 +105,7 @@ describe("OAuth consent 操作", () => {
   beforeEach(() => {
     bindCodeMock.mockReset();
     consentDeleteMock.mockReset();
+    consentUpdateMock.mockReset();
     consentUpsertMock.mockReset();
     deviceDeleteMock.mockReset();
     getSessionMock.mockReset();
@@ -128,6 +132,13 @@ describe("OAuth consent 操作", () => {
     txReadClientMock.mockResolvedValue(client);
     transactionMock.mockImplementation((run) => run(transactionClient));
     bindCodeMock.mockResolvedValue(true);
+    consentUpdateMock.mockResolvedValue({});
+    consentUpsertMock.mockResolvedValue({
+      grantId: "created-grant",
+      requestedUserInfoClaims: [],
+      resources: [],
+      scopes: [],
+    });
     verificationCreateMock.mockResolvedValue({});
     vi.stubEnv("APP_PUBLIC_ORIGIN", "https://life.example");
   });
@@ -136,7 +147,7 @@ describe("OAuth consent 操作", () => {
     vi.unstubAllEnvs();
   });
 
-  it("在同一事务轮换 grant、清理旧行并创建 exact-bound code", async () => {
+  it("在同一事务创建初始 grant 与 exact-bound code", async () => {
     const oauthQuery = await signedOAuthQuery({
       claims: JSON.stringify({
         id_token: { name: null },
@@ -166,28 +177,26 @@ describe("OAuth consent 操作", () => {
     });
 
     expect(transactionMock).toHaveBeenCalledTimes(1);
-    expect(tokenDeleteMock).toHaveBeenCalledTimes(2);
-    expect(deviceDeleteMock).toHaveBeenCalledWith({
-      where: { clientId: "client-1", userId: "user-1" },
-    });
+    expect(tokenDeleteMock).not.toHaveBeenCalled();
+    expect(deviceDeleteMock).not.toHaveBeenCalled();
     expect(consentUpsertMock).toHaveBeenCalledWith({
       where: {
         clientId_userId: { clientId: "client-1", userId: "user-1" },
       },
       create: expect.objectContaining({
         clientId: "client-1",
-        grantId: expect.any(String),
         requestedUserInfoClaims: ["email", "preferred_username"],
         resources: ["https://life.example/api/mcp"],
         scopes: ["openid", "profile"],
         userId: "user-1",
       }),
-      update: expect.objectContaining({
-        grantId: expect.any(String),
-        requestedUserInfoClaims: ["email", "preferred_username"],
-        resources: ["https://life.example/api/mcp"],
-        scopes: ["openid", "profile"],
-      }),
+      update: {},
+      select: {
+        grantId: true,
+        requestedUserInfoClaims: true,
+        resources: true,
+        scopes: true,
+      },
     });
     const stored = JSON.parse(
       verificationCreateMock.mock.calls[0][0].data.token,
@@ -204,6 +213,68 @@ describe("OAuth consent 操作", () => {
       "client-1",
       "https://life.example/oauth/authorize",
       stored.referenceId,
+    );
+  });
+
+  it("重复或较窄的 consent 复用 grant 并只扩展已有授权", async () => {
+    txReadClientMock.mockResolvedValue({
+      disabled: false,
+      redirectUris: ["https://client.example/callback"],
+      scopes: ["openid", "profile", "workspace.todo:read"],
+      skipConsent: false,
+    });
+    consentUpsertMock.mockResolvedValue({
+      grantId: "existing-grant",
+      requestedUserInfoClaims: ["email"],
+      resources: ["https://life.example/api/graphql"],
+      scopes: ["openid", "profile", "workspace.todo:read", "removed:scope"],
+    });
+    const oauthQuery = await signedOAuthQuery({
+      claims: JSON.stringify({
+        userinfo: { preferred_username: null },
+      }),
+      resource: "https://life.example/api/mcp",
+      scope: "openid profile",
+    });
+
+    await expect(
+      submitOAuthConsentAction({
+        request: consentRequest({
+          accept: "true",
+          scope: "openid profile",
+          oauthQuery,
+        }),
+      }),
+    ).rejects.toMatchObject({
+      status: 303,
+      location: expect.stringContaining("https://client.example/callback"),
+    });
+
+    expect(consentUpsertMock).toHaveBeenCalledOnce();
+    expect(consentUpdateMock).toHaveBeenCalledWith({
+      where: {
+        clientId_userId: { clientId: "client-1", userId: "user-1" },
+      },
+      data: {
+        requestedUserInfoClaims: ["email", "preferred_username"],
+        resources: [
+          "https://life.example/api/graphql",
+          "https://life.example/api/mcp",
+        ],
+        scopes: ["openid", "profile", "workspace.todo:read"],
+      },
+    });
+    expect(tokenDeleteMock).not.toHaveBeenCalled();
+    expect(deviceDeleteMock).not.toHaveBeenCalled();
+    const stored = JSON.parse(
+      verificationCreateMock.mock.calls[0][0].data.token,
+    );
+    expect(stored.referenceId).toBe("existing-grant");
+    expect(bindCodeMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "client-1",
+      "https://life.example/oauth/authorize",
+      "existing-grant",
     );
   });
 
@@ -284,6 +355,12 @@ describe("OAuth consent 操作", () => {
     body.append("scopes", "openid");
     body.append("scopes", "workspace.todo:read");
     body.append("scopes", "admin:write");
+    consentUpsertMock.mockResolvedValueOnce({
+      grantId: "selected-grant",
+      requestedUserInfoClaims: [],
+      resources: [],
+      scopes: ["openid", "workspace.todo:read"],
+    });
 
     await expect(
       submitOAuthConsentAction({ request: consentRequest(body) }),
@@ -299,14 +376,7 @@ describe("OAuth consent 操作", () => {
           resources: [],
           scopes: ["openid", "workspace.todo:read"],
         }),
-        update: expect.objectContaining({
-          requestedUserInfoClaims: [],
-          scopes: ["openid", "workspace.todo:read"],
-        }),
       }),
-    );
-    expect(consentUpsertMock.mock.calls[0]?.[0].update).not.toHaveProperty(
-      "resources",
     );
   });
 


### PR DESCRIPTION
## Summary

- reuse the existing OAuth consent grant instead of rotating it on every accepted authorization
- merge newly accepted scopes, resources, and claims while preserving still-registered authorization
- keep existing access, refresh, and device credentials active across incremental or repeated consent
- disable both consent actions while a submission is pending to reduce duplicate requests

## Root cause

Every accepted consent POST generated a new grant ID and deleted all existing credentials. Claude can repeat or narrow the authorization request, and duplicate consent POSTs were therefore invalidating tokens that had just been issued.

## Verification

- bunx vitest run (355 files, 2142 tests)
- bunx vitest run --config vitest.integration.config.ts tests/integration/oauth-consent-transaction.test.ts (4 tests)
- Playwright OAuth authorize suite on isolated PostgreSQL (6 tests)
- bunx svelte-check --tsconfig ./tsconfig.json
- bun run build
- bunx biome check
- application, test, and operational TypeScript checks
- bun run openapi:check
- GraphQL schema snapshot
- bunx wrangler types --include-runtime=false --check