### PR TITLE
fix(mcp): allow anonymous catalog tools

### DIFF
--- a/src/lib/api/routes/mcp-request-handler.ts
+++ b/src/lib/api/routes/mcp-request-handler.ts
@@ -1,3 +1,4 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import { rateLimitResponse } from "@/lib/api/helpers";
@@ -10,6 +11,7 @@ import {
   getMcpWriteRateLimitAction,
   getMcpWriteRateLimitTier,
   isMcpWriteTool,
+  mcpToolCallsRequireAuthentication,
 } from "@/lib/mcp/tool-scopes";
 import {
   checkUserMutationRateLimit,
@@ -45,31 +47,6 @@ export async function handleMcpRequest(request: Request) {
       return originError;
     }
 
-    const { authenticateMcpRequest, authorizeMcpToolScopes } = await import(
-      "@/lib/mcp/auth"
-    );
-    const authResult = await runCloudflareTraceSpan(
-      "mcp.authenticate",
-      { "http.request.method": request.method },
-      () => authenticateMcpRequest(request),
-    );
-    if ("response" in authResult) {
-      const res = authResult.response;
-      const www = res.headers.get("www-authenticate");
-      const wwwAuthenticatePrefix = www ? www.slice(0, 120) : null;
-      recordAndLogMcpResponse({
-        authFailureDiagnostics: authResult.authFailureDiagnostics,
-        context: logContext,
-        request,
-        phase: "auth-rejected",
-        rpcSummary,
-        status: res.status,
-        start,
-        wwwAuthenticatePrefix,
-      });
-      return withMcpCors(request, res);
-    }
-
     const { readMcpJsonBodyWithinLimit } = await import(
       "@/lib/mcp/request-body"
     );
@@ -90,24 +67,33 @@ export async function handleMcpRequest(request: Request) {
 
     const toolCallNames = extractMcpToolCallNames(bodyResult.body);
     const toolNames = Array.from(new Set(toolCallNames));
-    const toolAuthResult = authorizeMcpToolScopes(
-      authResult.authInfo,
-      toolNames,
-    );
-    if ("response" in toolAuthResult) {
-      const res = toolAuthResult.response;
-      const www = res.headers.get("www-authenticate");
-      recordAndLogMcpResponse({
-        authFailureDiagnostics: toolAuthResult.authFailureDiagnostics,
-        context: logContext,
-        request,
-        phase: "auth-rejected",
-        rpcSummary,
-        status: res.status,
-        start,
-        wwwAuthenticatePrefix: www ? www.slice(0, 120) : null,
-      });
-      return withMcpCors(request, res);
+    let authInfo: AuthInfo | undefined;
+    if (
+      request.headers.has("authorization") ||
+      mcpToolCallsRequireAuthentication(toolNames)
+    ) {
+      const { authenticateMcpRequest } = await import("@/lib/mcp/auth");
+      const authResult = await runCloudflareTraceSpan(
+        "mcp.authenticate",
+        { "http.request.method": request.method },
+        () => authenticateMcpRequest(request, toolNames),
+      );
+      if ("response" in authResult) {
+        const res = authResult.response;
+        const www = res.headers.get("www-authenticate");
+        recordAndLogMcpResponse({
+          authFailureDiagnostics: authResult.authFailureDiagnostics,
+          context: logContext,
+          request,
+          phase: "auth-rejected",
+          rpcSummary,
+          status: res.status,
+          start,
+          wwwAuthenticatePrefix: www ? www.slice(0, 120) : null,
+        });
+        return withMcpCors(request, res);
+      }
+      authInfo = authResult.authInfo;
     }
 
     const { summarizeMcpJsonRpcBody } = await import("@/lib/mcp/observability");
@@ -116,7 +102,7 @@ export async function handleMcpRequest(request: Request) {
         ? null
         : summarizeMcpJsonRpcBody(bodyResult.body);
 
-    const userId = toolAuthResult.authInfo.extra?.userId;
+    const userId = authInfo?.extra?.userId;
     if (typeof userId === "string" && userId.length > 0) {
       for (const toolName of toolCallNames) {
         if (!isMcpWriteTool(toolName)) continue;
@@ -171,7 +157,7 @@ export async function handleMcpRequest(request: Request) {
       },
       () =>
         transport.handleRequest(request, {
-          authInfo: toolAuthResult.authInfo,
+          authInfo,
           parsedBody: bodyResult.body,
         }),
     );

--- a/src/lib/mcp/auth.ts
+++ b/src/lib/mcp/auth.ts
@@ -11,7 +11,10 @@ import {
   accessTokenLooksLikeJwt,
   verifyMcpAccessTokenRequest,
 } from "./auth-token-verification";
-import { getRequiredMcpScopes } from "./tool-scopes";
+import {
+  getRequiredMcpScopes,
+  mcpToolCallsRequireAuthentication,
+} from "./tool-scopes";
 import { getOAuthMcpResourceUrl } from "./urls";
 
 function tokenFormat(
@@ -71,7 +74,16 @@ export async function authenticateMcpRequest(
     };
   }
 
-  if (!hasMcpScope(authInfo.scopes)) {
+  const toolNames =
+    typeof toolName === "string"
+      ? [toolName]
+      : Array.isArray(toolName)
+        ? toolName
+        : [];
+  if (
+    mcpToolCallsRequireAuthentication(toolNames) &&
+    !hasMcpScope(authInfo.scopes)
+  ) {
     const diagnostics: McpAuthFailureDiagnostics = {
       authFailureKind: "missing_feature_scope",
       authHeaderKind: "bearer",

--- a/src/lib/mcp/tool-descriptors.ts
+++ b/src/lib/mcp/tool-descriptors.ts
@@ -14,12 +14,15 @@ import {
   getExplicitMcpToolScopeNames,
   getRequiredMcpScopes,
   hasExplicitMcpToolScopes,
+  isPublicMcpTool,
 } from "./tool-scopes";
 
-type ToolSecurityScheme = {
-  type: "oauth2";
-  scopes: string[];
-};
+type ToolSecurityScheme =
+  | { type: "noauth" }
+  | {
+      type: "oauth2";
+      scopes: string[];
+    };
 
 type ToolDescriptorDefaults = {
   title: string;
@@ -129,12 +132,15 @@ export function installMcpToolListCompatibility(server: McpServer) {
 export function getMcpToolDescriptorDefaults(
   name: string,
 ): ToolDescriptorDefaults {
+  const isPublic = isPublicMcpTool(name);
   const requiredScopes = getRequiredMcpScopes(name);
   const scopes =
     requiredScopes.length > 0 ? requiredScopes : [...PUBLIC_REST_SCOPES];
-  const isWrite = scopes.some(isWriteScope);
+  const isWrite = !isPublic && scopes.some(isWriteScope);
   const title = humanizeToolName(name);
-  const securitySchemes: ToolSecurityScheme[] = [{ type: "oauth2", scopes }];
+  const securitySchemes: ToolSecurityScheme[] = isPublic
+    ? [{ type: "noauth" }]
+    : [{ type: "oauth2", scopes }];
 
   return {
     title,

--- a/src/lib/mcp/tool-scopes.ts
+++ b/src/lib/mcp/tool-scopes.ts
@@ -67,9 +67,7 @@ const TOOL_SCOPE_MAP: Record<string, ToolScopeRequirement[]> = {
   workspace_subscription_import: [
     { feature: "workspace.subscription", action: "write" },
   ],
-  catalog_section_calendar_feed_get: [
-    { feature: "catalog.section", action: "read" },
-  ],
+  catalog_section_calendar_feed_get: [],
 
   // Calendar
   workspace_calendar_event_list: [
@@ -108,7 +106,7 @@ const TOOL_SCOPE_MAP: Record<string, ToolScopeRequirement[]> = {
 
   // Dashboard / overview
   workspace_snapshot_get: [{ feature: "workspace.overview", action: "read" }],
-  catalog_link_list: [{ feature: "catalog.link", action: "read" }],
+  catalog_link_list: [],
   workspace_link_pin_list: [{ feature: "workspace.link-pin", action: "read" }],
   workspace_link_pin_set: [{ feature: "workspace.link-pin", action: "write" }],
   workspace_deadline_list: [{ feature: "workspace.overview", action: "read" }],
@@ -119,44 +117,40 @@ const TOOL_SCOPE_MAP: Record<string, ToolScopeRequirement[]> = {
   ],
 
   // Bus
-  catalog_bus_timetable_get: [{ feature: "catalog.bus", action: "read" }],
-  catalog_bus_route_list: [{ feature: "catalog.bus", action: "read" }],
-  catalog_bus_route_get: [{ feature: "catalog.bus", action: "read" }],
+  catalog_bus_timetable_get: [],
+  catalog_bus_route_list: [],
+  catalog_bus_route_get: [],
   workspace_bus_preferences_get: [
     { feature: "workspace.bus-preferences", action: "read" },
   ],
   workspace_bus_preferences_set: [
     { feature: "workspace.bus-preferences", action: "write" },
   ],
-  catalog_bus_route_search: [{ feature: "catalog.bus", action: "read" }],
-  catalog_bus_departure_next: [{ feature: "catalog.bus", action: "read" }],
+  catalog_bus_route_search: [],
+  catalog_bus_departure_next: [],
 
   // Course catalog
-  catalog_course_search: [{ feature: "catalog.course", action: "read" }],
-  catalog_course_get: [{ feature: "catalog.course", action: "read" }],
-  catalog_semester_list: [{ feature: "catalog.course", action: "read" }],
-  catalog_semester_current: [{ feature: "catalog.course", action: "read" }],
+  catalog_course_search: [],
+  catalog_course_get: [],
+  catalog_semester_list: [],
+  catalog_semester_current: [],
 
   // Sections
-  catalog_section_get: [{ feature: "catalog.section", action: "read" }],
-  catalog_section_search: [{ feature: "catalog.section", action: "read" }],
-  catalog_section_match_preview: [
-    { feature: "catalog.section", action: "read" },
-  ],
+  catalog_section_get: [],
+  catalog_section_search: [],
+  catalog_section_match_preview: [],
 
   // Teachers
-  catalog_teacher_search: [{ feature: "catalog.teacher", action: "read" }],
-  catalog_teacher_get: [{ feature: "catalog.teacher", action: "read" }],
+  catalog_teacher_search: [],
+  catalog_teacher_get: [],
 
   // Schedules
-  catalog_schedule_list: [{ feature: "catalog.schedule", action: "read" }],
-  catalog_section_schedule_list: [
-    { feature: "catalog.schedule", action: "read" },
-  ],
+  catalog_schedule_list: [],
+  catalog_section_schedule_list: [],
   workspace_schedule_list: [{ feature: "workspace.schedule", action: "read" }],
 
   // Exams
-  catalog_section_exam_list: [{ feature: "catalog.exam", action: "read" }],
+  catalog_section_exam_list: [],
   workspace_exam_list: [{ feature: "workspace.exam", action: "read" }],
 };
 
@@ -168,13 +162,26 @@ export function getExplicitMcpToolScopeNames(): string[] {
   return Object.keys(TOOL_SCOPE_MAP);
 }
 
+export function isPublicMcpTool(name: string): boolean {
+  return (
+    name.startsWith("catalog_") &&
+    hasExplicitMcpToolScopes(name) &&
+    TOOL_SCOPE_MAP[name]?.length === 0
+  );
+}
+
+export function mcpToolCallsRequireAuthentication(names: string[]): boolean {
+  return names.some(
+    (name) => hasExplicitMcpToolScopes(name) && !isPublicMcpTool(name),
+  );
+}
+
 /**
  * Returns the canonical OAuth scope strings required for the given tool name(s).
  *
  * - A single tool name returns the scopes for that tool.
  * - An array of tool names returns the union of their required scopes.
- * - An unknown/missing tool name contributes no additional scope requirement,
- *   falling back to the generic MCP scope check.
+ * - An unknown/missing tool name contributes no additional scope requirement.
  */
 export function getRequiredMcpScopes(
   toolName: string | string[] | undefined,

--- a/src/lib/mcp/tools/bus/bus-next-tool-handler.ts
+++ b/src/lib/mcp/tools/bus/bus-next-tool-handler.ts
@@ -1,6 +1,5 @@
 import { getNextBusDepartures } from "@/features/bus/server/bus-service";
 import {
-  getUserId,
   jsonToolResult,
   parseOptionalMcpDate,
   resolveMcpMode,
@@ -11,33 +10,29 @@ import type {
   BusDayType,
   BusLocale,
   McpModeInput,
-  ToolExtra,
 } from "./bus-tool-types";
 
-export async function getNextBusesTool(
-  {
-    originCampusId,
-    destinationCampusId,
-    atTime,
-    dayType,
-    includeDeparted,
-    limit,
-    versionKey,
-    locale,
-    mode,
-  }: {
-    originCampusId: number;
-    destinationCampusId: number;
-    atTime?: AtTimeInput;
-    dayType: BusDayType;
-    includeDeparted: boolean;
-    limit: number;
-    versionKey?: string;
-    locale: BusLocale;
-    mode?: McpModeInput;
-  },
-  extra: ToolExtra,
-) {
+export async function getNextBusesTool({
+  originCampusId,
+  destinationCampusId,
+  atTime,
+  dayType,
+  includeDeparted,
+  limit,
+  versionKey,
+  locale,
+  mode,
+}: {
+  originCampusId: number;
+  destinationCampusId: number;
+  atTime?: AtTimeInput;
+  dayType: BusDayType;
+  includeDeparted: boolean;
+  limit: number;
+  versionKey?: string;
+  locale: BusLocale;
+  mode?: McpModeInput;
+}) {
   const resolvedMode = resolveMcpMode(mode);
   const parsedAtTime = parseOptionalMcpDate("atTime", atTime);
   if (!parsedAtTime.ok) {
@@ -53,7 +48,6 @@ export async function getNextBusesTool(
     includeDeparted,
     limit,
     versionKey,
-    userId: getUserId(extra.authInfo),
   });
 
   if (result && resolvedMode !== "full") {

--- a/src/lib/mcp/tools/bus/bus-timetable-tool-handler.ts
+++ b/src/lib/mcp/tools/bus/bus-timetable-tool-handler.ts
@@ -1,6 +1,5 @@
 import { getBusTimetableData } from "@/features/bus/server/bus-service";
 import {
-  getUserId,
   jsonToolResult,
   resolveMcpMode,
 } from "@/lib/mcp/tools/_shared/helpers";
@@ -8,21 +7,21 @@ import {
   buildFullBusTimetable,
   summarizeBusTimetable,
 } from "@/lib/mcp/tools/bus/bus-timetable-summary";
-import type { BusLocale, McpModeInput, ToolExtra } from "./bus-tool-types";
+import type { BusLocale, McpModeInput } from "./bus-tool-types";
 
-export async function queryBusTimetableTool(
-  {
-    versionKey,
-    locale,
-    mode,
-  }: { versionKey?: string; locale: BusLocale; mode?: McpModeInput },
-  extra: ToolExtra,
-) {
+export async function queryBusTimetableTool({
+  versionKey,
+  locale,
+  mode,
+}: {
+  versionKey?: string;
+  locale: BusLocale;
+  mode?: McpModeInput;
+}) {
   const resolvedMode = resolveMcpMode(mode);
   const result = await getBusTimetableData({
     locale,
     versionKey,
-    userId: getUserId(extra.authInfo),
   });
 
   if (result && resolvedMode === "default") {

--- a/tests/e2e/src/app/api/mcp/seeded-tools.test.ts
+++ b/tests/e2e/src/app/api/mcp/seeded-tools.test.ts
@@ -783,17 +783,6 @@ test.describe("/api/mcp - 种子工具覆盖", () => {
             }
           | undefined;
         await expect(async () => {
-          const preferenceResponse = await page.request.post(
-            "/api/workspace/bus-preferences",
-            {
-              data: {
-                preferredOriginCampusId: 1,
-                preferredDestinationCampusId: 4,
-                showDepartedTrips: true,
-              },
-            },
-          );
-          expect(preferenceResponse.status()).toBe(200);
           busResult = await mcpClient.callTool({
             name: "catalog_bus_timetable_get",
             arguments: {
@@ -812,10 +801,7 @@ test.describe("/api/mcp - 种子工具覆盖", () => {
             ),
           ).toBe(true);
           expect(busPayload?.trips).toBeUndefined();
-          expect(busPayload?.preferences?.preferredOriginCampusId).toBe(1);
-          expect(busPayload?.preferences?.preferredDestinationCampusId).toBe(4);
-          expect(busPayload?.preferences?.showDepartedTrips).toBe(true);
-          expect((busPayload?.nextDepartures?.length ?? 0) > 0).toBe(true);
+          expect(busPayload?.preferences).toBeNull();
         }).toPass({
           timeout: 10_000,
           intervals: [250, 500, 1_000],

--- a/tests/e2e/src/app/api/mcp/seeded-tools.test.ts
+++ b/tests/e2e/src/app/api/mcp/seeded-tools.test.ts
@@ -869,14 +869,12 @@ test.describe("/api/mcp - 种子工具覆盖", () => {
         expect(typeof busSummaryPayload.counts?.routes).toBe("number");
         expect(typeof busSummaryPayload.counts?.weekdayTrips).toBe("number");
         expect(typeof busSummaryPayload.counts?.weekendTrips).toBe("number");
-        expect((busSummaryPayload.nextDepartures?.length ?? 0) > 0).toBe(true);
+        expect(busSummaryPayload.nextDepartures).toEqual([]);
         expect(Array.isArray(busSummaryPayload.campuses)).toBe(true);
         expect(Array.isArray(busSummaryPayload.routes)).toBe(true);
         expect(busSummaryPayload.trips).toBeUndefined();
         expect(busResult).toBeDefined();
-        if (busSummaryPayload.nextDepartures?.length === 0) {
-          expect(typeof busSummaryPayload.nextDeparturesMessage).toBe("string");
-        }
+        expect(typeof busSummaryPayload.nextDeparturesMessage).toBe("string");
 
         // catalog_bus_route_list — lightweight route catalog
         const listRoutesResult = await mcpClient.callTool({

--- a/tests/e2e/src/app/api/mcp/transport.test.ts
+++ b/tests/e2e/src/app/api/mcp/transport.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { type APIResponse, expect, test } from "@playwright/test";
 import { MCP_JSON_RPC_BATCH_LIMIT } from "@/lib/mcp/request-body";
 import { DEFAULT_OAUTH_CLIENT_SCOPES } from "@/lib/oauth/constants";
 import { MCP_BOOTSTRAP_SCOPE } from "@/lib/oauth/scope-registry";
@@ -13,10 +13,24 @@ import {
   TRUSTED_BROWSER_ORIGIN,
 } from "./helpers";
 
+async function readMcpJsonRpcResponse(response: APIResponse) {
+  const body = await response.text();
+  if (!response.headers()["content-type"]?.includes("text/event-stream")) {
+    return JSON.parse(body) as unknown;
+  }
+
+  const data = body
+    .split("\n")
+    .find((line) => line.startsWith("data: "))
+    ?.slice("data: ".length);
+  if (!data) throw new Error("MCP SSE response did not contain a data event");
+  return JSON.parse(data) as unknown;
+}
+
 test.describe("/api/mcp - 传输与授权", () => {
   test.describe.configure({ mode: "serial" });
 
-  test("/api/mcp 未认证时返回 OAuth bearer challenge", async ({ request }) => {
+  test("/api/mcp 未认证时可以初始化", async ({ request }) => {
     const response = await request.post("/api/mcp", {
       data: {
         jsonrpc: "2.0",
@@ -32,8 +46,62 @@ test.describe("/api/mcp - 传输与授权", () => {
         },
       },
       headers: {
+        Accept: "application/json, text/event-stream",
         "MCP-Protocol-Version": "2025-03-26",
       },
+    });
+
+    expect(response.status()).toBe(200);
+    expect(response.headers()["www-authenticate"]).toBeUndefined();
+    await expect(readMcpJsonRpcResponse(response)).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      result: {
+        protocolVersion: expect.any(String),
+        serverInfo: expect.objectContaining({ name: expect.any(String) }),
+      },
+      id: 1,
+    });
+  });
+
+  test("/api/mcp 未认证时可以调用公开 catalog 工具", async ({ request }) => {
+    const response = await request.post("/api/mcp", {
+      data: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "catalog_semester_current",
+          arguments: { mode: "default" },
+        },
+      },
+      headers: {
+        Accept: "application/json, text/event-stream",
+        "MCP-Protocol-Version": "2025-03-26",
+      },
+    });
+
+    expect(response.status()).toBe(200);
+    expect(response.headers()["www-authenticate"]).toBeUndefined();
+    await expect(readMcpJsonRpcResponse(response)).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        structuredContent: expect.objectContaining({ success: true }),
+      },
+    });
+  });
+
+  test("/api/mcp 未认证调用私有工具时返回 OAuth bearer challenge", async ({
+    request,
+  }) => {
+    const response = await request.post("/api/mcp", {
+      data: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "workspace_todo_list", arguments: {} },
+      },
+      headers: { "MCP-Protocol-Version": "2025-03-26" },
     });
 
     expect(response.status()).toBe(401);
@@ -43,11 +111,6 @@ test.describe("/api/mcp - 传输与授权", () => {
     expect(response.headers()["www-authenticate"]).toContain(
       `scope="${MCP_BOOTSTRAP_SCOPE}"`,
     );
-    await expect(response.json()).resolves.toMatchObject({
-      jsonrpc: "2.0",
-      error: { code: -32000 },
-      id: null,
-    });
   });
 
   test("/api/mcp 在认证后拒绝超过 64 KiB 的请求体", async ({
@@ -64,7 +127,7 @@ test.describe("/api/mcp - 传输与授权", () => {
       data: oversizedBody,
       headers,
     });
-    expect(unauthenticatedResponse.status()).toBe(401);
+    expect(unauthenticatedResponse.status()).toBe(413);
 
     const resource = `${PLAYWRIGHT_BASE_URL}/api/mcp`;
     await signInAsDebugUser(page, "/");
@@ -179,11 +242,11 @@ test.describe("/api/mcp - 传输与授权", () => {
         "MCP-Protocol-Version": "2025-03-26",
       },
     });
-    expect(unauthenticatedResponse.status()).toBe(401);
+    expect(unauthenticatedResponse.status()).toBe(200);
     expectMcpCorsHeaders(unauthenticatedResponse.headers(), origin);
-    expect(unauthenticatedResponse.headers()["www-authenticate"]).toContain(
-      "resource_metadata=",
-    );
+    expect(
+      unauthenticatedResponse.headers()["www-authenticate"],
+    ).toBeUndefined();
 
     const resource = `${PLAYWRIGHT_BASE_URL}/api/mcp`;
     await signInAsDebugUser(page, "/");
@@ -276,15 +339,8 @@ test.describe("/api/mcp - 传输与授权", () => {
       data: {
         jsonrpc: "2.0",
         id: 1,
-        method: "initialize",
-        params: {
-          protocolVersion: "2025-03-26",
-          capabilities: {},
-          clientInfo: {
-            name: "insufficient-scope-e2e-client",
-            version: "1.0.0",
-          },
-        },
+        method: "tools/call",
+        params: { name: "workspace_todo_list", arguments: {} },
       },
       headers: {
         Authorization: `Bearer ${accessToken}`,

--- a/tests/integration/mcp/bus/timetable.test.ts
+++ b/tests/integration/mcp/bus/timetable.test.ts
@@ -43,11 +43,7 @@ describe("catalog_bus_timetable_get", () => {
     expect(
       result.routes?.some((r) => r.id === fixtures.DEV_SEED.bus.routeId),
     ).toBe(true);
-    expect(result.preferences).toEqual({
-      preferredOriginCampusId: null,
-      preferredDestinationCampusId: null,
-      showDepartedTrips: false,
-    });
+    expect(result.preferences).toBeNull();
     expect(Array.isArray(result.nextDepartures)).toBe(true);
   });
 
@@ -78,7 +74,7 @@ describe("catalog_bus_timetable_get", () => {
     expect(typeof result.counts?.routes).toBe("number");
     expect(Array.isArray(result.campuses)).toBe(true);
     expect(Array.isArray(result.routes)).toBe(true);
-    expect(result.preferences).toBeDefined();
+    expect(result.preferences).toBeNull();
     expect(Array.isArray(result.nextDepartures)).toBe(true);
     expect(typeof result.nextDeparturesMessage).toBe("string");
   });
@@ -147,12 +143,14 @@ describe("catalog_bus_timetable_get", () => {
     expect(result.version?.key).toBe(fixtures.DEV_SEED.bus.versionKey);
   });
 
-  it("未认证调用因缺少用户上下文而被拒绝", async () => {
+  it("未认证调用返回公开时刻表且不包含个人偏好", async () => {
     const anonymous = await createAnonymousMcpHarness();
     try {
-      await expect(
-        anonymous.call("catalog_bus_timetable_get", { locale: "zh-cn" }),
-      ).rejects.toThrow();
+      const result = await anonymous.call<{ preferences?: unknown }>(
+        "catalog_bus_timetable_get",
+        { locale: "zh-cn" },
+      );
+      expect(result.preferences).toBeNull();
     } finally {
       await anonymous.close();
     }

--- a/tests/unit/mcp-auth.test.ts
+++ b/tests/unit/mcp-auth.test.ts
@@ -322,6 +322,14 @@ describe("MCP per-tool scope enforcement", () => {
     });
   });
 
+  it("accepts identity-only tokens for public catalog calls", async () => {
+    await expect(
+      authenticate(["openid"], "catalog_course_search"),
+    ).resolves.toMatchObject({
+      authInfo: { clientId: "client-id", scopes: ["openid"] },
+    });
+  });
+
   it("requires every scope in a mixed-tool batch", async () => {
     const result = await authenticate(
       [TODO_WRITE_SCOPE],
@@ -387,9 +395,9 @@ describe("MCP per-tool scope enforcement", () => {
     }
   });
 
-  it("allows an unmapped tool after the generic feature-scope gate", async () => {
+  it("allows an unmapped tool without a feature-scope gate", async () => {
     await expect(
-      authenticate([restReadScope("account.profile")], "not_a_real_tool"),
+      authenticate(["openid"], "not_a_real_tool"),
     ).resolves.toMatchObject({ authInfo: { clientId: "client-id" } });
   });
 });

--- a/tests/unit/mcp-request-rate-limit.test.ts
+++ b/tests/unit/mcp-request-rate-limit.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   authenticateMcpRequestMock,
-  authorizeMcpToolScopesMock,
   checkUserMutationRateLimitMock,
   connectMock,
   handleTransportRequestMock,
@@ -11,7 +10,6 @@ const {
   transportConstructorMock,
 } = vi.hoisted(() => ({
   authenticateMcpRequestMock: vi.fn(),
-  authorizeMcpToolScopesMock: vi.fn(),
   checkUserMutationRateLimitMock: vi.fn(),
   connectMock: vi.fn(),
   handleTransportRequestMock: vi.fn(),
@@ -35,7 +33,6 @@ vi.mock(
 
 vi.mock("@/lib/mcp/auth", () => ({
   authenticateMcpRequest: authenticateMcpRequestMock,
-  authorizeMcpToolScopes: authorizeMcpToolScopesMock,
 }));
 
 vi.mock("@/lib/mcp/observability", () => ({
@@ -83,9 +80,6 @@ describe("MCP mutation rate limits", () => {
   beforeEach(() => {
     vi.resetModules();
     authenticateMcpRequestMock.mockReset();
-    authorizeMcpToolScopesMock
-      .mockReset()
-      .mockImplementation((authInfo) => ({ authInfo }));
     checkUserMutationRateLimitMock.mockReset();
     connectMock.mockReset().mockResolvedValue(undefined);
     handleTransportRequestMock.mockReset().mockResolvedValue(
@@ -154,11 +148,9 @@ describe("MCP mutation rate limits", () => {
     expect(transportConstructorMock).not.toHaveBeenCalled();
     expect(connectMock).not.toHaveBeenCalled();
     expect(handleTransportRequestMock).not.toHaveBeenCalled();
-    expect(authenticateMcpRequestMock).toHaveBeenCalledWith(request);
-    expect(authorizeMcpToolScopesMock).toHaveBeenCalledWith(
-      expect.objectContaining({ extra: { userId: "user-1" } }),
-      ["workspace_todo_create"],
-    );
+    expect(authenticateMcpRequestMock).toHaveBeenCalledWith(request, [
+      "workspace_todo_create",
+    ]);
     expect(recordAndLogMcpResponseMock).toHaveBeenCalledWith(
       expect.objectContaining({
         phase: "rate-limit-rejected",
@@ -207,7 +199,37 @@ describe("MCP mutation rate limits", () => {
     );
   });
 
-  it("rejects unauthenticated oversized requests before inspecting the body", async () => {
+  it("allows anonymous public catalog calls without invoking OAuth", async () => {
+    const request = new Request("https://life.example/api/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "catalog_course_search", arguments: { query: "AI" } },
+      }),
+    });
+
+    const { handleMcpRequest } = await import(
+      "@/lib/api/routes/mcp-request-handler"
+    );
+    const response = await handleMcpRequest(request);
+
+    expect(response.status).toBe(200);
+    expect(authenticateMcpRequestMock).not.toHaveBeenCalled();
+    expect(handleTransportRequestMock).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({
+        authInfo: undefined,
+        parsedBody: expect.objectContaining({
+          params: expect.objectContaining({ name: "catalog_course_search" }),
+        }),
+      }),
+    );
+  });
+
+  it("still challenges anonymous protected tool calls", async () => {
     authenticateMcpRequestMock.mockResolvedValue({
       authFailureDiagnostics: { authFailureKind: "missing_bearer" },
       response: new Response(JSON.stringify({ error: "invalid_token" }), {
@@ -216,11 +238,13 @@ describe("MCP mutation rate limits", () => {
     });
     const request = new Request("https://life.example/api/mcp", {
       method: "POST",
-      headers: {
-        "content-length": String(65 * 1024),
-        "content-type": "application/json",
-      },
-      body: "{}",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "workspace_todo_list", arguments: {} },
+      }),
     });
 
     const { handleMcpRequest } = await import(
@@ -229,11 +253,13 @@ describe("MCP mutation rate limits", () => {
     const response = await handleMcpRequest(request);
 
     expect(response.status).toBe(401);
-    expect(authorizeMcpToolScopesMock).not.toHaveBeenCalled();
-    expect(transportConstructorMock).not.toHaveBeenCalled();
+    expect(authenticateMcpRequestMock).toHaveBeenCalledWith(request, [
+      "workspace_todo_list",
+    ]);
+    expect(handleTransportRequestMock).not.toHaveBeenCalled();
   });
 
-  it("rejects authenticated oversized requests before scope or SDK handling", async () => {
+  it("rejects anonymous oversized requests before authentication", async () => {
     const request = new Request("https://life.example/api/mcp", {
       method: "POST",
       headers: {
@@ -249,7 +275,28 @@ describe("MCP mutation rate limits", () => {
     const response = await handleMcpRequest(request);
 
     expect(response.status).toBe(413);
-    expect(authorizeMcpToolScopesMock).not.toHaveBeenCalled();
+    expect(authenticateMcpRequestMock).not.toHaveBeenCalled();
+    expect(transportConstructorMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects authenticated oversized requests before auth or SDK handling", async () => {
+    const request = new Request("https://life.example/api/mcp", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer token",
+        "content-length": String(65 * 1024),
+        "content-type": "application/json",
+      },
+      body: "{}",
+    });
+
+    const { handleMcpRequest } = await import(
+      "@/lib/api/routes/mcp-request-handler"
+    );
+    const response = await handleMcpRequest(request);
+
+    expect(response.status).toBe(413);
+    expect(authenticateMcpRequestMock).not.toHaveBeenCalled();
     expect(transportConstructorMock).not.toHaveBeenCalled();
     expect(recordAndLogMcpResponseMock).toHaveBeenCalledWith(
       expect.objectContaining({ phase: "body-rejected", status: 413 }),

--- a/tests/unit/mcp-tool-descriptors.test.ts
+++ b/tests/unit/mcp-tool-descriptors.test.ts
@@ -141,6 +141,26 @@ describe("MCP tool descriptors", () => {
     });
   });
 
+  it("advertises public catalog tools as noauth", async () => {
+    const result = await listTools();
+    const tool = result.tools.find(
+      (item) => item.name === "catalog_course_search",
+    );
+    const wireResult = await listToolsWireResult();
+    const wireTool = wireResult.tools.find(
+      (item) => item.name === "catalog_course_search",
+    );
+
+    expect(tool).toMatchObject({
+      annotations: { readOnlyHint: true },
+      _meta: { securitySchemes: [{ type: "noauth" }] },
+    });
+    expect(wireTool).toMatchObject({
+      securitySchemes: [{ type: "noauth" }],
+      _meta: { securitySchemes: [{ type: "noauth" }] },
+    });
+  });
+
   it("installs the tools/list compatibility wrapper once after registration", async () => {
     const mcpServer = new McpServer({
       name: "unit-test-list-compatibility",

--- a/tests/unit/mcp-tool-scopes.test.ts
+++ b/tests/unit/mcp-tool-scopes.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from "vitest";
 import {
   extractMcpToolCallNamesFromRequest,
   extractMcpToolNamesFromRequest,
+  getExplicitMcpToolScopeNames,
   getMcpWriteRateLimitAction,
   getMcpWriteRateLimitTier,
   getRequiredMcpScopes,
   isMcpWriteTool,
+  isPublicMcpTool,
+  mcpToolCallsRequireAuthentication,
 } from "@/lib/mcp/tool-scopes";
 import { restReadScope, restWriteScope } from "@/lib/oauth/constants";
 
@@ -51,27 +54,24 @@ describe("getRequiredMcpScopes", () => {
     expect(getRequiredMcpScopes(undefined)).toEqual([]);
   });
 
-  it("covers every major feature area", () => {
+  it("does not require scopes for public catalog tools", () => {
+    const publicTools = getExplicitMcpToolScopeNames().filter((name) =>
+      name.startsWith("catalog_"),
+    );
+
+    expect(publicTools.length).toBeGreaterThan(0);
+    for (const tool of publicTools) {
+      expect(getRequiredMcpScopes(tool)).toEqual([]);
+      expect(isPublicMcpTool(tool)).toBe(true);
+    }
+  });
+
+  it("covers every protected feature area", () => {
     expect(getRequiredMcpScopes("account_profile_get")).toEqual([
       restReadScope("account.profile"),
     ]);
     expect(getRequiredMcpScopes("workspace_snapshot_get")).toEqual([
       restReadScope("workspace.overview"),
-    ]);
-    expect(getRequiredMcpScopes("catalog_bus_departure_next")).toEqual([
-      restReadScope("catalog.bus"),
-    ]);
-    expect(getRequiredMcpScopes("catalog_course_search")).toEqual([
-      restReadScope("catalog.course"),
-    ]);
-    expect(getRequiredMcpScopes("catalog_section_get")).toEqual([
-      restReadScope("catalog.section"),
-    ]);
-    expect(getRequiredMcpScopes("catalog_teacher_search")).toEqual([
-      restReadScope("catalog.teacher"),
-    ]);
-    expect(getRequiredMcpScopes("catalog_schedule_list")).toEqual([
-      restReadScope("catalog.schedule"),
     ]);
     expect(getRequiredMcpScopes("workspace_exam_list")).toEqual([
       restReadScope("workspace.exam"),
@@ -94,6 +94,24 @@ describe("getRequiredMcpScopes", () => {
     expect(getRequiredMcpScopes("workspace_upload_list")).toEqual([
       restReadScope("workspace.upload"),
     ]);
+  });
+
+  it("requires authentication only for known protected tools", () => {
+    expect(mcpToolCallsRequireAuthentication(["catalog_course_search"])).toBe(
+      false,
+    );
+    expect(
+      mcpToolCallsRequireAuthentication([
+        "catalog_course_search",
+        "workspace_todo_list",
+      ]),
+    ).toBe(true);
+    expect(mcpToolCallsRequireAuthentication(["unknown_tool"])).toBe(false);
+    expect(mcpToolCallsRequireAuthentication(["graphql_operation_run"])).toBe(
+      true,
+    );
+    expect(isPublicMcpTool("workspace_todo_list")).toBe(false);
+    expect(isPublicMcpTool("unknown_tool")).toBe(false);
   });
 
   it("maps mutation tools to shared feature-action budgets", () => {


### PR DESCRIPTION
## What changed

- allow MCP initialization, tool discovery, and `catalog_*` calls without OAuth
- advertise catalog tools with `noauth` security metadata while keeping workspace, account, community, and GraphQL tools protected
- keep catalog bus responses strictly public by removing implicit user-preference enrichment
- add unit, integration, and HTTP end-to-end coverage for anonymous catalog access and protected-tool challenges

## Root cause

The MCP HTTP handler authenticated every POST before parsing its JSON-RPC method. That made public catalog tools unreachable without a bearer token even though their underlying data is public. Catalog tool descriptors also advertised OAuth scopes, and two bus catalog handlers assumed an authenticated user context.

## Impact

MCP clients can discover and call public catalog data without prompting users to authorize. OAuth is requested only when a protected tool is called, and scope challenges remain tool-specific.

## Validation

- `bunx vitest run` — 355 files, 2148 tests passed
- all three TypeScript typecheck configurations passed
- `bunx wrangler types --include-runtime=false --check`
- `bun run openapi:check`
- targeted MCP bus integration suite — 10 tests passed
- anonymous HTTP E2E cases passed for initialize, catalog call, and protected-tool 401 challenge
