### PR TITLE
fix(data): production catalog rematerialization and strict responses

### DIFF
--- a/prisma/migrations/20260816120000_track_static_import_transform_revision/migration.sql
+++ b/prisma/migrations/20260816120000_track_static_import_transform_revision/migration.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "StaticImportState"
+ADD COLUMN "transformRevision" INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE "StaticImportState"
+ALTER COLUMN "transformRevision" DROP DEFAULT;
+
+ALTER TABLE "StaticImportState"
+ADD CONSTRAINT "StaticImportState_transformRevision_check"
+CHECK ("transformRevision" >= 0);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -461,6 +461,7 @@ model StaticImportState {
 
   snapshotGeneratedAt DateTime
   snapshotSha256      String
+  transformRevision   Int
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/features/catalog/server/course-section-read-queries.ts
+++ b/src/features/catalog/server/course-section-read-queries.ts
@@ -19,7 +19,6 @@ import { cachedPublicDetailRuntimeData } from "@/lib/catalog-detail-runtime-cach
 import { getPrisma } from "@/lib/db/prisma";
 import { toLocalizedNameDto } from "@/lib/localized-name";
 import { toShanghaiIsoString } from "@/lib/time/serialize-date-output";
-import { serializeScheduleTimeFields } from "@/shared/lib/schedule-serialization";
 import { formatTime } from "@/shared/lib/time-utils";
 import {
   type CourseSummaryRecord,
@@ -347,25 +346,7 @@ export async function findSectionDetailByJwId(
         include: buildPartialSectionDetailInclude(options),
       });
 
-      if (!section) return null;
-
-      return {
-        ...section,
-        exams: "exams" in section && section.exams ? section.exams : [],
-        scheduleGroups:
-          "scheduleGroups" in section && section.scheduleGroups
-            ? section.scheduleGroups
-            : [],
-        schedules:
-          "schedules" in section && section.schedules
-            ? section.schedules.map(serializeScheduleTimeFields)
-            : [],
-        teacherAssignments:
-          "teacherAssignments" in section && section.teacherAssignments
-            ? section.teacherAssignments
-            : [],
-        teachers: section.teachers ?? [],
-      };
+      return section ? toSectionDetailDto(section, locale) : null;
     },
   });
 }
@@ -380,21 +361,20 @@ function buildPartialSectionDetailInclude(options: {
   return {
     ...sectionInclude,
     roomType: true,
-    schedules: includeSchedules,
-    scheduleGroups: includeSchedules,
+    schedules: { take: includeSchedules ? undefined : 0 },
+    scheduleGroups: { take: includeSchedules ? undefined : 0 },
     teachers: { select: teacherPublicReferenceSelect },
-    teacherAssignments:
-      options.includeTeacherDepartments === true
-        ? { select: teacherAssignmentPublicSelect }
-        : false,
-    exams: includeExams
-      ? {
-          include: {
-            examBatch: true,
-            examRooms: true,
-          },
-        }
-      : false,
+    teacherAssignments: {
+      take: options.includeTeacherDepartments === true ? undefined : 0,
+      select: teacherAssignmentPublicSelect,
+    },
+    exams: {
+      take: includeExams ? undefined : 0,
+      include: {
+        examBatch: true,
+        examRooms: true,
+      },
+    },
   } as const;
 }
 

--- a/src/lib/catalog-detail-cache-revision.ts
+++ b/src/lib/catalog-detail-cache-revision.ts
@@ -26,7 +26,7 @@ export async function getCatalogDetailCacheRevision() {
       try {
         const state = await prisma.staticImportState.findUnique({
           where: { id: "global" },
-          select: { snapshotSha256: true },
+          select: { snapshotSha256: true, updatedAt: true },
         });
         span?.setAttribute("cache.outcome", "success");
         return state;
@@ -36,7 +36,9 @@ export async function getCatalogDetailCacheRevision() {
       }
     },
   );
-  const value = state?.snapshotSha256?.slice(0, 16) ?? BOOTSTRAP_REVISION;
+  const value = state
+    ? `${state.snapshotSha256.slice(0, 16)}-${state.updatedAt.getTime().toString(36)}`
+    : BOOTSTRAP_REVISION;
   cachedRevision = { expiresAt: now + REVISION_CACHE_TTL_MS, value };
   return value;
 }

--- a/src/lib/catalog-runtime-cache.ts
+++ b/src/lib/catalog-runtime-cache.ts
@@ -30,11 +30,12 @@ export function publicCatalogKvCacheKey(
 
 export function publicCatalogColoCacheKey(
   origin: string,
+  revision: string,
   namespace: string,
   cacheKey: string,
 ) {
   return new URL(
-    `${PUBLIC_CATALOG_COLO_CACHE_PATH}/${encodeURIComponent(namespace)}/${encodeURIComponent(cacheKey)}`,
+    `${PUBLIC_CATALOG_COLO_CACHE_PATH}/${encodeURIComponent(revision)}/${encodeURIComponent(namespace)}/${encodeURIComponent(cacheKey)}`,
     origin,
   ).toString();
 }
@@ -48,6 +49,7 @@ export async function buildPublicCatalogRuntimeCacheOptions(input: {
   return {
     coloCacheKey: publicCatalogColoCacheKey(
       input.origin,
+      revision,
       input.namespace,
       input.cacheKey,
     ),
@@ -71,14 +73,21 @@ export async function cachedCatalogRuntimeData<T>(
   } = {},
 ) {
   const ttlMs = options.ttlMs ?? PUBLIC_CATALOG_RUNTIME_CACHE_TTL_MS;
-  return cachedPublicRuntimeData(namespace, cacheKey, ttlMs, load, {
-    ...(await buildPublicCatalogRuntimeCacheOptions({
-      cacheKey,
-      namespace,
-      origin,
-    })),
-    shouldCacheResult: options.shouldCacheResult,
+  const cacheOptions = await buildPublicCatalogRuntimeCacheOptions({
+    cacheKey,
+    namespace,
+    origin,
   });
+  return cachedPublicRuntimeData(
+    namespace,
+    cacheOptions.kvCacheKey,
+    ttlMs,
+    load,
+    {
+      ...cacheOptions,
+      shouldCacheResult: options.shouldCacheResult,
+    },
+  );
 }
 
 export async function cachedCatalogListRuntimeData<T>(

--- a/src/static-loader/import-state.ts
+++ b/src/static-loader/import-state.ts
@@ -3,6 +3,10 @@ import type { Prisma } from "../generated/prisma-node/client";
 const GLOBAL_IMPORT_STATE_ID = "global";
 const SHA256_PATTERN = /^[a-f0-9]{64}$/;
 
+// Increment whenever mapper semantics change and existing imported rows must be
+// rebuilt even when the source snapshot itself is unchanged.
+export const STATIC_IMPORT_TRANSFORM_REVISION = 1;
+
 type StaticImportStateTransaction = {
   staticImportState: Pick<
     Prisma.TransactionClient["staticImportState"],
@@ -13,6 +17,7 @@ type StaticImportStateTransaction = {
 type StaticImportStateInput = {
   observedAt: Date;
   snapshotSha256: string;
+  transformRevision: number;
 };
 
 function validateSnapshotSha256(snapshotSha256: string) {
@@ -21,17 +26,36 @@ function validateSnapshotSha256(snapshotSha256: string) {
   }
 }
 
+function validateTransformRevision(transformRevision: number) {
+  if (!Number.isSafeInteger(transformRevision) || transformRevision < 1) {
+    throw new Error(
+      "Static import transform revision must be a positive integer",
+    );
+  }
+}
+
 export async function assertStaticImportStateAllowsSnapshot(
   tx: StaticImportStateTransaction,
   input: StaticImportStateInput,
 ): Promise<boolean> {
   validateSnapshotSha256(input.snapshotSha256);
+  validateTransformRevision(input.transformRevision);
   const current = await tx.staticImportState.findUnique({
     where: { id: GLOBAL_IMPORT_STATE_ID },
-    select: { snapshotGeneratedAt: true, snapshotSha256: true },
+    select: {
+      snapshotGeneratedAt: true,
+      snapshotSha256: true,
+      transformRevision: true,
+    },
   });
 
   if (current == null) return false;
+
+  if (input.transformRevision < current.transformRevision) {
+    throw new Error(
+      `Refusing static import transform revision ${input.transformRevision} because revision ${current.transformRevision} was already committed`,
+    );
+  }
 
   const incomingTime = input.observedAt.getTime();
   const currentTime = current.snapshotGeneratedAt.getTime();
@@ -48,24 +72,30 @@ export async function assertStaticImportStateAllowsSnapshot(
       `Refusing snapshot SHA-256 ${input.snapshotSha256} because generated_at ${input.observedAt.toISOString()} was already committed with SHA-256 ${current.snapshotSha256}`,
     );
   }
-  return input.snapshotSha256 === current.snapshotSha256;
+  return (
+    input.snapshotSha256 === current.snapshotSha256 &&
+    input.transformRevision === current.transformRevision
+  );
 }
 
 export async function recordStaticImportState(
   tx: StaticImportStateTransaction,
-  input: Pick<StaticImportStateInput, "observedAt" | "snapshotSha256">,
+  input: StaticImportStateInput,
 ) {
   validateSnapshotSha256(input.snapshotSha256);
+  validateTransformRevision(input.transformRevision);
   await tx.staticImportState.upsert({
     where: { id: GLOBAL_IMPORT_STATE_ID },
     create: {
       id: GLOBAL_IMPORT_STATE_ID,
       snapshotGeneratedAt: input.observedAt,
       snapshotSha256: input.snapshotSha256,
+      transformRevision: input.transformRevision,
     },
     update: {
       snapshotGeneratedAt: input.observedAt,
       snapshotSha256: input.snapshotSha256,
+      transformRevision: input.transformRevision,
     },
   });
 }

--- a/src/static-loader/import.ts
+++ b/src/static-loader/import.ts
@@ -16,6 +16,7 @@ import { acquireStaticImportLock } from "./import-lock";
 import {
   assertStaticImportStateAllowsSnapshot,
   recordStaticImportState,
+  STATIC_IMPORT_TRANSFORM_REVISION,
 } from "./import-state";
 import { loadScheduleInfrastructure } from "./infrastructure-plan";
 import type {
@@ -135,6 +136,7 @@ export async function runImport(
         return assertStaticImportStateAllowsSnapshot(tx, {
           observedAt: snapshotGeneratedAt,
           snapshotSha256: config.snapshotSha256,
+          transformRevision: STATIC_IMPORT_TRANSFORM_REVISION,
         });
       },
       { maxWait: 60_000, timeout: 60_000 },
@@ -260,6 +262,7 @@ export async function runImport(
       assertStaticImportStateAllowsSnapshot(tx, {
         observedAt,
         snapshotSha256: config.snapshotSha256,
+        transformRevision: STATIC_IMPORT_TRANSFORM_REVISION,
       }),
     );
     if (alreadyImported && !config.dryRun) {
@@ -438,6 +441,7 @@ export async function runImport(
       recordStaticImportState(tx, {
         observedAt,
         snapshotSha256: config.snapshotSha256,
+        transformRevision: STATIC_IMPORT_TRANSFORM_REVISION,
       }),
     );
 

--- a/tests/integration/static-import-state.test.ts
+++ b/tests/integration/static-import-state.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, it } from "vitest";
 import {
   assertStaticImportStateAllowsSnapshot,
   recordStaticImportState,
+  STATIC_IMPORT_TRANSFORM_REVISION,
 } from "@/static-loader/import-state";
 import { createTestPrisma, disconnectTestPrisma } from "../shared/prisma";
 
@@ -24,11 +25,13 @@ describe("global static import state persistence", () => {
           assertStaticImportStateAllowsSnapshot(tx, {
             observedAt,
             snapshotSha256: snapshotSha,
+            transformRevision: STATIC_IMPORT_TRANSFORM_REVISION,
           }),
         ).resolves.toBe(false);
         await recordStaticImportState(tx, {
           observedAt,
           snapshotSha256: snapshotSha,
+          transformRevision: STATIC_IMPORT_TRANSFORM_REVISION,
         });
 
         await expect(
@@ -37,22 +40,33 @@ describe("global static import state persistence", () => {
             select: {
               snapshotGeneratedAt: true,
               snapshotSha256: true,
+              transformRevision: true,
             },
           }),
         ).resolves.toEqual({
           snapshotGeneratedAt: observedAt,
           snapshotSha256: snapshotSha,
+          transformRevision: STATIC_IMPORT_TRANSFORM_REVISION,
         });
         await expect(
           assertStaticImportStateAllowsSnapshot(tx, {
             observedAt,
+            snapshotSha256: snapshotSha,
+            transformRevision: STATIC_IMPORT_TRANSFORM_REVISION + 1,
+          }),
+        ).resolves.toBe(false);
+        await expect(
+          assertStaticImportStateAllowsSnapshot(tx, {
+            observedAt,
             snapshotSha256: otherSnapshotSha,
+            transformRevision: STATIC_IMPORT_TRANSFORM_REVISION,
           }),
         ).rejects.toThrow("already committed with SHA-256");
         await expect(
           assertStaticImportStateAllowsSnapshot(tx, {
             observedAt: new Date("2026-07-17T03:00:00.000Z"),
             snapshotSha256: snapshotSha,
+            transformRevision: STATIC_IMPORT_TRANSFORM_REVISION,
           }),
         ).rejects.toThrow("last committed snapshot");
 

--- a/tests/unit/catalog-detail-cache-revision.test.ts
+++ b/tests/unit/catalog-detail-cache-revision.test.ts
@@ -23,19 +23,36 @@ describe("catalog detail cache revision", () => {
     findUniqueMock.mockReset();
   });
 
-  it("uses the static import snapshot SHA prefix as the revision", async () => {
+  it("uses the snapshot SHA and committed materialization time as the revision", async () => {
     findUniqueMock.mockResolvedValue({
       snapshotSha256:
         "abcdef0123456789abcdef0123456789abcdef0123456789abcdef01",
+      updatedAt: new Date("2026-08-16T03:00:00.000Z"),
     });
 
     await expect(getCatalogDetailCacheRevision()).resolves.toBe(
-      "abcdef0123456789",
+      "abcdef0123456789-msv7vmo0",
     );
     await expect(getCatalogDetailCacheRevision()).resolves.toBe(
-      "abcdef0123456789",
+      "abcdef0123456789-msv7vmo0",
     );
     expect(findUniqueMock).toHaveBeenCalledOnce();
+  });
+
+  it("changes revision when the same snapshot is rematerialized", async () => {
+    findUniqueMock.mockResolvedValue({
+      snapshotSha256: "abcdef0123456789",
+      updatedAt: new Date("2026-08-16T03:00:00.000Z"),
+    });
+    const first = await getCatalogDetailCacheRevision();
+
+    resetCatalogDetailCacheRevisionForTest();
+    findUniqueMock.mockResolvedValue({
+      snapshotSha256: "abcdef0123456789",
+      updatedAt: new Date("2026-08-16T03:01:00.000Z"),
+    });
+
+    await expect(getCatalogDetailCacheRevision()).resolves.not.toBe(first);
   });
 
   it("falls back to bootstrap when static import state is missing", async () => {
@@ -45,7 +62,10 @@ describe("catalog detail cache revision", () => {
   });
 
   it("traces only the revision origin read with fixed cache attributes", async () => {
-    findUniqueMock.mockResolvedValue({ snapshotSha256: "abcdef0123456789" });
+    findUniqueMock.mockResolvedValue({
+      snapshotSha256: "abcdef0123456789",
+      updatedAt: new Date("2026-08-16T03:00:00.000Z"),
+    });
     const setAttribute = vi.fn();
     const enterSpan = vi.fn(
       <T>(

--- a/tests/unit/catalog-detail-read-cache.test.ts
+++ b/tests/unit/catalog-detail-read-cache.test.ts
@@ -32,6 +32,75 @@ vi.mock("@/lib/db/prisma", () => ({
   })),
 }));
 
+const sectionDetailRecord = {
+  id: 3,
+  jwId: 303,
+  retiredAt: null,
+  code: "SECTION-3",
+  bizTypeId: null,
+  credits: null,
+  period: null,
+  periodsPerWeek: null,
+  timesPerWeek: null,
+  stdCount: null,
+  limitCount: null,
+  graduateAndPostgraduate: null,
+  dateTimePlaceText: null,
+  dateTimePlacePersonText: null,
+  actualPeriods: null,
+  theoryPeriods: null,
+  practicePeriods: null,
+  experimentPeriods: null,
+  machinePeriods: null,
+  designPeriods: null,
+  testPeriods: null,
+  scheduleState: null,
+  suggestScheduleWeeks: null,
+  suggestScheduleWeekInfo: null,
+  scheduleJsonParams: null,
+  selectedStdCount: null,
+  remark: null,
+  scheduleRemark: null,
+  courseId: 1,
+  semesterId: null,
+  campusId: null,
+  examModeId: null,
+  openDepartmentId: null,
+  teachLanguageId: null,
+  roomTypeId: null,
+  course: {
+    id: 1,
+    jwId: 101,
+    code: "COURSE-1",
+    nameCn: "课程 1",
+    nameEn: null,
+    categoryId: null,
+    classTypeId: null,
+    classifyId: null,
+    educationLevelId: null,
+    gradationId: null,
+    typeId: null,
+    category: null,
+    classType: null,
+    classify: null,
+    educationLevel: null,
+    gradation: null,
+    type: null,
+  },
+  semester: null,
+  campus: null,
+  openDepartment: null,
+  examMode: null,
+  teachLanguage: null,
+  roomType: null,
+  exams: [],
+  scheduleGroups: [],
+  schedules: [],
+  teacherAssignments: [],
+  teachers: [],
+  adminClasses: [],
+};
+
 describe("shared public catalog detail cache", () => {
   beforeEach(() => {
     resetPublicRuntimeCacheForTest();
@@ -114,14 +183,7 @@ describe("shared public catalog detail cache", () => {
   });
 
   it("isolates section details by locale and requested child shape", async () => {
-    sectionFindUniqueMock.mockResolvedValue({
-      exams: [],
-      id: 3,
-      scheduleGroups: [],
-      schedules: [],
-      teacherAssignments: [],
-      teachers: [],
-    });
+    sectionFindUniqueMock.mockResolvedValue(sectionDetailRecord);
     const { findSectionDetailByJwId } = await import(
       "@/features/catalog/server/course-section-read-queries"
     );

--- a/tests/unit/catalog-runtime-cache.test.ts
+++ b/tests/unit/catalog-runtime-cache.test.ts
@@ -21,11 +21,12 @@ describe("catalog runtime cache keys", () => {
     expect(
       publicCatalogColoCacheKey(
         "https://life.example",
+        "rev123",
         "search:catalog:v4:zh-cn",
         "5:数学分析",
       ),
     ).toBe(
-      "https://life.example/_life-ustc-internal-cache/catalog-runtime/v1/search%3Acatalog%3Av4%3Azh-cn/5%3A%E6%95%B0%E5%AD%A6%E5%88%86%E6%9E%90",
+      "https://life.example/_life-ustc-internal-cache/catalog-runtime/v1/rev123/search%3Acatalog%3Av4%3Azh-cn/5%3A%E6%95%B0%E5%AD%A6%E5%88%86%E6%9E%90",
     );
   });
 

--- a/tests/unit/catalog-shared-list-cache.test.ts
+++ b/tests/unit/catalog-shared-list-cache.test.ts
@@ -1,25 +1,49 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resetPublicRuntimeCacheForTest } from "@/lib/public-runtime-cache";
 
-const { paginatedCourseQueryMock } = vi.hoisted(() => ({
-  paginatedCourseQueryMock: vi.fn(async () => ({
-    data: [],
-    pagination: { page: 1, pageSize: 20, total: 0, totalPages: 1 },
-  })),
-}));
+const { getCatalogDetailCacheRevisionMock, paginatedCourseQueryMock } =
+  vi.hoisted(() => ({
+    getCatalogDetailCacheRevisionMock: vi.fn(async () => "revision-1"),
+    paginatedCourseQueryMock: vi.fn(async () => ({
+      data: [],
+      pagination: { page: 1, pageSize: 20, total: 0, totalPages: 1 },
+    })),
+  }));
 
 vi.mock("@/features/catalog/server/academic-paginated-queries", () => ({
   paginatedCourseQuery: paginatedCourseQueryMock,
 }));
 
 vi.mock("@/lib/catalog-detail-cache-revision", () => ({
-  getCatalogDetailCacheRevision: vi.fn(async () => "revision-1"),
+  getCatalogDetailCacheRevision: getCatalogDetailCacheRevisionMock,
 }));
 
 describe("shared catalog list read cache", () => {
   beforeEach(() => {
     paginatedCourseQueryMock.mockClear();
+    getCatalogDetailCacheRevisionMock.mockReset();
+    getCatalogDetailCacheRevisionMock.mockResolvedValue("revision-1");
     resetPublicRuntimeCacheForTest();
+  });
+
+  it("isolates in-isolate entries by materialization revision", async () => {
+    const { listCourseSummaries } = await import(
+      "@/features/catalog/server/course-summary-read-model"
+    );
+
+    await listCourseSummaries({
+      filters: {},
+      locale: "zh-cn",
+      pagination: { page: 1, pageSize: 20 },
+    });
+    getCatalogDetailCacheRevisionMock.mockResolvedValue("revision-2");
+    await listCourseSummaries({
+      filters: {},
+      locale: "zh-cn",
+      pagination: { page: 1, pageSize: 20 },
+    });
+
+    expect(paginatedCourseQueryMock).toHaveBeenCalledTimes(2);
   });
 
   it("shares one canonical entry across callers", async () => {

--- a/tests/unit/section-detail-partial-query.test.ts
+++ b/tests/unit/section-detail-partial-query.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { sectionDetailSchema } from "@/lib/api/schemas/academic-section-detail-response-schemas";
+import { resetPublicRuntimeCacheForTest } from "@/lib/public-runtime-cache";
+
+const { sectionFindUniqueMock } = vi.hoisted(() => ({
+  sectionFindUniqueMock: vi.fn(),
+}));
+
+vi.mock("@/lib/catalog-detail-cache-revision", () => ({
+  getCatalogDetailCacheRevision: vi.fn(async () => "test-revision"),
+}));
+
+vi.mock("@/lib/db/prisma", () => ({
+  getPrisma: vi.fn(() => ({
+    section: { findUnique: sectionFindUniqueMock },
+  })),
+}));
+
+const course = {
+  id: 11,
+  jwId: 1011,
+  code: "COURSE-11",
+  nameCn: "测试课程",
+  nameEn: "Test Course",
+  categoryId: null,
+  classTypeId: null,
+  classifyId: null,
+  educationLevelId: null,
+  gradationId: null,
+  typeId: null,
+  category: null,
+  classType: null,
+  classify: null,
+  educationLevel: null,
+  gradation: null,
+  type: null,
+};
+
+const schedule = {
+  id: 21,
+  periods: 2,
+  date: null,
+  weekday: 1,
+  startTime: 750,
+  endTime: 925,
+  experiment: null,
+  customPlace: null,
+  lessonType: null,
+  weekIndex: 1,
+  exerciseClass: null,
+  startUnit: 1,
+  endUnit: 2,
+  roomId: null,
+  sectionId: 1,
+  scheduleGroupId: 31,
+};
+
+const scheduleGroup = {
+  id: 31,
+  jwId: 1031,
+  no: 1,
+  limitCount: 40,
+  stdCount: 30,
+  actualPeriods: 2,
+  isDefault: true,
+  sectionId: 1,
+};
+
+const exam = {
+  id: 41,
+  jwId: 1041,
+  examType: 1,
+  startTime: 900,
+  endTime: 1100,
+  examDate: new Date("2026-08-17T00:00:00.000Z"),
+  examTakeCount: 30,
+  examMode: "闭卷",
+  examBatchId: null,
+  sectionId: 1,
+  examBatch: null,
+  examRooms: [],
+};
+
+const teacherAssignment = {
+  id: 51,
+  teacherId: 61,
+  sectionId: 1,
+  role: null,
+  period: 32,
+  weekIndices: [1, 2],
+  weekIndicesMsg: "1-2",
+  teacherLessonTypeId: null,
+  teacherTitleId: null,
+  teacherLessonType: null,
+  teacherTitle: null,
+};
+
+const sectionBase = {
+  id: 1,
+  jwId: 1001,
+  retiredAt: null,
+  code: "COURSE-11.01",
+  bizTypeId: null,
+  credits: 2,
+  period: 32,
+  periodsPerWeek: 2,
+  timesPerWeek: 1,
+  stdCount: 30,
+  limitCount: 40,
+  graduateAndPostgraduate: null,
+  dateTimePlaceText: null,
+  dateTimePlacePersonText: null,
+  actualPeriods: 32,
+  theoryPeriods: 32,
+  practicePeriods: 0,
+  experimentPeriods: 0,
+  machinePeriods: 0,
+  designPeriods: 0,
+  testPeriods: 0,
+  scheduleState: null,
+  suggestScheduleWeeks: null,
+  suggestScheduleWeekInfo: null,
+  scheduleJsonParams: null,
+  selectedStdCount: 30,
+  remark: null,
+  scheduleRemark: null,
+  courseId: course.id,
+  semesterId: null,
+  campusId: null,
+  examModeId: null,
+  openDepartmentId: null,
+  teachLanguageId: null,
+  roomTypeId: null,
+  course,
+  semester: null,
+  campus: null,
+  openDepartment: null,
+  examMode: null,
+  teachLanguage: null,
+  roomType: null,
+  teachers: [],
+  adminClasses: [],
+};
+
+describe("partial section detail query", () => {
+  beforeEach(() => {
+    resetPublicRuntimeCacheForTest();
+    sectionFindUniqueMock.mockReset();
+    sectionFindUniqueMock.mockImplementation(async ({ include }) => ({
+      ...sectionBase,
+      exams: include.exams.take === 0 ? [] : [exam],
+      schedules: include.schedules.take === 0 ? [] : [schedule],
+      scheduleGroups: include.scheduleGroups.take === 0 ? [] : [scheduleGroup],
+      teacherAssignments:
+        include.teacherAssignments.take === 0 ? [] : [teacherAssignment],
+    }));
+  });
+
+  it.each([
+    {
+      name: "exams",
+      options: { includeExams: true },
+      expected: {
+        exams: [exam.id],
+        schedules: [],
+        groups: [],
+        assignments: [],
+      },
+    },
+    {
+      name: "schedules",
+      options: { includeSchedules: true },
+      expected: {
+        exams: [],
+        schedules: [schedule.id],
+        groups: [scheduleGroup.id],
+        assignments: [],
+      },
+    },
+    {
+      name: "teacher departments",
+      options: { includeTeacherDepartments: true },
+      expected: {
+        exams: [],
+        schedules: [],
+        groups: [],
+        assignments: [teacherAssignment.id],
+      },
+    },
+    {
+      name: "all requested relations",
+      options: {
+        includeExams: true,
+        includeSchedules: true,
+        includeTeacherDepartments: true,
+      },
+      expected: {
+        exams: [exam.id],
+        schedules: [schedule.id],
+        groups: [scheduleGroup.id],
+        assignments: [teacherAssignment.id],
+      },
+    },
+  ])("maps $name through the strict section detail DTO", async ({
+    options,
+    expected,
+  }) => {
+    const { findSectionDetailByJwId } = await import(
+      "@/features/catalog/server/course-section-read-queries"
+    );
+
+    const result = await findSectionDetailByJwId(
+      sectionBase.jwId,
+      "zh-cn",
+      options,
+    );
+
+    expect(() => sectionDetailSchema.parse(result)).not.toThrow();
+    expect(result).toMatchObject({
+      exams: expected.exams.map((id) => ({ id })),
+      schedules: expected.schedules.map((id) => ({ id })),
+      scheduleGroups: expected.groups.map((id) => ({ id })),
+      teacherAssignments: expected.assignments.map((id) => ({ id })),
+    });
+    if (expected.schedules.length > 0) {
+      expect(result?.schedules[0]).toMatchObject({
+        startTime: "07:50",
+        endTime: "09:25",
+      });
+    }
+
+    const include = sectionFindUniqueMock.mock.calls[0]?.[0].include;
+    expect(include.exams.take !== 0).toBe(options.includeExams === true);
+    expect(include.schedules.take !== 0).toBe(
+      options.includeSchedules === true,
+    );
+    expect(include.scheduleGroups.take !== 0).toBe(
+      options.includeSchedules === true,
+    );
+    expect(include.teacherAssignments.take !== 0).toBe(
+      options.includeTeacherDepartments === true,
+    );
+  });
+});

--- a/tests/unit/static-import-lifecycle-order.test.ts
+++ b/tests/unit/static-import-lifecycle-order.test.ts
@@ -1,6 +1,7 @@
 /// <reference path="../../src/static-loader/bun-sqlite.d.ts" />
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { STATIC_IMPORT_TRANSFORM_REVISION } from "@/static-loader/import-state";
 
 const GENERATED_AT = "2026-07-18T03:00:00.000Z";
 const SNAPSHOT_SHA = "a".repeat(64);
@@ -44,6 +45,7 @@ function completedSnapshotTransaction() {
       findUnique: vi.fn().mockResolvedValue({
         snapshotGeneratedAt: new Date(GENERATED_AT),
         snapshotSha256: SNAPSHOT_SHA,
+        transformRevision: STATIC_IMPORT_TRANSFORM_REVISION,
       }),
     },
     semester: { count },

--- a/tests/unit/static-import-state.test.ts
+++ b/tests/unit/static-import-state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   assertStaticImportStateAllowsSnapshot,
   recordStaticImportState,
+  STATIC_IMPORT_TRANSFORM_REVISION,
 } from "@/static-loader/import-state";
 
 const OBSERVED_AT = new Date("2026-07-18T03:00:00.000Z");
@@ -18,11 +19,16 @@ function stateClient() {
 }
 
 function input(
-  overrides: Partial<{ observedAt: Date; snapshotSha256: string }> = {},
+  overrides: Partial<{
+    observedAt: Date;
+    snapshotSha256: string;
+    transformRevision: number;
+  }> = {},
 ) {
   return {
     observedAt: OBSERVED_AT,
     snapshotSha256: SNAPSHOT_SHA,
+    transformRevision: STATIC_IMPORT_TRANSFORM_REVISION,
     ...overrides,
   };
 }
@@ -42,6 +48,7 @@ describe("global static import state", () => {
     tx.staticImportState.findUnique.mockResolvedValue({
       snapshotGeneratedAt: OBSERVED_AT,
       snapshotSha256: SNAPSHOT_SHA,
+      transformRevision: STATIC_IMPORT_TRANSFORM_REVISION,
     });
 
     await expect(
@@ -49,11 +56,38 @@ describe("global static import state", () => {
     ).resolves.toBe(true);
   });
 
+  it("reimports an unchanged snapshot after mapper semantics change", async () => {
+    const tx = stateClient();
+    tx.staticImportState.findUnique.mockResolvedValue({
+      snapshotGeneratedAt: OBSERVED_AT,
+      snapshotSha256: SNAPSHOT_SHA,
+      transformRevision: STATIC_IMPORT_TRANSFORM_REVISION - 1,
+    });
+
+    await expect(
+      assertStaticImportStateAllowsSnapshot(tx, input()),
+    ).resolves.toBe(false);
+  });
+
+  it("rejects an importer older than the committed transform revision", async () => {
+    const tx = stateClient();
+    tx.staticImportState.findUnique.mockResolvedValue({
+      snapshotGeneratedAt: OBSERVED_AT,
+      snapshotSha256: SNAPSHOT_SHA,
+      transformRevision: STATIC_IMPORT_TRANSFORM_REVISION + 1,
+    });
+
+    await expect(
+      assertStaticImportStateAllowsSnapshot(tx, input()),
+    ).rejects.toThrow("revision 2 was already committed");
+  });
+
   it("rejects older snapshots and changed content at the same time", async () => {
     const tx = stateClient();
     tx.staticImportState.findUnique.mockResolvedValue({
       snapshotGeneratedAt: OBSERVED_AT,
       snapshotSha256: SNAPSHOT_SHA,
+      transformRevision: STATIC_IMPORT_TRANSFORM_REVISION,
     });
 
     await expect(
@@ -81,11 +115,25 @@ describe("global static import state", () => {
         id: "global",
         snapshotGeneratedAt: OBSERVED_AT,
         snapshotSha256: SNAPSHOT_SHA,
+        transformRevision: STATIC_IMPORT_TRANSFORM_REVISION,
       },
       update: {
         snapshotGeneratedAt: OBSERVED_AT,
         snapshotSha256: SNAPSHOT_SHA,
+        transformRevision: STATIC_IMPORT_TRANSFORM_REVISION,
       },
     });
+  });
+
+  it("requires a positive integer transform revision", async () => {
+    const tx = stateClient();
+
+    await expect(
+      assertStaticImportStateAllowsSnapshot(
+        tx,
+        input({ transformRevision: 0 }),
+      ),
+    ).rejects.toThrow("must be a positive integer");
+    expect(tx.staticImportState.findUnique).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/wrangler-rate-limit-config.test.ts
+++ b/tests/unit/wrangler-rate-limit-config.test.ts
@@ -38,7 +38,7 @@ describe("Wrangler mutation rate-limit bindings", () => {
     ]);
   });
 
-  it("keeps raw invocation logs disabled while retaining complete safe custom logs", async () => {
+  it("disables platform URL-bearing traces while retaining custom logs", async () => {
     const source = await readFile(
       new URL("../../wrangler.jsonc", import.meta.url),
       "utf8",
@@ -46,10 +46,12 @@ describe("Wrangler mutation rate-limit bindings", () => {
     const config = JSON.parse(source) as {
       observability?: {
         logs?: {
+          enabled?: boolean;
           head_sampling_rate?: number;
           invocation_logs?: boolean;
+          persist?: boolean;
         };
-        traces?: { head_sampling_rate?: number };
+        traces?: { enabled?: boolean };
       };
       preview_urls?: boolean;
       workers_dev?: boolean;
@@ -57,12 +59,14 @@ describe("Wrangler mutation rate-limit bindings", () => {
 
     expect(config.preview_urls).toBe(false);
     expect(config.workers_dev).toBe(false);
+    expect(config.observability?.logs?.enabled).toBe(true);
     expect(config.observability?.logs?.invocation_logs).toBe(false);
     expect(config.observability?.logs?.head_sampling_rate).toBe(1);
-    expect(config.observability?.traces?.head_sampling_rate).toBe(0.1);
+    expect(config.observability?.logs?.persist).toBe(true);
+    expect(config.observability?.traces?.enabled).toBe(false);
   });
 
-  it("uploads production source maps for trace and exception symbolication", async () => {
+  it("uploads production source maps for exception symbolication", async () => {
     const source = await readFile(
       new URL("../../wrangler.jsonc", import.meta.url),
       "utf8",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -42,8 +42,7 @@
       "persist": true
     },
     "traces": {
-      "enabled": true,
-      "head_sampling_rate": 0.1
+      "enabled": false
     }
   },
   "routes": [


### PR DESCRIPTION
## What changed

- track a static-loader transform revision independently of the source snapshot SHA
- invalidate catalog L1, KV, and colo caches after same-SHA rematerialization
- route every section partial include response through the canonical strict DTO mapper
- disable Cloudflare automatic traces that persist credential-bearing request URLs while retaining custom logs and Analytics Engine

## Root causes

The exact schedule-unit mapper was deployed after the current static snapshot had already been recorded, so the unchanged snapshot was skipped and existing PostgreSQL rows were never recomputed. The cache revision also depended only on the snapshot SHA. Separately, partial section queries returned raw Prisma payloads instead of the canonical presenter, which failed strict Zod validation. Cloudflare automatic trace attributes include full request and Cache API URLs, beyond application-level redaction.

## Impact

After migration, the next static sync rematerializes the unchanged snapshot exactly once and sets custom-time units to `0/0`. Cache keys change after that commit. Section include flags return strict, transport-safe DTOs. New deployments stop persisting platform traces containing calendar-feed credentials.

## Validation

- 2,199 unit tests
- application, tests, and operational TypeScript checks
- Svelte check, Biome, Wrangler config/type check
- production build, OpenAPI check, GraphQL schema snapshot
- all 82 migrations on a clean database and DB-backed static import-state integration
- local same-SHA static replay: `committed`, 131,956 schedules, zero unit-rule violations; second replay: `unchanged`
- built Workerd requests for every partial include flag and their combination: HTTP 200 and strict Zod parse

## Deployment order

Deploy the Prisma migration before triggering static sync. After merge, manually run static sync and wait for the 60-second cache-revision window before production acceptance checks.
