### PR TITLE
fix(ui): harden public and auth mobile layouts

### DIFF
--- a/src/features/auth/components/SignInPage.svelte
+++ b/src/features/auth/components/SignInPage.svelte
@@ -118,11 +118,11 @@ function providerInitial(name: string) {
     />
   </div>
 
-  <div class="grid w-full max-w-md gap-6 px-4">
+  <div class="grid min-w-0 w-full max-w-md gap-6 px-4">
     <PageHeader title={data.copy.title} />
 
-    <Card.Root>
-      <Card.Content class="grid gap-4">
+    <Card.Root class="min-w-0">
+      <Card.Content class="grid min-w-0 gap-4">
         {#if data.reauthentication}
           <Alert.Root>
             <Alert.Description>{data.copy.reauthenticationRequired}</Alert.Description>
@@ -141,13 +141,17 @@ function providerInitial(name: string) {
           </Alert.Root>
         {/if}
 
-        <div class="grid gap-2">
+        <div class="grid min-w-0 gap-2">
           {#each data.providers as provider}
-            <form method="POST" use:enhance={signInAction(provider.id)}>
+            <form
+              class="min-w-0 max-w-full"
+              method="POST"
+              use:enhance={signInAction(provider.id)}
+            >
               <input type="hidden" name="providerId" value={provider.id} />
               <input type="hidden" name="callbackUrl" value={data.callbackUrl} />
               <Button
-                class="h-auto w-full justify-start p-3 text-left"
+                class="h-auto min-w-0 w-full max-w-full justify-start p-3 text-left"
                 disabled={Boolean(pendingProviderId) || passkeyPending}
                 type="submit"
                 variant="outline"
@@ -168,7 +172,7 @@ function providerInitial(name: string) {
           {/each}
         </div>
 
-        <div class="grid gap-2">
+        <div class="grid min-w-0 gap-2">
           <Button
             class="h-auto w-full justify-start p-3 text-left"
             disabled={passkeySupport !== "supported" || passkeyPending || Boolean(pendingProviderId)}
@@ -203,7 +207,7 @@ function providerInitial(name: string) {
           {/if}
         </div>
 
-        <p class="text-muted-foreground text-center text-xs leading-5">
+        <p class="min-w-0 break-words text-center text-muted-foreground text-xs leading-5">
           {data.copy.termsNotice.beforeTerms}<a class="text-primary hover:underline" href="/terms">{data.copy.termsNotice.terms}</a>{data.copy.termsNotice.between}<a class="text-primary hover:underline" href="/privacy">{data.copy.termsNotice.privacy}</a>{data.copy.termsNotice.afterPrivacy}
         </p>
       </Card.Content>

--- a/src/features/oauth/components/DeviceCodeForm.svelte
+++ b/src/features/oauth/components/DeviceCodeForm.svelte
@@ -20,15 +20,15 @@ function sanitizeDeviceCode(value: string) {
 }
 </script>
 
-<form method="GET" action="/oauth/device">
+<form class="min-w-0" method="GET" action="/oauth/device">
   <input type="hidden" name="step" value="approve" />
-  <Field.Group>
-    <Field.Field>
+  <Field.Group class="min-w-0">
+    <Field.Field class="min-w-0">
       <Field.Label for="code">{copy.deviceCodeLabel}</Field.Label>
       <InputOTP.Root
         autocomplete="off"
         bind:value={inputCode}
-        class="justify-center"
+        class="min-w-0 justify-center gap-1 sm:gap-2"
         id="device-code"
         inputId="code"
         inputmode="text"
@@ -45,14 +45,14 @@ function sanitizeDeviceCode(value: string) {
           <InputOTP.Group
           >
             {#each cells.slice(0, 4) as cell}
-              <InputOTP.Slot {cell} />
+              <InputOTP.Slot class="size-7 sm:size-8" {cell} />
             {/each}
           </InputOTP.Group>
           <InputOTP.Separator />
           <InputOTP.Group
           >
             {#each cells.slice(4, 8) as cell}
-              <InputOTP.Slot {cell} />
+              <InputOTP.Slot class="size-7 sm:size-8" {cell} />
             {/each}
           </InputOTP.Group>
         {/snippet}

--- a/src/features/oauth/components/OAuthDevicePage.svelte
+++ b/src/features/oauth/components/OAuthDevicePage.svelte
@@ -53,7 +53,7 @@ $: deviceResult = data.result === "approved" ? "approved" : "denied";
   <Card.Root class="grid gap-0 p-0 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
     <DeviceSidePanel />
 
-    <Card.Content class="grid gap-5 p-6">
+    <Card.Content class="grid min-w-0 gap-5 p-4 sm:p-6">
       {#if data.state === "result"}
         <DeviceResultPanel copy={data.copy} result={deviceResult} />
       {:else if data.state === "error"}

--- a/src/lib/components/markdown-preview.css
+++ b/src/lib/components/markdown-preview.css
@@ -21,6 +21,11 @@
   padding-left: 1.25rem;
 }
 
+.markdown-preview :where(li, li > p) {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .markdown-preview ul {
   list-style: disc;
 }

--- a/src/lib/components/shell/AppTopbar.svelte
+++ b/src/lib/components/shell/AppTopbar.svelte
@@ -39,8 +39,11 @@ export let signedIn = false;
     />
 
     <a
-      class="inline-flex min-h-11 min-w-0 items-center gap-2 rounded-md font-semibold leading-none transition-opacity hover:opacity-75 md:hidden"
+      aria-label="Life@USTC"
+      class="inline-flex size-11 shrink-0 items-center justify-center gap-2 rounded-md font-semibold leading-none transition-opacity hover:opacity-75 md:hidden sm:w-auto sm:px-2"
+      data-shell-brand
       href="/"
+      title="Life@USTC"
     >
       <img
         class="size-7 rounded-md"
@@ -48,7 +51,7 @@ export let signedIn = false;
         alt=""
         aria-hidden="true"
       />
-      <span class="truncate">Life@USTC</span>
+      <span class="sr-only sm:not-sr-only">Life@USTC</span>
     </a>
 
     <div class="hidden min-w-0 flex-1 justify-center px-4 md:flex">

--- a/src/lib/components/shell/AppTopbar.svelte
+++ b/src/lib/components/shell/AppTopbar.svelte
@@ -40,7 +40,7 @@ export let signedIn = false;
 
     <a
       aria-label="Life@USTC"
-      class="inline-flex size-11 shrink-0 items-center justify-center gap-2 rounded-md font-semibold leading-none transition-opacity hover:opacity-75 md:hidden sm:w-auto sm:px-2"
+      class="hidden size-11 shrink-0 items-center justify-center gap-2 rounded-md font-semibold leading-none transition-opacity hover:opacity-75 min-[320px]:inline-flex md:hidden sm:w-auto sm:px-2"
       data-shell-brand
       href="/"
       title="Life@USTC"

--- a/src/routes/_components/LegalDocument.svelte
+++ b/src/routes/_components/LegalDocument.svelte
@@ -11,8 +11,8 @@ export let content: {
 
 <svelte:head><title>{content.title} - Life@USTC</title></svelte:head>
 
-<Card.Root class="mx-auto w-full max-w-3xl">
-  <Card.Content class="px-6 md:px-8">
+<Card.Root class="mx-auto min-w-0 w-full max-w-3xl">
+  <Card.Content class="min-w-0 px-4 sm:px-6 md:px-8">
     <RenderedMarkdown class="legal-document" html={content.renderedHtml} />
   </Card.Content>
 </Card.Root>

--- a/tests/e2e/src/app/oauth/device/test.ts
+++ b/tests/e2e/src/app/oauth/device/test.ts
@@ -231,6 +231,15 @@ test("/oauth/device 移动端只呈现一个标题和一个代码输入", async 
     page.getByText(/^(设备验证码|Device Code)$/, { exact: true }),
   ).toHaveCount(1);
   await expect(page.locator('[data-slot="input-otp-slot"]')).toHaveCount(8);
+  const otpMetrics = await page
+    .locator('[data-slot="input-otp"]')
+    .evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    }));
+  expect(otpMetrics.scrollWidth).toBeLessThanOrEqual(
+    otpMetrics.clientWidth + 1,
+  );
   const verifyButton = page.getByRole("button", {
     name: /^(验证|Verify)$/i,
     exact: true,
@@ -248,6 +257,39 @@ test("/oauth/device 移动端只呈现一个标题和一个代码输入", async 
   ).toBe(true);
 
   await captureStepScreenshot(page, testInfo, "oauth/device/form-mobile");
+});
+
+test("/oauth/device 320px 和 375px 输入槽完整显示", async ({
+  page,
+}, testInfo) => {
+  for (const width of [320, 375]) {
+    await page.setViewportSize({ width, height: 800 });
+    await gotoAndWaitForReady(page, "/oauth/device", { testInfo });
+
+    const otp = page.locator('[data-slot="input-otp"]');
+    await expect(otp).toBeVisible();
+    await expect(page.locator('[data-slot="input-otp-slot"]')).toHaveCount(8);
+
+    const metrics = await otp.evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    }));
+    expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
+
+    const card = page.locator('[data-slot="card"]');
+    const cardBox = await card.boundingBox();
+    if (!cardBox) throw new Error("Device code Card is not visible");
+    for (const slot of await page
+      .locator('[data-slot="input-otp-slot"]')
+      .all()) {
+      const slotBox = await slot.boundingBox();
+      if (!slotBox) throw new Error("Device code slot is not visible");
+      expect(slotBox.x).toBeGreaterThanOrEqual(cardBox.x - 1);
+      expect(slotBox.x + slotBox.width).toBeLessThanOrEqual(
+        cardBox.x + cardBox.width + 1,
+      );
+    }
+  }
 });
 
 test("/oauth/device 无效用户代码显示公开错误", async ({ page }, testInfo) => {

--- a/tests/e2e/src/app/privacy/test.ts
+++ b/tests/e2e/src/app/privacy/test.ts
@@ -34,6 +34,32 @@ test.describe("/privacy 隐私政策页", () => {
     expect(await listItems.count()).toBeGreaterThan(0);
   });
 
+  test("320px 列表内容在 Card 内完整换行", async ({ page }, testInfo) => {
+    await page.setViewportSize({ width: 320, height: 800 });
+    await gotoAndWaitForReady(page, "/privacy", { testInfo });
+
+    const overflow = await page
+      .locator('[data-slot="card"] .markdown-preview')
+      .evaluate((markdown) => {
+        const elements = [
+          markdown,
+          ...Array.from(markdown.querySelectorAll<HTMLElement>("ul, ol, li")),
+        ];
+        return elements
+          .map((element) => ({
+            clientWidth: element.clientWidth,
+            scrollWidth: element.scrollWidth,
+            tag: element.tagName,
+          }))
+          .filter(
+            ({ clientWidth, scrollWidth }) => scrollWidth > clientWidth + 1,
+          );
+      });
+
+    expect(overflow).toEqual([]);
+    await expect(page.locator('[data-slot="card"] li').first()).toBeVisible();
+  });
+
   test("登录用户绕过 PublicSsr 缓存并直接 SSR viewer", async ({ page }) => {
     await signInAsDebugUser(page, "/privacy", "/privacy");
 

--- a/tests/e2e/src/app/signin/test.ts
+++ b/tests/e2e/src/app/signin/test.ts
@@ -62,7 +62,7 @@ test("/account/sign-in 页面契约", async ({ page }, testInfo) => {
 test("/account/sign-in narrow mobile shell uses an accessible compact brand", async ({
   page,
 }, testInfo) => {
-  for (const width of [375, 390]) {
+  for (const width of [280, 375, 390]) {
     await page.setViewportSize({ width, height: 800 });
     await gotoAndWaitForReady(page, "/account/sign-in", {
       testInfo,
@@ -70,6 +70,16 @@ test("/account/sign-in narrow mobile shell uses an accessible compact brand", as
     });
 
     const brand = page.locator("[data-shell-topbar] [data-shell-brand]");
+    if (width < 320) {
+      await expect(brand).toBeHidden();
+      expect(
+        await page.evaluate(
+          () => document.documentElement.scrollWidth <= window.innerWidth,
+        ),
+      ).toBe(true);
+      continue;
+    }
+
     await expect(brand).toBeVisible();
     await expect(brand).toHaveAttribute("aria-label", "Life@USTC");
     await expect(brand).toHaveAttribute("title", "Life@USTC");

--- a/tests/e2e/src/app/signin/test.ts
+++ b/tests/e2e/src/app/signin/test.ts
@@ -59,6 +59,65 @@ test("/account/sign-in 页面契约", async ({ page }, testInfo) => {
   await assertPageContract(page, { routePath: "/account/sign-in", testInfo });
 });
 
+test("/account/sign-in narrow mobile shell uses an accessible compact brand", async ({
+  page,
+}, testInfo) => {
+  for (const width of [375, 390]) {
+    await page.setViewportSize({ width, height: 800 });
+    await gotoAndWaitForReady(page, "/account/sign-in", {
+      testInfo,
+      screenshotLabel: `signin-brand-${width}`,
+    });
+
+    const brand = page.locator("[data-shell-topbar] [data-shell-brand]");
+    await expect(brand).toBeVisible();
+    await expect(brand).toHaveAttribute("aria-label", "Life@USTC");
+    await expect(brand).toHaveAttribute("title", "Life@USTC");
+    await expect(brand.locator("span")).toHaveClass(/sr-only/);
+    await expect(brand.locator("span")).not.toHaveClass(/truncate/);
+
+    const metrics = await brand.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        clientWidth: element.clientWidth,
+        right: rect.right,
+        viewportWidth: window.innerWidth,
+      };
+    });
+    expect(metrics.clientWidth).toBe(44);
+    expect(metrics.right).toBeLessThanOrEqual(metrics.viewportWidth);
+  }
+});
+
+test("/account/sign-in 320px actions and legal links stay inside the Card", async ({
+  page,
+}, testInfo) => {
+  await page.setViewportSize({ width: 320, height: 800 });
+  await gotoAndWaitForReady(page, "/account/sign-in", { testInfo });
+
+  const overflow = await page.locator('[data-slot="card"]').evaluate((card) => {
+    const elements = [
+      card,
+      ...Array.from(card.querySelectorAll<HTMLElement>("form, button, p")),
+    ];
+    return elements
+      .map((element) => ({
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+        tag: element.tagName,
+      }))
+      .filter(({ clientWidth, scrollWidth }) => scrollWidth > clientWidth + 1);
+  });
+
+  expect(overflow).toEqual([]);
+  await expect(
+    page.locator('[data-slot="card"] a[href="/terms"]'),
+  ).toBeVisible();
+  await expect(
+    page.locator('[data-slot="card"] a[href="/privacy"]'),
+  ).toBeVisible();
+});
+
 test("/account/sign-in 显示所有必填字段", async ({ page }, testInfo) => {
   await gotoAndWaitForReady(page, "/account/sign-in", {
     testInfo,


### PR DESCRIPTION
## Summary

- make the narrow mobile shell brand intentionally icon-only while preserving its accessible full name
- make sign-in provider actions and legal links shrink-safe inside the Card
- compact the OAuth device-code InputOTP and add responsive Card padding
- wrap legal markdown list content safely at narrow widths
- add focused 320–390px E2E assertions for internal overflow and compact-brand behavior

Closes #867
Closes #874
Closes #877
Closes #880