### PR TITLE
fix(admin): improve mobile navigation and records

### DIFF
--- a/src/features/admin/components/AdminBusVersionActions.svelte
+++ b/src/features/admin/components/AdminBusVersionActions.svelte
@@ -14,6 +14,7 @@ import type {
 } from "./admin-bus-types";
 
 export let copy: AdminBusCopy;
+export let compact = false;
 export let enhancedAction: AdminBusEnhancedAction;
 export let isPending: (actionKey: string) => boolean;
 export let onDelete: (version: AdminBusVersion) => void;
@@ -24,23 +25,48 @@ let activateDialogOpen = false;
 </script>
 
 {#if !version.isEnabled}
-  <DashboardTableRowActions class="justify-end">
-    <DashboardTableIconButton
-      disabled={Boolean(pendingAction)}
-      label={copy.activateAction}
-      onclick={() => (activateDialogOpen = true)}
-    >
-      {#if isPending(`activate-${version.id}`)}<Spinner />{:else}<CheckCircle />{/if}
-    </DashboardTableIconButton>
-    <DashboardTableIconButton
-      disabled={Boolean(pendingAction)}
-      label={copy.deleteAction}
-      variant="destructive"
-      onclick={() => onDelete(version)}
-    >
-      <Trash2 />
-    </DashboardTableIconButton>
-  </DashboardTableRowActions>
+  {#if compact}
+    <div class="flex flex-wrap justify-end gap-2">
+      <Button
+        disabled={Boolean(pendingAction)}
+        onclick={() => (activateDialogOpen = true)}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
+        {#if isPending(`activate-${version.id}`)}<Spinner data-icon="inline-start" />{:else}<CheckCircle data-icon="inline-start" />{/if}
+        {copy.activateAction}
+      </Button>
+      <Button
+        disabled={Boolean(pendingAction)}
+        onclick={() => onDelete(version)}
+        size="sm"
+        type="button"
+        variant="destructive"
+      >
+        <Trash2 data-icon="inline-start" />
+        {copy.deleteAction}
+      </Button>
+    </div>
+  {:else}
+    <DashboardTableRowActions class="justify-end">
+      <DashboardTableIconButton
+        disabled={Boolean(pendingAction)}
+        label={copy.activateAction}
+        onclick={() => (activateDialogOpen = true)}
+      >
+        {#if isPending(`activate-${version.id}`)}<Spinner />{:else}<CheckCircle />{/if}
+      </DashboardTableIconButton>
+      <DashboardTableIconButton
+        disabled={Boolean(pendingAction)}
+        label={copy.deleteAction}
+        variant="destructive"
+        onclick={() => onDelete(version)}
+      >
+        <Trash2 />
+      </DashboardTableIconButton>
+    </DashboardTableRowActions>
+  {/if}
 
   <AlertDialog.Root
     open={activateDialogOpen}

--- a/src/features/admin/components/AdminBusVersionsMobileList.svelte
+++ b/src/features/admin/components/AdminBusVersionsMobileList.svelte
@@ -23,9 +23,9 @@ export let versions: AdminBusVersion[];
 {#if versions.length === 0}
   <SoftEmptyMessage class="xl:hidden" message={copy.noVersions} />
 {:else}
-  <Item.Group class="xl:hidden gap-0 border-y" data-testid="admin-bus-mobile-list" role="list">
+  <Item.Group class="xl:hidden gap-0 border-y" data-testid="admin-bus-mobile-list">
     {#each versions as version, index (version.id)}
-      <Item.Root class="items-start px-1 py-3" role="listitem" size="sm">
+      <Item.Root class="items-start px-1 py-3" size="sm">
         <Item.Content class="min-w-0">
           <Item.Title>{version.title}</Item.Title>
           <Item.Description class="break-all font-mono">{version.key}</Item.Description>

--- a/src/features/admin/components/AdminBusVersionsMobileList.svelte
+++ b/src/features/admin/components/AdminBusVersionsMobileList.svelte
@@ -23,9 +23,9 @@ export let versions: AdminBusVersion[];
 {#if versions.length === 0}
   <SoftEmptyMessage class="xl:hidden" message={copy.noVersions} />
 {:else}
-  <Item.Group class="xl:hidden" data-testid="admin-bus-mobile-list">
-    {#each versions as version}
-      <Item.Root class="items-start" size="sm" variant="outline">
+  <Item.Group class="xl:hidden gap-0 border-y" data-testid="admin-bus-mobile-list" role="list">
+    {#each versions as version, index (version.id)}
+      <Item.Root class="items-start px-1 py-3" role="listitem" size="sm">
         <Item.Content class="min-w-0">
           <Item.Title>{version.title}</Item.Title>
           <Item.Description class="break-all font-mono">{version.key}</Item.Description>
@@ -61,12 +61,14 @@ export let versions: AdminBusVersion[];
                 {isPending}
                 {onDelete}
                 {pendingAction}
+                compact
                 {version}
               />
             </div>
           {/if}
         </Item.Footer>
       </Item.Root>
+      {#if index < versions.length - 1}<Item.Separator class="my-0" />{/if}
     {/each}
   </Item.Group>
 {/if}

--- a/src/features/admin/components/AdminMobileNav.svelte
+++ b/src/features/admin/components/AdminMobileNav.svelte
@@ -69,14 +69,13 @@ $: currentLink = links.find((link) => isActiveLink(link)) ?? links[0];
       <Sheet.Description>{copy.nav.admin.title}</Sheet.Description>
     </Sheet.Header>
 
-    <Item.Group class="gap-0 px-4 pb-4" role="list">
+    <Item.Group class="gap-0 px-4 pb-4">
       {#each links as link, index (link.href)}
         {@const active = isActiveLink(link)}
         {@const Icon = link.icon}
         <Item.Root
           class="px-0 py-1.5"
           data-active={active}
-          role="listitem"
           variant={active ? "muted" : "default"}
         >
           <a

--- a/src/features/admin/components/AdminMobileNav.svelte
+++ b/src/features/admin/components/AdminMobileNav.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
+import MenuIcon from "@lucide/svelte/icons/menu";
+import ShieldCheckIcon from "@lucide/svelte/icons/shield-check";
+import type { ShellLink } from "$lib/components/shell/types";
+import { Button } from "$lib/components/ui/button/index.js";
+import * as Item from "$lib/components/ui/item/index.js";
+import * as Sheet from "$lib/components/ui/sheet/index.js";
+import type { LayoutCopy } from "$lib/shell/layout-server-data";
+
+export let copy: LayoutCopy;
+export let links: ShellLink[];
+export let isActiveLink: (link: ShellLink) => boolean;
+
+let open = false;
+
+$: currentLink = links.find((link) => isActiveLink(link)) ?? links[0];
+</script>
+
+<Sheet.Root bind:open>
+  <nav
+    aria-label={copy.nav.groups.adminTools}
+    class="bg-card/95 fixed inset-x-0 bottom-0 z-30 border-t pb-[env(safe-area-inset-bottom)] backdrop-blur md:hidden"
+    data-shell-navigation="admin-mobile"
+    data-testid="admin-mobile-navigation"
+  >
+    <div class="mx-auto flex min-h-14 w-full max-w-3xl items-center gap-2 px-3">
+      <Sheet.Trigger>
+        {#snippet child({ props })}
+          <Button
+            {...props}
+            aria-label={copy.nav.groups.adminTools}
+            class="min-w-0 flex-1 justify-start gap-2"
+            data-testid="admin-mobile-navigation-trigger"
+            type="button"
+            variant="ghost"
+          >
+            <ShieldCheckIcon aria-hidden="true" data-icon="inline-start" />
+            <span class="truncate">{copy.nav.groups.adminTools}</span>
+            <MenuIcon aria-hidden="true" data-icon="inline-end" />
+          </Button>
+        {/snippet}
+      </Sheet.Trigger>
+
+      {#if currentLink}
+        {@const CurrentIcon = currentLink.icon}
+        <div
+          aria-current="page"
+          class="flex min-w-0 max-w-[48%] items-center gap-1.5 rounded-md bg-accent px-2.5 py-1.5 text-sm font-medium"
+          data-testid="admin-mobile-navigation-current"
+          title={currentLink.label}
+        >
+          {#if CurrentIcon}
+            <CurrentIcon aria-hidden="true" data-icon="inline-start" />
+          {/if}
+          <span class="truncate">{currentLink.label}</span>
+        </div>
+      {/if}
+    </div>
+  </nav>
+
+  <Sheet.Content
+    class="max-h-[min(80dvh,32rem)] overflow-y-auto p-0"
+    data-testid="admin-mobile-navigation-panel"
+    side="bottom"
+  >
+    <Sheet.Header class="border-b pr-12">
+      <Sheet.Title>{copy.nav.groups.adminTools}</Sheet.Title>
+      <Sheet.Description>{copy.nav.admin.title}</Sheet.Description>
+    </Sheet.Header>
+
+    <Item.Group class="gap-0 px-4 pb-4" role="list">
+      {#each links as link, index (link.href)}
+        {@const active = isActiveLink(link)}
+        {@const Icon = link.icon}
+        <Item.Root
+          class="px-0 py-1.5"
+          data-active={active}
+          role="listitem"
+          variant={active ? "muted" : "default"}
+        >
+          <a
+            aria-current={active ? "page" : undefined}
+            class="flex min-h-11 min-w-0 flex-1 items-center gap-3 rounded-md px-2 py-2 text-sm font-medium outline-none transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
+            href={link.href}
+            onclick={() => (open = false)}
+          >
+            {#if Icon}
+              <Icon aria-hidden="true" data-icon="inline-start" />
+            {/if}
+            <span class="min-w-0 flex-1 truncate">{link.label}</span>
+            <ChevronRightIcon aria-hidden="true" data-icon="inline-end" />
+          </a>
+        </Item.Root>
+        {#if index < links.length - 1}<Item.Separator class="my-0" />{/if}
+      {/each}
+    </Item.Group>
+  </Sheet.Content>
+</Sheet.Root>

--- a/src/features/admin/components/AdminModerationCommentDialog.svelte
+++ b/src/features/admin/components/AdminModerationCommentDialog.svelte
@@ -3,6 +3,7 @@ import * as Alert from "$lib/components/ui/alert/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
 import * as Dialog from "$lib/components/ui/dialog/index.js";
 import { ScrollArea } from "$lib/components/ui/scroll-area/index.js";
+import { Separator } from "$lib/components/ui/separator/index.js";
 import { Spinner } from "$lib/components/ui/spinner/index.js";
 import AdminModerationCommentPreview from "./AdminModerationCommentPreview.svelte";
 import AdminModerationCommentStatusSection from "./AdminModerationCommentStatusSection.svelte";
@@ -43,8 +44,9 @@ export let targetLabel: (comment: AdminModerationComment) => string;
     }}
   >
     <Dialog.Content
-      class="max-w-2xl sm:max-w-2xl"
+      class="grid max-h-[calc(100dvh-1rem)] min-h-0 max-w-2xl grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden sm:max-w-2xl"
       aria-labelledby="manage-comment-title"
+      showCloseButton={false}
     >
       <Dialog.Header>
         <div class="flex items-start justify-between gap-3">
@@ -58,7 +60,7 @@ export let targetLabel: (comment: AdminModerationComment) => string;
         </div>
       </Dialog.Header>
 
-      <ScrollArea class="h-[min(62vh,34rem)]">
+      <ScrollArea class="min-h-0 h-[min(56vh,34rem)] max-h-[calc(100dvh-12rem)]">
         <div class="grid gap-5 px-5 py-4">
           {#if dialogMessage}<Alert.Root class="py-2"><Alert.Description>{dialogMessage}</Alert.Description></Alert.Root>{/if}
 
@@ -67,6 +69,7 @@ export let targetLabel: (comment: AdminModerationComment) => string;
             {copy}
             {targetHref}
           />
+          <Separator />
 
           <AdminModerationCommentStatusSection
             bind:commentStatus

--- a/src/features/admin/components/AdminModerationComments.svelte
+++ b/src/features/admin/components/AdminModerationComments.svelte
@@ -25,6 +25,7 @@ export let targetLabel: AdminModerationCommentFormatter;
       {commentAuthorLabel}
       {comments}
       {formatDate}
+      manageLabel={copy.manageComment}
       {onManage}
       {statusLabel}
       {targetLabel}

--- a/src/features/admin/components/AdminModerationCommentsMobile.svelte
+++ b/src/features/admin/components/AdminModerationCommentsMobile.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
+import { Button } from "$lib/components/ui/button/index.js";
 import * as Item from "$lib/components/ui/item/index.js";
 import type {
   AdminModerationComment,
@@ -10,33 +12,41 @@ import ModerationStatusBadge from "./ModerationStatusBadge.svelte";
 export let comments: AdminModerationComment[];
 export let commentAuthorLabel: AdminModerationCommentFormatter;
 export let formatDate: (value: string | Date) => string;
+export let manageLabel: string;
 export let onManage: (comment: AdminModerationComment) => void;
 export let statusLabel: AdminModerationCommentStatusFormatter;
 export let targetLabel: AdminModerationCommentFormatter;
 </script>
 
-<Item.Group class="xl:hidden" data-testid="admin-moderation-mobile-list">
-  {#each comments as comment}
-    <Item.Root variant="outline" class="items-start">
-      {#snippet child({ props })}
-        <button {...props} type="button" onclick={() => onManage(comment)}>
-          <Item.Content class="min-w-0">
-            <Item.Title>{targetLabel(comment)}</Item.Title>
-            <Item.Description>
-              {commentAuthorLabel(comment)} · {formatDate(comment.createdAt)}
-            </Item.Description>
-            <Item.Description class="line-clamp-3 whitespace-pre-wrap">
-              {comment.body}
-            </Item.Description>
-          </Item.Content>
-          <Item.Actions>
-            <ModerationStatusBadge
-              label={statusLabel(comment.status)}
-              status={comment.status}
-            />
-          </Item.Actions>
-        </button>
-      {/snippet}
+<Item.Group class="xl:hidden gap-0 border-y" data-testid="admin-moderation-mobile-list" role="list">
+  {#each comments as comment, index (comment.id)}
+    <Item.Root class="items-start px-1 py-3" role="listitem">
+      <Item.Content class="min-w-0">
+        <Item.Title>{targetLabel(comment)}</Item.Title>
+        <Item.Description>
+          {commentAuthorLabel(comment)} · {formatDate(comment.createdAt)}
+        </Item.Description>
+        <Item.Description class="line-clamp-3 whitespace-pre-wrap">
+          {comment.body}
+        </Item.Description>
+      </Item.Content>
+      <Item.Actions class="shrink-0 self-start">
+        <ModerationStatusBadge
+          label={statusLabel(comment.status)}
+          status={comment.status}
+        />
+        <Button
+          aria-label={manageLabel}
+          onclick={() => onManage(comment)}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          {manageLabel}
+          <ChevronRightIcon aria-hidden="true" data-icon="inline-end" />
+        </Button>
+      </Item.Actions>
     </Item.Root>
+    {#if index < comments.length - 1}<Item.Separator class="my-0" />{/if}
   {/each}
 </Item.Group>

--- a/src/features/admin/components/AdminModerationCommentsMobile.svelte
+++ b/src/features/admin/components/AdminModerationCommentsMobile.svelte
@@ -18,9 +18,9 @@ export let statusLabel: AdminModerationCommentStatusFormatter;
 export let targetLabel: AdminModerationCommentFormatter;
 </script>
 
-<Item.Group class="xl:hidden gap-0 border-y" data-testid="admin-moderation-mobile-list" role="list">
+<Item.Group class="xl:hidden gap-0 border-y" data-testid="admin-moderation-mobile-list">
   {#each comments as comment, index (comment.id)}
-    <Item.Root class="items-start px-1 py-3" role="listitem">
+    <Item.Root class="items-start px-1 py-3">
       <Item.Content class="min-w-0">
         <Item.Title>{targetLabel(comment)}</Item.Title>
         <Item.Description>

--- a/src/features/admin/components/AdminModerationDescriptionCards.svelte
+++ b/src/features/admin/components/AdminModerationDescriptionCards.svelte
@@ -23,9 +23,9 @@ export let onManage: (description: AdminModerationDescription) => void;
 export let targetLabel: (description: AdminModerationDescription) => string;
 </script>
 
-<Item.Group class="xl:hidden gap-0 border-y" role="list">
+<Item.Group class="xl:hidden gap-0 border-y">
   {#each descriptions as description, index (description.id)}
-    <Item.Root class="items-start px-1 py-3" role="listitem">
+    <Item.Root class="items-start px-1 py-3">
       <Item.Content class="min-w-0 gap-2">
         <Item.Title class="line-clamp-none">{targetLabel(description)}</Item.Title>
         <Item.Description>

--- a/src/features/admin/components/AdminModerationDescriptionCards.svelte
+++ b/src/features/admin/components/AdminModerationDescriptionCards.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
+import { Button } from "$lib/components/ui/button/index.js";
 import * as Item from "$lib/components/ui/item/index.js";
 import {
   adminModerationDescriptionEditedAt,
@@ -16,31 +18,41 @@ export let formatMessage: (
   template: string,
   values: Record<string, string>,
 ) => string;
+export let manageLabel: string;
 export let onManage: (description: AdminModerationDescription) => void;
 export let targetLabel: (description: AdminModerationDescription) => string;
 </script>
 
-<Item.Group class="xl:hidden">
-  {#each descriptions as description}
-    <Item.Root variant="outline" class="items-start">
-      {#snippet child({ props })}
-        <button {...props} type="button" onclick={() => onManage(description)}>
-          <Item.Content class="min-w-0 gap-2">
-            <Item.Title class="line-clamp-none">{targetLabel(description)}</Item.Title>
-            <Item.Description>
-              {formatDate(adminModerationDescriptionEditedAt(description))}
-            </Item.Description>
-            <Item.Description class="line-clamp-4 whitespace-pre-wrap">
-              {description.content || copy.emptyDescription}
-            </Item.Description>
-            <Item.Description>
-              {formatMessage(copy.lastEditor, {
-                name: adminModerationDescriptionLastEditor(description, copy),
-              })}
-            </Item.Description>
-          </Item.Content>
-        </button>
-      {/snippet}
+<Item.Group class="xl:hidden gap-0 border-y" role="list">
+  {#each descriptions as description, index (description.id)}
+    <Item.Root class="items-start px-1 py-3" role="listitem">
+      <Item.Content class="min-w-0 gap-2">
+        <Item.Title class="line-clamp-none">{targetLabel(description)}</Item.Title>
+        <Item.Description>
+          {formatDate(adminModerationDescriptionEditedAt(description))}
+        </Item.Description>
+        <Item.Description class="line-clamp-4 whitespace-pre-wrap">
+          {description.content || copy.emptyDescription}
+        </Item.Description>
+        <Item.Description>
+          {formatMessage(copy.lastEditor, {
+            name: adminModerationDescriptionLastEditor(description, copy),
+          })}
+        </Item.Description>
+      </Item.Content>
+      <Item.Actions class="shrink-0 self-start">
+        <Button
+          aria-label={manageLabel}
+          onclick={() => onManage(description)}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          {manageLabel}
+          <ChevronRightIcon aria-hidden="true" data-icon="inline-end" />
+        </Button>
+      </Item.Actions>
     </Item.Root>
+    {#if index < descriptions.length - 1}<Item.Separator class="my-0" />{/if}
   {/each}
 </Item.Group>

--- a/src/features/admin/components/AdminModerationDescriptionDialog.svelte
+++ b/src/features/admin/components/AdminModerationDescriptionDialog.svelte
@@ -41,15 +41,17 @@ export let targetLabel: (description: AdminModerationDescription) => string;
     }}
   >
     <Dialog.Content
-      class="max-w-3xl sm:max-w-3xl"
+      class="grid max-h-[calc(100dvh-1rem)] min-h-0 max-w-3xl grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden sm:max-w-3xl"
       aria-labelledby="manage-description-title"
+      showCloseButton={false}
     >
       <form
+        class="grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden"
         method="POST"
         action="?/moderateDescription"
         use:enhance={enhanceAction}
       >
-        <Field.Group class="gap-4">
+        <Field.Group class="grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] gap-4 overflow-hidden">
           <Dialog.Header>
             <div class="flex items-start justify-between gap-3">
               <div>
@@ -62,7 +64,7 @@ export let targetLabel: (description: AdminModerationDescription) => string;
             </div>
           </Dialog.Header>
 
-          <ScrollArea class="h-[min(62vh,34rem)]">
+          <ScrollArea class="min-h-0 h-[min(56vh,34rem)] max-h-[calc(100dvh-12rem)]">
             <Field.Group class="gap-4 px-5 py-4">
               <input type="hidden" name="id" value={description.id} />
               <AdminModerationDescriptionMeta

--- a/src/features/admin/components/AdminModerationDescriptions.svelte
+++ b/src/features/admin/components/AdminModerationDescriptions.svelte
@@ -35,6 +35,7 @@ export let targetLabel: (description: AdminModerationDescription) => string;
       {descriptions}
       {formatDate}
       {formatMessage}
+      manageLabel={copy.manageDescription}
       {onManage}
       {targetLabel}
     />

--- a/src/features/admin/components/AdminModerationHomeworks.svelte
+++ b/src/features/admin/components/AdminModerationHomeworks.svelte
@@ -5,6 +5,7 @@ import DashboardTableRowActions from "@/features/dashboard/components/DashboardT
 import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import TruncatedText from "$lib/components/TruncatedText.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
+import { Button } from "$lib/components/ui/button/index.js";
 import * as Item from "$lib/components/ui/item/index.js";
 import * as Table from "$lib/components/ui/table/index.js";
 
@@ -44,9 +45,9 @@ export let onDelete: (homework: ModerationHomework) => void;
   {#if homeworks.length === 0}
     <SoftEmptyMessage message={copy.noHomeworks} />
   {:else}
-    <Item.Group class="xl:hidden">
-      {#each homeworks as homework}
-        <Item.Root variant="outline" class="items-start">
+    <Item.Group class="xl:hidden gap-0 border-y" role="list">
+      {#each homeworks as homework, index (homework.id)}
+        <Item.Root class="items-start px-1 py-3" role="listitem">
           <Item.Content class="min-w-0 gap-2">
             <Item.Title class="line-clamp-none">{homework.title}</Item.Title>
             <Item.Description>
@@ -66,16 +67,20 @@ export let onDelete: (homework: ModerationHomework) => void;
               <Badge variant="destructive">{copy.homeworkStatusDeleted}</Badge>
             {:else}
               <Badge>{copy.homeworkStatusActive}</Badge>
-              <DashboardTableIconButton
-                label={copy.deleteHomeworkAction}
-                variant="destructive"
+              <Button
+                aria-label={copy.deleteHomeworkAction}
                 onclick={() => onDelete(homework)}
+                size="sm"
+                type="button"
+                variant="destructive"
               >
-                <Trash2 />
-              </DashboardTableIconButton>
+                <Trash2 data-icon="inline-start" />
+                {copy.deleteHomeworkAction}
+              </Button>
             {/if}
           </Item.Actions>
         </Item.Root>
+        {#if index < homeworks.length - 1}<Item.Separator class="my-0" />{/if}
       {/each}
     </Item.Group>
 

--- a/src/features/admin/components/AdminModerationHomeworks.svelte
+++ b/src/features/admin/components/AdminModerationHomeworks.svelte
@@ -45,9 +45,9 @@ export let onDelete: (homework: ModerationHomework) => void;
   {#if homeworks.length === 0}
     <SoftEmptyMessage message={copy.noHomeworks} />
   {:else}
-    <Item.Group class="xl:hidden gap-0 border-y" role="list">
+    <Item.Group class="xl:hidden gap-0 border-y">
       {#each homeworks as homework, index (homework.id)}
-        <Item.Root class="items-start px-1 py-3" role="listitem">
+        <Item.Root class="items-start px-1 py-3">
           <Item.Content class="min-w-0 gap-2">
             <Item.Title class="line-clamp-none">{homework.title}</Item.Title>
             <Item.Description>

--- a/src/features/admin/components/AdminModerationSuspensions.svelte
+++ b/src/features/admin/components/AdminModerationSuspensions.svelte
@@ -84,9 +84,9 @@ function confirmedLiftAction(suspension: ModerationSuspension): SubmitFunction {
   {#if suspensions.length === 0}
     <SoftEmptyMessage message={copy.noSuspensions} />
   {:else}
-    <Item.Group class="xl:hidden">
-      {#each suspensions as suspension}
-        <Item.Root variant="outline" class="items-start">
+    <Item.Group class="xl:hidden gap-0 border-y" role="list">
+      {#each suspensions as suspension, index (suspension.id)}
+        <Item.Root class="items-start px-1 py-3" role="listitem">
           <Item.Content class="min-w-0 gap-2">
             <Item.Title>{userLabel(suspension)}</Item.Title>
             {#if suspension.user.username}
@@ -103,18 +103,23 @@ function confirmedLiftAction(suspension: ModerationSuspension): SubmitFunction {
               <Badge variant="ghost">{copy.lifted}</Badge>
             {:else}
               <Badge variant="destructive">{copy.active}</Badge>
-              <DashboardTableIconButton
+              <Button
                 disabled={Boolean(liftingSuspensionId)}
-                label={liftingSuspensionId === suspension.id
+                aria-label={liftingSuspensionId === suspension.id
                   ? copy.saving
                   : copy.liftSuspensionAction}
                 onclick={() => (pendingLiftSuspension = suspension)}
+                size="sm"
+                type="button"
+                variant="ghost"
               >
-                {#if liftingSuspensionId === suspension.id}<Spinner />{:else}<Unlock />{/if}
-              </DashboardTableIconButton>
+                {#if liftingSuspensionId === suspension.id}<Spinner data-icon="inline-start" />{:else}<Unlock data-icon="inline-start" />{/if}
+                {liftingSuspensionId === suspension.id ? copy.saving : copy.liftSuspensionAction}
+              </Button>
             {/if}
           </Item.Actions>
         </Item.Root>
+        {#if index < suspensions.length - 1}<Item.Separator class="my-0" />{/if}
       {/each}
     </Item.Group>
 

--- a/src/features/admin/components/AdminModerationSuspensions.svelte
+++ b/src/features/admin/components/AdminModerationSuspensions.svelte
@@ -84,9 +84,9 @@ function confirmedLiftAction(suspension: ModerationSuspension): SubmitFunction {
   {#if suspensions.length === 0}
     <SoftEmptyMessage message={copy.noSuspensions} />
   {:else}
-    <Item.Group class="xl:hidden gap-0 border-y" role="list">
+    <Item.Group class="xl:hidden gap-0 border-y">
       {#each suspensions as suspension, index (suspension.id)}
-        <Item.Root class="items-start px-1 py-3" role="listitem">
+        <Item.Root class="items-start px-1 py-3">
           <Item.Content class="min-w-0 gap-2">
             <Item.Title>{userLabel(suspension)}</Item.Title>
             {#if suspension.user.username}

--- a/src/features/admin/components/AdminUsersMobileList.svelte
+++ b/src/features/admin/components/AdminUsersMobileList.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
 import { Badge } from "$lib/components/ui/badge/index.js";
+import { Button } from "$lib/components/ui/button/index.js";
 import * as Item from "$lib/components/ui/item/index.js";
 import type {
   AdminUserFormatter,
@@ -15,48 +17,52 @@ export let suspensionLabel: AdminUserFormatter;
 export let users: AdminUserRow[];
 </script>
 
-<Item.Group class="xl:hidden" data-testid="admin-users-mobile-list">
-  {#each users as user}
-    <Item.Root class="items-start text-left" size="sm" variant="outline">
-      {#snippet child({ props })}
-        <button {...props} type="button" onclick={() => onSelect(user)}>
-          <Item.Content class="min-w-0">
-            <Item.Title>{displayName(user)}</Item.Title>
-            <Item.Description class="font-mono">
-              @{user.username ?? copy.noUsername}
-            </Item.Description>
-            <Item.Description class="line-clamp-none break-words">
-              {user.email ?? copy.noVerifiedEmail}
-            </Item.Description>
-          </Item.Content>
-          <Item.Actions>
-            <Badge variant={user.isAdmin ? "secondary" : "ghost"}>
-              {user.isAdmin ? copy.adminRole : copy.userRole}
-            </Badge>
-          </Item.Actions>
-          <Item.Footer class="block">
-            <dl class="grid grid-cols-2 gap-2 text-xs">
-              <div>
-                <dt class="text-muted-foreground">{copy.createdAt}</dt>
-                <dd class="tabular-nums">{formatDate(user.createdAt)}</dd>
-              </div>
-              <div class="text-right">
-                <dt class="text-muted-foreground">{copy.suspension}</dt>
-                <dd>
-                  {#if user.activeSuspension}
-                    <Badge class="mb-1 ml-auto" variant="destructive">{copy.suspendedStatus}</Badge>
-                    <span class="block text-muted-foreground">
-                      {suspensionLabel(user)}
-                    </span>
-                  {:else}
-                    {copy.clearStatus}
-                  {/if}
-                </dd>
-              </div>
-            </dl>
-          </Item.Footer>
-        </button>
-      {/snippet}
+<Item.Group class="xl:hidden gap-0 border-y" data-testid="admin-users-mobile-list" role="list">
+  {#each users as user, index (user.id)}
+    <Item.Root class="items-start px-1 py-3" role="listitem" size="sm">
+      <Item.Content class="min-w-0">
+        <Item.Title>{displayName(user)}</Item.Title>
+        <Item.Description class="font-mono">
+          @{user.username ?? copy.noUsername}
+        </Item.Description>
+        <Item.Description class="line-clamp-none break-words">
+          {user.email ?? copy.noVerifiedEmail}
+        </Item.Description>
+        <Item.Footer class="block pt-1">
+          <dl class="grid grid-cols-2 gap-2 text-xs">
+            <div>
+              <dt class="text-muted-foreground">{copy.createdAt}</dt>
+              <dd class="tabular-nums">{formatDate(user.createdAt)}</dd>
+            </div>
+            <div class="text-right">
+              <dt class="text-muted-foreground">{copy.suspension}</dt>
+              <dd>
+                {#if user.activeSuspension}
+                  <Badge class="mb-1 ml-auto" variant="destructive">{copy.suspendedStatus}</Badge>
+                  <span class="block text-muted-foreground">
+                    {suspensionLabel(user)}
+                  </span>
+                {:else}
+                  {copy.clearStatus}
+                {/if}
+              </dd>
+            </div>
+          </dl>
+        </Item.Footer>
+      </Item.Content>
+      <Item.Actions class="shrink-0 self-start">
+        <Button
+          aria-label={copy.editTitle}
+          onclick={() => onSelect(user)}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          {copy.editTitle}
+          <ChevronRightIcon aria-hidden="true" data-icon="inline-end" />
+        </Button>
+      </Item.Actions>
     </Item.Root>
+    {#if index < users.length - 1}<Item.Separator class="my-0" />{/if}
   {/each}
 </Item.Group>

--- a/src/features/admin/components/AdminUsersMobileList.svelte
+++ b/src/features/admin/components/AdminUsersMobileList.svelte
@@ -17,9 +17,9 @@ export let suspensionLabel: AdminUserFormatter;
 export let users: AdminUserRow[];
 </script>
 
-<Item.Group class="xl:hidden gap-0 border-y" data-testid="admin-users-mobile-list" role="list">
+<Item.Group class="xl:hidden gap-0 border-y" data-testid="admin-users-mobile-list">
   {#each users as user, index (user.id)}
-    <Item.Root class="items-start px-1 py-3" role="listitem" size="sm">
+    <Item.Root class="items-start px-1 py-3" size="sm">
       <Item.Content class="min-w-0">
         <Item.Title>{displayName(user)}</Item.Title>
         <Item.Description class="font-mono">

--- a/src/lib/components/shell/AppShell.svelte
+++ b/src/lib/components/shell/AppShell.svelte
@@ -20,6 +20,7 @@ import SmartphoneIcon from "@lucide/svelte/icons/smartphone";
 import TerminalIcon from "@lucide/svelte/icons/terminal";
 import UsersIcon from "@lucide/svelte/icons/users";
 import { onMount } from "svelte";
+import AdminMobileNav from "@/features/admin/components/AdminMobileNav.svelte";
 import { afterNavigate, goto } from "$app/navigation";
 import { navigating, page } from "$app/stores";
 import { shouldRedirectIncompleteProfileToWelcome } from "$lib/auth/auth-routing";
@@ -121,6 +122,9 @@ $: mobileNavGroups = viewerUser
     )
   : navGroups;
 $: mobilePrimaryLinks = buildMobilePrimaryLinks(data.copy);
+$: adminRoute =
+  $page.url.pathname === "/admin" || $page.url.pathname.startsWith("/admin/");
+$: adminMobileLinks = buildAdminShellLinks(data.copy);
 $: mobileSecondaryHasActive =
   Boolean($page.url.pathname) &&
   mobileNavGroups.some((group) =>
@@ -798,12 +802,20 @@ afterNavigate(({ from, to }) => {
   {/if}
 
   {#if viewerUser}
-    <MobilePrimaryNav
-      copy={data.copy}
-      hasSecondaryCurrent={mobileSecondaryHasActive}
-      isActiveLink={isMobilePrimaryActive}
-      links={mobilePrimaryLinks}
-    />
+    {#if viewerUser.isAdmin && adminRoute}
+      <AdminMobileNav
+        copy={data.copy}
+        isActiveLink={isActiveLink}
+        links={adminMobileLinks}
+      />
+    {:else}
+      <MobilePrimaryNav
+        copy={data.copy}
+        hasSecondaryCurrent={mobileSecondaryHasActive}
+        isActiveLink={isMobilePrimaryActive}
+        links={mobilePrimaryLinks}
+      />
+    {/if}
   {/if}
 </Sidebar.Provider>
 

--- a/src/routes/admin/audit/+page.svelte
+++ b/src/routes/admin/audit/+page.svelte
@@ -186,7 +186,6 @@ function displayValue(value: unknown) {
               <Item.Actions class="flex-wrap">
                 <Badge variant={row.outcome === "success" ? "secondary" : "destructive"}>{auditOutcomeLabel(data.locale, row.outcome)}</Badge>
                 <Badge variant="outline">{auditChannelLabel(data.locale, row.channel)}</Badge>
-                <ChevronRightIcon aria-hidden="true" data-icon="inline-end" />
               </Item.Actions>
               <Item.Footer>
                 <div class="grid w-full gap-2 text-xs">
@@ -198,7 +197,10 @@ function displayValue(value: unknown) {
                   </dl>
                   {#if row.metadata}
                     <details class="pt-1">
-                      <summary class="cursor-pointer font-medium">{data.copy.audit.details}</summary>
+                      <summary class="flex cursor-pointer items-center gap-1 font-medium">
+                        {data.copy.audit.details}
+                        <ChevronRightIcon aria-hidden="true" data-icon="inline-end" />
+                      </summary>
                       <dl class="grid gap-2 pt-2">
                         {#each Object.entries(row.metadata) as [key, value]}
                           <div><dt class="text-muted-foreground">{auditMetadataLabel(data.locale, key)}</dt><dd class="break-words">{displayValue(value)}</dd></div>

--- a/src/routes/admin/audit/+page.svelte
+++ b/src/routes/admin/audit/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
 import AdminWorkspace from "@/features/admin/components/AdminWorkspace.svelte";
 import {
   auditActionLabel,
@@ -165,7 +166,7 @@ function displayValue(value: unknown) {
       </div>
     </div>
 
-    <div class="min-w-0 border-y">
+    <div class="min-w-0">
       {#if data.rows.length === 0}
         <Empty.Root class="items-start px-0 text-left">
           <Empty.Header class="items-start text-left">
@@ -173,11 +174,11 @@ function displayValue(value: unknown) {
           </Empty.Header>
         </Empty.Root>
       {:else}
-        <Item.Group class="grid gap-3 py-4 xl:hidden" role="list">
-          {#each data.rows as row (row.id)}
+        <Item.Group class="gap-0 border-y py-1 xl:hidden" role="list">
+          {#each data.rows as row, index (row.id)}
             {@const actor = identity(row.user)}
             {@const subject = identity(row.subjectUser)}
-            <Item.Root role="listitem" variant="outline" class="grid gap-3">
+            <Item.Root role="listitem" variant="default" class="grid gap-3 px-1 py-3">
               <Item.Content class="min-w-0">
                 <Item.Title>{auditActionLabel(data.locale, row.action)}</Item.Title>
                 <Item.Description>{formatDate.format(new Date(row.createdAt))}</Item.Description>
@@ -185,6 +186,7 @@ function displayValue(value: unknown) {
               <Item.Actions class="flex-wrap">
                 <Badge variant={row.outcome === "success" ? "secondary" : "destructive"}>{auditOutcomeLabel(data.locale, row.outcome)}</Badge>
                 <Badge variant="outline">{auditChannelLabel(data.locale, row.channel)}</Badge>
+                <ChevronRightIcon aria-hidden="true" data-icon="inline-end" />
               </Item.Actions>
               <Item.Footer>
                 <div class="grid w-full gap-2 text-xs">
@@ -207,6 +209,7 @@ function displayValue(value: unknown) {
                 </div>
               </Item.Footer>
             </Item.Root>
+            {#if index < data.rows.length - 1}<Item.Separator class="my-0" />{/if}
           {/each}
         </Item.Group>
 

--- a/src/routes/admin/audit/+page.svelte
+++ b/src/routes/admin/audit/+page.svelte
@@ -174,11 +174,11 @@ function displayValue(value: unknown) {
           </Empty.Header>
         </Empty.Root>
       {:else}
-        <Item.Group class="gap-0 border-y py-1 xl:hidden" role="list">
+        <Item.Group class="gap-0 border-y py-1 xl:hidden">
           {#each data.rows as row, index (row.id)}
             {@const actor = identity(row.user)}
             {@const subject = identity(row.subjectUser)}
-            <Item.Root role="listitem" variant="default" class="grid gap-3 px-1 py-3">
+            <Item.Root variant="default" class="grid gap-3 px-1 py-3">
               <Item.Content class="min-w-0">
                 <Item.Title>{auditActionLabel(data.locale, row.action)}</Item.Title>
                 <Item.Description>{formatDate.format(new Date(row.createdAt))}</Item.Description>

--- a/tests/e2e/src/app/admin/moderation/test.ts
+++ b/tests/e2e/src/app/admin/moderation/test.ts
@@ -151,14 +151,16 @@ test("/admin/moderation 移动端工作区可管理首条筛选结果", async ({
     .fill(keyword);
   const record = page
     .getByTestId("admin-moderation-mobile-list")
-    .getByRole("button")
+    .getByRole("listitem")
     .filter({ hasText: keyword })
     .first();
   await expect(record).toBeVisible();
   await expect(
     page.getByTestId("admin-workspace").locator("table"),
   ).toBeHidden();
-  await record.click();
+  await record
+    .getByRole("button", { name: /管理评论|Manage Comment/i })
+    .click();
   await expect(
     page.getByRole("dialog").filter({
       has: page.getByRole("heading", { name: /管理评论|Manage Comment/i }),
@@ -173,6 +175,79 @@ test("/admin/moderation 移动端工作区可管理首条筛选结果", async ({
     testInfo,
     "admin-moderation-mobile-workspace",
   );
+});
+
+test("/admin/moderation 移动端弹窗滚动体不遮挡封禁控件", async ({ page }) => {
+  const viewports = [
+    { width: 320, height: 568 },
+    { width: 320, height: 800 },
+  ] as const;
+  await page.setViewportSize(viewports[0]);
+  await signInAsDevAdmin(page, "/admin/moderation");
+
+  const activeResponse = await page.request.get(
+    "/api/admin/comments?status=active",
+  );
+  const activeBody = (await activeResponse.json()) as {
+    data?: Array<{ body?: string }>;
+  };
+  const keyword =
+    activeBody.data?.find((item) => item.body?.trim())?.body?.slice(0, 16) ??
+    "";
+  expect(keyword.length).toBeGreaterThan(0);
+
+  for (const viewport of viewports) {
+    await page.setViewportSize(viewport);
+    await gotoAndWaitForReady(
+      page,
+      `/admin/moderation?search=${encodeURIComponent(keyword)}`,
+    );
+    await page
+      .getByPlaceholder(/搜索评论内容或用户名|Search comments/i)
+      .fill(keyword);
+
+    const record = page
+      .getByTestId("admin-moderation-mobile-list")
+      .getByRole("listitem")
+      .filter({ hasText: keyword })
+      .first();
+    await expect(record).toBeVisible();
+    await record
+      .getByRole("button", { name: /管理评论|Manage Comment/i })
+      .click();
+
+    const dialog = page.getByRole("dialog").filter({
+      has: page.getByRole("heading", { name: /管理评论|Manage Comment/i }),
+    });
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: /关闭|Close/i }),
+    ).toHaveCount(1);
+
+    const suspendButton = dialog.getByRole("button", {
+      name: /^(封禁|Suspend)$/i,
+    });
+    await suspendButton.scrollIntoViewIfNeeded();
+    const reasonInput = dialog.locator("#moderation-suspension-reason");
+    await reasonInput.scrollIntoViewIfNeeded();
+    const [footerBox, reasonBox, suspendBox] = await Promise.all([
+      dialog.locator('[data-slot="dialog-footer"]').boundingBox(),
+      reasonInput.boundingBox(),
+      suspendButton.boundingBox(),
+    ]);
+    expect(footerBox).not.toBeNull();
+    expect(reasonBox).not.toBeNull();
+    expect(suspendBox).not.toBeNull();
+    expect(footerBox?.y).toBeGreaterThanOrEqual(
+      Math.max(
+        (reasonBox?.y ?? 0) + (reasonBox?.height ?? 0),
+        (suspendBox?.y ?? 0) + (suspendBox?.height ?? 0),
+      ),
+    );
+
+    await dialog.getByRole("button", { name: /关闭|Close/i }).click();
+    await expect(dialog).toBeHidden();
+  }
 });
 
 test("/admin/moderation 可更新评论状态与备注", async ({ page }, testInfo) => {

--- a/tests/e2e/src/app/admin/moderation/test.ts
+++ b/tests/e2e/src/app/admin/moderation/test.ts
@@ -151,7 +151,7 @@ test("/admin/moderation 移动端工作区可管理首条筛选结果", async ({
     .fill(keyword);
   const record = page
     .getByTestId("admin-moderation-mobile-list")
-    .getByRole("listitem")
+    .locator('[data-slot="item"]')
     .filter({ hasText: keyword })
     .first();
   await expect(record).toBeVisible();
@@ -208,7 +208,7 @@ test("/admin/moderation 移动端弹窗滚动体不遮挡封禁控件", async ({
 
     const record = page
       .getByTestId("admin-moderation-mobile-list")
-      .getByRole("listitem")
+      .locator('[data-slot="item"]')
       .filter({ hasText: keyword })
       .first();
     await expect(record).toBeVisible();

--- a/tests/e2e/src/app/admin/test.ts
+++ b/tests/e2e/src/app/admin/test.ts
@@ -143,6 +143,41 @@ test("/admin 主导航可跳转到各管理工具", async ({ page }, testInfo) =
   }
 });
 
+test("/admin 移动端导航覆盖全部管理工具且显示当前位置", async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 568 });
+  await signInAsDevAdmin(page, "/admin/users");
+
+  const paths = [
+    { path: "/admin/users", name: /用户管理|User Management/i },
+    { path: "/admin/moderation", name: /内容审核|Moderation/i },
+    { path: "/admin/oauth", name: /OAuth|OAuth 客户端/i },
+    { path: "/admin/bus", name: /校车管理|Bus Management/i },
+    { path: "/admin/audit", name: /审计日志|Audit Log/i },
+    { path: "/admin/analytics", name: /聚合分析|Aggregate Analytics/i },
+  ] as const;
+
+  const mobileNavigation = page.getByTestId("admin-mobile-navigation");
+  await expect(mobileNavigation).toBeVisible();
+  await expect(page.getByTestId("mobile-primary-navigation")).toHaveCount(0);
+
+  for (const { path, name } of paths) {
+    await gotoAndWaitForReady(page, path);
+    await expect(
+      mobileNavigation.getByTestId("admin-mobile-navigation-current"),
+    ).toContainText(name);
+
+    await mobileNavigation
+      .getByTestId("admin-mobile-navigation-trigger")
+      .click();
+    const panel = page.getByTestId("admin-mobile-navigation-panel");
+    await expect(panel).toBeVisible();
+    await expect(panel.getByRole("link", { name })).toBeVisible();
+    await expect(panel.getByRole("link", { name: /./ })).toHaveCount(6);
+    await panel.getByRole("link", { name }).click();
+    await expect(page).toHaveURL(new RegExp(`${path}(?:\\?.*)?$`));
+  }
+});
+
 test("页面契约", async ({ page }, testInfo) => {
   await assertPageContract(page, { routePath: "/admin", testInfo });
 });

--- a/tests/e2e/src/app/admin/users/test.ts
+++ b/tests/e2e/src/app/admin/users/test.ts
@@ -132,12 +132,12 @@ test("/admin/users 移动端工作区可搜索并管理首条记录", async ({
 
   const record = page
     .getByTestId("admin-users-mobile-list")
-    .getByRole("button")
+    .getByRole("listitem")
     .filter({ hasText: DEV_SEED.debugUsername })
     .first();
   await expect(record).toBeVisible();
   await expect(record).toBeInViewport();
-  await record.click();
+  await record.getByRole("button", { name: /管理用户|Manage User/i }).click();
   await expect(
     page.getByRole("dialog", { name: /管理用户|Manage User/i }),
   ).toBeVisible();

--- a/tests/e2e/src/app/admin/users/test.ts
+++ b/tests/e2e/src/app/admin/users/test.ts
@@ -132,7 +132,7 @@ test("/admin/users 移动端工作区可搜索并管理首条记录", async ({
 
   const record = page
     .getByTestId("admin-users-mobile-list")
-    .getByRole("listitem")
+    .locator('[data-slot="item"]')
     .filter({ hasText: DEV_SEED.debugUsername })
     .first();
   await expect(record).toBeVisible();


### PR DESCRIPTION
Closes #878
Closes #883
Closes #884

- Replace student mobile bottom nav on admin routes with an admin context bar and Sheet covering all six destinations.
- Use borderless Item.Group rows, separators, and explicit mobile actions across admin records.
- Bound moderation dialogs to a viewport-safe scrolling body/footer and keep a single Close control.

Checks: focused Biome, svelte-check, source/test TypeScript checks, and production build.