### PR TITLE
fix(ui): standardize feedback and destructive states

### DIFF
--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -2269,6 +2269,8 @@
     "editAriaLabel": "Edit todo",
     "delete": "Delete",
     "deleteAriaLabel": "Delete todo",
+    "deleteConfirmTitle": "Delete this todo?",
+    "deleteConfirmDescription": "This action cannot be undone.",
     "cancel": "Cancel",
     "saving": "Saving...",
     "createAction": "Create Todo",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -2235,6 +2235,8 @@
     "editAriaLabel": "编辑待办",
     "delete": "删除",
     "deleteAriaLabel": "删除待办",
+    "deleteConfirmTitle": "删除此待办？",
+    "deleteConfirmDescription": "此操作无法撤销。",
     "cancel": "取消",
     "saving": "保存中...",
     "createAction": "创建待办",

--- a/src/features/auth/components/SignInPage.svelte
+++ b/src/features/auth/components/SignInPage.svelte
@@ -158,7 +158,7 @@ function providerInitial(name: string) {
               >
                 <span class="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted font-semibold text-primary text-xs">
                   {#if pendingProviderId === provider.id}
-                    <Spinner data-icon="inline-start" />
+                    <Spinner />
                   {:else if provider.debug}
                     <CircleUserRound />
                   {:else}
@@ -182,7 +182,7 @@ function providerInitial(name: string) {
           >
             <span class="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-primary">
               {#if passkeyPending}
-                <Spinner data-icon="inline-start" />
+                <Spinner />
               {:else}
                 <Fingerprint />
               {/if}

--- a/src/features/bus/components/BusTransitCampusNodes.svelte
+++ b/src/features/bus/components/BusTransitCampusNodes.svelte
@@ -19,7 +19,7 @@ export let positions: Map<number, BusMapPoint>;
     <g>
       <circle cx={position.x} cy={position.y} r={NODE_R + 10} fill="var(--background)" stroke="var(--border)" stroke-width="2" />
       <circle cx={position.x} cy={position.y} r={NODE_R} fill="var(--card)" stroke="var(--border)" stroke-width="3" />
-      <circle cx={position.x} cy={position.y} r={NODE_R - 8} fill="var(--muted)" stroke="#57606a" stroke-width="2" />
+      <circle cx={position.x} cy={position.y} r={NODE_R - 8} fill="var(--muted)" stroke="var(--muted-foreground)" stroke-width="2" />
       <text
         x={position.x + label.dx}
         y={position.y + label.dy}
@@ -38,7 +38,7 @@ export let positions: Map<number, BusMapPoint>;
           x={position.x + label.dx}
           y={position.y + label.dy + 22}
           text-anchor={label.textAnchor}
-          class="fill-[#57606a] text-[16px]"
+          class="fill-muted-foreground text-[16px]"
           paint-order="stroke"
           stroke="var(--card)"
           stroke-linejoin="round"

--- a/src/features/comments/components/CommentComposerTargetSelect.svelte
+++ b/src/features/comments/components/CommentComposerTargetSelect.svelte
@@ -14,7 +14,10 @@ export let viewer: ViewerContext;
 </script>
 
 {#if postTargetOptions.length > 1}
-  <Field.Field class="max-w-sm">
+  <Field.Field
+    class="max-w-sm"
+    data-disabled={!viewer.isAuthenticated || viewer.isSuspended ? "true" : undefined}
+  >
     <Field.Label for="comment-composer-target">
       {commentCopy.commentTargetPlaceholder}
     </Field.Label>

--- a/src/features/dashboard/components/HomeworkCreateAdvancedDateFields.svelte
+++ b/src/features/dashboard/components/HomeworkCreateAdvancedDateFields.svelte
@@ -17,7 +17,7 @@ export let toShanghaiDateTimeLocalValue: (value: Date) => string;
 </script>
 
 <Field.Group class="grid gap-3 sm:grid-cols-2">
-  <Field.Field>
+  <Field.Field data-disabled={isCreatingHomework ? "true" : undefined}>
     <Field.Title id="dashboard-homework-published-at-label">
       {homeworksCopy.publishedAt}
     </Field.Title>
@@ -53,7 +53,7 @@ export let toShanghaiDateTimeLocalValue: (value: Date) => string;
       </Button>
     </ButtonGroup.Root>
   </Field.Field>
-  <Field.Field>
+  <Field.Field data-disabled={isCreatingHomework ? "true" : undefined}>
     <Field.Title id="dashboard-homework-submission-start-label">
       {homeworksCopy.submissionStart}
     </Field.Title>

--- a/src/features/dashboard/components/HomeworkCreateDueDateField.svelte
+++ b/src/features/dashboard/components/HomeworkCreateDueDateField.svelte
@@ -19,7 +19,7 @@ export let isCreatingHomework: boolean;
 export let selectedCreateHomeworkSection: DashboardHomeworkCreateSectionGetter;
 </script>
 
-<Field.Field>
+<Field.Field data-disabled={isCreatingHomework ? "true" : undefined}>
   <Field.Title id="dashboard-homework-submission-due-label">
     {homeworksCopy.submissionDue}
   </Field.Title>

--- a/src/features/dashboard/components/HomeworkCreateFormFields.svelte
+++ b/src/features/dashboard/components/HomeworkCreateFormFields.svelte
@@ -52,7 +52,7 @@ $: sectionOptions = sections.map((section) => ({
       <Alert.Description>{createHomeworkError}</Alert.Description>
     </Alert.Root>
   {/if}
-  <Field.Field>
+  <Field.Field data-disabled={isCreatingHomework ? "true" : undefined}>
     <Field.Label for="dashboard-homework-section">
       {homeworksCopy.sectionLabel}
     </Field.Label>
@@ -71,7 +71,7 @@ $: sectionOptions = sections.map((section) => ({
       {/each}
     </NativeSelect.Root>
   </Field.Field>
-  <Field.Field>
+  <Field.Field data-disabled={isCreatingHomework ? "true" : undefined}>
     <Field.Label for="dashboard-homework-title">
       {homeworksCopy.titleLabel}
     </Field.Label>
@@ -89,7 +89,7 @@ $: sectionOptions = sections.map((section) => ({
     copy={homeworksCopy}
     testIdPrefix="dashboard-homework"
   />
-  <Field.Field>
+  <Field.Field data-disabled={isCreatingHomework ? "true" : undefined}>
     <Field.Title id="dashboard-homework-description-label">
       {homeworksCopy.descriptionLabel}
     </Field.Title>
@@ -121,12 +121,16 @@ $: sectionOptions = sections.map((section) => ({
     {selectedCreateHomeworkSection}
     {toShanghaiDateTimeLocalValue}
   />
-  <Field.Set>
+  <Field.Set data-disabled={isCreatingHomework ? "true" : undefined}>
     <Field.Legend variant="label" class="sr-only">
       {homeworksCopy.tagMajor} / {homeworksCopy.tagTeam}
     </Field.Legend>
     <Field.Group class="flex-row flex-wrap gap-4" data-slot="checkbox-group">
-      <Field.Field class="w-fit" orientation="horizontal">
+      <Field.Field
+        data-disabled={isCreatingHomework ? "true" : undefined}
+        class="w-fit"
+        orientation="horizontal"
+      >
         <Checkbox
           disabled={isCreatingHomework}
           id="dashboard-homework-is-major"
@@ -136,7 +140,11 @@ $: sectionOptions = sections.map((section) => ({
           {homeworksCopy.tagMajor}
         </Field.Label>
       </Field.Field>
-      <Field.Field class="w-fit" orientation="horizontal">
+      <Field.Field
+        data-disabled={isCreatingHomework ? "true" : undefined}
+        class="w-fit"
+        orientation="horizontal"
+      >
         <Checkbox
           disabled={isCreatingHomework}
           id="dashboard-homework-requires-team"

--- a/src/features/dashboard/components/HomeworksCardsView.svelte
+++ b/src/features/dashboard/components/HomeworksCardsView.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 import ArrowUpRight from "@lucide/svelte/icons/arrow-up-right";
 import CheckCircleIcon from "@lucide/svelte/icons/check-circle";
-import LoaderCircle from "@lucide/svelte/icons/loader-circle";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import type { DashboardHomeworkItem } from "@/features/dashboard/lib/dashboard-controller-types";
 import { Badge } from "$lib/components/ui/badge/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
 import * as Empty from "$lib/components/ui/empty/index.js";
 import * as Item from "$lib/components/ui/item/index.js";
+import { Spinner } from "$lib/components/ui/spinner/index.js";
 import DashboardTableIconButton from "./DashboardTableIconButton.svelte";
 
 type HomeworkDateFormatter = (
@@ -93,7 +93,7 @@ export let toggleHomeworkCompletion: (
               onclick={() => toggleHomeworkCompletion(homework)}
             >
               {#if homeworkSavingById[homework.id]}
-                <LoaderCircle class="animate-spin" />
+                <Spinner />
               {:else if homework.completion}
                 <RefreshCw />
               {:else}

--- a/src/features/dashboard/components/HomeworksListView.svelte
+++ b/src/features/dashboard/components/HomeworksListView.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 import CheckCircleIcon from "@lucide/svelte/icons/check-circle";
-import LoaderCircle from "@lucide/svelte/icons/loader-circle";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import type { DashboardHomeworkItem } from "@/features/dashboard/lib/dashboard-controller-types";
 import TruncatedText from "$lib/components/TruncatedText.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
 import * as Empty from "$lib/components/ui/empty/index.js";
+import { Spinner } from "$lib/components/ui/spinner/index.js";
 import * as Table from "$lib/components/ui/table/index.js";
 import DashboardTableIconButton from "./DashboardTableIconButton.svelte";
 import DashboardTableRowActions from "./DashboardTableRowActions.svelte";
@@ -109,7 +109,7 @@ export let toggleHomeworkCompletion: (
               onclick={() => toggleHomeworkCompletion(homework)}
             >
               {#if homeworkSavingById[homework.id]}
-                <LoaderCircle class="animate-spin" />
+                <Spinner />
               {:else if homework.completion}
                 <RefreshCw />
               {:else}

--- a/src/features/dashboard/components/TodoDetailDialog.svelte
+++ b/src/features/dashboard/components/TodoDetailDialog.svelte
@@ -7,9 +7,11 @@ import type {
   DashboardTodosCopy,
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
 import MarkdownPreview from "$lib/components/MarkdownPreview.svelte";
+import * as AlertDialog from "$lib/components/ui/alert-dialog/index.js";
 import { Badge } from "$lib/components/ui/badge/index.js";
-import { Button } from "$lib/components/ui/button/index.js";
+import { Button, buttonVariants } from "$lib/components/ui/button/index.js";
 import * as Dialog from "$lib/components/ui/dialog/index.js";
+import { Spinner } from "$lib/components/ui/spinner/index.js";
 
 export let deleteTodo: (todo: DashboardTodoItem) => void;
 export let fmtDate: (value: string | Date | null | undefined) => string;
@@ -21,6 +23,8 @@ export let todoSavingById: Record<string, boolean>;
 export let todosCopy: DashboardTodosCopy;
 export let todoStatus: (todo: DashboardTodoItem) => string;
 export let toggleTodoCompletion: (todo: DashboardTodoItem) => void;
+
+let deleteConfirmOpen = false;
 </script>
 
 {#if todo}
@@ -49,20 +53,43 @@ export let toggleTodoCompletion: (todo: DashboardTodoItem) => void;
           <Badge>{todoStatus(todo)}</Badge>
         </div>
         <div class="flex justify-between gap-2">
-          <Button
-            aria-label={todosCopy.deleteAriaLabel}
-            disabled={todoSavingById[todo.id]}
-            type="button"
-            variant="destructive"
-            onclick={() => {
-              deleteTodo(todo);
-            }}
-          >
-            <Trash2 data-icon="inline-start" />
-            {todoSavingById[todo.id] ? todosCopy.saving : todosCopy.delete}
-          </Button>
+          <AlertDialog.Root bind:open={deleteConfirmOpen}>
+            <AlertDialog.Trigger
+              aria-label={todosCopy.deleteAriaLabel}
+              class={buttonVariants({ variant: "destructive" })}
+              disabled={todoSavingById[todo.id]}
+              type="button"
+            >
+              <Trash2 data-icon="inline-start" />
+              {todosCopy.delete}
+            </AlertDialog.Trigger>
+            <AlertDialog.Content class="max-w-md sm:max-w-md">
+              <AlertDialog.Header>
+                <AlertDialog.Title>{todosCopy.deleteConfirmTitle}</AlertDialog.Title>
+                <AlertDialog.Description>
+                  {todosCopy.deleteConfirmDescription}
+                </AlertDialog.Description>
+              </AlertDialog.Header>
+              <AlertDialog.Footer>
+                <AlertDialog.Cancel disabled={todoSavingById[todo.id]}>
+                  {todosCopy.cancel}
+                </AlertDialog.Cancel>
+                <AlertDialog.Action
+                  disabled={todoSavingById[todo.id]}
+                  variant="destructive"
+                  onclick={() => deleteTodo(todo)}
+                >
+                  {#if todoSavingById[todo.id]}
+                    <Spinner data-icon="inline-start" />
+                  {/if}
+                  {todoSavingById[todo.id] ? todosCopy.saving : todosCopy.delete}
+                </AlertDialog.Action>
+              </AlertDialog.Footer>
+            </AlertDialog.Content>
+          </AlertDialog.Root>
           <div class="flex flex-wrap justify-end gap-2">
             <Button
+              disabled={todoSavingById[todo.id]}
               type="button"
               variant="outline"
               onclick={() => {

--- a/src/features/dashboard/components/TodoFormFields.svelte
+++ b/src/features/dashboard/components/TodoFormFields.svelte
@@ -30,7 +30,7 @@ $: dueAtLabelId = `${idPrefix}-due-at-label`;
 $: contentLabelId = `${idPrefix}-content-label`;
 </script>
 
-<Field.Field>
+<Field.Field data-disabled={disabled ? "true" : undefined}>
   <Field.Label for={titleId}>{todosCopy.titleLabel}</Field.Label>
   <Input
     id={titleId}
@@ -41,7 +41,7 @@ $: contentLabelId = `${idPrefix}-content-label`;
     value={titleValue}
   />
 </Field.Field>
-<Field.Field>
+<Field.Field data-disabled={disabled ? "true" : undefined}>
   <Field.Label for={priorityId}>{todosCopy.priorityLabel}</Field.Label>
   <NativeSelect.Root
     bind:value={priorityValue}
@@ -57,7 +57,7 @@ $: contentLabelId = `${idPrefix}-content-label`;
     {/each}
   </NativeSelect.Root>
 </Field.Field>
-<Field.Field>
+<Field.Field data-disabled={disabled ? "true" : undefined}>
   <Field.Title id={dueAtLabelId}>{todosCopy.dueAtLabel}</Field.Title>
   <DateTimePicker
     aria-labelledby={dueAtLabelId}
@@ -68,7 +68,7 @@ $: contentLabelId = `${idPrefix}-content-label`;
     value={dueAtValue}
   />
 </Field.Field>
-<Field.Field>
+<Field.Field data-disabled={disabled ? "true" : undefined}>
   <Field.Title id={contentLabelId}>{todosCopy.contentLabel}</Field.Title>
   <MarkdownEditor
     aria-labelledby={contentLabelId}

--- a/src/features/dashboard/components/TodosCardsView.svelte
+++ b/src/features/dashboard/components/TodosCardsView.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import CheckCircleIcon from "@lucide/svelte/icons/check-circle";
-import LoaderCircle from "@lucide/svelte/icons/loader-circle";
 import Pencil from "@lucide/svelte/icons/pencil";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import type {
@@ -9,6 +8,7 @@ import type {
 } from "@/features/dashboard/lib/dashboard-controller-types";
 import { Badge } from "$lib/components/ui/badge/index.js";
 import * as Item from "$lib/components/ui/item/index.js";
+import { Spinner } from "$lib/components/ui/spinner/index.js";
 import DashboardTableIconButton from "./DashboardTableIconButton.svelte";
 import TodoEmptyState from "./TodoEmptyState.svelte";
 
@@ -75,7 +75,7 @@ export let toggleTodoCompletion: TodoCompletionToggle;
               onclick={() => void toggleTodoCompletion(todo)}
             >
               {#if todoSavingById[todo.id]}
-                <LoaderCircle class="animate-spin" />
+                <Spinner />
               {:else if todo.completed}
                 <RefreshCw />
               {:else}

--- a/src/features/dashboard/components/TodosListView.svelte
+++ b/src/features/dashboard/components/TodosListView.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import CheckCircleIcon from "@lucide/svelte/icons/check-circle";
-import LoaderCircle from "@lucide/svelte/icons/loader-circle";
 import Pencil from "@lucide/svelte/icons/pencil";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import type {
@@ -10,6 +9,7 @@ import type {
 import TruncatedText from "$lib/components/TruncatedText.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
 import * as Empty from "$lib/components/ui/empty/index.js";
+import { Spinner } from "$lib/components/ui/spinner/index.js";
 import * as Table from "$lib/components/ui/table/index.js";
 import DashboardTableIconButton from "./DashboardTableIconButton.svelte";
 import DashboardTableRowActions from "./DashboardTableRowActions.svelte";
@@ -92,7 +92,7 @@ export let toggleTodoCompletion: TodoCompletionToggle;
               onclick={() => void toggleTodoCompletion(todo)}
             >
               {#if todoSavingById[todo.id]}
-                <LoaderCircle class="animate-spin" />
+                <Spinner />
               {:else if todo.completed}
                 <RefreshCw />
               {:else}

--- a/src/features/dashboard/lib/dashboard-controller-types.ts
+++ b/src/features/dashboard/lib/dashboard-controller-types.ts
@@ -359,6 +359,8 @@ export type DashboardTodosCopy = DashboardRecord & {
   createTitle: string;
   delete: string;
   deleteAriaLabel: string;
+  deleteConfirmDescription: string;
+  deleteConfirmTitle: string;
   dueAtLabel: string;
   editTitle: string;
   errorContentTooLong: string;

--- a/src/features/section-detail/components/SectionCalendarUrlRow.svelte
+++ b/src/features/section-detail/components/SectionCalendarUrlRow.svelte
@@ -16,7 +16,7 @@ export let value: string;
 export let warning = "";
 </script>
 
-<Field.Field>
+<Field.Field data-disabled={!value ? "true" : undefined}>
   <Field.Label for={id}>{label}</Field.Label>
   {#if description}
     <Field.Description>{description}</Field.Description>

--- a/src/lib/components/shell/AppFooter.svelte
+++ b/src/lib/components/shell/AppFooter.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import * as Sidebar from "$lib/components/ui/sidebar/index.js";
+import { Skeleton } from "$lib/components/ui/skeleton/index.js";
 import type {
   LayoutCopy,
   LayoutUserSummary,
@@ -57,10 +58,10 @@ const accountCollapsed = $derived(sidebar.state === "collapsed");
           class="flex h-12 w-full items-center gap-2 px-2"
           data-testid="sidebar-viewer-loading"
         >
-          <div class="size-8 animate-pulse rounded-lg bg-sidebar-accent"></div>
+          <Skeleton class="size-8 rounded-lg bg-sidebar-accent" />
           <div class="grid flex-1 gap-1 group-data-[collapsible=icon]:hidden">
-            <div class="h-3 w-24 animate-pulse rounded bg-sidebar-accent"></div>
-            <div class="h-2.5 w-16 animate-pulse rounded bg-sidebar-accent"></div>
+            <Skeleton class="h-3 w-24 rounded bg-sidebar-accent" />
+            <Skeleton class="h-2.5 w-16 rounded bg-sidebar-accent" />
           </div>
         </div>
       {:else if user}

--- a/src/lib/components/shell/AppSidebar.svelte
+++ b/src/lib/components/shell/AppSidebar.svelte
@@ -3,6 +3,7 @@ import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
 import appIconUrl from "$lib/assets/life-ustc-icon-192.png";
 import * as Collapsible from "$lib/components/ui/collapsible/index.js";
 import * as Sidebar from "$lib/components/ui/sidebar/index.js";
+import { Skeleton } from "$lib/components/ui/skeleton/index.js";
 import type {
   LayoutCopy,
   LayoutUserSummary,
@@ -289,10 +290,10 @@ function closeMobileSidebar(): void {
           class="flex h-12 items-center gap-2 px-2"
           data-testid="sidebar-viewer-loading"
         >
-          <div class="size-8 animate-pulse rounded-lg bg-sidebar-accent"></div>
+          <Skeleton class="size-8 rounded-lg bg-sidebar-accent" />
           <div class="grid flex-1 gap-1 group-data-[collapsible=icon]:hidden">
-            <div class="h-3 w-24 animate-pulse rounded bg-sidebar-accent"></div>
-            <div class="h-2.5 w-16 animate-pulse rounded bg-sidebar-accent"></div>
+            <Skeleton class="h-3 w-24 rounded bg-sidebar-accent" />
+            <Skeleton class="h-2.5 w-16 rounded bg-sidebar-accent" />
           </div>
         </div>
       {:else}

--- a/src/lib/components/shell/AppTopbar.svelte
+++ b/src/lib/components/shell/AppTopbar.svelte
@@ -3,6 +3,7 @@ import appIconUrl from "$lib/assets/life-ustc-icon-192.png";
 import type { ThemeMode } from "$lib/components/shell/layout-shell";
 import { Button } from "$lib/components/ui/button/index.js";
 import * as Sidebar from "$lib/components/ui/sidebar/index.js";
+import { Skeleton } from "$lib/components/ui/skeleton/index.js";
 import type {
   LayoutCopy,
   LayoutUserSummary,
@@ -88,11 +89,11 @@ export let signedIn = false;
       />
 
       {#if viewerLoading}
-        <div
+        <Skeleton
           aria-hidden="true"
-          class="h-8 w-20 animate-pulse rounded-md bg-muted"
+          class="h-8 w-20 rounded-md"
           data-testid="viewer-loading"
-        ></div>
+        />
       {:else if !user}
         <Button href="/account/sign-in">
           {copy.menu.signIn}

--- a/src/lib/components/ui/progress/index.ts
+++ b/src/lib/components/ui/progress/index.ts
@@ -1,0 +1,7 @@
+import Root from "./progress.svelte";
+
+export {
+	Root,
+	//
+	Root as Progress,
+};

--- a/src/lib/components/ui/progress/progress.svelte
+++ b/src/lib/components/ui/progress/progress.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { Progress as ProgressPrimitive } from "bits-ui";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		max = 100,
+		value,
+		...restProps
+	}: WithoutChildrenOrChild<ProgressPrimitive.RootProps> = $props();
+</script>
+
+<ProgressPrimitive.Root
+	bind:ref
+	data-slot="progress"
+	class={cn("h-1 rounded-full bg-muted relative flex w-full items-center overflow-x-hidden", className)}
+	{value}
+	{max}
+	{...restProps}
+>
+	<div
+		data-slot="progress-indicator"
+		class="bg-primary size-full flex-1 transition-all"
+		style="transform: translateX(-{100 - (100 * (value ?? 0)) / (max ?? 1)}%)"
+	></div>
+</ProgressPrimitive.Root>

--- a/src/routes/admin/analytics/+page.svelte
+++ b/src/routes/admin/analytics/+page.svelte
@@ -7,6 +7,7 @@ import {
 import PageHeader from "$lib/components/PageHeader.svelte";
 import { Button } from "$lib/components/ui/button/index.js";
 import * as Empty from "$lib/components/ui/empty/index.js";
+import { Progress } from "$lib/components/ui/progress/index.js";
 import * as Table from "$lib/components/ui/table/index.js";
 import type { PageData } from "./$types";
 
@@ -192,9 +193,12 @@ function failureLabel(count: number) {
                     <span class="truncate font-medium">{rankingLabel(ranking.kind as "channel" | "client" | "feature", row.label)}</span>
                     <span class="shrink-0 tabular-nums">{numberFormatter.format(row.count)}</span>
                   </div>
-                  <div class="h-1.5 overflow-hidden rounded-full bg-muted" aria-hidden="true">
-                    <div class="h-full rounded-full bg-primary" style={`width: ${Math.max(2, (row.count / ranking.rows[0].count) * 100)}%`}></div>
-                  </div>
+                  <Progress
+                    aria-label={`${rankingLabel(ranking.kind as "channel" | "client" | "feature", row.label)}: ${numberFormatter.format(row.count)}`}
+                    class="h-1.5"
+                    max={ranking.rows[0]?.count ?? 1}
+                    value={row.count}
+                  />
                   {#if row.failures > 0}<span class="text-xs text-destructive">{failureLabel(row.failures)}</span>{/if}
                 </li>
               {/each}

--- a/tests/e2e/src/app/dashboard/homeworks/test.ts
+++ b/tests/e2e/src/app/dashboard/homeworks/test.ts
@@ -491,7 +491,32 @@ test.describe("仪表盘作业", () => {
       }),
     ).toBeVisible();
     await titleInput.fill(title);
-    await page.getByTestId("dashboard-homework-create").click();
+
+    let releaseCreateRequest: (() => void) | undefined;
+    const createRequestHeld = new Promise<void>((resolve) => {
+      releaseCreateRequest = resolve;
+    });
+    const createRoutePattern = "**/workspace/homeworks**";
+    await page.route(createRoutePattern, async (route) => {
+      if (
+        route.request().method() !== "POST" ||
+        !route.request().url().includes("createHomework")
+      ) {
+        await route.continue();
+        return;
+      }
+      await createRequestHeld;
+      await route.continue();
+    });
+    try {
+      await page.getByTestId("dashboard-homework-create").click();
+      await expect(
+        createDialog.locator('[data-slot="field"][data-disabled="true"]'),
+      ).toHaveCount(6);
+    } finally {
+      releaseCreateRequest?.();
+      await page.unroute(createRoutePattern);
+    }
 
     await expect(visibleText(page, title)).toBeVisible({
       timeout: 15_000,

--- a/tests/e2e/src/app/dashboard/homeworks/test.ts
+++ b/tests/e2e/src/app/dashboard/homeworks/test.ts
@@ -496,6 +496,11 @@ test.describe("仪表盘作业", () => {
     const createRequestHeld = new Promise<void>((resolve) => {
       releaseCreateRequest = resolve;
     });
+    let createRequestIntercepted = false;
+    let resolveCreateRouteHandled: (() => void) | undefined;
+    const createRouteHandled = new Promise<void>((resolve) => {
+      resolveCreateRouteHandled = resolve;
+    });
     const createRoutePattern = "**/workspace/homeworks**";
     await page.route(createRoutePattern, async (route) => {
       if (
@@ -505,8 +510,13 @@ test.describe("仪表盘作业", () => {
         await route.continue();
         return;
       }
+      createRequestIntercepted = true;
       await createRequestHeld;
-      await route.continue();
+      try {
+        await route.continue();
+      } finally {
+        resolveCreateRouteHandled?.();
+      }
     });
     try {
       await page.getByTestId("dashboard-homework-create").click();
@@ -515,6 +525,7 @@ test.describe("仪表盘作业", () => {
       ).toHaveCount(6);
     } finally {
       releaseCreateRequest?.();
+      if (createRequestIntercepted) await createRouteHandled;
       await page.unroute(createRoutePattern);
     }
 

--- a/tests/e2e/src/app/dashboard/todos/test.ts
+++ b/tests/e2e/src/app/dashboard/todos/test.ts
@@ -287,14 +287,35 @@ test.describe("仪表盘待办", () => {
       await page
         .getByRole("button", { name: editedTitle, exact: true })
         .click();
+      const deleteButton = page
+        .getByRole("button", { name: /删除待办|Delete todo/i })
+        .first();
+      await deleteButton.click();
+      const confirmDialog = page.getByRole("alertdialog");
+      await expect(confirmDialog).toBeVisible();
+      await page.keyboard.press("Escape");
+      await expect(confirmDialog).toBeHidden();
+      await expect(page.getByText(editedTitle)).toBeVisible();
+
+      await deleteButton.click();
+      await expect(confirmDialog).toBeVisible();
+      await expect(
+        confirmDialog.getByRole("button", { name: /取消|Cancel/i }),
+      ).toBeEnabled();
+      await confirmDialog.getByRole("button", { name: /取消|Cancel/i }).click();
+      await expect(confirmDialog).toBeHidden();
+      await expect(page.getByText(editedTitle)).toBeVisible();
+
+      await deleteButton.click();
+      const reopenedConfirmDialog = page.getByRole("alertdialog");
+      await expect(reopenedConfirmDialog).toBeVisible();
       const deleteResponse = page.waitForResponse(
         (response) =>
           response.request().method() === "DELETE" &&
           response.url().includes("/api/workspace/todos/"),
       );
-      await page
-        .getByRole("button", { name: /删除待办|Delete todo/i })
-        .first()
+      await reopenedConfirmDialog
+        .getByRole("button", { name: /删除|Delete/i })
         .click();
       await expect((await deleteResponse).status()).toBe(200);
 

--- a/tests/e2e/src/app/dashboard/todos/test.ts
+++ b/tests/e2e/src/app/dashboard/todos/test.ts
@@ -287,6 +287,13 @@ test.describe("仪表盘待办", () => {
       await page
         .getByRole("button", { name: editedTitle, exact: true })
         .click();
+      const editedDetailDialog = page.getByRole("dialog", {
+        name: editedTitle,
+      });
+      const detailTitle = editedDetailDialog.locator(
+        '[data-slot="dialog-title"]',
+      );
+      await expect(detailTitle).toHaveText(editedTitle);
       const deleteButton = page
         .getByRole("button", { name: /删除待办|Delete todo/i })
         .first();
@@ -295,7 +302,7 @@ test.describe("仪表盘待办", () => {
       await expect(confirmDialog).toBeVisible();
       await page.keyboard.press("Escape");
       await expect(confirmDialog).toBeHidden();
-      await expect(page.getByText(editedTitle)).toBeVisible();
+      await expect(detailTitle).toBeVisible();
 
       await deleteButton.click();
       await expect(confirmDialog).toBeVisible();
@@ -304,7 +311,7 @@ test.describe("仪表盘待办", () => {
       ).toBeEnabled();
       await confirmDialog.getByRole("button", { name: /取消|Cancel/i }).click();
       await expect(confirmDialog).toBeHidden();
-      await expect(page.getByText(editedTitle)).toBeVisible();
+      await expect(detailTitle).toBeVisible();
 
       await deleteButton.click();
       const reopenedConfirmDialog = page.getByRole("alertdialog");


### PR DESCRIPTION
## Summary
- standardize shell loading placeholders and action spinners with shadcn Skeleton/Spinner
- add semantic admin analytics Progress bars and dark-theme campus tokens
- mark disabled Field wrappers and guard todo deletion with nested AlertDialog confirmation
- add focused E2E coverage for pending Field states and todo cancel/Escape/confirm persistence

Closes #895
Closes #890
Closes #893
Closes #894
Closes #864

## Checks
- bunx biome check (modified files)
- bunx svelte-check --tsconfig ./tsconfig.json
- bunx tsc --noEmit -p tsconfig.typecheck.json
- bunx tsc --noEmit -p tsconfig.typecheck.tests.json
- bunx vitest run (372 files, 2283 tests)
- DATABASE_URL=... bun run build

E2E browser tests were not run locally because no database containers were available.