### PR TITLE
fix(ui): standardize pagination empty and linked layouts

### DIFF
--- a/src/features/admin/components/AdminBusVersionsMobileList.svelte
+++ b/src/features/admin/components/AdminBusVersionsMobileList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import * as Item from "$lib/components/ui/item/index.js";
 import AdminBusVersionActions from "./AdminBusVersionActions.svelte";
 import AdminBusVersionStatusBadge from "./AdminBusVersionStatusBadge.svelte";
@@ -21,7 +21,11 @@ export let versions: AdminBusVersion[];
 </script>
 
 {#if versions.length === 0}
-  <SoftEmptyMessage class="xl:hidden" message={copy.noVersions} />
+  <Empty.Root class="min-h-20 border-0 px-2 py-6 xl:hidden">
+    <Empty.Header>
+      <Empty.Description>{copy.noVersions}</Empty.Description>
+    </Empty.Header>
+  </Empty.Root>
 {:else}
   <Item.Group class="xl:hidden gap-0 border-y" data-testid="admin-bus-mobile-list">
     {#each versions as version, index (version.id)}

--- a/src/features/admin/components/AdminBusVersionsTable.svelte
+++ b/src/features/admin/components/AdminBusVersionsTable.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import TruncatedText from "$lib/components/TruncatedText.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import * as Table from "$lib/components/ui/table/index.js";
 import AdminBusVersionActions from "./AdminBusVersionActions.svelte";
 import AdminBusVersionStatusBadge from "./AdminBusVersionStatusBadge.svelte";
@@ -73,9 +73,11 @@ export let versions: AdminBusVersion[];
       {:else}
         <Table.Row>
           <Table.Cell class="p-0" colspan={7}>
-            <div class="px-2 py-6">
-              <SoftEmptyMessage message={copy.noVersions} />
-            </div>
+            <Empty.Root class="min-h-20 rounded-none border-0 px-2 py-6">
+              <Empty.Header>
+                <Empty.Description>{copy.noVersions}</Empty.Description>
+              </Empty.Header>
+            </Empty.Root>
           </Table.Cell>
         </Table.Row>
       {/each}

--- a/src/features/admin/components/AdminModerationComments.svelte
+++ b/src/features/admin/components/AdminModerationComments.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import AdminModerationCommentsMobile from "./AdminModerationCommentsMobile.svelte";
 import AdminModerationCommentsTable from "./AdminModerationCommentsTable.svelte";
 import type {
@@ -41,6 +41,10 @@ export let targetLabel: AdminModerationCommentFormatter;
       {targetLabel}
     />
   {:else}
-    <SoftEmptyMessage message={copy.noComments} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{copy.noComments}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {/if}
 </section>

--- a/src/features/admin/components/AdminModerationDescriptions.svelte
+++ b/src/features/admin/components/AdminModerationDescriptions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import AdminModerationDescriptionCards from "./AdminModerationDescriptionCards.svelte";
 import AdminModerationDescriptionSummary from "./AdminModerationDescriptionSummary.svelte";
 import AdminModerationDescriptionTable from "./AdminModerationDescriptionTable.svelte";
@@ -48,6 +48,10 @@ export let targetLabel: (description: AdminModerationDescription) => string;
       {targetLabel}
     />
   {:else}
-    <SoftEmptyMessage message={copy.noDescriptions} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{copy.noDescriptions}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {/if}
 </section>

--- a/src/features/admin/components/AdminModerationHomeworks.svelte
+++ b/src/features/admin/components/AdminModerationHomeworks.svelte
@@ -2,10 +2,10 @@
 import Trash2 from "@lucide/svelte/icons/trash-2";
 import DashboardTableIconButton from "@/features/dashboard/components/DashboardTableIconButton.svelte";
 import DashboardTableRowActions from "@/features/dashboard/components/DashboardTableRowActions.svelte";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import TruncatedText from "$lib/components/TruncatedText.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import * as Item from "$lib/components/ui/item/index.js";
 import * as Table from "$lib/components/ui/table/index.js";
 
@@ -43,7 +43,11 @@ export let onDelete: (homework: ModerationHomework) => void;
 
 <section class="grid gap-3">
   {#if homeworks.length === 0}
-    <SoftEmptyMessage message={copy.noHomeworks} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{copy.noHomeworks}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {:else}
     <Item.Group class="xl:hidden gap-0 border-y">
       {#each homeworks as homework, index (homework.id)}

--- a/src/features/admin/components/AdminModerationSuspensions.svelte
+++ b/src/features/admin/components/AdminModerationSuspensions.svelte
@@ -4,11 +4,11 @@ import type { SubmitFunction } from "@sveltejs/kit";
 import DashboardTableIconButton from "@/features/dashboard/components/DashboardTableIconButton.svelte";
 import DashboardTableRowActions from "@/features/dashboard/components/DashboardTableRowActions.svelte";
 import { enhance } from "$app/forms";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import TruncatedText from "$lib/components/TruncatedText.svelte";
 import * as AlertDialog from "$lib/components/ui/alert-dialog/index.js";
 import { Badge } from "$lib/components/ui/badge/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import * as Item from "$lib/components/ui/item/index.js";
 import { Spinner } from "$lib/components/ui/spinner/index.js";
 import * as Table from "$lib/components/ui/table/index.js";
@@ -82,7 +82,11 @@ function confirmedLiftAction(suspension: ModerationSuspension): SubmitFunction {
 
 <section class="grid gap-3">
   {#if suspensions.length === 0}
-    <SoftEmptyMessage message={copy.noSuspensions} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{copy.noSuspensions}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {:else}
     <Item.Group class="xl:hidden gap-0 border-y">
       {#each suspensions as suspension, index (suspension.id)}

--- a/src/features/admin/components/AdminUsersTableCard.svelte
+++ b/src/features/admin/components/AdminUsersTableCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import AdminUsersDesktopTable from "./AdminUsersDesktopTable.svelte";
 import AdminUsersMobileList from "./AdminUsersMobileList.svelte";
 import type {
@@ -39,7 +39,11 @@ export let users: AdminUserRow[];
   </div>
 
   {#if users.length === 0}
-    <SoftEmptyMessage message={copy.noResults} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{copy.noResults}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {:else}
     <AdminUsersMobileList
       {copy}

--- a/src/features/catalog/components/CatalogPagination.svelte
+++ b/src/features/catalog/components/CatalogPagination.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
 import ChevronLeftIcon from "@lucide/svelte/icons/chevron-left";
 import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
-import MoreHorizontalIcon from "@lucide/svelte/icons/more-horizontal";
-import { Button } from "$lib/components/ui/button/index.js";
-import { getPaginationTokens } from "$lib/navigation/pagination";
+import * as Pagination from "$lib/components/ui/pagination/index.js";
 
 export let ariaLabel: string;
 export let nextLabel: string;
@@ -13,63 +11,84 @@ export let pageHref: (targetPage: number) => string;
 export let previousLabel: string;
 export let previousPageLabel: string;
 export let totalPages: number;
-
-$: tokens = getPaginationTokens({
-  currentPage: page,
-  maxVisible: 3,
-  totalPages,
-});
 </script>
 
 {#if totalPages > 1}
-  <nav aria-label={ariaLabel} class="flex justify-center py-5" data-testid="catalog-pagination">
-    <ul class="flex items-center gap-0.5">
-      <li>
-        <Button
-          aria-label={previousPageLabel}
-          disabled={page <= 1}
-          href={pageHref(Math.max(1, page - 1))}
-          size="icon"
-          variant="ghost"
-        >
-          <ChevronLeftIcon aria-hidden="true" />
-          <span class="sr-only">{previousLabel}</span>
-        </Button>
-      </li>
-      {#each tokens as token}
-        <li>
-          {#if token === "ellipsis"}
-            <span
-              aria-hidden="true"
-              class="flex size-8 items-center justify-center text-muted-foreground"
-            >
-              <MoreHorizontalIcon class="size-4" />
-            </span>
+  <Pagination.Root
+    aria-label={ariaLabel}
+    class="py-5"
+    count={totalPages}
+    data-testid="catalog-pagination"
+    page={page}
+    perPage={1}
+  >
+    {#snippet children({ pages, currentPage })}
+      <Pagination.Content>
+        <Pagination.Item>
+          <Pagination.PrevButton
+            aria-label={previousPageLabel}
+            disabled={page <= 1}
+          >
+            {#snippet child({ props })}
+              <a
+                {...props}
+                href={page <= 1 ? undefined : pageHref(page - 1)}
+                aria-label={previousPageLabel}
+                aria-disabled={page <= 1 ? "true" : undefined}
+                tabindex={page <= 1 ? -1 : undefined}
+              >
+                <ChevronLeftIcon aria-hidden="true" />
+                <span class="sr-only">{previousLabel}</span>
+              </a>
+            {/snippet}
+          </Pagination.PrevButton>
+        </Pagination.Item>
+
+        {#each pages as pageItem (pageItem.key)}
+          {#if pageItem.type === "ellipsis"}
+            <Pagination.Item>
+              <Pagination.Ellipsis />
+            </Pagination.Item>
           {:else}
-            <Button
-              aria-current={token === page ? "page" : undefined}
-              aria-label={`${ariaLabel} ${token}`}
-              href={pageHref(token)}
-              size="icon"
-              variant={token === page ? "outline" : "ghost"}
-            >
-              {token}
-            </Button>
+            <Pagination.Item>
+              <Pagination.Link
+                isActive={currentPage === pageItem.value}
+                page={pageItem}
+              >
+                {#snippet child({ props })}
+                  <a
+                    {...props}
+                    href={pageHref(pageItem.value)}
+                    aria-label={`${ariaLabel} ${pageItem.value}`}
+                  >
+                    {pageItem.value}
+                  </a>
+                {/snippet}
+              </Pagination.Link>
+            </Pagination.Item>
           {/if}
-        </li>
-      {/each}
-      <li>
-        <Button
-          aria-label={nextPageLabel}
-          disabled={page >= totalPages}
-          href={pageHref(Math.min(totalPages, page + 1))}
-          size="icon"
-          variant="ghost"
-        >
-          <ChevronRightIcon aria-hidden="true" />
-          <span class="sr-only">{nextLabel}</span>
-        </Button>
-      </li>
-    </ul>
-  </nav>
+        {/each}
+
+        <Pagination.Item>
+          <Pagination.NextButton
+            aria-label={nextPageLabel}
+            disabled={page >= totalPages}
+          >
+            {#snippet child({ props })}
+              <a
+                {...props}
+                href={page >= totalPages ? undefined : pageHref(page + 1)}
+                aria-label={nextPageLabel}
+                aria-disabled={page >= totalPages ? "true" : undefined}
+                tabindex={page >= totalPages ? -1 : undefined}
+              >
+                <ChevronRightIcon aria-hidden="true" />
+                <span class="sr-only">{nextLabel}</span>
+              </a>
+            {/snippet}
+          </Pagination.NextButton>
+        </Pagination.Item>
+      </Pagination.Content>
+    {/snippet}
+  </Pagination.Root>
 {/if}

--- a/src/features/catalog/components/CourseDetailSectionsMobile.svelte
+++ b/src/features/catalog/components/CourseDetailSectionsMobile.svelte
@@ -3,8 +3,8 @@ import {
   type CatalogNamed,
   catalogLocalizedNames,
 } from "@/features/catalog/lib/catalog-list-display";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import TruncatedCode from "$lib/components/TruncatedCode.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import * as Item from "$lib/components/ui/item/index.js";
 import type {
   CourseDetailCopy,
@@ -20,7 +20,11 @@ export let primaryName: (item: CatalogNamed | null | undefined) => string;
 
 {#if course.sections.length === 0}
   <div class="md:hidden">
-    <SoftEmptyMessage message={copy.courseDetail.noSections} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{copy.courseDetail.noSections}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   </div>
 {:else}
   <Item.Group class="md:hidden">

--- a/src/features/catalog/components/CourseDetailSectionsTable.svelte
+++ b/src/features/catalog/components/CourseDetailSectionsTable.svelte
@@ -3,9 +3,9 @@ import {
   type CatalogNamed,
   catalogLocalizedNames,
 } from "@/features/catalog/lib/catalog-list-display";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import TruncatedCode from "$lib/components/TruncatedCode.svelte";
 import TruncatedText from "$lib/components/TruncatedText.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import * as Table from "$lib/components/ui/table/index.js";
 import CatalogTableLink from "./CatalogTableLink.svelte";
 import type {
@@ -22,7 +22,11 @@ export let primaryName: (item: CatalogNamed | null | undefined) => string;
 
 <div class="hidden md:block">
   {#if course.sections.length === 0}
-    <SoftEmptyMessage message={copy.courseDetail.noSections} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{copy.courseDetail.noSections}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {:else}
     <Table.Root class="">
       <Table.Header>

--- a/src/features/catalog/components/TeacherDetailSectionsMobile.svelte
+++ b/src/features/catalog/components/TeacherDetailSectionsMobile.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { catalogLocalizedDisplayName } from "@/features/catalog/lib/catalog-list-display";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import TruncatedCode from "$lib/components/TruncatedCode.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import * as Item from "$lib/components/ui/item/index.js";
 import type {
   TeacherDetailCopy,
@@ -16,7 +16,11 @@ export let teacher: TeacherDetailTeacher;
 
 {#if teacher.sections.length === 0}
   <div class="md:hidden">
-    <SoftEmptyMessage message={copy.teacherDetail.noSections} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{copy.teacherDetail.noSections}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   </div>
 {:else}
   <Item.Group class="md:hidden">

--- a/src/features/catalog/components/TeacherDetailSectionsTable.svelte
+++ b/src/features/catalog/components/TeacherDetailSectionsTable.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import { catalogLocalizedDisplayName } from "@/features/catalog/lib/catalog-list-display";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import TruncatedCode from "$lib/components/TruncatedCode.svelte";
 import TruncatedText from "$lib/components/TruncatedText.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import * as Table from "$lib/components/ui/table/index.js";
 import CatalogTableLink from "./CatalogTableLink.svelte";
 import type {
@@ -18,7 +18,11 @@ export let teacher: TeacherDetailTeacher;
 
 <div class="hidden md:block">
   {#if teacher.sections.length === 0}
-    <SoftEmptyMessage message={copy.teacherDetail.noSections} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{copy.teacherDetail.noSections}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {:else}
     <Table.Root class="">
       <Table.Header>

--- a/src/features/comments/components/CommentsThreadSection.svelte
+++ b/src/features/comments/components/CommentsThreadSection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { CommentNodeWithContext } from "@/features/comments/lib/comment-ui";
 import type { ViewerContext } from "@/lib/auth/viewer-context";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import { Skeleton } from "$lib/components/ui/skeleton/index.js";
 import CommentsThreadList from "./CommentsThreadList.svelte";
 import type {
@@ -63,7 +63,11 @@ export let visibilityOptions: CommentThreadProps["visibilityOptions"];
     <Skeleton class="h-24 w-full" />
   </div>
 {:else if comments.length === 0}
-  <SoftEmptyMessage message={commentCopy.emptyTitle} />
+  <Empty.Root class="min-h-20 border-0 px-2 py-6">
+    <Empty.Header>
+      <Empty.Description>{commentCopy.emptyTitle}</Empty.Description>
+    </Empty.Header>
+  </Empty.Root>
 {:else}
   <CommentsThreadList
     bind:actionMenuId

--- a/src/features/dashboard/components/OverviewExamSummaryCard.svelte
+++ b/src/features/dashboard/components/OverviewExamSummaryCard.svelte
@@ -5,7 +5,8 @@ import type {
   DashboardSectionCopy,
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
 import { DASHBOARD_OVERVIEW_PREVIEW_LIMIT } from "@/features/dashboard/lib/overview-preview";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
+import * as Item from "$lib/components/ui/item/index.js";
 import type { DashboardCalendarTabHref } from "./dashboard-calendar-component-types";
 import OverviewSection from "./OverviewSection.svelte";
 
@@ -32,27 +33,34 @@ export let viewAllLabel = "View all";
   {/snippet}
 
   {#if upcomingExams.length === 0}
-    <SoftEmptyMessage message={dashboardCopy.radar.empty} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{dashboardCopy.radar.empty}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {:else}
-    <ul class="divide-y divide-border/60">
-      {#each upcomingExams.slice(0, previewLimit) as exam}
-        <li>
-          <a
-            class="flex items-start justify-between gap-3 py-2.5 transition-colors hover:bg-muted/40 -mx-2 px-2 rounded-md"
-            href={dashboardTabHref("exams")}
-          >
-            <span class="grid min-w-0 gap-0.5">
-              <span class="font-medium text-sm">{exam.courseName}</span>
-              <span class="text-muted-foreground text-xs">
-                {calendarExamDetail(exam) || sectionCopy.dateTBD}
-              </span>
-            </span>
-            <span class="shrink-0 text-muted-foreground text-xs tabular-nums">
-              {fmtDate(exam.date)}
-            </span>
-          </a>
-        </li>
+    {@const examPreview = upcomingExams.slice(0, previewLimit)}
+    <Item.Group class="gap-0">
+      {#each examPreview as exam, index (exam.id)}
+        <Item.Root class="rounded-md border-0 px-2 py-2.5" size="sm">
+          {#snippet child({ props })}
+            <a href={dashboardTabHref("exams")} {...props}>
+              <Item.Content class="min-w-0">
+                <Item.Title>{exam.courseName}</Item.Title>
+                <Item.Description>
+                  {calendarExamDetail(exam) || sectionCopy.dateTBD}
+                </Item.Description>
+              </Item.Content>
+              <Item.Actions class="shrink-0">
+                <span class="text-muted-foreground text-xs tabular-nums">
+                  {fmtDate(exam.date)}
+                </span>
+              </Item.Actions>
+            </a>
+          {/snippet}
+        </Item.Root>
+        {#if index < examPreview.length - 1}<Item.Separator class="my-0" />{/if}
       {/each}
-    </ul>
+    </Item.Group>
   {/if}
 </OverviewSection>

--- a/src/features/dashboard/components/OverviewFocusCard.svelte
+++ b/src/features/dashboard/components/OverviewFocusCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { DashboardFocusItem } from "@/features/dashboard/lib/dashboard-agenda";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import OverviewSection from "./OverviewSection.svelte";
 
 export let copy: {
@@ -40,6 +40,10 @@ function statusLabel(status: DashboardFocusItem["status"]) {
       </p>
     </a>
   {:else}
-    <SoftEmptyMessage message={copy.noUpcoming} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{copy.noUpcoming}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {/if}
 </OverviewSection>

--- a/src/features/dashboard/components/OverviewHomeworkSummaryCard.svelte
+++ b/src/features/dashboard/components/OverviewHomeworkSummaryCard.svelte
@@ -6,7 +6,8 @@ import type {
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
 import { DASHBOARD_OVERVIEW_PREVIEW_LIMIT } from "@/features/dashboard/lib/overview-preview";
 import { sectionDetailHomeworkPath } from "@/features/section-detail/lib/section-detail-tab";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
+import * as Item from "$lib/components/ui/item/index.js";
 import type { DashboardCalendarTabHref } from "./dashboard-calendar-component-types";
 import OverviewSection from "./OverviewSection.svelte";
 
@@ -28,34 +29,42 @@ export let viewAllLabel = "View all";
   viewAllVisible={pendingHomeworks.length > previewLimit}
 >
   {#if pendingHomeworks.length === 0}
-    <SoftEmptyMessage message={dashboardCopy.homeworks.empty} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{dashboardCopy.homeworks.empty}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {:else}
-    <ul class="divide-y divide-border/60">
-      {#each pendingHomeworks.slice(0, previewLimit) as homework}
-        <li>
-          <a
-            class="flex items-start justify-between gap-3 py-2.5 transition-colors hover:bg-muted/40 -mx-2 px-2 rounded-md"
-            href={homework.section?.jwId
-              ? sectionDetailHomeworkPath(homework.section.jwId, {
-                  homeworkId: homework.id,
-                })
-              : dashboardTabHref("homeworks")}
-          >
-            <span class="grid min-w-0 gap-0.5">
-              <span class="font-medium text-sm">{homework.title}</span>
-              <span class="text-muted-foreground text-xs">
-                {homework.section?.course?.namePrimary ?? commonCopy.sections}
-              </span>
-            </span>
-            <span class="grid shrink-0 justify-items-end gap-0.5 text-xs">
-              <span class="text-foreground">{homeworkEtaLabel(homework.submissionDueAt)}</span>
-              <span class="text-muted-foreground tabular-nums"
-                >{fmtDate(homework.submissionDueAt)}</span
-              >
-            </span>
-          </a>
-        </li>
+    {@const homeworkPreview = pendingHomeworks.slice(0, previewLimit)}
+    <Item.Group class="gap-0">
+      {#each homeworkPreview as homework, index (homework.id)}
+        <Item.Root class="rounded-md border-0 px-2 py-2.5" size="sm">
+          {#snippet child({ props })}
+            <a
+              href={homework.section?.jwId
+                ? sectionDetailHomeworkPath(homework.section.jwId, {
+                    homeworkId: homework.id,
+                  })
+                : dashboardTabHref("homeworks")}
+              {...props}
+            >
+              <Item.Content class="min-w-0">
+                <Item.Title>{homework.title}</Item.Title>
+                <Item.Description>
+                  {homework.section?.course?.namePrimary ?? commonCopy.sections}
+                </Item.Description>
+              </Item.Content>
+              <Item.Actions class="grid shrink-0 justify-items-end gap-0.5 text-xs">
+                <span class="text-foreground">{homeworkEtaLabel(homework.submissionDueAt)}</span>
+                <span class="text-muted-foreground tabular-nums">
+                  {fmtDate(homework.submissionDueAt)}
+                </span>
+              </Item.Actions>
+            </a>
+          {/snippet}
+        </Item.Root>
+        {#if index < homeworkPreview.length - 1}<Item.Separator class="my-0" />{/if}
       {/each}
-    </ul>
+    </Item.Group>
   {/if}
 </OverviewSection>

--- a/src/features/dashboard/components/OverviewLinksGrid.svelte
+++ b/src/features/dashboard/components/OverviewLinksGrid.svelte
@@ -6,7 +6,7 @@ import type {
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
 import { DASHBOARD_OVERVIEW_PREVIEW_LIMIT } from "@/features/dashboard/lib/overview-preview";
 import { dashboardLinkVisitHref } from "@/features/dashboard-links/lib/dashboard-links";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import type { DashboardCalendarTabHref } from "./dashboard-calendar-component-types";
 import LinksTabPinButton from "./LinksTabPinButton.svelte";
 import OverviewSection from "./OverviewSection.svelte";
@@ -83,6 +83,10 @@ function pinAction(link: DashboardOverviewLinkItem): DashboardLinkPinAction {
       {/each}
     </div>
   {:else}
-    <SoftEmptyMessage message={dashboardCopy.linkHub.empty} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{dashboardCopy.linkHub.empty}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {/if}
 </OverviewSection>

--- a/src/features/dashboard/components/OverviewTodayCard.svelte
+++ b/src/features/dashboard/components/OverviewTodayCard.svelte
@@ -7,7 +7,8 @@ import type {
   DashboardTodoItem,
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
 import { sectionDetailHomeworkPath } from "@/features/section-detail/lib/section-detail-tab";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
+import * as Item from "$lib/components/ui/item/index.js";
 import type { DashboardCalendarTabHref } from "./dashboard-calendar-component-types";
 import OverviewSection from "./OverviewSection.svelte";
 
@@ -32,52 +33,80 @@ $: isEmpty =
   title={dashboardCopy.today.title}
 >
   {#if isEmpty}
-    <SoftEmptyMessage message={dashboardCopy.today.empty} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{dashboardCopy.today.empty}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {:else}
-    <ul class="divide-y divide-border/60">
-      {#each todaySessions as session}
-        <li>
-          <a
-            class="grid gap-0.5 py-2.5 transition-colors hover:bg-muted/40 -mx-2 px-2 rounded-md"
-            href={sessionHref(session)}
-          >
-            <span class="font-medium text-sm">{session.courseName}</span>
-            <span class="text-muted-foreground text-xs">
-              {fmtTime(session.startTime)}-{fmtTime(session.endTime)} · {session.location}
-            </span>
-          </a>
-        </li>
+    <Item.Group class="gap-0">
+      {#each todaySessions as session, index (session.id)}
+        <Item.Root class="rounded-md border-0 px-2 py-2.5" size="sm">
+          {#snippet child({ props })}
+            <a href={sessionHref(session)} {...props}>
+              <Item.Content class="min-w-0">
+                <Item.Title>{session.courseName}</Item.Title>
+                <Item.Description>
+                  {session.location}
+                </Item.Description>
+              </Item.Content>
+              <Item.Actions class="shrink-0">
+                <span class="text-muted-foreground text-xs tabular-nums">
+                  {fmtTime(session.startTime)}-{fmtTime(session.endTime)}
+                </span>
+              </Item.Actions>
+            </a>
+          {/snippet}
+        </Item.Root>
+        {#if index < todaySessions.length - 1 || dueTodayHomeworks.length > 0 || dueTodayTodos.length > 0}<Item.Separator class="my-0" />{/if}
       {/each}
-      {#each dueTodayHomeworks as homework}
-        <li>
-          <a
-            class="grid gap-0.5 py-2.5 transition-colors hover:bg-muted/40 -mx-2 px-2 rounded-md"
-            href={homework.section?.jwId
-              ? sectionDetailHomeworkPath(homework.section.jwId, {
-                  homeworkId: homework.id,
-                })
-              : dashboardTabHref("homeworks")}
-          >
-            <span class="font-medium text-sm">{homework.title}</span>
-            <span class="text-muted-foreground text-xs">
-              {copy.CalendarEventCard.homework} · {fmtDate(homework.submissionDueAt)}
-            </span>
-          </a>
-        </li>
+      {#each dueTodayHomeworks as homework, index (homework.id)}
+        <Item.Root class="rounded-md border-0 px-2 py-2.5" size="sm">
+          {#snippet child({ props })}
+            <a
+              href={homework.section?.jwId
+                ? sectionDetailHomeworkPath(homework.section.jwId, {
+                    homeworkId: homework.id,
+                  })
+                : dashboardTabHref("homeworks")}
+              {...props}
+            >
+              <Item.Content class="min-w-0">
+                <Item.Title>{homework.title}</Item.Title>
+                <Item.Description>
+                  {copy.CalendarEventCard.homework}
+                </Item.Description>
+              </Item.Content>
+              <Item.Actions class="shrink-0">
+                <span class="text-muted-foreground text-xs tabular-nums">
+                  {fmtDate(homework.submissionDueAt)}
+                </span>
+              </Item.Actions>
+            </a>
+          {/snippet}
+        </Item.Root>
+        {#if index < dueTodayHomeworks.length - 1 || dueTodayTodos.length > 0}<Item.Separator class="my-0" />{/if}
       {/each}
-      {#each dueTodayTodos as todo}
-        <li>
-          <a
-            class="grid gap-0.5 py-2.5 transition-colors hover:bg-muted/40 -mx-2 px-2 rounded-md"
-            href={dashboardTabHref("todos")}
-          >
-            <span class="font-medium text-sm">{todo.title}</span>
-            <span class="text-muted-foreground text-xs">
-              {copy.CalendarEventCard.todo} · {fmtDate(todo.dueAt)}
-            </span>
-          </a>
-        </li>
+      {#each dueTodayTodos as todo, index (todo.id)}
+        <Item.Root class="rounded-md border-0 px-2 py-2.5" size="sm">
+          {#snippet child({ props })}
+            <a href={dashboardTabHref("todos")} {...props}>
+              <Item.Content class="min-w-0">
+                <Item.Title>{todo.title}</Item.Title>
+                <Item.Description>
+                  {copy.CalendarEventCard.todo}
+                </Item.Description>
+              </Item.Content>
+              <Item.Actions class="shrink-0">
+                <span class="text-muted-foreground text-xs tabular-nums">
+                  {fmtDate(todo.dueAt)}
+                </span>
+              </Item.Actions>
+            </a>
+          {/snippet}
+        </Item.Root>
+        {#if index < dueTodayTodos.length - 1}<Item.Separator class="my-0" />{/if}
       {/each}
-    </ul>
+    </Item.Group>
   {/if}
 </OverviewSection>

--- a/src/features/dashboard/components/OverviewTodayOverdueCards.svelte
+++ b/src/features/dashboard/components/OverviewTodayOverdueCards.svelte
@@ -10,8 +10,9 @@ import type {
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
 import { DASHBOARD_OVERVIEW_PREVIEW_LIMIT } from "@/features/dashboard/lib/overview-preview";
 import { sectionDetailHomeworkPath } from "@/features/section-detail/lib/section-detail-tab";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
+import * as Empty from "$lib/components/ui/empty/index.js";
+import * as Item from "$lib/components/ui/item/index.js";
 import type { DashboardCalendarTabHref } from "./dashboard-calendar-component-types";
 import OverviewSection from "./OverviewSection.svelte";
 import OverviewTodayCard from "./OverviewTodayCard.svelte";
@@ -65,61 +66,72 @@ $: overdueEmpty = overdueHomeworks.length === 0 && overdueTodos.length === 0;
     viewAllVisible={showOverdueViewAll}
   >
     {#if overdueEmpty}
-      <SoftEmptyMessage message={dashboardCopy.overdue.empty} />
+      <Empty.Root class="min-h-20 border-0 px-2 py-6">
+        <Empty.Header>
+          <Empty.Description>{dashboardCopy.overdue.empty}</Empty.Description>
+        </Empty.Header>
+      </Empty.Root>
     {:else}
-      <ul class="divide-y divide-border/60">
-        {#each overdueHomeworkPreview as homework}
-          <li>
-            <a
-              class="flex items-start justify-between gap-3 py-2.5 transition-colors hover:bg-muted/40 -mx-2 px-2 rounded-md"
-              href={homework.section?.jwId
-                ? sectionDetailHomeworkPath(homework.section.jwId, {
-                    homeworkId: homework.id,
-                  })
-                : dashboardTabHref("homeworks")}
-            >
-              <span class="grid min-w-0 gap-1">
-                <span class="line-clamp-2 font-medium text-sm">{homework.title}</span>
-                <span class="flex flex-wrap items-center gap-1.5 text-muted-foreground text-xs">
-                  <Badge variant="secondary">{copy.CalendarEventCard.homework}</Badge>
-                  <span>{homework.section?.course?.namePrimary ?? commonCopy.sections}</span>
-                </span>
-              </span>
-              <span class="shrink-0 text-muted-foreground text-xs tabular-nums">
-                {homeworkEtaLabel(homework.submissionDueAt)}
-              </span>
-            </a>
-          </li>
+      <Item.Group class="gap-0">
+        {#each overdueHomeworkPreview as homework, index (homework.id)}
+          <Item.Root class="rounded-md border-0 px-2 py-2.5" size="sm">
+            {#snippet child({ props })}
+              <a
+                href={homework.section?.jwId
+                  ? sectionDetailHomeworkPath(homework.section.jwId, {
+                      homeworkId: homework.id,
+                    })
+                  : dashboardTabHref("homeworks")}
+                {...props}
+              >
+                <Item.Content class="min-w-0 gap-1">
+                  <Item.Title class="line-clamp-2">{homework.title}</Item.Title>
+                  <Item.Description class="flex flex-wrap items-center gap-1.5">
+                    <Badge variant="secondary">{copy.CalendarEventCard.homework}</Badge>
+                    <span>{homework.section?.course?.namePrimary ?? commonCopy.sections}</span>
+                  </Item.Description>
+                </Item.Content>
+                <Item.Actions class="shrink-0">
+                  <span class="text-muted-foreground text-xs tabular-nums">
+                    {homeworkEtaLabel(homework.submissionDueAt)}
+                  </span>
+                </Item.Actions>
+              </a>
+            {/snippet}
+          </Item.Root>
+          {#if index < overdueHomeworkPreview.length - 1 || overdueTodoPreview.length > 0}<Item.Separator class="my-0" />{/if}
         {/each}
-        {#each overdueTodoPreview as todo}
-          <li>
-            <a
-              class="flex items-start justify-between gap-3 py-2.5 transition-colors hover:bg-muted/40 -mx-2 px-2 rounded-md"
-              href={dashboardTabHref("todos")}
-            >
-              <span class="grid min-w-0 gap-1">
-                <span class="line-clamp-2 font-medium text-sm">{todo.title}</span>
-                <span class="flex flex-wrap gap-1.5">
-                  <Badge variant="secondary">{copy.CalendarEventCard.todo}</Badge>
-                  <Badge
-                    variant={todo.priority === "high"
-                      ? "destructive"
-                      : todo.priority === "medium"
-                        ? "secondary"
-                        : "outline"}
-                  >
-                    {todosCopy.priority[todo.priority]}
-                  </Badge>
-                  <Badge variant="ghost">{todoStatus(todo)}</Badge>
-                </span>
-              </span>
-              <span class="shrink-0 text-muted-foreground text-xs tabular-nums">
-                {fmtDate(todo.dueAt)}
-              </span>
-            </a>
-          </li>
+        {#each overdueTodoPreview as todo, index (todo.id)}
+          <Item.Root class="rounded-md border-0 px-2 py-2.5" size="sm">
+            {#snippet child({ props })}
+              <a href={dashboardTabHref("todos")} {...props}>
+                <Item.Content class="min-w-0 gap-1">
+                  <Item.Title class="line-clamp-2">{todo.title}</Item.Title>
+                  <Item.Description class="flex flex-wrap gap-1.5">
+                    <Badge variant="secondary">{copy.CalendarEventCard.todo}</Badge>
+                    <Badge
+                      variant={todo.priority === "high"
+                        ? "destructive"
+                        : todo.priority === "medium"
+                          ? "secondary"
+                          : "outline"}
+                    >
+                      {todosCopy.priority[todo.priority]}
+                    </Badge>
+                    <Badge variant="ghost">{todoStatus(todo)}</Badge>
+                  </Item.Description>
+                </Item.Content>
+                <Item.Actions class="shrink-0">
+                  <span class="text-muted-foreground text-xs tabular-nums">
+                    {fmtDate(todo.dueAt)}
+                  </span>
+                </Item.Actions>
+              </a>
+            {/snippet}
+          </Item.Root>
+          {#if index < overdueTodoPreview.length - 1}<Item.Separator class="my-0" />{/if}
         {/each}
-      </ul>
+      </Item.Group>
     {/if}
   </OverviewSection>
 </div>

--- a/src/features/dashboard/components/OverviewTodoSummaryCard.svelte
+++ b/src/features/dashboard/components/OverviewTodoSummaryCard.svelte
@@ -5,8 +5,9 @@ import type {
   DashboardTodosCopy,
 } from "@/features/dashboard/lib/dashboard-controller-helpers";
 import { DASHBOARD_OVERVIEW_PREVIEW_LIMIT } from "@/features/dashboard/lib/overview-preview";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
+import * as Empty from "$lib/components/ui/empty/index.js";
+import * as Item from "$lib/components/ui/item/index.js";
 import type { DashboardCalendarTabHref } from "./dashboard-calendar-component-types";
 import OverviewSection from "./OverviewSection.svelte";
 
@@ -50,38 +51,45 @@ export let viewAllLabel = "View all";
   {/snippet}
 
   {#if pendingTodos.length === 0}
-    <SoftEmptyMessage message={todosCopy.filterEmptyTitle} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{todosCopy.filterEmptyTitle}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {:else}
-    <ul class="divide-y divide-border/60">
-      {#each pendingTodos.slice(0, previewLimit) as todo}
-        <li>
-          <a
-            class="flex items-start justify-between gap-3 py-2.5 transition-colors hover:bg-muted/40 -mx-2 px-2 rounded-md"
-            href={dashboardTabHref("todos")}
-          >
-            <span class="grid min-w-0 gap-1">
-              <span class="font-medium text-sm">{todo.title}</span>
-              <span class="flex flex-wrap gap-1.5">
-                <Badge
-                  variant={todo.priority === "high"
-                    ? "destructive"
-                    : todo.priority === "medium"
-                      ? "secondary"
-                      : "outline"}
-                >
-                  {todosCopy.priority[todo.priority]}
-                </Badge>
-                <Badge variant="ghost">{todoStatus(todo)}</Badge>
-              </span>
-            </span>
-            {#if todo.dueAt}
-              <span class="shrink-0 text-muted-foreground text-xs tabular-nums">
-                {fmtDate(todo.dueAt)}
-              </span>
-            {/if}
-          </a>
-        </li>
+    {@const todoPreview = pendingTodos.slice(0, previewLimit)}
+    <Item.Group class="gap-0">
+      {#each todoPreview as todo, index (todo.id)}
+        <Item.Root class="rounded-md border-0 px-2 py-2.5" size="sm">
+          {#snippet child({ props })}
+            <a href={dashboardTabHref("todos")} {...props}>
+              <Item.Content class="min-w-0">
+                <Item.Title>{todo.title}</Item.Title>
+                <Item.Description class="flex flex-wrap gap-1.5">
+                  <Badge
+                    variant={todo.priority === "high"
+                      ? "destructive"
+                      : todo.priority === "medium"
+                        ? "secondary"
+                        : "outline"}
+                  >
+                    {todosCopy.priority[todo.priority]}
+                  </Badge>
+                  <Badge variant="ghost">{todoStatus(todo)}</Badge>
+                </Item.Description>
+              </Item.Content>
+              {#if todo.dueAt}
+                <Item.Actions class="shrink-0">
+                  <span class="text-muted-foreground text-xs tabular-nums">
+                    {fmtDate(todo.dueAt)}
+                  </span>
+                </Item.Actions>
+              {/if}
+            </a>
+          {/snippet}
+        </Item.Root>
+        {#if index < todoPreview.length - 1}<Item.Separator class="my-0" />{/if}
       {/each}
-    </ul>
+    </Item.Group>
   {/if}
 </OverviewSection>

--- a/src/features/descriptions/components/DescriptionCard.svelte
+++ b/src/features/descriptions/components/DescriptionCard.svelte
@@ -9,9 +9,9 @@ import {
 } from "@/features/descriptions/lib/description-card-actions";
 import type { AppLocale } from "@/i18n/config";
 import { createShanghaiDateTimeFormatter } from "@/lib/time/shanghai-format";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import * as Alert from "$lib/components/ui/alert/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import DescriptionCardHeader from "./DescriptionCardHeader.svelte";
 import DescriptionEditPanel from "./DescriptionEditPanel.svelte";
 import DescriptionReadPanel from "./DescriptionReadPanel.svelte";
@@ -171,7 +171,11 @@ const { cancelEdit, editorName, saveDescription, startEdit } =
         {saveDescription}
       />
     {:else if softEmpty}
-      <SoftEmptyMessage message={copy.empty} />
+      <Empty.Root class="min-h-20 border-0 px-2 py-6">
+        <Empty.Header>
+          <Empty.Description>{copy.empty}</Empty.Description>
+        </Empty.Header>
+      </Empty.Root>
     {:else}
       <DescriptionReadPanel
         bind:activePanelTab

--- a/src/features/section-detail/components/SectionCalendarTab.svelte
+++ b/src/features/section-detail/components/SectionCalendarTab.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { formatMessage } from "@/features/section-detail/lib/display";
 import { formatShanghaiDate } from "@/lib/time/shanghai-format";
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import * as Table from "$lib/components/ui/table/index.js";
 import type { SectionCalendarEvent } from "./section-calendar-tab-types";
 
@@ -115,5 +115,9 @@ $: classLectureNumberById = new Map(
     </Table.Root>
   </div>
 {:else}
-  <SoftEmptyMessage message={sectionCopy.calendarEmpty} />
+  <Empty.Root class="min-h-20 border-0 px-2 py-6">
+    <Empty.Header>
+      <Empty.Description>{sectionCopy.calendarEmpty}</Empty.Description>
+    </Empty.Header>
+  </Empty.Root>
 {/if}

--- a/src/features/section-detail/components/SectionExamSection.svelte
+++ b/src/features/section-detail/components/SectionExamSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import * as Table from "$lib/components/ui/table/index.js";
 import type { SectionCalendarEvent } from "./section-calendar-tab-types";
 
@@ -63,5 +63,9 @@ function examTime(event: SectionCalendarEvent) {
     </Table.Root>
   </div>
 {:else}
-  <SoftEmptyMessage message={sectionCopy.calendarEmpty} />
+  <Empty.Root class="min-h-20 border-0 px-2 py-6">
+    <Empty.Header>
+      <Empty.Description>{sectionCopy.calendarEmpty}</Empty.Description>
+    </Empty.Header>
+  </Empty.Root>
 {/if}

--- a/src/features/section-detail/components/SectionHomeworkListView.svelte
+++ b/src/features/section-detail/components/SectionHomeworkListView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import SoftEmptyMessage from "$lib/components/SoftEmptyMessage.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
+import * as Empty from "$lib/components/ui/empty/index.js";
 import * as Table from "$lib/components/ui/table/index.js";
 import type {
   SectionCopy,
@@ -17,7 +17,11 @@ export let selectHomework: (homework: SectionHomework) => void;
 
 <div data-testid="section-homeworks-list">
   {#if homeworks.length === 0}
-    <SoftEmptyMessage message={sectionCopy.noHomework} />
+    <Empty.Root class="min-h-20 border-0 px-2 py-6">
+      <Empty.Header>
+        <Empty.Description>{sectionCopy.noHomework}</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {:else}
     <div class="min-w-0 overflow-x-auto">
       <Table.Root>

--- a/src/lib/components/shell/AppSidebar.svelte
+++ b/src/lib/components/shell/AppSidebar.svelte
@@ -165,10 +165,12 @@ function closeMobileSidebar(): void {
                                 <Icon />
                               {/if}
                               <span>{link.label}</span>
-                              {@render badge(link.badge)}
                             </a>
                           {/snippet}
                         </Sidebar.MenuButton>
+                        {#if link.badge != null && link.badge > 0}
+                          <Sidebar.MenuBadge>{link.badge}</Sidebar.MenuBadge>
+                        {/if}
 
                         {#if ownActive || childActive}
                           <Sidebar.MenuSub>
@@ -250,10 +252,12 @@ function closeMobileSidebar(): void {
                                 <Icon />
                               {/if}
                               <span>{link.label}</span>
-                              {@render badge(link.badge)}
                             </a>
                           {/snippet}
                         </Sidebar.MenuButton>
+                        {#if link.badge != null && link.badge > 0}
+                          <Sidebar.MenuBadge>{link.badge}</Sidebar.MenuBadge>
+                        {/if}
                       </Sidebar.MenuItem>
                     {/if}
                   {/each}

--- a/tests/e2e/src/app/dashboard/test.ts
+++ b/tests/e2e/src/app/dashboard/test.ts
@@ -193,7 +193,10 @@ test.describe("仪表盘", () => {
         payload.navigation.subscribedSectionCount,
       ],
     ] as const) {
-      const badge = sidebarNavigationLink(page, label).locator(":scope > div");
+      const menuItem = sidebarNavigationLink(page, label).locator(
+        "xpath=ancestor::*[@data-slot='sidebar-menu-item'][1]",
+      );
+      const badge = menuItem.locator("[data-slot='sidebar-menu-badge']");
       if (count > 0) {
         await expect(badge).toHaveText(String(count));
       } else {

--- a/tests/unit/catalog-list-query.test.ts
+++ b/tests/unit/catalog-list-query.test.ts
@@ -107,6 +107,33 @@ describe("catalog list shared-cache admission", () => {
 });
 
 describe("catalogListPageHref", () => {
+  test.each([
+    [
+      1,
+      "/catalog/sections?order=desc&search=math&semesterId=3&sort=code&teacher=%E5%BC%A0",
+    ],
+    [
+      2,
+      "/catalog/sections?order=desc&page=2&search=math&semesterId=3&sort=code&teacher=%E5%BC%A0",
+    ],
+    [
+      9,
+      "/catalog/sections?order=desc&page=9&search=math&semesterId=3&sort=code&teacher=%E5%BC%A0",
+    ],
+  ])(
+    "preserves filters for first, middle, and last page (%s)",
+    (page, expected) => {
+      expect(
+        catalogListPageHref(
+          new URL(
+            "https://example.test/catalog/sections?page=4&semesterId=3&teacher=%E5%BC%A0&sort=code&order=desc&search=math",
+          ),
+          page,
+        ),
+      ).toBe(expected);
+    },
+  );
+
   test("preserves section filters when changing page", () => {
     const href = catalogListPageHref(
       new URL(


### PR DESCRIPTION
## Summary
- standardize catalog pagination on shadcn Pagination primitives while preserving filter query URLs and server navigation
- replace complete no-data SoftEmptyMessage states with compact shadcn Empty compositions, retaining the inline term-selection hint
- migrate overview linked rows to Item primitives and use Sidebar.MenuBadge for top-level nav counts

Closes #897
Closes #898
Closes #891
Closes #889

## Checks
- `bunx biome check $(git diff --name-only HEAD^)`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx wrangler types --include-runtime=false --check`
- `bunx vitest run tests/unit` (2286 passed)
- `DATABASE_URL=... bun run build`
