### PR TITLE
fix(ui): make shared dialogs viewport safe

### DIFF
--- a/src/features/dashboard/components/SubscriptionsQuickAddDialog.svelte
+++ b/src/features/dashboard/components/SubscriptionsQuickAddDialog.svelte
@@ -156,7 +156,7 @@ async function subscribeSelectedSections() {
     }}
   >
     <Dialog.Content
-      class="flex h-[calc(100dvh-1rem)] max-h-[calc(100dvh-1rem)] min-h-0 max-w-lg flex-col gap-0 overflow-clip p-0 sm:h-[min(64vh,36rem)] sm:max-h-[min(64vh,36rem)] sm:max-w-lg"
+      class="flex h-[calc(100dvh-2rem)] max-h-[calc(100dvh-2rem)] min-h-0 max-w-lg flex-col gap-0 overflow-clip p-0 sm:h-[min(64vh,36rem)] sm:max-h-[min(64vh,36rem)] sm:max-w-lg"
     >
       <Dialog.Header class="shrink-0 px-5 pb-2 pt-4">
         <Dialog.Title>{subscriptionsCopy.quickAdd.title}</Dialog.Title>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -24,7 +24,7 @@
 		data-slot="alert-dialog-content"
 		data-size={size}
 		class={cn(
-			"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-4 rounded-xl p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+			"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 fixed top-1/2 left-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl p-4 ring-1 outline-none duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs group/alert-dialog-content data-[size=default]:sm:max-w-sm",
 			className
 		)}
 		{...restProps}

--- a/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/lib/components/ui/dialog/dialog-content.svelte
@@ -28,7 +28,7 @@
 		bind:ref
 		data-slot="dialog-content"
 		class={cn(
-			"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+			"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 fixed top-1/2 left-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl p-4 text-sm ring-1 outline-none duration-100 sm:max-w-sm",
 			className
 		)}
 		{...restProps}
@@ -38,7 +38,7 @@
 			<DialogPrimitive.Close data-slot="dialog-close">
 				{#snippet child({ props })}
 					<Button variant="ghost" class="absolute top-2 right-2" size="icon-sm" {...props}>
-						<XIcon  />
+						<XIcon data-icon="inline-start" />
 						<span class="sr-only">Close</span>
 					</Button>
 				{/snippet}

--- a/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/lib/components/ui/dialog/dialog-content.svelte
@@ -28,7 +28,7 @@
 		bind:ref
 		data-slot="dialog-content"
 		class={cn(
-			"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+			"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 fixed top-1/2 left-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl p-4 text-sm ring-1 outline-none duration-100 sm:max-w-sm",
 			className
 		)}
 		{...restProps}

--- a/src/lib/components/ui/dialog/dialog-header.svelte
+++ b/src/lib/components/ui/dialog/dialog-header.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="dialog-header"
-	class={cn("gap-2 flex flex-col", className)}
+	class={cn("gap-2 flex flex-col", className, "pr-10")}
 	{...restProps}
 >
 	{@render children?.()}

--- a/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
+++ b/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
@@ -55,6 +55,40 @@ async function openBulkImportDialog(page: import("@playwright/test").Page) {
   return textarea.first();
 }
 
+async function assertDialogViewportSafe(
+  page: import("@playwright/test").Page,
+  dialog: import("@playwright/test").Locator,
+) {
+  const viewport = page.viewportSize();
+  const viewportWidth = viewport?.width ?? 390;
+  const viewportHeight = viewport?.height ?? 844;
+  const dialogBox = await dialog.boundingBox();
+  const footerBox = await dialog
+    .locator('[data-slot="dialog-footer"]')
+    .boundingBox();
+  const closeBox = await dialog
+    .getByRole("button", { name: "Close" })
+    .boundingBox();
+
+  expect(dialogBox).not.toBeNull();
+  expect(footerBox).not.toBeNull();
+  expect(closeBox).not.toBeNull();
+  if (!dialogBox || !footerBox || !closeBox) {
+    throw new Error("Expected the mobile dialog bounds");
+  }
+
+  expect(dialogBox.x).toBeGreaterThanOrEqual(16);
+  expect(dialogBox.x + dialogBox.width).toBeLessThanOrEqual(viewportWidth - 16);
+  expect(dialogBox.y).toBeGreaterThanOrEqual(0);
+  expect(dialogBox.y + dialogBox.height).toBeLessThanOrEqual(viewportHeight);
+  expect(footerBox.y).toBeGreaterThanOrEqual(0);
+  expect(footerBox.y + footerBox.height).toBeLessThanOrEqual(viewportHeight);
+  expect(closeBox.y).toBeGreaterThanOrEqual(0);
+  expect(closeBox.y + closeBox.height).toBeLessThanOrEqual(viewportHeight);
+  await expect(dialog.locator('[data-slot="dialog-footer"]')).toBeInViewport();
+  await expect(dialog.getByRole("button", { name: "Close" })).toBeInViewport();
+}
+
 test.describe("仪表盘教学班订阅", () => {
   test.describe.configure({ mode: "serial" });
   test.beforeEach(async ({ context, baseURL }) => {
@@ -477,7 +511,7 @@ test.describe("仪表盘教学班订阅", () => {
     page,
   }, testInfo) => {
     test.setTimeout(60_000);
-    await page.setViewportSize({ height: 600, width: 390 });
+    await page.setViewportSize({ height: 844, width: 390 });
     await signInAsDebugUser(page, "/workspace/subscriptions");
     const seedSectionIds = (await resolveSeedSectionMatches(page)).map(
       (section) => section.id,
@@ -518,25 +552,16 @@ test.describe("仪表盘教学班订阅", () => {
     await expect(
       quickAddDialog.getByText(DEV_SEED.section.code).first(),
     ).toBeVisible();
-    const viewportHeight = page.viewportSize()?.height ?? 600;
-    const dialogBox = await quickAddDialog.boundingBox();
+    await assertDialogViewportSafe(page, quickAddDialog);
     const footer = quickAddDialog.locator('[data-slot="dialog-footer"]');
     const closeButton = quickAddDialog.getByRole("button", {
       name: "Close",
     });
-    const [footerBox, closeBox] = await Promise.all([
-      footer.boundingBox(),
-      closeButton.boundingBox(),
-    ]);
-    expect(dialogBox).not.toBeNull();
+    const footerBox = await footer.boundingBox();
     expect(footerBox).not.toBeNull();
-    expect(closeBox).not.toBeNull();
-    if (!dialogBox || !footerBox || !closeBox) {
-      throw new Error("Expected the mobile quick-add dialog bounds");
+    if (!footerBox) {
+      throw new Error("Expected the mobile quick-add footer bounds");
     }
-    expect(dialogBox.y).toBeGreaterThanOrEqual(0);
-    expect(dialogBox.y + dialogBox.height).toBeLessThanOrEqual(viewportHeight);
-    expect(footerBox.y + footerBox.height).toBeLessThanOrEqual(viewportHeight);
     expect(await quickAddDialog.evaluate((element) => element.scrollTop)).toBe(
       0,
     );
@@ -651,6 +676,27 @@ test.describe("仪表盘教学班订阅", () => {
       })
       .click();
     await subscribeResponse;
+    await expect(quickAddDialog).not.toBeVisible();
+  });
+
+  test("单个添加弹窗在 320×568 视口保持关闭控件和操作区可达", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ height: 568, width: 320 });
+    await signInAsDebugUser(page, "/workspace/subscriptions");
+    await gotoAndWaitForReady(page, "/workspace/subscriptions");
+
+    await page
+      .getByRole("button", { name: /添加订阅|Add Subscription/i })
+      .first()
+      .click();
+    const quickAddDialog = page
+      .getByRole("dialog", { name: /添加订阅|Add Subscription/i })
+      .first();
+    await expect(quickAddDialog).toBeVisible();
+    await assertDialogViewportSafe(page, quickAddDialog);
+
+    await quickAddDialog.getByRole("button", { name: "Close" }).click();
     await expect(quickAddDialog).not.toBeVisible();
   });
 


### PR DESCRIPTION
Fixes #902

## Summary
- enforce a 1rem horizontal gutter and dynamic viewport max height for shared Dialog and AlertDialog content
- let long overlay content scroll within the viewport
- reserve close-button space in shared Dialog headers
- keep subscription quick-add content within a dynamic viewport gutter
- add subscription dialog bounds assertions at 390x844 and 320x568

## Checks
- `bunx biome check src/lib/components/ui/dialog src/lib/components/ui/alert-dialog tests/e2e/src/app/dashboard/subscriptions/sections/test.ts`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx svelte-check --tsconfig ./tsconfig.json` (0 errors; existing warnings only)
- `bunx playwright test tests/e2e/src/app/dashboard/subscriptions/sections/test.ts --list`

Full browser E2E was not run because the local Worker/database services were unavailable.