### PR TITLE
fix(ui): redesign task and record item views

### DIFF
--- a/src/features/dashboard/components/DashboardTableIconButton.svelte
+++ b/src/features/dashboard/components/DashboardTableIconButton.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
-import { Button, type ButtonVariant } from "$lib/components/ui/button/index.js";
+import {
+  Button,
+  type ButtonSize,
+  type ButtonVariant,
+} from "$lib/components/ui/button/index.js";
 import * as Tooltip from "$lib/components/ui/tooltip/index.js";
 
 export let label: string;
 export let disabled = false;
 export let href: string | undefined = undefined;
+export let className = "";
+export let size: ButtonSize = "icon-sm";
 export let type: "button" | "submit" | "reset" | undefined = undefined;
 export let variant: ButtonVariant = "outline";
 export let onclick: ((event: MouseEvent) => void) | undefined = undefined;
@@ -16,9 +22,10 @@ export let onclick: ((event: MouseEvent) => void) | undefined = undefined;
       <Button
         {...props}
         aria-label={label}
+        class={className}
         {disabled}
         {href}
-        size="icon-sm"
+        {size}
         type={href ? undefined : (type ?? "button")}
         {variant}
         {onclick}

--- a/src/features/dashboard/components/ExamsCardsView.svelte
+++ b/src/features/dashboard/components/ExamsCardsView.svelte
@@ -29,8 +29,8 @@ export let subscriptionsCopy: ExamsCopyProps["subscriptionsCopy"];
     {@const detailHref = exam.section.jwId
       ? `/catalog/sections/${exam.section.jwId}`
       : dashboardTabHref("subscriptions")}
-    <Item.Root class="items-start gap-3 p-3" variant="muted">
-      <Item.Content class="basis-full gap-1 min-w-0">
+    <Item.Root class="items-start gap-3 px-2 py-3">
+      <Item.Content class="min-w-0 gap-1">
         <Item.Title class="line-clamp-none w-full min-w-0">
           <a
             class="flex min-h-11 w-full min-w-0 max-w-full items-center underline-offset-4 hover:underline"
@@ -63,7 +63,7 @@ export let subscriptionsCopy: ExamsCopyProps["subscriptionsCopy"];
           {#each examMetadataLabels(exam) as label}<Badge variant="secondary">{label}</Badge>{/each}
         </Item.Description>
       </Item.Content>
-      <Item.Actions class="w-full justify-end">
+      <Item.Actions class="shrink-0 self-start">
         <DashboardTableIconButton
           className="size-11"
           href={detailHref}

--- a/src/features/dashboard/components/ExamsCardsView.svelte
+++ b/src/features/dashboard/components/ExamsCardsView.svelte
@@ -29,18 +29,33 @@ export let subscriptionsCopy: ExamsCopyProps["subscriptionsCopy"];
     {@const detailHref = exam.section.jwId
       ? `/catalog/sections/${exam.section.jwId}`
       : dashboardTabHref("subscriptions")}
-    <Item.Root class="items-start px-2 py-2" size="sm">
-      <Item.Content class="min-w-0 gap-0.5">
-        <Item.Title class="block min-w-0 max-w-full">
-          <a class="block min-w-0 max-w-full truncate underline-offset-4 hover:underline" href={detailHref}>
+    <Item.Root class="items-start gap-3 p-3" variant="muted">
+      <Item.Content class="basis-full gap-1 min-w-0">
+        <Item.Title class="line-clamp-none w-full min-w-0">
+          <a
+            class="flex min-h-11 w-full min-w-0 max-w-full items-center underline-offset-4 hover:underline"
+            href={detailHref}
+          >
+            <span class="line-clamp-2 min-w-0 max-w-full break-words">
             {exam.courseName}
+            </span>
           </a>
         </Item.Title>
-        <Item.Description class="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
-          {exam.section.code ?? subscriptionsCopy.section}{#if exam.section.semester} · {namePrimary(exam.section.semester)}{/if}
-          <span>{sectionCopy.examDate}: {#if exam.examDate}{fmtExamDate(exam.examDate)}{:else}{sectionCopy.examDateTBD}{/if}</span>
-          <span>{sectionCopy.examTime}: {examTimeLabel(exam.startTime, exam.endTime) || "—"}</span>
-          <span>{sectionCopy.room}: {exam.rooms || sectionCopy.roomTbd}</span>
+        <Item.Description
+          class="line-clamp-none flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 break-words"
+        >
+          <span class="max-w-full break-words">
+            {exam.section.code ?? subscriptionsCopy.section}{#if exam.section.semester} · {namePrimary(exam.section.semester)}{/if}
+          </span>
+          <span class="max-w-full break-words">
+            {sectionCopy.examDate}: {#if exam.examDate}{fmtExamDate(exam.examDate)}{:else}{sectionCopy.examDateTBD}{/if}
+          </span>
+          <span class="max-w-full break-words">
+            {sectionCopy.examTime}: {examTimeLabel(exam.startTime, exam.endTime) || "—"}
+          </span>
+          <span class="max-w-full break-words">
+            {sectionCopy.room}: {exam.rooms || sectionCopy.roomTbd}
+          </span>
           <Badge variant="outline">
             {exam.completed ? dashboardCopy.nav.exams.filterCompleted : dashboardCopy.nav.exams.filterIncomplete}
           </Badge>
@@ -48,8 +63,12 @@ export let subscriptionsCopy: ExamsCopyProps["subscriptionsCopy"];
           {#each examMetadataLabels(exam) as label}<Badge variant="secondary">{label}</Badge>{/each}
         </Item.Description>
       </Item.Content>
-      <Item.Actions class="shrink-0 self-start">
-        <DashboardTableIconButton href={detailHref} label={sectionCopy.moreDetails}>
+      <Item.Actions class="w-full justify-end">
+        <DashboardTableIconButton
+          className="size-11"
+          href={detailHref}
+          label={sectionCopy.moreDetails}
+        >
           <ArrowUpRight />
         </DashboardTableIconButton>
       </Item.Actions>

--- a/src/features/dashboard/components/HomeworksCardsView.svelte
+++ b/src/features/dashboard/components/HomeworksCardsView.svelte
@@ -40,28 +40,37 @@ export let toggleHomeworkCompletion: (
     <Item.Group class="gap-0">
       {#each filteredHomeworkItems as homework, index (homework.id)}
         <Item.Root
-          class="items-start px-2 py-2"
+          class="items-start gap-3 p-3"
           id={`homework-${homework.id}`}
-          size="sm"
+          variant="muted"
         >
-          <Item.Content class="min-w-0 gap-0.5">
-            <Item.Title class="block min-w-0 max-w-full">
+          <Item.Content class="basis-full gap-1 min-w-0">
+            <Item.Title class="line-clamp-none w-full min-w-0">
               <button
-                class="block min-w-0 max-w-full truncate text-left underline-offset-4 hover:underline"
+                class="flex min-h-11 w-full min-w-0 max-w-full items-center text-left underline-offset-4 hover:underline"
                 type="button"
                 onclick={() => {
                   selectedHomework = homework;
                 }}
               >
-                {homework.title}
+                <span class="line-clamp-2 min-w-0 max-w-full break-words">
+                  {homework.title}
+                </span>
               </button>
             </Item.Title>
-            <Item.Description class="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
-              <a class="max-w-full truncate hover:underline" href={homeworkSectionHref(homework)}>
+            <Item.Description
+              class="line-clamp-none flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 break-words"
+            >
+              <a
+                class="max-w-full break-words hover:underline"
+                href={homeworkSectionHref(homework)}
+              >
                 {homework.section?.courseName ?? homeworkCopy.section}
               </a>
               <span aria-hidden="true">·</span>
-              <span class="truncate">{homeworkCopy.due}: {fmtDate(homework.submissionDueAt)}</span>
+              <span class="max-w-full break-words"
+                >{homeworkCopy.due}: {fmtDate(homework.submissionDueAt)}</span
+              >
               <Badge variant={homeworkIsOverdue(homework.submissionDueAt) ? "destructive" : "ghost"}>
                 {homeworkEtaLabel(homework.submissionDueAt)}
               </Badge>
@@ -76,20 +85,14 @@ export let toggleHomeworkCompletion: (
               {/if}
             </Item.Description>
           </Item.Content>
-          <Item.Actions class="shrink-0 self-start">
+          <Item.Actions class="w-full justify-end">
             <DashboardTableIconButton
-              label={homeworksCopy.viewDetails}
-              onclick={() => {
-                selectedHomework = homework;
-              }}
-            >
-              <ArrowUpRight />
-            </DashboardTableIconButton>
-            <DashboardTableIconButton
+              className="size-11"
               disabled={homeworkSavingById[homework.id]}
               label={homeworkSavingById[homework.id]
                 ? homeworksCopy.saving
                 : homeworkCompletionActionLabel(homework)}
+              variant={homework.completion ? "secondary" : "default"}
               onclick={() => toggleHomeworkCompletion(homework)}
             >
               {#if homeworkSavingById[homework.id]}
@@ -99,6 +102,16 @@ export let toggleHomeworkCompletion: (
               {:else}
                 <CheckCircleIcon />
               {/if}
+            </DashboardTableIconButton>
+            <DashboardTableIconButton
+              className="size-11"
+              label={homeworksCopy.viewDetails}
+              variant="outline"
+              onclick={() => {
+                selectedHomework = homework;
+              }}
+            >
+              <ArrowUpRight />
             </DashboardTableIconButton>
           </Item.Actions>
         </Item.Root>

--- a/src/features/dashboard/components/HomeworksCardsView.svelte
+++ b/src/features/dashboard/components/HomeworksCardsView.svelte
@@ -40,11 +40,10 @@ export let toggleHomeworkCompletion: (
     <Item.Group class="gap-0">
       {#each filteredHomeworkItems as homework, index (homework.id)}
         <Item.Root
-          class="items-start gap-3 p-3"
+          class="items-start gap-3 px-2 py-3"
           id={`homework-${homework.id}`}
-          variant="muted"
         >
-          <Item.Content class="basis-full gap-1 min-w-0">
+          <Item.Content class="min-w-0 gap-1">
             <Item.Title class="line-clamp-none w-full min-w-0">
               <button
                 class="flex min-h-11 w-full min-w-0 max-w-full items-center text-left underline-offset-4 hover:underline"
@@ -85,7 +84,7 @@ export let toggleHomeworkCompletion: (
               {/if}
             </Item.Description>
           </Item.Content>
-          <Item.Actions class="w-full justify-end">
+          <Item.Actions class="shrink-0 self-start">
             <DashboardTableIconButton
               className="size-11"
               disabled={homeworkSavingById[homework.id]}

--- a/src/features/dashboard/components/HomeworksListView.svelte
+++ b/src/features/dashboard/components/HomeworksListView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import ArrowUpRight from "@lucide/svelte/icons/arrow-up-right";
 import CheckCircleIcon from "@lucide/svelte/icons/check-circle";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import type { DashboardHomeworkItem } from "@/features/dashboard/lib/dashboard-controller-types";
@@ -61,13 +62,13 @@ export let toggleHomeworkCompletion: (
         </Table.Cell>
         <Table.Cell>
           <button
-            class="block min-w-0 max-w-full overflow-hidden text-left hover:underline"
+            class="block min-h-11 min-w-0 max-w-full text-left hover:underline"
             type="button"
             onclick={() => {
               selectedHomework = homework;
             }}
           >
-            <TruncatedText text={homework.title} />
+            <TruncatedText text={homework.title} lines={2} />
           </button>
         </Table.Cell>
         <Table.Cell>
@@ -102,11 +103,12 @@ export let toggleHomeworkCompletion: (
         <Table.Cell>
           <DashboardTableRowActions>
             <DashboardTableIconButton
-              disabled={homeworkSavingById[homework.id]}
-              label={homeworkSavingById[homework.id]
-                ? homeworksCopy.saving
-                : homeworkCompletionActionLabel(homework)}
-              onclick={() => toggleHomeworkCompletion(homework)}
+            disabled={homeworkSavingById[homework.id]}
+            label={homeworkSavingById[homework.id]
+              ? homeworksCopy.saving
+              : homeworkCompletionActionLabel(homework)}
+            variant={homework.completion ? "secondary" : "default"}
+            onclick={() => toggleHomeworkCompletion(homework)}
             >
               {#if homeworkSavingById[homework.id]}
                 <Spinner />
@@ -115,6 +117,15 @@ export let toggleHomeworkCompletion: (
               {:else}
                 <CheckCircleIcon />
               {/if}
+            </DashboardTableIconButton>
+            <DashboardTableIconButton
+              label={homeworksCopy.viewDetails}
+              variant="outline"
+              onclick={() => {
+                selectedHomework = homework;
+              }}
+            >
+              <ArrowUpRight />
             </DashboardTableIconButton>
           </DashboardTableRowActions>
         </Table.Cell>

--- a/src/features/dashboard/components/SubscriptionsCardsView.svelte
+++ b/src/features/dashboard/components/SubscriptionsCardsView.svelte
@@ -8,6 +8,7 @@ import type {
   SubscriptionsData,
 } from "@/features/dashboard/lib/dashboard-controller-types";
 import { Badge } from "$lib/components/ui/badge/index.js";
+import * as Item from "$lib/components/ui/item/index.js";
 import { Spinner } from "$lib/components/ui/spinner/index.js";
 import DashboardTableIconButton from "./DashboardTableIconButton.svelte";
 
@@ -35,26 +36,42 @@ function courseName(section: SubscriptionSection) {
 }
 </script>
 
-<div class="grid gap-3" data-testid="subscription-semester-cards">
-  {#each sections as section}
-    <div class="group grid gap-2 border-b border-border/60 py-3 last:border-b-0">
-      <div class="flex items-start justify-between gap-3">
-        <div class="grid min-w-0 gap-1">
-          <a
-            class="font-medium hover:underline"
-            href={`/catalog/sections/${section.jwId}`}
-            data-testid="subscription-course-link"
+<div class="min-w-0" data-testid="subscription-semester-cards">
+  <Item.Group class="gap-0">
+    {#each sections as section, index}
+      <Item.Root class="items-start gap-3 p-3" variant="muted">
+        <Item.Content class="basis-full gap-1 min-w-0">
+          <Item.Title class="line-clamp-none w-full min-w-0">
+            <a
+              class="flex min-h-11 w-full min-w-0 max-w-full items-center font-medium hover:underline"
+              href={`/catalog/sections/${section.jwId}`}
+              data-testid="subscription-course-link"
+            >
+              <span class="line-clamp-2 min-w-0 max-w-full break-words">
+                {courseName(section)}
+              </span>
+            </a>
+          </Item.Title>
+          <Item.Description
+            class="line-clamp-none flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 break-words"
           >
-            {courseName(section)}
-          </a>
-          <p class="text-muted-foreground text-sm">{teacherNames(section)}</p>
-        </div>
-        <div class="flex shrink-0 items-center gap-1">
-          <Badge variant="outline">
-            {section.credits ?? dashboardCopy.notAvailable}
-            {subscriptionsCopy.credits}
-          </Badge>
+            <span class="max-w-full break-words">{teacherNames(section)}</span>
+            <Badge variant="outline">
+              {section.credits ?? dashboardCopy.notAvailable}
+              {subscriptionsCopy.credits}
+            </Badge>
+          </Item.Description>
+        </Item.Content>
+        <Item.Actions class="w-full justify-end">
           <DashboardTableIconButton
+            className="size-11"
+            href={`/catalog/sections/${section.jwId}`}
+            label={sectionCopy.moreDetails}
+          >
+            <ArrowUpRight />
+          </DashboardTableIconButton>
+          <DashboardTableIconButton
+            className="size-11"
             disabled={removingSectionId === section.id}
             label={subscriptionsCopy.unsubscribe}
             variant="destructive"
@@ -66,14 +83,11 @@ function courseName(section: SubscriptionSection) {
               <UserMinus />
             {/if}
           </DashboardTableIconButton>
-          <DashboardTableIconButton
-            href={`/catalog/sections/${section.jwId}`}
-            label={sectionCopy.moreDetails}
-          >
-            <ArrowUpRight />
-          </DashboardTableIconButton>
-        </div>
-      </div>
-    </div>
-  {/each}
+        </Item.Actions>
+      </Item.Root>
+      {#if index < sections.length - 1}
+        <Item.Separator class="my-0" />
+      {/if}
+    {/each}
+  </Item.Group>
 </div>

--- a/src/features/dashboard/components/SubscriptionsCardsView.svelte
+++ b/src/features/dashboard/components/SubscriptionsCardsView.svelte
@@ -39,8 +39,8 @@ function courseName(section: SubscriptionSection) {
 <div class="min-w-0" data-testid="subscription-semester-cards">
   <Item.Group class="gap-0">
     {#each sections as section, index}
-      <Item.Root class="items-start gap-3 p-3" variant="muted">
-        <Item.Content class="basis-full gap-1 min-w-0">
+      <Item.Root class="items-start gap-3 px-2 py-3">
+        <Item.Content class="min-w-0 gap-1">
           <Item.Title class="line-clamp-none w-full min-w-0">
             <a
               class="flex min-h-11 w-full min-w-0 max-w-full items-center font-medium hover:underline"
@@ -62,7 +62,7 @@ function courseName(section: SubscriptionSection) {
             </Badge>
           </Item.Description>
         </Item.Content>
-        <Item.Actions class="w-full justify-end">
+        <Item.Actions class="shrink-0 self-start">
           <DashboardTableIconButton
             className="size-11"
             href={`/catalog/sections/${section.jwId}`}

--- a/src/features/dashboard/components/TodosCardsView.svelte
+++ b/src/features/dashboard/components/TodosCardsView.svelte
@@ -34,8 +34,8 @@ export let toggleTodoCompletion: TodoCompletionToggle;
   {#if filteredTodos.length > 0}
     <Item.Group class="gap-0">
       {#each filteredTodos as todo, index (todo.id)}
-        <Item.Root class="items-start gap-3 p-3" variant="muted">
-          <Item.Content class="basis-full gap-1 min-w-0">
+        <Item.Root class="items-start gap-3 px-2 py-3">
+          <Item.Content class="min-w-0 gap-1">
             <Item.Title class="line-clamp-none w-full min-w-0">
               <button
                 class="flex min-h-11 w-full min-w-0 max-w-full items-center text-left underline-offset-4 hover:underline"
@@ -67,7 +67,7 @@ export let toggleTodoCompletion: TodoCompletionToggle;
               <Badge variant="ghost">{todoStatus(todo)}</Badge>
             </Item.Description>
           </Item.Content>
-          <Item.Actions class="w-full justify-end">
+          <Item.Actions class="shrink-0 self-start">
             <DashboardTableIconButton
               className="size-11"
               disabled={todoSavingById[todo.id]}

--- a/src/features/dashboard/components/TodosCardsView.svelte
+++ b/src/features/dashboard/components/TodosCardsView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import CheckCircleIcon from "@lucide/svelte/icons/check-circle";
+import MoreHorizontal from "@lucide/svelte/icons/more-horizontal";
 import Pencil from "@lucide/svelte/icons/pencil";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import type {
@@ -7,6 +8,8 @@ import type {
   DashboardTodosCopy,
 } from "@/features/dashboard/lib/dashboard-controller-types";
 import { Badge } from "$lib/components/ui/badge/index.js";
+import { Button } from "$lib/components/ui/button/index.js";
+import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
 import * as Item from "$lib/components/ui/item/index.js";
 import { Spinner } from "$lib/components/ui/spinner/index.js";
 import DashboardTableIconButton from "./DashboardTableIconButton.svelte";
@@ -31,22 +34,26 @@ export let toggleTodoCompletion: TodoCompletionToggle;
   {#if filteredTodos.length > 0}
     <Item.Group class="gap-0">
       {#each filteredTodos as todo, index (todo.id)}
-        <Item.Root class="items-start px-2 py-2" size="sm">
-          <Item.Content class="min-w-0 gap-0.5">
-            <Item.Title class="block min-w-0 max-w-full">
+        <Item.Root class="items-start gap-3 p-3" variant="muted">
+          <Item.Content class="basis-full gap-1 min-w-0">
+            <Item.Title class="line-clamp-none w-full min-w-0">
               <button
-                class:line-through={todo.completed}
-                class="block min-w-0 max-w-full truncate text-left underline-offset-4 hover:underline"
+                class="flex min-h-11 w-full min-w-0 max-w-full items-center text-left underline-offset-4 hover:underline"
                 type="button"
                 onclick={() => {
                   selectedTodo = todo;
                 }}
               >
-                {todo.title}
+                <span
+                  class:line-through={todo.completed}
+                  class="line-clamp-2 min-w-0 max-w-full break-words"
+                >{todo.title}</span>
               </button>
             </Item.Title>
-            <Item.Description class="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
-              <span class="truncate">{fmtDate(todo.dueAt)}</span>
+            <Item.Description
+              class="line-clamp-none flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 break-words"
+            >
+              <span class="max-w-full break-words">{fmtDate(todo.dueAt)}</span>
               <span aria-hidden="true">·</span>
               <Badge
                 variant={todo.priority === "high"
@@ -60,18 +67,14 @@ export let toggleTodoCompletion: TodoCompletionToggle;
               <Badge variant="ghost">{todoStatus(todo)}</Badge>
             </Item.Description>
           </Item.Content>
-          <Item.Actions class="shrink-0 self-start">
+          <Item.Actions class="w-full justify-end">
             <DashboardTableIconButton
-              label={todosCopy.editTitle}
-              onclick={() => openTodoEditor(todo)}
-            >
-              <Pencil />
-            </DashboardTableIconButton>
-            <DashboardTableIconButton
+              className="size-11"
               disabled={todoSavingById[todo.id]}
               label={todoSavingById[todo.id]
                 ? todosCopy.saving
                 : todoActionLabel(todo)}
+              variant={todo.completed ? "secondary" : "default"}
               onclick={() => void toggleTodoCompletion(todo)}
             >
               {#if todoSavingById[todo.id]}
@@ -82,6 +85,30 @@ export let toggleTodoCompletion: TodoCompletionToggle;
                 <CheckCircleIcon />
               {/if}
             </DashboardTableIconButton>
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger>
+                {#snippet child({ props })}
+                  <Button
+                    {...props}
+                    aria-label={todosCopy.editAriaLabel}
+                    class="size-11"
+                    size="icon"
+                    type="button"
+                    variant="outline"
+                  >
+                    <MoreHorizontal />
+                  </Button>
+                {/snippet}
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content align="end">
+                <DropdownMenu.Group>
+                  <DropdownMenu.Item onSelect={() => openTodoEditor(todo)}>
+                    <Pencil />
+                    {todosCopy.editTitle}
+                  </DropdownMenu.Item>
+                </DropdownMenu.Group>
+              </DropdownMenu.Content>
+            </DropdownMenu.Root>
           </Item.Actions>
         </Item.Root>
         {#if index < filteredTodos.length - 1}

--- a/src/features/dashboard/components/TodosListView.svelte
+++ b/src/features/dashboard/components/TodosListView.svelte
@@ -41,25 +41,17 @@ export let toggleTodoCompletion: TodoCompletionToggle;
   </Table.Header>
   <Table.Body>
     {#each filteredTodos as todo}
-      <Table.Row
-        class="group cursor-pointer"
-        onclick={(event) => {
-          const target = event.target;
-          if (!(target instanceof Element)) return;
-          if (target.closest("button, a")) return;
-          selectedTodo = todo;
-        }}
-      >
+      <Table.Row class="group">
         <Table.Cell>
           <button
-            class="block min-w-0 max-w-full overflow-hidden text-left hover:underline"
+            class="block min-h-11 min-w-0 max-w-full text-left hover:underline"
             class:line-through={todo.completed}
             type="button"
             onclick={() => {
               selectedTodo = todo;
             }}
           >
-            <TruncatedText text={todo.title} />
+            <TruncatedText text={todo.title} lines={2} />
           </button>
         </Table.Cell>
         <Table.Cell>
@@ -79,16 +71,11 @@ export let toggleTodoCompletion: TodoCompletionToggle;
         <Table.Cell>
           <DashboardTableRowActions>
             <DashboardTableIconButton
-              label={todosCopy.editTitle}
-              onclick={() => openTodoEditor(todo)}
-            >
-              <Pencil />
-            </DashboardTableIconButton>
-            <DashboardTableIconButton
               disabled={todoSavingById[todo.id]}
               label={todoSavingById[todo.id]
                 ? todosCopy.saving
                 : todoActionLabel(todo)}
+              variant={todo.completed ? "secondary" : "default"}
               onclick={() => void toggleTodoCompletion(todo)}
             >
               {#if todoSavingById[todo.id]}
@@ -98,6 +85,13 @@ export let toggleTodoCompletion: TodoCompletionToggle;
               {:else}
                 <CheckCircleIcon />
               {/if}
+            </DashboardTableIconButton>
+            <DashboardTableIconButton
+              label={todosCopy.editTitle}
+              variant="outline"
+              onclick={() => openTodoEditor(todo)}
+            >
+              <Pencil />
             </DashboardTableIconButton>
           </DashboardTableRowActions>
         </Table.Cell>

--- a/src/features/dashboard/lib/dashboard-controller-types.ts
+++ b/src/features/dashboard/lib/dashboard-controller-types.ts
@@ -364,6 +364,7 @@ export type DashboardTodosCopy = DashboardRecord & {
   deleteConfirmTitle: string;
   dueAtLabel: string;
   dueAtPlaceholder: string;
+  editAriaLabel: string;
   editDescription: string;
   editTitle: string;
   errorContentTooLong: string;

--- a/src/features/section-detail/components/SectionHomeworkListView.svelte
+++ b/src/features/section-detail/components/SectionHomeworkListView.svelte
@@ -27,8 +27,8 @@ export let selectHomework: (homework: SectionHomework) => void;
     <div class="md:hidden" data-testid="section-homeworks-items">
       <Item.Group class="gap-0">
         {#each homeworks as homework, index (homework.id)}
-          <Item.Root class="items-start gap-3 p-3" variant="muted">
-            <Item.Content class="basis-full gap-1 min-w-0">
+          <Item.Root class="items-start gap-3 px-2 py-3">
+            <Item.Content class="min-w-0 gap-1">
               <Item.Title class="line-clamp-none w-full min-w-0">
                 <button
                   class="flex min-h-11 w-full min-w-0 max-w-full items-center text-left hover:underline"

--- a/src/features/section-detail/components/SectionHomeworkListView.svelte
+++ b/src/features/section-detail/components/SectionHomeworkListView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { Badge } from "$lib/components/ui/badge/index.js";
 import * as Empty from "$lib/components/ui/empty/index.js";
+import * as Item from "$lib/components/ui/item/index.js";
 import * as Table from "$lib/components/ui/table/index.js";
 import type {
   SectionCopy,
@@ -23,7 +24,46 @@ export let selectHomework: (homework: SectionHomework) => void;
       </Empty.Header>
     </Empty.Root>
   {:else}
-    <div class="min-w-0 overflow-x-auto">
+    <div class="md:hidden" data-testid="section-homeworks-items">
+      <Item.Group class="gap-0">
+        {#each homeworks as homework, index (homework.id)}
+          <Item.Root class="items-start gap-3 p-3" variant="muted">
+            <Item.Content class="basis-full gap-1 min-w-0">
+              <Item.Title class="line-clamp-none w-full min-w-0">
+                <button
+                  class="flex min-h-11 w-full min-w-0 max-w-full items-center text-left hover:underline"
+                  type="button"
+                  onclick={() => {
+                    selectHomework(homework);
+                  }}
+                >
+                  <span class="line-clamp-2 min-w-0 max-w-full break-words">
+                    {homework.title}
+                  </span>
+                </button>
+              </Item.Title>
+              <Item.Description
+                class="line-clamp-none flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 break-words"
+              >
+                <span class="max-w-full break-words">
+                  {sectionCopy.due}: {fmtDateTime(homework.submissionDueAt)}
+                </span>
+                {#if homework.isMajor}
+                  <Badge variant="secondary">{homeworkCopy.tagMajor}</Badge>
+                {/if}
+                {#if homework.requiresTeam}
+                  <Badge variant="secondary">{homeworkCopy.tagTeam}</Badge>
+                {/if}
+              </Item.Description>
+            </Item.Content>
+          </Item.Root>
+          {#if index < homeworks.length - 1}
+            <Item.Separator class="my-0" />
+          {/if}
+        {/each}
+      </Item.Group>
+    </div>
+    <div class="hidden min-w-0 md:block">
       <Table.Root>
         <Table.Header>
           <Table.Row>
@@ -37,7 +77,7 @@ export let selectHomework: (homework: SectionHomework) => void;
             <Table.Row>
               <Table.Cell>
                 <button
-                  class="text-left hover:underline"
+                  class="min-h-11 max-w-full text-left break-words hover:underline"
                   type="button"
                   onclick={() => {
                     selectHomework(homework);

--- a/tests/e2e/src/app/dashboard/homeworks/test.ts
+++ b/tests/e2e/src/app/dashboard/homeworks/test.ts
@@ -90,6 +90,16 @@ test.describe("仪表盘作业", () => {
         .first(),
     ).toBeVisible();
 
+    const detailButton = hwRow.getByRole("button", {
+      name: new RegExp(DEV_SEED.homeworks.title),
+    });
+    await detailButton.focus();
+    await page.keyboard.press("Enter");
+    await expect(
+      page.locator('[data-slot="dialog-content"]').first(),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+
     await captureStepScreenshot(page, testInfo, "homeworks/seed-list-fields");
   });
 
@@ -141,6 +151,14 @@ test.describe("仪表盘作业", () => {
     await expect(
       homeworkItem.locator('[data-slot="item-actions"]'),
     ).toBeVisible();
+    for (const control of await homeworkItem
+      .locator('[data-slot="item-actions"]')
+      .getByRole("button")
+      .all()) {
+      const box = await control.boundingBox();
+      expect(box?.width ?? 0).toBeGreaterThanOrEqual(44);
+      expect(box?.height ?? 0).toBeGreaterThanOrEqual(44);
+    }
     expect(
       await page.evaluate(
         () => document.documentElement.scrollWidth <= window.innerWidth,

--- a/tests/e2e/src/app/dashboard/todos/test.ts
+++ b/tests/e2e/src/app/dashboard/todos/test.ts
@@ -71,6 +71,17 @@ test.describe("仪表盘待办", () => {
     await expect(completionButton).toBeVisible();
     await expect(completionButton).toBeEnabled();
 
+    const detailButton = row.getByRole("button", {
+      name: DEV_SEED.todos.dueTodayTitle,
+      exact: true,
+    });
+    await detailButton.focus();
+    await page.keyboard.press("Enter");
+    await expect(
+      page.getByRole("dialog", { name: DEV_SEED.todos.dueTodayTitle }),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+
     await captureStepScreenshot(page, testInfo, "dashboard-todos-seed");
   });
 
@@ -109,6 +120,14 @@ test.describe("仪表盘待办", () => {
     await expect(todoItem).toBeVisible();
     await expect(todoItem.locator('[data-slot="item-content"]')).toBeVisible();
     await expect(todoItem.locator('[data-slot="item-actions"]')).toBeVisible();
+    for (const control of await todoItem
+      .locator('[data-slot="item-actions"]')
+      .getByRole("button")
+      .all()) {
+      const box = await control.boundingBox();
+      expect(box?.width ?? 0).toBeGreaterThanOrEqual(44);
+      expect(box?.height ?? 0).toBeGreaterThanOrEqual(44);
+    }
     expect(
       await page.evaluate(
         () => document.documentElement.scrollWidth <= window.innerWidth,

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -1160,6 +1160,26 @@ test.describe("/catalog/sections/[jwId] 班级详情页", () => {
     await jumpToSection(page, /作业|Homework/i, "#homework");
 
     await expect(page.getByTestId("section-homeworks-list")).toBeVisible();
+    await page.setViewportSize({ width: 320, height: 568 });
+    await gotoAndWaitForReady(page, `${SECTION_URL}#homework`);
+    await expect(page.getByTestId("section-homeworks-items")).toBeVisible();
+    await expect(
+      page.getByTestId("section-homeworks-list").locator("table"),
+    ).toBeHidden();
+    const homeworkItem = page
+      .getByTestId("section-homeworks-items")
+      .locator('[data-slot="item"]')
+      .first();
+    await expect(homeworkItem).toBeVisible();
+    const detailButton = homeworkItem.getByRole("button").first();
+    const detailBox = await detailButton.boundingBox();
+    expect(detailBox?.width ?? 0).toBeGreaterThanOrEqual(44);
+    expect(detailBox?.height ?? 0).toBeGreaterThanOrEqual(44);
+    expect(
+      await page.evaluate(
+        () => document.documentElement.scrollWidth <= window.innerWidth,
+      ),
+    ).toBe(true);
     await captureStepScreenshot(page, testInfo, "section/homework-list-view");
   });
 


### PR DESCRIPTION
Closes #919

## Summary
- use shadcn Item groups for Todo, Homework, Exam, Subscription, and section Homework records
- make mobile action targets 44px+, keep completion as the primary action, and move Todo edit into a grouped overflow menu
- add a dedicated mobile section Homework Item layout and keyboard/overflow E2E coverage

## Validation
- `bunx vitest run tests/unit` (372 files, 2286 tests passed)
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx svelte-check --tsconfig ./tsconfig.json` (0 errors; 5 pre-existing warnings)
- `bunx biome check ...`
- `DATABASE_URL=... bun run build`

Focused Playwright Todo smoke was attempted but blocked before UI assertions by the existing `life_ustc_dev` BetterAuth JWKS being encrypted with a different secret (`Failed to decrypt private key`).
