### PR TITLE
fix(ux): use toast-only success feedback

### DIFF
--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -134,7 +134,6 @@
     "linkCopiedDescription": "Calendar link has been copied to clipboard",
     "optOut": "Opt out",
     "optOutConfirm": "Confirm",
-    "optOutSuccess": "Section removed",
     "optOutSuccessDescription": "This section has been removed from your Life@USTC subscriptions",
     "optOutError": "Failed to remove section",
     "optOutRetry": "Please try again",
@@ -194,7 +193,6 @@
       "unmatchedCodes": "Unmatched codes ({count})",
       "cancel": "Cancel",
       "subscribeSelected": "Subscribe to {count} sections",
-      "success": "Added successfully",
       "successDescription": "Added {count} new section{plural} to Life@USTC",
       "importFailed": "Add failed"
     }

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -134,7 +134,6 @@
     "linkCopiedDescription": "日历链接已复制到剪贴板",
     "optOut": "移除",
     "optOutConfirm": "确认",
-    "optOutSuccess": "已移除班级",
     "optOutSuccessDescription": "该教学班已从订阅列表中移除",
     "optOutError": "移除失败",
     "optOutRetry": "请稍后重试",
@@ -194,7 +193,6 @@
       "unmatchedCodes": "未匹配到的代码 ({count})",
       "cancel": "取消",
       "subscribeSelected": "订阅已选的 {count} 个教学班",
-      "success": "已加入",
       "successDescription": "已新增 {count} 个教学班订阅",
       "importFailed": "订阅失败"
     }

--- a/src/features/admin/components/AdminBusStatusAlerts.svelte
+++ b/src/features/admin/components/AdminBusStatusAlerts.svelte
@@ -7,7 +7,7 @@ export let form:
   | undefined;
 </script>
 
-{#if form?.message}
+{#if form?.message && form.variant === "destructive"}
   <Alert.Root variant={form.variant ?? "default"}>
     <Alert.Description>{form.message}</Alert.Description>
   </Alert.Root>

--- a/src/features/admin/components/AdminModerationPageController.svelte
+++ b/src/features/admin/components/AdminModerationPageController.svelte
@@ -148,6 +148,7 @@ const {
     toast.success(
       action === "comment" ? _copy.commentUpdateSuccess : _copy.suspendSuccess,
     );
+    _dialogMessage = "";
   },
   setCommentStatus: (value) => {
     _commentStatus = value;

--- a/src/features/admin/components/AdminModerationStatusAlerts.svelte
+++ b/src/features/admin/components/AdminModerationStatusAlerts.svelte
@@ -12,7 +12,7 @@ export let refreshError = "";
   </Alert.Root>
 {/if}
 
-{#if form?.message}
+{#if form?.message && form.kind !== "success"}
   <Alert.Root variant={formAlertVariant(form.kind)}>
     <Alert.Description>{form.message}</Alert.Description>
   </Alert.Root>

--- a/src/features/admin/components/AdminOAuthPageController.svelte
+++ b/src/features/admin/components/AdminOAuthPageController.svelte
@@ -123,6 +123,9 @@ const {
   getPendingDeleteClient: () => pendingDeleteClient,
   getSelectedAuthMethod: () => selectedAuthMethod,
   getSelectedScopes: () => selectedScopes,
+  onCopySuccess: (message) => {
+    toast.success(message);
+  },
   onSuccess: (action) => {
     toast.success(
       action === "create" ? _copy.createSuccess : _copy.deleteSuccess,

--- a/src/features/admin/components/AdminOAuthStatusAlerts.svelte
+++ b/src/features/admin/components/AdminOAuthStatusAlerts.svelte
@@ -13,13 +13,13 @@ export let form:
   | undefined;
 </script>
 
-{#if copyMessage}
-  <Alert.Root variant={copyMessageVariant}>
+{#if copyMessage && copyMessageVariant === "destructive"}
+  <Alert.Root variant="destructive">
     <Alert.Description>{copyMessage}</Alert.Description>
   </Alert.Root>
 {/if}
 
-{#if form?.message && !form?.createdClientId}
+{#if form?.message && !form?.createdClientId && form.variant === "destructive"}
   <Alert.Root variant={form.variant ?? "default"}>
     <Alert.Description>{form.message}</Alert.Description>
   </Alert.Root>

--- a/src/features/admin/components/AdminUserDialog.svelte
+++ b/src/features/admin/components/AdminUserDialog.svelte
@@ -70,7 +70,7 @@ async function confirmRoleChange() {
 
       <ScrollArea class="min-h-0 h-[min(62dvh,34rem)] max-h-[calc(100dvh-10rem)]">
         <div class="grid gap-5 px-5 py-4">
-          {#if message}<Alert.Root variant={messageVariant}><Alert.Description>{message}</Alert.Description></Alert.Root>{/if}
+          {#if message && messageVariant === "destructive"}<Alert.Root variant={messageVariant}><Alert.Description>{message}</Alert.Description></Alert.Root>{/if}
 
           <AdminUserProfileSection
             {copy}

--- a/src/features/admin/components/AdminUsersPageContent.svelte
+++ b/src/features/admin/components/AdminUsersPageContent.svelte
@@ -50,7 +50,7 @@ function handlePageChange(page: number) {
     />
   {/snippet}
   {#snippet feedback()}
-    {#if message}<Alert.Root variant={messageVariant}><Alert.Description>{message}</Alert.Description></Alert.Root>{/if}
+    {#if message && messageVariant === "destructive"}<Alert.Root variant={messageVariant}><Alert.Description>{message}</Alert.Description></Alert.Root>{/if}
   {/snippet}
   {#snippet controls()}
     <AdminUsersSearchCard

--- a/src/features/admin/components/AdminUsersPageController.svelte
+++ b/src/features/admin/components/AdminUsersPageController.svelte
@@ -132,6 +132,7 @@ const {
           ? _copy.suspendSuccess
           : _copy.liftSuccess,
     );
+    _message = null;
   },
   getSuspendState: () => ({
     duration: suspendDuration,

--- a/src/features/admin/lib/oauth-page-actions.ts
+++ b/src/features/admin/lib/oauth-page-actions.ts
@@ -12,6 +12,7 @@ export function createOAuthPageActions<
   getPendingDeleteClient: () => ClientShape | null;
   getSelectedAuthMethod: () => string;
   getSelectedScopes: () => string[];
+  onCopySuccess?: (message: string) => void;
   onSuccess?: (action: "create" | "delete") => void;
   setCopyMessage: (value: string) => void;
   setCopyMessageVariant: (value: "destructive" | "default") => void;
@@ -39,8 +40,9 @@ export function createOAuthPageActions<
     try {
       if (!value) throw new Error(copy.copyError);
       await writeClipboardText(value);
-      input.setCopyMessage(successMessage);
+      input.setCopyMessage("");
       input.setCopyMessageVariant("default");
+      input.onCopySuccess?.(successMessage);
       return true;
     } catch {
       input.setCopyMessage(copy.copyErrorDescription);

--- a/src/features/comments/components/CommentsPanel.svelte
+++ b/src/features/comments/components/CommentsPanel.svelte
@@ -421,6 +421,9 @@ const {
   getPendingReactionKey: () => _pendingReactionKey,
   getViewer: () => _viewer,
   loadComments: _loadComments,
+  onCopySuccess: (message) => {
+    toast.success(message);
+  },
   onSuccess: (action) => {
     toast.success(
       action === "reaction"

--- a/src/features/comments/lib/comment-panel-interactions.ts
+++ b/src/features/comments/lib/comment-panel-interactions.ts
@@ -33,6 +33,7 @@ export function createCommentPanelInteractions(input: {
   getPendingReactionKey: () => string | null;
   getViewer: () => ViewerContext;
   loadComments: () => Promise<void>;
+  onCopySuccess?: (message: string) => void;
   onSuccess?: (action: "reaction" | "delete") => void;
   setActionMenuId: (value: string | null) => void;
   setDeleteTarget: (value: CommentNode | null) => void;
@@ -97,8 +98,9 @@ export function createCommentPanelInteractions(input: {
           permalinkBaseHref,
         }),
       );
+      input.setMessage("");
       input.setMessageVariant("default");
-      input.setMessage(copy.linkCopied);
+      input.onCopySuccess?.(copy.linkCopied);
     } catch {
       input.setMessageVariant("destructive");
       input.setMessage(copy.pleaseRetry);

--- a/src/features/comments/lib/comment-panel-upload-actions.ts
+++ b/src/features/comments/lib/comment-panel-upload-actions.ts
@@ -83,13 +83,6 @@ export function createCommentPanelUploadActions(input: {
       });
       applyCommentUploadState(next, input);
       input.replaceMarkdownToken(token, attachmentMarkdown(file, upload), mode);
-      input.setMessage(
-        uploadCopy.toastUploadSuccessDescription.replace(
-          "{name}",
-          upload.filename,
-        ),
-      );
-      input.setMessageVariant("default");
       input.onSuccess?.(upload.filename);
     } catch (error) {
       input.replaceMarkdownToken(token, "", mode);

--- a/src/features/dashboard/components/DashboardPageController.svelte
+++ b/src/features/dashboard/components/DashboardPageController.svelte
@@ -311,6 +311,11 @@ const {
           : subscriptionsCopy.bulkImport.success,
       ),
     );
+    if (action === "remove") {
+      subscriptionActionMessage = "";
+    } else {
+      bulkImportMessage = "";
+    }
   },
   setBulkImportError: (value) => {
     bulkImportError = value;
@@ -512,23 +517,16 @@ onMount(() => {
     clearPendingRemoveSection,
     copy: {
       dashboard: dashboardCopy,
-      subscriptions: subscriptionsCopy,
     },
     getLinkSearchInput: () => linkSearchInput,
     replaceState: (href) => {
       replaceState(href, {});
-    },
-    setBulkImportMessage: (value) => {
-      bulkImportMessage = value;
     },
     setLinkActionError: (value) => {
       linkActionError = value;
     },
     setLinkReturnTo: (value) => {
       linkReturnTo = value;
-    },
-    setSubscriptionActionMessage: (value) => {
-      subscriptionActionMessage = value;
     },
   });
 });

--- a/src/features/dashboard/components/DashboardPageController.svelte
+++ b/src/features/dashboard/components/DashboardPageController.svelte
@@ -126,7 +126,6 @@ let {
   signedData,
   signedLinkGroups,
   subscriptionActionError,
-  subscriptionActionMessage,
   todoActionError,
   todoFilter,
   todoItems,
@@ -303,19 +302,8 @@ const {
   getSelectedImportSectionIds: () => selectedImportSectionIds,
   getSubscriptionsCopy: () => subscriptionsCopy,
   invalidateAll,
-  onSuccess: (action) => {
-    toast.success(
-      String(
-        action === "remove"
-          ? subscriptionsCopy.optOutSuccess
-          : subscriptionsCopy.bulkImport.success,
-      ),
-    );
-    if (action === "remove") {
-      subscriptionActionMessage = "";
-    } else {
-      bulkImportMessage = "";
-    }
+  onSuccess: (message) => {
+    toast.success(message);
   },
   setBulkImportError: (value) => {
     bulkImportError = value;
@@ -352,9 +340,6 @@ const {
   },
   setSubscriptionActionError: (value) => {
     subscriptionActionError = value;
-  },
-  setSubscriptionActionMessage: (value) => {
-    subscriptionActionMessage = value;
   },
   setUnmatchedSectionCodes: (value) => {
     unmatchedSectionCodes = value;
@@ -656,7 +641,6 @@ onMount(() => {
         {isMatchingSections}
         {isImportingSections}
         {removingSectionId}
-        {subscriptionActionMessage}
         {subscriptionActionError}
         {matchedSections}
         {unmatchedSectionCodes}

--- a/src/features/dashboard/components/SignedDashboardSubscriptionsBranch.svelte
+++ b/src/features/dashboard/components/SignedDashboardSubscriptionsBranch.svelte
@@ -33,7 +33,6 @@ export let selectedImportCount: number;
 export let selectedImportSectionIdSet: Set<number>;
 export let signedData: DashboardSubscriptionsTabProps["signedData"];
 export let subscriptionActionError: string;
-export let subscriptionActionMessage: string;
 export let subscribeQuickAddSections: DashboardSubscriptionsTabProps["subscribeQuickAddSections"];
 export let subscriptionsCopy: DashboardSubscriptionsTabProps["subscriptionsCopy"];
 export let toggleImportSectionSelection: DashboardSubscriptionsTabProps["toggleImportSectionSelection"];
@@ -63,7 +62,6 @@ export let unmatchedSectionCodes: string[];
   {isMatchingSections}
   {isImportingSections}
   {removingSectionId}
-  {subscriptionActionMessage}
   {subscribeQuickAddSections}
   {subscriptionActionError}
   {matchedSections}

--- a/src/features/dashboard/components/SubscriptionsStatusAlerts.svelte
+++ b/src/features/dashboard/components/SubscriptionsStatusAlerts.svelte
@@ -4,7 +4,6 @@ import * as Alert from "$lib/components/ui/alert/index.js";
 export let bulkImportError: string;
 export let bulkImportMessage: string;
 export let subscriptionActionError: string;
-export let subscriptionActionMessage: string;
 </script>
 
 {#if bulkImportMessage}
@@ -15,11 +14,6 @@ export let subscriptionActionMessage: string;
 {#if bulkImportError}
   <Alert.Root variant="destructive">
     <Alert.Description>{bulkImportError}</Alert.Description>
-  </Alert.Root>
-{/if}
-{#if subscriptionActionMessage}
-  <Alert.Root>
-    <Alert.Description>{subscriptionActionMessage}</Alert.Description>
   </Alert.Root>
 {/if}
 {#if subscriptionActionError}

--- a/src/features/dashboard/components/SubscriptionsTab.svelte
+++ b/src/features/dashboard/components/SubscriptionsTab.svelte
@@ -40,7 +40,6 @@ export let bulkImportError: string;
 export let isMatchingSections: boolean;
 export let isImportingSections: boolean;
 export let removingSectionId: DashboardSubscriptionsTabProps["removingSectionId"];
-export let subscriptionActionMessage: string;
 export let subscribeQuickAddSections: DashboardSubscriptionsTabProps["subscribeQuickAddSections"];
 export let subscriptionActionError: string;
 export let matchedSections: MatchedImportSection[];
@@ -68,7 +67,6 @@ function openQuickAddDialog() {
     {bulkImportError}
     {bulkImportMessage}
     {subscriptionActionError}
-    {subscriptionActionMessage}
   />
 
   <SubscriptionsList

--- a/src/features/dashboard/components/subscription-tab-types.ts
+++ b/src/features/dashboard/components/subscription-tab-types.ts
@@ -124,7 +124,6 @@ export type DashboardSubscriptionsTabProps = {
   selectedImportSectionIdSet: Set<number>;
   signedData: DashboardSubscriptionsSignedData;
   subscriptionActionError: string;
-  subscriptionActionMessage: string;
   subscribeQuickAddSections: (
     selectedSectionIds: number[],
   ) => void | Promise<void>;

--- a/src/features/dashboard/lib/dashboard-controller-default-state.ts
+++ b/src/features/dashboard/lib/dashboard-controller-default-state.ts
@@ -72,7 +72,6 @@ export function createDashboardControllerDefaultState() {
     signedData: null as SignedDashboardData | null,
     signedLinkGroups: [] as SignedLinkGroup[],
     subscriptionActionError: "",
-    subscriptionActionMessage: "",
     todoActionError: "",
     todoFilter: "incomplete" as TodoFilter,
     todoItems: [] as TodoItem[],

--- a/src/features/dashboard/lib/dashboard-controller-mount.ts
+++ b/src/features/dashboard/lib/dashboard-controller-mount.ts
@@ -2,7 +2,6 @@ import { getLocalStorageItem } from "@/lib/browser/local-storage";
 import { mountPageSearchShortcut } from "@/lib/browser/page-search-shortcut";
 import type { DashboardViewState } from "./dashboard-controller-helpers";
 import { currentDashboardLinkReturnTo } from "./dashboard-link-ui";
-import { formatMessage } from "./overview";
 import {
   DASHBOARD_VIEW_STORAGE_KEY,
   dashboardViewsFromPreference,
@@ -14,12 +13,6 @@ type DashboardMountCopy = {
       pinFailedDescription: string;
     };
   };
-  subscriptions: {
-    bulkImport: {
-      successDescription: string;
-    };
-    optOutSuccessDescription: string;
-  };
 };
 
 export function mountDashboardController(input: {
@@ -28,29 +21,11 @@ export function mountDashboardController(input: {
   copy: DashboardMountCopy;
   getLinkSearchInput: () => HTMLInputElement | null;
   replaceState: (href: string) => void;
-  setBulkImportMessage: (value: string) => void;
   setLinkActionError: (value: string) => void;
   setLinkReturnTo: (value: string) => void;
-  setSubscriptionActionMessage: (value: string) => void;
 }) {
   const url = new URL(window.location.href);
   input.setLinkReturnTo(currentDashboardLinkReturnTo());
-
-  const importedCount = url.searchParams.get("imported");
-  if (importedCount) {
-    input.setBulkImportMessage(
-      formatMessage(input.copy.subscriptions.bulkImport.successDescription, {
-        count: importedCount,
-        plural: importedCount === "1" ? "" : "s",
-      }),
-    );
-  }
-
-  if (url.searchParams.get("removed")) {
-    input.setSubscriptionActionMessage(
-      input.copy.subscriptions.optOutSuccessDescription,
-    );
-  }
 
   if (url.searchParams.get("dashboardLinkPinError") === "1") {
     input.setLinkActionError(input.copy.dashboard.linkHub.pinFailedDescription);

--- a/src/features/dashboard/lib/dashboard-controller-subscription-bulk-actions.ts
+++ b/src/features/dashboard/lib/dashboard-controller-subscription-bulk-actions.ts
@@ -80,8 +80,7 @@ export function createDashboardBulkImportActions(
       input.setBulkImportOpen(false);
       resetBulkImport();
       void input.invalidateAll().then(() => {
-        input.setBulkImportMessage(message);
-        input.onSuccess?.("import");
+        input.onSuccess?.(message);
       });
     } catch (error) {
       input.setBulkImportError(error instanceof Error ? error.message : "");
@@ -114,8 +113,7 @@ export function createDashboardBulkImportActions(
       selectedSectionIds,
     });
     void input.invalidateAll().then(() => {
-      input.setBulkImportMessage(message);
-      input.onSuccess?.("subscribe");
+      input.onSuccess?.(message);
     });
   }
 

--- a/src/features/dashboard/lib/dashboard-controller-subscription-removal-actions.ts
+++ b/src/features/dashboard/lib/dashboard-controller-subscription-removal-actions.ts
@@ -7,7 +7,6 @@ export function createDashboardSubscriptionRemovalActions(
   function clearPendingRemoveSection() {}
 
   async function removeSubscribedSection(sectionId: number) {
-    input.setSubscriptionActionMessage("");
     input.setSubscriptionActionError("");
 
     input.setRemovingSectionId(sectionId);
@@ -18,8 +17,7 @@ export function createDashboardSubscriptionRemovalActions(
       });
 
       await input.invalidateAll();
-      input.setSubscriptionActionMessage(message);
-      input.onSuccess?.("remove");
+      input.onSuccess?.(message);
       return true;
     } catch (error) {
       input.setSubscriptionActionError(

--- a/src/features/dashboard/lib/dashboard-controller-subscription-types.ts
+++ b/src/features/dashboard/lib/dashboard-controller-subscription-types.ts
@@ -14,7 +14,6 @@ export type SubscriptionActionSetters = {
   setRemovingSectionId: (value: number | null) => void;
   setSelectedImportSectionIds: (value: number[]) => void;
   setSubscriptionActionError: (value: string) => void;
-  setSubscriptionActionMessage: (value: string) => void;
   setUnmatchedSectionCodes: (value: string[]) => void;
 };
 
@@ -29,5 +28,5 @@ export type SubscriptionActionGetters = {
 export type DashboardSubscriptionActionInput = SubscriptionActionGetters &
   SubscriptionActionSetters & {
     invalidateAll: () => Promise<void>;
-    onSuccess?: (action: "remove" | "import" | "subscribe") => void;
+    onSuccess?: (message: string) => void;
   };

--- a/src/features/dashboard/lib/dashboard-controller-subscriptions.ts
+++ b/src/features/dashboard/lib/dashboard-controller-subscriptions.ts
@@ -13,7 +13,6 @@ export type SubscriptionsCopy = {
     importFailed: string;
     noMatches: string;
     noValidCodes: string;
-    success: string;
     successDescription: string;
   };
   optOutError: string;

--- a/src/features/dashboard/lib/dashboard-controller-types.ts
+++ b/src/features/dashboard/lib/dashboard-controller-types.ts
@@ -240,7 +240,6 @@ export type DashboardSubscriptionsCopy = DashboardRecord & {
     matching: string;
     noMatches: string;
     noValidCodes: string;
-    success: string;
     placeholder: string;
     sectionCodesLabel: string;
     selectSection: string;

--- a/src/features/dashboard/lib/dashboard-nav.ts
+++ b/src/features/dashboard/lib/dashboard-nav.ts
@@ -25,10 +25,8 @@ const homeDashboardQueryKeys = new Set([
   "dashboardLinkPinError",
   "examView",
   "homeworkView",
-  "imported",
   "linkView",
   "overviewWeek",
-  "removed",
   "snapshotAt",
   "todoView",
 ]);

--- a/src/features/settings/components/SettingsPageController.svelte
+++ b/src/features/settings/components/SettingsPageController.svelte
@@ -21,6 +21,8 @@ import {
   createSettingsAccountAction,
 } from "@/features/settings/lib/settings-page-actions";
 import type { SettingsTab } from "@/features/settings/lib/settings-tabs";
+import { replaceState } from "$app/navigation";
+import { page } from "$app/stores";
 import DetailSectionNav from "$lib/components/DetailSectionNav.svelte";
 import type {
   SettingsAccount,
@@ -79,19 +81,35 @@ $: avatarOptions =
 $: currentImage = data.user.image ?? "";
 $: previewImage = selectedImage || currentImage || "/images/icon.png";
 $: statusMessage = form?.message ?? data.message;
-$: if (data.message && typeof window !== "undefined") {
-  const statusKey = `${window.location.pathname}?${window.location.search}`;
+$: redirectStatus = $page.url.searchParams.get("message");
+$: if (!redirectStatus) {
+  consumedStatusKey = "";
+}
+$: if (
+  typeof window !== "undefined" &&
+  redirectStatus &&
+  [
+    "CalendarTokenRotated",
+    "AuthorizationRevoked",
+    "AccountDisconnected",
+    "Success",
+  ].includes(redirectStatus)
+) {
+  const statusKey = `${$page.url.pathname}:${redirectStatus}`;
   if (statusKey !== consumedStatusKey) {
     consumedStatusKey = statusKey;
     const message =
-      data.message === "CalendarTokenRotated"
+      redirectStatus === "CalendarTokenRotated"
         ? copy.settings.security.calendarTokenRotated
-        : data.message === "AuthorizationRevoked"
+        : redirectStatus === "AuthorizationRevoked"
           ? copy.settings.authorizations.revokeSuccess
-          : data.message === "AccountDisconnected"
+          : redirectStatus === "AccountDisconnected"
             ? copy.profile.disconnectSuccess
             : copy.profile.updateSuccess;
     toast.success(message);
+    const nextUrl = new URL($page.url);
+    nextUrl.searchParams.delete("message");
+    replaceState(nextUrl, {});
   }
 }
 $: if (

--- a/src/features/settings/components/SettingsPageController.svelte
+++ b/src/features/settings/components/SettingsPageController.svelte
@@ -156,7 +156,10 @@ function tabIcon(icon: string) {
 }
 
 onMount(() => {
-  _isMounted = true;
+  const mountTimer = setTimeout(() => {
+    _isMounted = true;
+  }, 0);
+  return () => clearTimeout(mountTimer);
 });
 </script>
 

--- a/src/features/settings/components/SettingsPageController.svelte
+++ b/src/features/settings/components/SettingsPageController.svelte
@@ -86,7 +86,7 @@ $: if (!redirectStatus) {
   consumedStatusKey = "";
 }
 $: if (
-  typeof window !== "undefined" &&
+  _isMounted &&
   redirectStatus &&
   [
     "CalendarTokenRotated",

--- a/src/features/settings/components/SettingsPasskeyRow.svelte
+++ b/src/features/settings/components/SettingsPasskeyRow.svelte
@@ -12,7 +12,7 @@ import { Spinner } from "$lib/components/ui/spinner/index.js";
 import type { SettingsCopy } from "./settings-component-types";
 
 type Status = {
-  kind: "error" | "success";
+  kind: "error";
   message: string;
 };
 
@@ -52,9 +52,7 @@ async function renamePasskey() {
       reportStatus({ kind: "error", message: errorMessage(result.error) });
       return;
     }
-    const message = copy.settings.passkeys.renamed;
-    reportStatus({ kind: "success", message });
-    onSuccess(message);
+    onSuccess(copy.settings.passkeys.renamed);
   } catch {
     reportStatus({
       kind: "error",
@@ -78,9 +76,7 @@ async function deletePasskey() {
       return;
     }
     deleteOpen = false;
-    const message = copy.settings.passkeys.deleted;
-    reportStatus({ kind: "success", message });
-    onSuccess(message);
+    onSuccess(copy.settings.passkeys.deleted);
   } catch {
     deleteOpen = false;
     reportStatus({

--- a/src/features/settings/components/SettingsPasskeysCard.svelte
+++ b/src/features/settings/components/SettingsPasskeysCard.svelte
@@ -19,7 +19,7 @@ import SettingsPasskeyRow from "./SettingsPasskeyRow.svelte";
 import type { SettingsCopy } from "./settings-component-types";
 
 type Status = {
-  kind: "error" | "success";
+  kind: "error";
   message: string;
 };
 
@@ -61,10 +61,7 @@ async function addPasskey() {
       return;
     }
     name = "";
-    status = {
-      kind: "success",
-      message: copy.settings.passkeys.added,
-    };
+    status = null;
     toast.success(copy.settings.passkeys.added);
     await $passkeyQuery.refetch();
   } catch {
@@ -95,8 +92,8 @@ async function addPasskey() {
       </Alert.Root>
     {/if}
 
-    {#if status}
-      <Alert.Root variant={status.kind === "error" ? "destructive" : "default"}>
+    {#if status && status.kind === "error"}
+      <Alert.Root variant="destructive">
         <Alert.Description>{status.message}</Alert.Description>
       </Alert.Root>
     {/if}

--- a/src/features/settings/components/SettingsStatusAlert.svelte
+++ b/src/features/settings/components/SettingsStatusAlert.svelte
@@ -10,30 +10,12 @@ $: isSuccessStatus =
   statusMessage === "AccountDisconnected" ||
   statusMessage === "AuthorizationRevoked" ||
   statusMessage === "CalendarTokenRotated";
-$: statusTitle = isSuccessStatus
-  ? statusMessage === "CalendarTokenRotated"
-    ? copy.settings.security.calendarTokenRotated
-    : statusMessage === "AuthorizationRevoked"
-      ? copy.settings.authorizations.revokeSuccess
-      : statusMessage === "AccountDisconnected"
-        ? copy.profile.disconnectSuccess
-        : copy.profile.updateSuccess
-  : copy.profile.updateError;
-$: statusDescription = isSuccessStatus
-  ? statusMessage === "CalendarTokenRotated"
-    ? copy.settings.security.calendarTokenRotatedDescription
-    : statusMessage === "AuthorizationRevoked"
-      ? copy.settings.authorizations.revokeSuccessDescription
-      : statusMessage === "AccountDisconnected"
-        ? copy.profile.disconnectSuccessDescription
-        : copy.profile.updateSuccessDescription
-  : statusMessage;
+$: statusTitle = copy.profile.updateError;
+$: statusDescription = statusMessage;
 </script>
 
-{#if statusMessage}
-  <Alert.Root
-    variant={isSuccessStatus ? "default" : "destructive"}
-  >
+{#if statusMessage && !isSuccessStatus}
+  <Alert.Root variant="destructive">
     <Alert.Title role="heading" aria-level={2}>{statusTitle}</Alert.Title>
     <Alert.Description>{statusDescription}</Alert.Description>
   </Alert.Root>

--- a/tests/e2e/src/app/admin/moderation/test.ts
+++ b/tests/e2e/src/app/admin/moderation/test.ts
@@ -295,6 +295,11 @@ test("/admin/moderation 可更新评论状态与备注", async ({ page }, testIn
   await dialog.getByRole("button", { name: /确认|Confirm/i }).click();
   await patchResponse;
   await expect(dialog).not.toBeVisible({ timeout: 15_000 });
+  await expect(
+    page
+      .locator("[data-sonner-toast]")
+      .filter({ hasText: /评论已更新|Comment updated/i }),
+  ).toBeVisible();
   await captureStepScreenshot(page, testInfo, "admin-moderation-updated");
 });
 
@@ -434,6 +439,11 @@ test("/admin/moderation 封禁列表可解除封禁", async ({ page }, testInfo)
     expect((await liftResponse).status()).toBe(200);
     lifted = true;
     await expect(row.getByText(/已解除|Lifted/i)).toBeVisible();
+    await expect(
+      page
+        .locator("[data-sonner-toast]")
+        .filter({ hasText: /封禁已解除|Suspension lifted/i }),
+    ).toBeVisible();
     await captureStepScreenshot(page, testInfo, "admin-moderation-suspended");
   } finally {
     if (!lifted) {
@@ -508,7 +518,9 @@ test("/admin/moderation 可从评论弹窗封禁并解除用户", async ({
     suspensionId = createdBody.suspension?.id;
     expect(typeof suspensionId).toBe("string");
     await expect(
-      dialog.getByText(/封禁成功|Suspended successfully/i),
+      page
+        .locator("[data-sonner-toast]")
+        .filter({ hasText: /封禁成功|Suspended successfully/i }),
     ).toBeVisible();
     await expect(
       dialog.getByRole("button", { name: /^(封禁|Suspend)$/i }),
@@ -621,6 +633,12 @@ test("/admin/moderation 可更新课程简介内容", async ({ page }, testInfo)
       (entry) => entry.id === description.id && entry.content === nextContent,
     ),
   ).toBe(true);
+
+  await expect(
+    page
+      .locator("[data-sonner-toast]")
+      .filter({ hasText: /课程简介已更新|Description updated/i }),
+  ).toBeVisible();
 
   await page.request.patch(`/api/admin/descriptions/${description.id}`, {
     data: { content: description.content ?? "" },

--- a/tests/e2e/src/app/admin/users/test.ts
+++ b/tests/e2e/src/app/admin/users/test.ts
@@ -308,6 +308,11 @@ test("/admin/users 可打开管理弹窗并保存姓名", async ({ page }, testI
     const save = await saveResponse;
     expect(save.status()).toBe(200);
     await expect(dialog).toBeHidden();
+    await expect(
+      page
+        .locator("[data-sonner-toast]")
+        .filter({ hasText: /更新成功|Updated successfully/i }),
+    ).toBeVisible();
     await captureStepScreenshot(page, testInfo, "admin-users-updated");
 
     await gotoAndWaitForReady(
@@ -407,6 +412,11 @@ test("/admin/users 可创建默认时长封禁并通过 API 解除", async ({
     expect(body.suspension?.reason).toBe(reason);
     expect(typeof body.suspension?.id).toBe("string");
     suspensionId = body.suspension?.id;
+    await expect(
+      page
+        .locator("[data-sonner-toast]")
+        .filter({ hasText: /封禁成功|Suspended successfully/i }),
+    ).toBeVisible();
     await captureStepScreenshot(page, testInfo, "admin-users-suspend-created");
 
     await gotoAndWaitForReady(

--- a/tests/e2e/src/app/courses/[jwId]/test.ts
+++ b/tests/e2e/src/app/courses/[jwId]/test.ts
@@ -373,6 +373,11 @@ test.describe("/catalog/courses/[jwId] 课程详情", () => {
         .filter({ hasText: body })
         .first();
       await expect(commentCard).toBeVisible();
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /评论已发布|Comment posted/i }),
+      ).toBeVisible();
       // comment.author.name visible
       await expect(
         commentCard.getByText(DEV_SEED.debugName).first(),
@@ -403,6 +408,11 @@ test.describe("/catalog/courses/[jwId] 课程详情", () => {
         .filter({ hasText: editedBody })
         .first();
       await expect(editedCommentCard).toBeVisible();
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /评论已更新|Comment updated/i }),
+      ).toBeVisible();
 
       // Delete
       await editedCommentCard.hover();
@@ -423,6 +433,11 @@ test.describe("/catalog/courses/[jwId] 课程详情", () => {
       await expect(dialog).toBeVisible();
       await dialog.getByRole("button", { name: /删除|Delete/i }).click();
       await deleteResponse;
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /评论已删除|Comment deleted/i }),
+      ).toBeVisible();
       await captureStepScreenshot(page, testInfo, "course/comment-deleted");
     } finally {
       await cleanupCommentsForE2e([commentId]);

--- a/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
+++ b/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
@@ -710,6 +710,7 @@ test.describe("仪表盘教学班订阅", () => {
             `${escapeForRegExp(DEV_SEED.course.nameCn)}|${escapeForRegExp(DEV_SEED.course.nameEn)}`,
           ),
         })
+        .filter({ visible: true })
         .first(),
     ).toBeVisible();
   });
@@ -843,6 +844,7 @@ test.describe("仪表盘教学班订阅", () => {
             `${escapeForRegExp(DEV_SEED.course.nameCn)}|${escapeForRegExp(DEV_SEED.course.nameEn)}`,
           ),
         })
+        .filter({ visible: true })
         .first(),
     ).toBeVisible();
 

--- a/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
+++ b/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
@@ -413,9 +413,10 @@ test.describe("仪表盘教学班订阅", () => {
     await expect(confirmDialog).not.toBeVisible();
     await expect(courseLink).toHaveCount(0);
     await expect(
-      page
-        .locator("[data-sonner-toast]")
-        .filter({ hasText: /已移除班级|Section removed/i }),
+      page.locator("[data-sonner-toast]").filter({
+        hasText:
+          /该教学班已从订阅列表中移除|This section has been removed from your Life@USTC subscriptions/i,
+      }),
     ).toBeVisible();
     await expect(
       page.locator('[data-slot="alert"][role="alert"]').filter({

--- a/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
+++ b/tests/e2e/src/app/dashboard/subscriptions/sections/test.ts
@@ -412,6 +412,17 @@ test.describe("仪表盘教学班订阅", () => {
     await unsubscribeResponse;
     await expect(confirmDialog).not.toBeVisible();
     await expect(courseLink).toHaveCount(0);
+    await expect(
+      page
+        .locator("[data-sonner-toast]")
+        .filter({ hasText: /已移除班级|Section removed/i }),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-slot="alert"][role="alert"]').filter({
+        hasText:
+          /该教学班已从订阅列表中移除|This section has been removed from your Life@USTC subscriptions/i,
+      }),
+    ).toHaveCount(0);
 
     await captureStepScreenshot(
       page,
@@ -677,6 +688,29 @@ test.describe("仪表盘教学班订阅", () => {
       .click();
     await subscribeResponse;
     await expect(quickAddDialog).not.toBeVisible();
+    await expect(
+      page.locator("[data-sonner-toast]").filter({
+        hasText:
+          /已新增 \d+ 个教学班订阅|Added \d+ new sections? to Life@USTC/i,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-slot="alert"][role="alert"]').filter({
+        hasText:
+          /已新增 \d+ 个教学班订阅|Added \d+ new sections? to Life@USTC/i,
+      }),
+    ).toHaveCount(0);
+    await waitForUiSettled(page);
+    await expect(
+      page
+        .getByTestId("subscription-course-link")
+        .filter({
+          hasText: new RegExp(
+            `${escapeForRegExp(DEV_SEED.course.nameCn)}|${escapeForRegExp(DEV_SEED.course.nameEn)}`,
+          ),
+        })
+        .first(),
+    ).toBeVisible();
   });
 
   test("单个添加弹窗在 320×568 视口保持关闭控件和操作区可达", async ({
@@ -788,13 +822,28 @@ test.describe("仪表盘教学班订阅", () => {
       .click();
 
     await expect(
-      page
-        .getByText(
+      page.locator("[data-sonner-toast]").filter({
+        hasText:
           /已新增 \d+ 个教学班订阅|Added \d+ new sections? to Life@USTC/i,
-        )
-        .first(),
+      }),
     ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.locator('[data-slot="alert"][role="alert"]').filter({
+        hasText:
+          /已新增 \d+ 个教学班订阅|Added \d+ new sections? to Life@USTC/i,
+      }),
+    ).toHaveCount(0);
     await waitForUiSettled(page);
+    await expect(
+      page
+        .getByTestId("subscription-course-link")
+        .filter({
+          hasText: new RegExp(
+            `${escapeForRegExp(DEV_SEED.course.nameCn)}|${escapeForRegExp(DEV_SEED.course.nameEn)}`,
+          ),
+        })
+        .first(),
+    ).toBeVisible();
 
     await captureStepScreenshot(
       page,

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -1482,6 +1482,11 @@ test.describe("/catalog/sections/[jwId] 班级详情页", () => {
       expect(createResponseBody.id).toBeTruthy();
       commentId = createResponseBody.id;
       await expect(page.getByText(body).first()).toBeVisible();
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /评论已发布|Comment posted/i }),
+      ).toBeVisible();
       await captureStepScreenshot(page, testInfo, "section/comment-posted");
 
       const commentCard = page
@@ -1518,6 +1523,11 @@ test.describe("/catalog/sections/[jwId] 班级详情页", () => {
       await expect(
         commentCard.getByRole("button", { name: /👍/ }),
       ).toBeVisible();
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /表情已更新|Reaction updated/i }),
+      ).toBeVisible();
       await captureStepScreenshot(page, testInfo, "section/comment-upvoted");
 
       // Edit comment (canEdit action)
@@ -1548,6 +1558,11 @@ test.describe("/catalog/sections/[jwId] 班级详情页", () => {
         .filter({ hasText: editedBody })
         .first();
       await expect(editedCommentCard).toBeVisible();
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /评论已更新|Comment updated/i }),
+      ).toBeVisible();
 
       // Reply (canReply action, comment.replies[])
       await editedCommentCard
@@ -1576,6 +1591,11 @@ test.describe("/catalog/sections/[jwId] 班级详情页", () => {
       expect(replyResponseBody.id).toBeTruthy();
       replyId = replyResponseBody.id;
       await expect(page.getByText(replyBody).first()).toBeVisible();
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /回复已发布|Reply posted/i }),
+      ).toBeVisible();
       await captureStepScreenshot(page, testInfo, "section/comment-replied");
 
       // Delete comment
@@ -1637,6 +1657,11 @@ test.describe("/catalog/sections/[jwId] 班级详情页", () => {
       await deleteResponse;
       await page.unroute("**/api/community/comments/**");
       await expect(editedCommentCard).toHaveCount(0);
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /评论已删除|Comment deleted/i }),
+      ).toBeVisible();
       await captureStepScreenshot(page, testInfo, "section/comment-deleted");
     } finally {
       await cleanupCommentsForE2e([replyId, commentId]);
@@ -1830,6 +1855,11 @@ test.describe("/catalog/sections/[jwId] 班级详情页", () => {
         .filter({ hasText: body })
         .first();
       await expect(commentCard).toBeVisible();
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /已可分享|is ready to share/i }),
+      ).toBeVisible();
       // comment.attachments[] filename/open action (comment.yml display.fields)
       await expect(
         commentCard

--- a/tests/e2e/src/app/settings/accounts/test.ts
+++ b/tests/e2e/src/app/settings/accounts/test.ts
@@ -209,6 +209,12 @@ test.describe("/account/settings/accounts 关联账号设置", () => {
           name: /断开连接|Disconnect/i,
         }),
       ).toHaveCount(0);
+      await expect(page).toHaveURL(/\/account\/settings\/accounts$/);
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /已断开连接|Disconnected/i }),
+      ).toBeVisible();
       await captureStepScreenshot(page, testInfo, "settings-accounts-unlinked");
     } finally {
       await deleteLinkedAccountFixture({ userId: user.id, provider });

--- a/tests/e2e/src/app/settings/authorizations/test.ts
+++ b/tests/e2e/src/app/settings/authorizations/test.ts
@@ -91,34 +91,32 @@ test.describe("/account/settings/authorizations OAuth 授权", () => {
       await dialog.getByRole("button", { name: /撤销|Revoke/i }).click();
 
       await expect(dialog).not.toBeVisible();
-      await expect(page).toHaveURL(
-        /\/account\/settings\/authorizations\?message=AuthorizationRevoked$/,
-      );
       const revokeSuccessText = /已撤销应用授权|Application access revoked/i;
-      const inlineSuccessAlert = page
-        .locator('[data-slot="alert"][role="alert"]')
-        .filter({ hasText: revokeSuccessText });
-      await expect(inlineSuccessAlert).toHaveCount(1);
+      await expect(page).toHaveURL(/\/account\/settings\/authorizations$/);
       await expect(
-        inlineSuccessAlert.getByRole("heading", {
-          name: revokeSuccessText,
-        }),
-      ).toBeVisible();
-
-      const notifications = page.getByRole("region", {
-        name: /Notifications/i,
-      });
-      await expect(
-        notifications
+        page
           .locator("[data-sonner-toast]")
           .filter({ hasText: revokeSuccessText }),
       ).toBeVisible();
+      await expect(
+        page
+          .locator('[data-slot="alert"][role="alert"]')
+          .filter({ hasText: revokeSuccessText }),
+      ).toHaveCount(0);
       await expect(region.getByText(name, { exact: true })).toHaveCount(0);
       await captureStepScreenshot(
         page,
         testInfo,
         "settings-authorizations-revoked",
       );
+      await page.reload({ waitUntil: "domcontentloaded" });
+      await expect(page).toHaveURL(/\/account\/settings\/authorizations$/);
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: revokeSuccessText }),
+      ).toHaveCount(0);
+      await expect(region.getByText(name, { exact: true })).toHaveCount(0);
     } finally {
       await deleteOAuthClientsByName(name);
     }

--- a/tests/e2e/src/app/settings/passkeys/test.ts
+++ b/tests/e2e/src/app/settings/passkeys/test.ts
@@ -49,7 +49,9 @@ test.describe("/account/settings/accounts 通行密钥", () => {
         .click();
 
       await expect(
-        passkeyCard.getByText(/通行密钥已添加|Passkey added/i),
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /通行密钥已添加|Passkey added/i }),
       ).toBeVisible();
       await expect(
         passkeyCard.getByLabel(/重命名 E2E laptop|Rename E2E laptop/i),
@@ -73,7 +75,9 @@ test.describe("/account/settings/accounts 通行密钥", () => {
         .getByRole("button", { name: /保存名称|Save name/i })
         .click();
       await expect(
-        passkeyCard.getByText(/通行密钥名称已更新|Passkey name updated/i),
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /通行密钥名称已更新|Passkey name updated/i }),
       ).toBeVisible();
       await expect(
         passkeyCard.getByLabel(
@@ -121,6 +125,11 @@ test.describe("/account/settings/accounts 通行密钥", () => {
       await dialog.getByRole("button", { name: /删除|Delete/i }).click();
       await expect(
         page.getByText(/尚未添加通行密钥|No passkeys yet/i),
+      ).toBeVisible();
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /通行密钥已删除|Passkey deleted/i }),
       ).toBeVisible();
     } finally {
       await deletePasskeysForUserFixture(user.id);

--- a/tests/e2e/src/app/settings/profile/test.ts
+++ b/tests/e2e/src/app/settings/profile/test.ts
@@ -16,7 +16,7 @@
  * - Unauthenticated → redirects to /signin
  * - Invalid username pattern → browser validation prevents submission
  * - Empty username → browser validation prevents submission
- * - Save success → toast with "Success" heading
+ * - Save success → one visible Sonner toast
  * - Name change persists across page reload
  */
 import { expect, test } from "@playwright/test";
@@ -71,9 +71,9 @@ test.describe("/account/settings/profile 个人资料设置", () => {
 
     const nameInput = page.locator("input#name");
     const saveButton = page.getByRole("button", { name: /保存|Save/i });
-    const successToast = page.getByRole("heading", {
-      name: /成功|Success/i,
-    });
+    const successToast = page
+      .locator("[data-sonner-toast]")
+      .filter({ hasText: /成功|Success|updated successfully/i });
     const originalName = await nameInput.inputValue();
     const newName = `e2e-${Date.now()}`;
 
@@ -86,6 +86,7 @@ test.describe("/account/settings/profile 个人资料设置", () => {
     await saveButton.click();
     await saveResponsePromise;
     await expect(successToast).toBeVisible();
+    await expect(page).toHaveURL(/\/account\/settings\/profile$/);
     await page.reload({ waitUntil: "domcontentloaded" });
     await expect(page.locator("input#name")).toHaveValue(newName, {
       timeout: 10_000,
@@ -101,6 +102,7 @@ test.describe("/account/settings/profile 个人资料设置", () => {
     await saveButton.click();
     await rollbackResponsePromise;
     await expect(successToast).toBeVisible();
+    await expect(page).toHaveURL(/\/account\/settings\/profile$/);
     await page.reload({ waitUntil: "domcontentloaded" });
     await expect(page.locator("input#name")).toHaveValue(originalName, {
       timeout: 10_000,

--- a/tests/e2e/src/app/settings/security/test.ts
+++ b/tests/e2e/src/app/settings/security/test.ts
@@ -68,14 +68,6 @@ test.describe("/account/settings/security 安全活动", () => {
         .locator("[data-sonner-toast]")
         .filter({ hasText: /日历链接已轮换|Calendar link rotated/i }),
     ).toBeVisible();
-    await expect(
-      page
-        .getByRole("region", {
-          name: /账户安全活动|Account security activity/i,
-        })
-        .getByText(/轮换日历令牌|Rotated calendar token/i)
-        .first(),
-    ).toBeVisible();
   });
 });
 

--- a/tests/e2e/src/app/settings/security/test.ts
+++ b/tests/e2e/src/app/settings/security/test.ts
@@ -62,12 +62,20 @@ test.describe("/account/settings/security 安全活动", () => {
         name: /确认轮换|Rotate link/i,
       })
       .click();
-    await expect(page).toHaveURL(
-      /\/account\/settings\/security\?message=CalendarTokenRotated$/,
-    );
-    await expect(page.getByRole("alert")).toContainText(
-      /日历链接已轮换|Calendar link rotated/i,
-    );
+    await expect(page).toHaveURL(/\/account\/settings\/security$/);
+    await expect(
+      page
+        .locator("[data-sonner-toast]")
+        .filter({ hasText: /日历链接已轮换|Calendar link rotated/i }),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByRole("region", {
+          name: /账户安全活动|Account security activity/i,
+        })
+        .getByText(/轮换日历令牌|Rotated calendar token/i)
+        .first(),
+    ).toBeVisible();
   });
 });
 

--- a/tests/e2e/src/app/teachers/[id]/test.ts
+++ b/tests/e2e/src/app/teachers/[id]/test.ts
@@ -367,6 +367,11 @@ test.describe("/catalog/teachers/[id] 教师详情页", () => {
         .filter({ hasText: body })
         .first();
       await expect(commentCard).toBeVisible();
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /评论已发布|Comment posted/i }),
+      ).toBeVisible();
       // comment.body
       await expect(commentCard.getByText(body).first()).toBeVisible();
       // comment.createdAt (timestamp text)
@@ -405,6 +410,11 @@ test.describe("/catalog/teachers/[id] 教师详情页", () => {
         .filter({ hasText: editedBody })
         .first();
       await expect(editedCommentCard).toBeVisible();
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /评论已更新|Comment updated/i }),
+      ).toBeVisible();
 
       // Delete
       await editedCommentCard.hover();
@@ -428,6 +438,11 @@ test.describe("/catalog/teachers/[id] 教师详情页", () => {
       await expect(dialog).toBeVisible();
       await dialog.getByRole("button", { name: /删除|Delete/i }).click();
       await deleteResponse;
+      await expect(
+        page
+          .locator("[data-sonner-toast]")
+          .filter({ hasText: /评论已删除|Comment deleted/i }),
+      ).toBeVisible();
       await captureStepScreenshot(page, testInfo, "teacher/comment-deleted");
     } finally {
       await cleanupCommentsForE2e([commentId]);

--- a/tests/unit/dashboard-nav.test.ts
+++ b/tests/unit/dashboard-nav.test.ts
@@ -22,7 +22,7 @@ describe("dashboardRedirectHrefFromHome", () => {
     );
 
     expect(dashboardRedirectHrefFromHome(url)).toBe(
-      "/workspace/overview?homeworkView=completed&removed=3",
+      "/workspace/overview?homeworkView=completed",
     );
   });
 });

--- a/tests/unit/layout-shell.test.ts
+++ b/tests/unit/layout-shell.test.ts
@@ -91,3 +91,23 @@ describe("mobile toast placement", () => {
     expect(sonner).toContain("pointer-events: auto;");
   });
 });
+
+describe("settings redirect success feedback", () => {
+  it("consumes redirect markers through SvelteKit navigation state", async () => {
+    const controller = await readFile(
+      resolve(
+        process.cwd(),
+        "src/features/settings/components/SettingsPageController.svelte",
+      ),
+      "utf8",
+    );
+
+    expect(controller).toContain(
+      'import { replaceState } from "$app/navigation";',
+    );
+    expect(controller).toContain('import { page } from "$app/stores";');
+    expect(controller).toContain('$page.url.searchParams.get("message")');
+    expect(controller).toContain("replaceState(nextUrl, {})");
+    expect(controller).not.toContain("window.history.replaceState");
+  });
+});

--- a/tests/unit/layout-shell.test.ts
+++ b/tests/unit/layout-shell.test.ts
@@ -107,6 +107,7 @@ describe("settings redirect success feedback", () => {
     );
     expect(controller).toContain('import { page } from "$app/stores";');
     expect(controller).toContain('$page.url.searchParams.get("message")');
+    expect(controller).toContain("_isMounted &&");
     expect(controller).toContain("replaceState(nextUrl, {})");
     expect(controller).not.toContain("window.history.replaceState");
   });

--- a/tests/unit/layout-shell.test.ts
+++ b/tests/unit/layout-shell.test.ts
@@ -108,6 +108,8 @@ describe("settings redirect success feedback", () => {
     expect(controller).toContain('import { page } from "$app/stores";');
     expect(controller).toContain('$page.url.searchParams.get("message")');
     expect(controller).toContain("_isMounted &&");
+    expect(controller).toContain("const mountTimer = setTimeout(() => {");
+    expect(controller).toContain("return () => clearTimeout(mountTimer);");
     expect(controller).toContain("replaceState(nextUrl, {})");
     expect(controller).not.toContain("window.history.replaceState");
   });


### PR DESCRIPTION
Closes #920. Consolidates persisted mutation success feedback into Sonner toasts, keeps inline alerts for errors and validation, removes obsolete imported/removed dashboard query success paths, clears transient subscription success messages, and adds localized E2E assertions. Checks: biome, tsc, svelte-check, vitest 372 files/2288 tests, build. Focused Playwright blocked by BetterAuth JWKS private-key decryption/secret mismatch before hydration.