### PR TITLE
fix(ui): redesign homework detail hierarchy

### DIFF
--- a/src/features/dashboard/components/HomeworkDetailActions.svelte
+++ b/src/features/dashboard/components/HomeworkDetailActions.svelte
@@ -11,7 +11,6 @@ import type {
 export let SelectedCompletionIcon: Component;
 export let homework: DashboardHomeworkDetailItem;
 export let homeworkCompletionActionLabel: DashboardHomeworkDetailAction;
-export let homeworkDetailHref: DashboardHomeworkDetailAction;
 export let homeworkSavingById: Record<string, boolean>;
 export let homeworkSectionHref: DashboardHomeworkDetailAction;
 export let homeworksCopy: DashboardHomeworkDetailCopy;
@@ -19,26 +18,25 @@ export let selectedCourseLabel: string;
 export let toggleHomeworkCompletion: DashboardHomeworkCompletionToggle;
 </script>
 
-<div class="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-  <Button class="w-full sm:w-auto" href={homeworkSectionHref(homework)} variant="outline">
-    {selectedCourseLabel}
+<div class="flex w-full flex-col gap-2 sm:flex-row sm:items-center">
+  <Button
+    class="w-full justify-start overflow-hidden sm:mr-auto sm:w-auto sm:max-w-[24rem]"
+    href={homeworkSectionHref(homework)}
+    variant="ghost"
+  >
+    <span class="truncate">{selectedCourseLabel}</span>
   </Button>
-  <div class="flex flex-col gap-2 sm:flex-row sm:justify-end">
-    <Button
-      class="w-full sm:w-auto"
-      disabled={homeworkSavingById[homework.id]}
-      type="button"
-      onclick={() => {
-        if (homework) toggleHomeworkCompletion(homework);
-      }}
-    >
-      <SelectedCompletionIcon data-icon="inline-start" />
-      {homeworkSavingById[homework.id]
-        ? homeworksCopy.saving
-        : homeworkCompletionActionLabel(homework)}
-    </Button>
-    <Button class="w-full sm:w-auto" href={homeworkDetailHref(homework)} variant="outline">
-      {homeworksCopy.viewDetails}
-    </Button>
-  </div>
+  <Button
+    class="w-full sm:w-auto"
+    disabled={homeworkSavingById[homework.id]}
+    type="button"
+    onclick={() => {
+      if (homework) toggleHomeworkCompletion(homework);
+    }}
+  >
+    <SelectedCompletionIcon data-icon="inline-start" />
+    {homeworkSavingById[homework.id]
+      ? homeworksCopy.saving
+      : homeworkCompletionActionLabel(homework)}
+  </Button>
 </div>

--- a/src/features/dashboard/components/HomeworkDetailActions.svelte
+++ b/src/features/dashboard/components/HomeworkDetailActions.svelte
@@ -20,14 +20,14 @@ export let toggleHomeworkCompletion: DashboardHomeworkCompletionToggle;
 
 <div class="flex w-full flex-col gap-2 sm:flex-row sm:items-center">
   <Button
-    class="w-full justify-start overflow-hidden sm:mr-auto sm:w-auto sm:max-w-[24rem]"
+    class="order-2 w-full justify-start overflow-hidden sm:order-1 sm:mr-auto sm:w-auto sm:max-w-[24rem]"
     href={homeworkSectionHref(homework)}
     variant="ghost"
   >
     <span class="truncate">{selectedCourseLabel}</span>
   </Button>
   <Button
-    class="w-full sm:w-auto"
+    class="order-1 w-full sm:order-2 sm:w-auto"
     disabled={homeworkSavingById[homework.id]}
     type="button"
     onclick={() => {

--- a/src/features/dashboard/components/HomeworkDetailDescription.svelte
+++ b/src/features/dashboard/components/HomeworkDetailDescription.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import MarkdownPreview from "$lib/components/MarkdownPreview.svelte";
-import * as Item from "$lib/components/ui/item/index.js";
 import type {
   DashboardHomeworkDetailCopy,
   DashboardHomeworkDetailItem,
@@ -11,15 +10,13 @@ export let homework: DashboardHomeworkDetailItem;
 export let homeworksCopy: DashboardHomeworkDetailCopy;
 </script>
 
-<Item.Root variant="outline" class="items-start">
-  <Item.Content class="min-w-0">
-    {#if homework.description}
-      <MarkdownPreview
-        content={homework.description}
-        remarkPlugins={campusReferenceMarkdownPlugins}
-      />
-    {:else}
-      <Item.Description>{homeworksCopy.descriptionEmpty}</Item.Description>
-    {/if}
-  </Item.Content>
-</Item.Root>
+<section class="min-w-0 text-sm leading-6">
+  {#if homework.description}
+    <MarkdownPreview
+      content={homework.description}
+      remarkPlugins={campusReferenceMarkdownPlugins}
+    />
+  {:else}
+    <p class="text-muted-foreground">{homeworksCopy.descriptionEmpty}</p>
+  {/if}
+</section>

--- a/src/features/dashboard/components/HomeworkDetailDialog.svelte
+++ b/src/features/dashboard/components/HomeworkDetailDialog.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import CheckCircleIcon from "@lucide/svelte/icons/check-circle";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
-import type { DashboardMyHomeworksCopy } from "@/features/dashboard/lib/dashboard-controller-types";
 import * as Dialog from "$lib/components/ui/dialog/index.js";
 import { ScrollArea } from "$lib/components/ui/scroll-area/index.js";
 import type {
@@ -13,8 +12,8 @@ import type {
   DashboardHomeworkDetailItem,
 } from "./dashboard-homework-detail-types";
 import HomeworkDetailActions from "./HomeworkDetailActions.svelte";
-import HomeworkDetailCommentsAside from "./HomeworkDetailCommentsAside.svelte";
 import HomeworkDetailDescription from "./HomeworkDetailDescription.svelte";
+import HomeworkDetailDiscussion from "./HomeworkDetailDiscussion.svelte";
 import HomeworkDetailMetadata from "./HomeworkDetailMetadata.svelte";
 
 export let CommentsPanel: DashboardHomeworkCommentsPanel;
@@ -22,13 +21,11 @@ export let CommentsPanel: DashboardHomeworkCommentsPanel;
 export let fmtDate: DashboardHomeworkDetailFormatter;
 export let homework: DashboardHomeworkDetailItem | null;
 export let homeworkCompletionActionLabel: DashboardHomeworkDetailAction;
-export let homeworkDetailHref: DashboardHomeworkDetailAction;
 export let homeworkEtaLabel: DashboardHomeworkDetailFormatter;
 export let homeworkCourseLabel: DashboardHomeworkDetailAction;
 export let homeworkSavingById: Record<string, boolean>;
 export let homeworkSectionHref: DashboardHomeworkDetailAction;
 export let homeworksCopy: DashboardHomeworkDetailCopy;
-export let homeworkCopy: DashboardMyHomeworksCopy;
 export let homeworkStatus: DashboardHomeworkDetailAction;
 export let onClose: () => void;
 export let toggleHomeworkCompletion: DashboardHomeworkCompletionToggle;
@@ -42,46 +39,37 @@ export let toggleHomeworkCompletion: DashboardHomeworkCompletionToggle;
     }}
   >
     <Dialog.Content
-      class="flex h-[calc(100dvh-2rem)] max-h-[calc(100dvh-2rem)] min-h-0 max-w-5xl flex-col gap-0 overflow-clip p-0 sm:h-[min(76vh,52rem)] sm:max-h-[min(76vh,52rem)] sm:max-w-5xl"
+      class="inset-0 flex h-dvh max-h-dvh w-screen max-w-none translate-x-0 translate-y-0 flex-col gap-0 overflow-clip rounded-none p-0 sm:top-1/2 sm:left-1/2 sm:h-[min(68vh,40rem)] sm:max-h-[min(68vh,40rem)] sm:w-[calc(100%-2rem)] sm:max-w-3xl sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-xl"
+      data-homework-id={homework.id}
     >
       {@const selectedCourseLabel = homeworkCourseLabel(homework)}
       {@const SelectedCompletionIcon = homework.completion ? RefreshCw : CheckCircleIcon}
-      <Dialog.Header class="shrink-0 px-5 pb-2 pt-4">
+      <Dialog.Header class="shrink-0 border-b px-6 py-5 pr-14">
         <Dialog.Title class="break-words">{homework.title}</Dialog.Title>
-        <Dialog.Description>
-          {selectedCourseLabel} · {homeworkCopy.due}:
-          {fmtDate(homework.submissionDueAt)}
-        </Dialog.Description>
+        <Dialog.Description>{selectedCourseLabel}</Dialog.Description>
       </Dialog.Header>
       <ScrollArea class="h-0 min-h-0 flex-1">
-        <div class="grid gap-5 px-5 py-4 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,24rem)]">
-          <div class="grid min-w-0 gap-4">
-            <HomeworkDetailDescription
-              {homework}
-              {homeworksCopy}
-            />
-
-            <HomeworkDetailMetadata
-              {fmtDate}
-              {homework}
-              {homeworkEtaLabel}
-              {homeworksCopy}
-              {homeworkStatus}
-            />
-          </div>
-          <HomeworkDetailCommentsAside
+        <div class="grid min-w-0 gap-6 px-6 py-6">
+          <HomeworkDetailMetadata
+            {fmtDate}
+            {homework}
+            {homeworkEtaLabel}
+            {homeworksCopy}
+            {homeworkStatus}
+          />
+          <HomeworkDetailDescription {homework} {homeworksCopy} />
+          <HomeworkDetailDiscussion
             {CommentsPanel}
             {homework}
             {homeworksCopy}
           />
         </div>
       </ScrollArea>
-      <Dialog.Footer class="mx-0 mb-0 shrink-0 p-4">
+      <Dialog.Footer class="mx-0 mb-0 shrink-0 rounded-none p-4 sm:rounded-b-xl sm:px-6">
         <HomeworkDetailActions
           {SelectedCompletionIcon}
           {homework}
           {homeworkCompletionActionLabel}
-          {homeworkDetailHref}
           {homeworkSavingById}
           {homeworkSectionHref}
           {homeworksCopy}

--- a/src/features/dashboard/components/HomeworkDetailDiscussion.svelte
+++ b/src/features/dashboard/components/HomeworkDetailDiscussion.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { commentTargetPermalinkBaseHref } from "@/features/comments/lib/comment-panel-controller";
-import { Separator } from "$lib/components/ui/separator/index.js";
 import type {
   DashboardHomeworkCommentsPanel,
   DashboardHomeworkDetailCopy,
@@ -20,16 +19,11 @@ $: permalinkBaseHref = homework.section?.jwId
   : null;
 </script>
 
-<aside class="min-w-0">
-  <Separator class="mb-5 lg:hidden" />
-  <div class="lg:grid lg:grid-cols-[auto_minmax(0,1fr)] lg:gap-5">
-    <Separator class="hidden lg:block" orientation="vertical" />
-    <div class="min-w-0">
-      <h3 class="font-semibold text-base">{homeworksCopy.commentsTitle}</h3>
-      <p class="mt-1 mb-3 text-muted-foreground text-sm">{homeworksCopy.commentsLabel}</p>
-      {#key `comments:homework:${homework.id}`}
-        <CommentsPanel {permalinkBaseHref} targetId={homework.id} targetType="homework" />
-      {/key}
-    </div>
+<section class="min-w-0 border-t pt-6">
+  <h3 class="font-semibold text-base">{homeworksCopy.commentsTitle}</h3>
+  <div class="mt-4">
+    {#key `comments:homework:${homework.id}`}
+      <CommentsPanel {permalinkBaseHref} targetId={homework.id} targetType="homework" />
+    {/key}
   </div>
-</aside>
+</section>

--- a/src/features/dashboard/components/HomeworkDetailMetadata.svelte
+++ b/src/features/dashboard/components/HomeworkDetailMetadata.svelte
@@ -15,27 +15,29 @@ export let homeworkStatus: DashboardHomeworkDetailAction;
 </script>
 
 <section class="grid gap-4 rounded-lg bg-muted/50 px-4 py-4">
-  <div class="flex items-start justify-between gap-4">
-    <div class="min-w-0">
-      <p class="text-muted-foreground text-xs">{homeworksCopy.submissionDue}</p>
-      <p class="mt-1 font-semibold text-base">{fmtDate(homework.submissionDueAt)}</p>
-      <p class="mt-1 text-muted-foreground text-sm">
-        {homeworkEtaLabel(homework.submissionDueAt)}
-      </p>
+  <dl class="grid gap-4">
+    <div class="flex items-start justify-between gap-4">
+      <div class="min-w-0">
+        <dt class="text-muted-foreground text-xs">{homeworksCopy.submissionDue}</dt>
+        <dd class="mt-1 font-semibold text-base">{fmtDate(homework.submissionDueAt)}</dd>
+        <dd class="mt-1 text-muted-foreground text-sm">
+          {homeworkEtaLabel(homework.submissionDueAt)}
+        </dd>
+      </div>
+      <Badge variant={homework.completion ? "default" : "secondary"}>
+        {homeworkStatus(homework)}
+      </Badge>
     </div>
-    <Badge variant={homework.completion ? "default" : "secondary"}>
-      {homeworkStatus(homework)}
-    </Badge>
-  </div>
 
-  <dl class="grid gap-3 border-t pt-4 sm:grid-cols-2">
-    <div>
-      <dt class="text-muted-foreground text-xs">{homeworksCopy.submissionStart}</dt>
-      <dd class="mt-1 font-medium text-sm">{fmtDate(homework.submissionStartAt)}</dd>
-    </div>
-    <div>
-      <dt class="text-muted-foreground text-xs">{homeworksCopy.homeworkPublishedAt}</dt>
-      <dd class="mt-1 font-medium text-sm">{fmtDate(homework.publishedAt)}</dd>
+    <div class="grid gap-3 border-t pt-4 sm:grid-cols-2">
+      <div>
+        <dt class="text-muted-foreground text-xs">{homeworksCopy.submissionStart}</dt>
+        <dd class="mt-1 font-medium text-sm">{fmtDate(homework.submissionStartAt)}</dd>
+      </div>
+      <div>
+        <dt class="text-muted-foreground text-xs">{homeworksCopy.homeworkPublishedAt}</dt>
+        <dd class="mt-1 font-medium text-sm">{fmtDate(homework.publishedAt)}</dd>
+      </div>
     </div>
   </dl>
 

--- a/src/features/dashboard/components/HomeworkDetailMetadata.svelte
+++ b/src/features/dashboard/components/HomeworkDetailMetadata.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
 import { Badge } from "$lib/components/ui/badge/index.js";
-import * as Item from "$lib/components/ui/item/index.js";
-import { Separator } from "$lib/components/ui/separator/index.js";
 import type {
   DashboardHomeworkDetailAction,
   DashboardHomeworkDetailCopy,
@@ -16,47 +14,37 @@ export let homeworksCopy: DashboardHomeworkDetailCopy;
 export let homeworkStatus: DashboardHomeworkDetailAction;
 </script>
 
-<Item.Root variant="muted" class="items-start">
-  <Item.Header>
-    <Item.Content>
-      <Item.Description>
-        {homeworksCopy.submissionDue}
-      </Item.Description>
-      <Item.Title>{fmtDate(homework.submissionDueAt)}</Item.Title>
-    </Item.Content>
-    <Item.Actions>
-      <Badge variant={homework.completion ? "default" : "secondary"}>
-        {homeworkStatus(homework)}
-      </Badge>
-    </Item.Actions>
-  </Item.Header>
-  <Item.Description>{homeworkEtaLabel(homework.submissionDueAt)}</Item.Description>
-  <Separator />
-  <Item.Group class="grid gap-3 sm:grid-cols-2">
-    <Item.Root variant="outline" size="sm">
-      <Item.Content>
-        <Item.Description>{homeworksCopy.submissionStart}</Item.Description>
-        <Item.Title>{fmtDate(homework.submissionStartAt)}</Item.Title>
-      </Item.Content>
-    </Item.Root>
-    <Item.Root variant="outline" size="sm">
-      <Item.Content>
-        <Item.Description>{homeworksCopy.homeworkPublishedAt}</Item.Description>
-        <Item.Title>{fmtDate(homework.publishedAt)}</Item.Title>
-      </Item.Content>
-    </Item.Root>
-  </Item.Group>
-</Item.Root>
+<section class="grid gap-4 rounded-lg bg-muted/50 px-4 py-4">
+  <div class="flex items-start justify-between gap-4">
+    <div class="min-w-0">
+      <p class="text-muted-foreground text-xs">{homeworksCopy.submissionDue}</p>
+      <p class="mt-1 font-semibold text-base">{fmtDate(homework.submissionDueAt)}</p>
+      <p class="mt-1 text-muted-foreground text-sm">
+        {homeworkEtaLabel(homework.submissionDueAt)}
+      </p>
+    </div>
+    <Badge variant={homework.completion ? "default" : "secondary"}>
+      {homeworkStatus(homework)}
+    </Badge>
+  </div>
 
-<div class="flex flex-wrap gap-2">
-  {#if homework.isMajor}
-    <Badge variant="secondary">
-      {homeworksCopy.tagMajor}
-    </Badge>
-  {/if}
-  {#if homework.requiresTeam}
-    <Badge variant="outline">
-      {homeworksCopy.tagTeam}
-    </Badge>
-  {/if}
-</div>
+  <dl class="grid gap-3 border-t pt-4 sm:grid-cols-2">
+    <div>
+      <dt class="text-muted-foreground text-xs">{homeworksCopy.submissionStart}</dt>
+      <dd class="mt-1 font-medium text-sm">{fmtDate(homework.submissionStartAt)}</dd>
+    </div>
+    <div>
+      <dt class="text-muted-foreground text-xs">{homeworksCopy.homeworkPublishedAt}</dt>
+      <dd class="mt-1 font-medium text-sm">{fmtDate(homework.publishedAt)}</dd>
+    </div>
+  </dl>
+
+  <div class="flex flex-wrap gap-2">
+    {#if homework.isMajor}
+      <Badge variant="secondary">{homeworksCopy.tagMajor}</Badge>
+    {/if}
+    {#if homework.requiresTeam}
+      <Badge variant="outline">{homeworksCopy.tagTeam}</Badge>
+    {/if}
+  </div>
+</section>

--- a/src/features/dashboard/components/HomeworksTab.svelte
+++ b/src/features/dashboard/components/HomeworksTab.svelte
@@ -76,7 +76,6 @@ export let isCreatingHomework: boolean;
 let fmtDate: HomeworkDateFormatter;
 let homeworkCompletionActionLabel: HomeworkAction;
 let homeworkCourseLabel: HomeworkAction;
-let homeworkDetailHref: HomeworkAction;
 let homeworkEtaLabel: HomeworkDateFormatter;
 let homeworkIsOverdue: HomeworkOverduePredicate;
 let homeworkSectionHref: HomeworkAction;
@@ -104,7 +103,6 @@ $: ({
   fmtDate,
   homeworkCompletionActionLabel,
   homeworkCourseLabel,
-  homeworkDetailHref,
   homeworkEtaLabel,
   homeworkIsOverdue,
   homeworkSectionHref,
@@ -197,9 +195,7 @@ $: ({
       bind:createHomeworkSubmissionStartAt
       {fmtDate}
       {homeworkCompletionActionLabel}
-      {homeworkCopy}
       {homeworkCourseLabel}
-      {homeworkDetailHref}
       {homeworkEtaLabel}
       {homeworksCopy}
       {homeworkSavingById}

--- a/src/features/dashboard/components/HomeworksTabDialogs.svelte
+++ b/src/features/dashboard/components/HomeworksTabDialogs.svelte
@@ -3,7 +3,6 @@ import type { SubmitFunction } from "@sveltejs/kit";
 import type {
   DashboardHomeworkItem,
   DashboardHomeworksCopy,
-  DashboardMyHomeworksCopy,
 } from "@/features/dashboard/lib/dashboard-controller-types";
 import { toShanghaiDateTimeLocalValue } from "@/lib/time/shanghai-format";
 import type {
@@ -36,9 +35,7 @@ export let createHomeworkSubmissionDueAt: string;
 export let createHomeworkSubmissionStartAt: string;
 export let fmtDate: DashboardHomeworkDetailFormatter;
 export let homeworkCompletionActionLabel: HomeworkAction;
-export let homeworkCopy: DashboardMyHomeworksCopy;
 export let homeworkCourseLabel: HomeworkAction;
-export let homeworkDetailHref: HomeworkAction;
 export let homeworkEtaLabel: DashboardHomeworkDetailFormatter;
 export let homeworksCopy: DashboardHomeworksCopy;
 export let homeworkSavingById: Record<string, boolean>;
@@ -88,13 +85,11 @@ export let toggleHomeworkCompletion: (
   {fmtDate}
   homework={selectedHomework}
   {homeworkCompletionActionLabel}
-  {homeworkDetailHref}
   {homeworkEtaLabel}
   {homeworkCourseLabel}
   {homeworkSavingById}
   {homeworkSectionHref}
   {homeworksCopy}
-  {homeworkCopy}
   {homeworkStatus}
   onClose={() => {
     selectedHomework = null;

--- a/src/features/dashboard/lib/homeworks-tab-display.ts
+++ b/src/features/dashboard/lib/homeworks-tab-display.ts
@@ -12,7 +12,6 @@ import {
 import {
   homeworkCompletionActionLabel as buildHomeworkCompletionActionLabel,
   homeworkCourseLabel as buildHomeworkCourseLabel,
-  homeworkDetailHref as buildHomeworkDetailHref,
   homeworkSectionHref as buildHomeworkSectionHref,
   homeworkSectionOptionLabel,
   homeworkStatusLabel,
@@ -68,8 +67,6 @@ export function createHomeworkTabDisplayActions({
       }),
     homeworkCourseLabel: (homework: DashboardHomeworkItem) =>
       buildHomeworkCourseLabel(homework, homeworkCopy.section),
-    homeworkDetailHref: (homework: DashboardHomeworkItem) =>
-      buildHomeworkDetailHref(homework, returnTo),
     homeworkEtaLabel: (value: Date | string | null | undefined) =>
       formatDashboardDueRelativeTime(
         value,

--- a/src/features/dashboard/lib/homeworks.ts
+++ b/src/features/dashboard/lib/homeworks.ts
@@ -1,5 +1,3 @@
-import { sectionDetailHomeworkPath } from "@/features/section-detail/lib/section-detail-tab";
-
 type HomeworkCompletionState = {
   completion?: unknown | null;
 };
@@ -39,17 +37,6 @@ export function homeworkSectionOptionLabel(
       .filter(Boolean)
       .join(" · ") || fallback
   );
-}
-
-export function homeworkDetailHref(
-  homework: HomeworkWithSection,
-  fallbackHref: string,
-) {
-  return homework.section?.jwId
-    ? sectionDetailHomeworkPath(homework.section.jwId, {
-        homeworkId: homework.id,
-      })
-    : fallbackHref;
 }
 
 export function homeworkSectionHref(

--- a/src/features/section-detail/components/SectionHomeworkActionBar.svelte
+++ b/src/features/section-detail/components/SectionHomeworkActionBar.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { Button } from "$lib/components/ui/button/index.js";
-import { Separator } from "$lib/components/ui/separator/index.js";
 import type {
   SectionHomeworkAction,
   SectionHomeworkCopy,
@@ -48,9 +47,7 @@ export let toggleHomeworkCompletion: SectionHomeworkAction;
       </div>
     {/if}
     {#if canManage}
-      <Separator class="sm:hidden" />
-      <Separator class="hidden sm:block" orientation="vertical" />
-      <div class="sm:ml-auto">
+      <div class="sm:ml-auto sm:pl-2">
         <Button
           class="w-full sm:w-auto"
           variant="destructive"

--- a/src/features/section-detail/components/SectionHomeworkAuditTrail.svelte
+++ b/src/features/section-detail/components/SectionHomeworkAuditTrail.svelte
@@ -20,36 +20,38 @@ export let logs: SectionHomeworkAuditLog[];
 </script>
 
 {#if logs.length > 0}
-  <Accordion.Root type="single">
-    <Accordion.Item value="history">
-      <Accordion.Trigger>{homeworkCopy.contentHistoryAction}</Accordion.Trigger>
-      <Accordion.Content>
-        <Item.Group>
-          {#each logs.slice(0, 5) as log}
-            <Item.Root
-              size="sm"
-              variant="muted"
-            >
-              <Item.Content class="min-w-0">
-                <Item.Title>{homeworkAuditActionLabel(log.action)}</Item.Title>
-                <Item.Description class="line-clamp-none">
-                  {log.titleSnapshot}
-                </Item.Description>
-              </Item.Content>
-              <Item.Actions>
-                {fmtDateTime(log.createdAt)}
-              </Item.Actions>
-              {#if log.actor}
-                <Item.Footer>
-                  {formatMessage(homeworkCopy.contentHistoryActor, {
-                    name: log.actor.name ?? log.actor.username ?? commonCopy.unknown,
-                  })}
-                </Item.Footer>
-              {/if}
-            </Item.Root>
-          {/each}
-        </Item.Group>
-      </Accordion.Content>
-    </Accordion.Item>
-  </Accordion.Root>
+  <section class="border-t pt-6">
+    <Accordion.Root type="single">
+      <Accordion.Item value="history">
+        <Accordion.Trigger>{homeworkCopy.contentHistoryAction}</Accordion.Trigger>
+        <Accordion.Content>
+          <Item.Group>
+            {#each logs.slice(0, 5) as log}
+              <Item.Root
+                size="sm"
+                variant="muted"
+              >
+                <Item.Content class="min-w-0">
+                  <Item.Title>{homeworkAuditActionLabel(log.action)}</Item.Title>
+                  <Item.Description class="line-clamp-none">
+                    {log.titleSnapshot}
+                  </Item.Description>
+                </Item.Content>
+                <Item.Actions>
+                  {fmtDateTime(log.createdAt)}
+                </Item.Actions>
+                {#if log.actor}
+                  <Item.Footer>
+                    {formatMessage(homeworkCopy.contentHistoryActor, {
+                      name: log.actor.name ?? log.actor.username ?? commonCopy.unknown,
+                    })}
+                  </Item.Footer>
+                {/if}
+              </Item.Root>
+            {/each}
+          </Item.Group>
+        </Accordion.Content>
+      </Accordion.Item>
+    </Accordion.Root>
+  </section>
 {/if}

--- a/src/features/section-detail/components/SectionHomeworkDetailDialog.svelte
+++ b/src/features/section-detail/components/SectionHomeworkDetailDialog.svelte
@@ -3,7 +3,6 @@ import type { Component } from "svelte";
 import { commentTargetPermalinkBaseHref } from "@/features/comments/lib/comment-panel-controller";
 import * as Dialog from "$lib/components/ui/dialog/index.js";
 import { ScrollArea } from "$lib/components/ui/scroll-area/index.js";
-import { Separator } from "$lib/components/ui/separator/index.js";
 import SectionHomeworkActionBar from "./SectionHomeworkActionBar.svelte";
 import SectionHomeworkAuditTrail from "./SectionHomeworkAuditTrail.svelte";
 import SectionHomeworkEditForm from "./SectionHomeworkEditForm.svelte";
@@ -69,18 +68,16 @@ export let sectionJwId: number | string;
     }}
   >
     <Dialog.Content
-      class="flex h-[calc(100dvh-2rem)] max-h-[calc(100dvh-2rem)] min-h-0 max-w-5xl flex-col gap-0 overflow-clip p-0 sm:h-[min(76vh,52rem)] sm:max-h-[min(76vh,52rem)] sm:max-w-5xl"
+      class="inset-0 flex h-dvh max-h-dvh w-screen max-w-none translate-x-0 translate-y-0 flex-col gap-0 overflow-clip rounded-none p-0 sm:top-1/2 sm:left-1/2 sm:h-[min(68vh,40rem)] sm:max-h-[min(68vh,40rem)] sm:w-[calc(100%-2rem)] sm:max-w-3xl sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-xl"
     >
-      <Dialog.Header class="shrink-0 px-5 pb-2 pt-4">
+      <Dialog.Header class="shrink-0 border-b px-6 py-5 pr-14">
         <Dialog.Title class="break-words">{_selectedHomework.title}</Dialog.Title>
-        <Dialog.Description>
-          {_sectionCopy.due} {_fmtDateTime(_selectedHomework.submissionDueAt)} · {_homeworkStatus(_selectedHomework)}
-        </Dialog.Description>
+        <Dialog.Description>{_homeworkStatus(_selectedHomework)}</Dialog.Description>
       </Dialog.Header>
 
       <ScrollArea class="h-0 min-h-0 flex-1">
-        <div class="grid min-w-0 gap-5 px-5 py-4 lg:grid-cols-[minmax(0,1fr)_auto_minmax(22rem,26rem)]">
-          <section class="grid gap-4">
+        <div class="grid min-w-0 gap-6 px-6 py-6">
+          <section class="grid gap-6">
             {#if _editingHomework}
               <SectionHomeworkEditForm
                 applyDueAtSemesterEnd={_applyEditDueAtSemesterEnd}
@@ -108,20 +105,9 @@ export let sectionJwId: number | string;
               />
             {/if}
 
-            <SectionHomeworkAuditTrail
-              commonCopy={_commonCopy}
-              fmtDateTime={_fmtDateTime}
-              formatMessage={_formatMessage}
-              homeworkAuditActionLabel={_homeworkAuditActionLabel}
-              homeworkCopy={_homeworkCopy}
-              logs={_auditLogsForHomework(_selectedHomework.id)}
-            />
           </section>
 
-          <Separator class="hidden lg:block" orientation="vertical" />
-
-          <section class="min-w-0">
-            <Separator class="mb-4 lg:hidden" />
+          <section class="min-w-0 border-t pt-6">
             {#key `comments:homework:${_selectedHomework.id}`}
               <CommentsPanel
                 permalinkBaseHref={commentTargetPermalinkBaseHref({
@@ -134,10 +120,19 @@ export let sectionJwId: number | string;
               />
             {/key}
           </section>
+
+          <SectionHomeworkAuditTrail
+            commonCopy={_commonCopy}
+            fmtDateTime={_fmtDateTime}
+            formatMessage={_formatMessage}
+            homeworkAuditActionLabel={_homeworkAuditActionLabel}
+            homeworkCopy={_homeworkCopy}
+            logs={_auditLogsForHomework(_selectedHomework.id)}
+          />
         </div>
       </ScrollArea>
       {#if _canWriteHomework || _canManageSelectedHomework}
-        <Dialog.Footer class="mx-0 mb-0 shrink-0 p-4">
+        <Dialog.Footer class="mx-0 mb-0 shrink-0 rounded-none p-4 sm:rounded-b-xl sm:px-6">
           <SectionHomeworkActionBar
             canManage={_canManageSelectedHomework}
             canWrite={_canWriteHomework}

--- a/src/features/section-detail/components/SectionHomeworkReadOnlySummary.svelte
+++ b/src/features/section-detail/components/SectionHomeworkReadOnlySummary.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import RenderedMarkdown from "$lib/components/RenderedMarkdown.svelte";
 import { Badge } from "$lib/components/ui/badge/index.js";
-import * as Item from "$lib/components/ui/item/index.js";
 import type {
   SectionHomeworkCopy,
   SectionHomeworkDisplay,
@@ -13,8 +12,8 @@ export let homework: SectionHomeworkDisplay;
 export let homeworkCopy: SectionHomeworkCopy;
 </script>
 
-<Item.Root variant="muted" class="items-start">
-  <Item.Content class="min-w-0">
+<section class="grid gap-6">
+  <div class="min-w-0 text-sm leading-6">
     {#if homework.description?.content}
       {#if homework.description.renderedHtml}
         <RenderedMarkdown html={homework.description.renderedHtml} />
@@ -31,27 +30,28 @@ export let homeworkCopy: SectionHomeworkCopy;
         {/await}
       {/if}
     {:else}
-      <Item.Description>{homeworkCopy.descriptionEmpty}</Item.Description>
+      <p class="text-muted-foreground">{homeworkCopy.descriptionEmpty}</p>
     {/if}
-  </Item.Content>
-</Item.Root>
+  </div>
 
-<dl class="grid gap-3 sm:grid-cols-3">
-  <Item.Root variant="outline" size="sm" class="block">
-    <dt class="text-muted-foreground text-xs">{homeworkCopy.publishedAt}</dt>
-    <dd class="mt-1 font-medium text-sm">{fmtDateTime(homework.publishedAt)}</dd>
-  </Item.Root>
-  <Item.Root variant="outline" size="sm" class="block">
-    <dt class="text-muted-foreground text-xs">{homeworkCopy.submissionStart}</dt>
-    <dd class="mt-1 font-medium text-sm">{fmtDateTime(homework.submissionStartAt)}</dd>
-  </Item.Root>
-  <Item.Root variant="outline" size="sm" class="block">
-    <dt class="text-muted-foreground text-xs">{homeworkCopy.submissionDue}</dt>
-    <dd class="mt-1 font-medium text-sm">{fmtDateTime(homework.submissionDueAt)}</dd>
-  </Item.Root>
-</dl>
-
-<div class="flex flex-wrap gap-2">
-  {#if homework.isMajor}<Badge variant="secondary">{homeworkCopy.tagMajor}</Badge>{/if}
-  {#if homework.requiresTeam}<Badge variant="outline">{homeworkCopy.tagTeam}</Badge>{/if}
-</div>
+  <div class="grid gap-4 rounded-lg bg-muted/50 px-4 py-4">
+    <div>
+      <p class="text-muted-foreground text-xs">{homeworkCopy.submissionDue}</p>
+      <p class="mt-1 font-semibold text-base">{fmtDateTime(homework.submissionDueAt)}</p>
+    </div>
+    <dl class="grid gap-3 border-t pt-4 sm:grid-cols-2">
+      <div>
+        <dt class="text-muted-foreground text-xs">{homeworkCopy.submissionStart}</dt>
+        <dd class="mt-1 font-medium text-sm">{fmtDateTime(homework.submissionStartAt)}</dd>
+      </div>
+      <div>
+        <dt class="text-muted-foreground text-xs">{homeworkCopy.publishedAt}</dt>
+        <dd class="mt-1 font-medium text-sm">{fmtDateTime(homework.publishedAt)}</dd>
+      </div>
+    </dl>
+    <div class="flex flex-wrap gap-2">
+      {#if homework.isMajor}<Badge variant="secondary">{homeworkCopy.tagMajor}</Badge>{/if}
+      {#if homework.requiresTeam}<Badge variant="outline">{homeworkCopy.tagTeam}</Badge>{/if}
+    </div>
+  </div>
+</section>

--- a/src/features/section-detail/components/SectionHomeworkReadOnlySummary.svelte
+++ b/src/features/section-detail/components/SectionHomeworkReadOnlySummary.svelte
@@ -35,18 +35,20 @@ export let homeworkCopy: SectionHomeworkCopy;
   </div>
 
   <div class="grid gap-4 rounded-lg bg-muted/50 px-4 py-4">
-    <div>
-      <p class="text-muted-foreground text-xs">{homeworkCopy.submissionDue}</p>
-      <p class="mt-1 font-semibold text-base">{fmtDateTime(homework.submissionDueAt)}</p>
-    </div>
-    <dl class="grid gap-3 border-t pt-4 sm:grid-cols-2">
+    <dl class="grid gap-4">
       <div>
-        <dt class="text-muted-foreground text-xs">{homeworkCopy.submissionStart}</dt>
-        <dd class="mt-1 font-medium text-sm">{fmtDateTime(homework.submissionStartAt)}</dd>
+        <dt class="text-muted-foreground text-xs">{homeworkCopy.submissionDue}</dt>
+        <dd class="mt-1 font-semibold text-base">{fmtDateTime(homework.submissionDueAt)}</dd>
       </div>
-      <div>
-        <dt class="text-muted-foreground text-xs">{homeworkCopy.publishedAt}</dt>
-        <dd class="mt-1 font-medium text-sm">{fmtDateTime(homework.publishedAt)}</dd>
+      <div class="grid gap-3 border-t pt-4 sm:grid-cols-2">
+        <div>
+          <dt class="text-muted-foreground text-xs">{homeworkCopy.submissionStart}</dt>
+          <dd class="mt-1 font-medium text-sm">{fmtDateTime(homework.submissionStartAt)}</dd>
+        </div>
+        <div>
+          <dt class="text-muted-foreground text-xs">{homeworkCopy.publishedAt}</dt>
+          <dd class="mt-1 font-medium text-sm">{fmtDateTime(homework.publishedAt)}</dd>
+        </div>
       </div>
     </dl>
     <div class="flex flex-wrap gap-2">

--- a/tests/e2e/src/app/dashboard/homeworks/test.ts
+++ b/tests/e2e/src/app/dashboard/homeworks/test.ts
@@ -13,7 +13,7 @@
  *
  * ## Features
  * - Desktop list rows expose a completion button; mobile uses cards
- * - "View details" link → /catalog/sections/{jwId}?homeworkId={id}#homework
+ * - Homework detail keeps completion and section navigation distinct
  * - Create homework button → modal form
  *
  * ## Edge Cases
@@ -291,9 +291,9 @@ test.describe("仪表盘作业", () => {
       if (!dialogBox || !footerBox) {
         throw new Error("Expected the mobile homework detail bounds");
       }
-      expect(dialogBox.y).toBeGreaterThanOrEqual(16);
+      expect(dialogBox.y).toBeGreaterThanOrEqual(0);
       expect(dialogBox.y + dialogBox.height).toBeLessThanOrEqual(
-        viewportHeight - 16,
+        viewportHeight,
       );
       expect(footerBox.y + footerBox.height).toBeLessThanOrEqual(
         viewportHeight,
@@ -303,21 +303,19 @@ test.describe("仪表盘作业", () => {
       const completion = footer.getByRole("button", {
         name: /标记为完成|Mark as complete/i,
       });
-      const details = footer.getByRole("link", {
-        name: /查看详情|View details/i,
-      });
-      for (const control of [completion, details]) {
+      const section = footer.locator('a[href*="/catalog/sections/"]').first();
+      for (const control of [completion, section]) {
         await expect(control).toBeVisible();
         const box = await control.boundingBox();
         expect(box).not.toBeNull();
         expect(box?.width ?? 0).toBeGreaterThanOrEqual(240);
       }
-      const [completionBox, detailsBox] = await Promise.all([
+      const [completionBox, sectionBox] = await Promise.all([
         completion.boundingBox(),
-        details.boundingBox(),
+        section.boundingBox(),
       ]);
       expect(completionBox?.y).toBeLessThan(
-        detailsBox?.y ?? Number.POSITIVE_INFINITY,
+        sectionBox?.y ?? Number.POSITIVE_INFINITY,
       );
       expect(
         await page.evaluate(
@@ -325,14 +323,8 @@ test.describe("仪表盘作业", () => {
         ),
       ).toBe(true);
 
-      const sectionLink = detailDialog
-        .locator('a[href*="homeworkId="]')
-        .first();
-      const href = await sectionLink.getAttribute("href");
-      homeworkId = href
-        ? (new URL(href, "http://localhost").searchParams.get("homeworkId") ??
-          undefined)
-        : undefined;
+      homeworkId =
+        (await detailDialog.getAttribute("data-homework-id")) ?? undefined;
     } finally {
       await cleanupHomeworksForE2e([homeworkId]);
     }
@@ -537,7 +529,9 @@ test.describe("仪表盘作业", () => {
     await captureStepScreenshot(page, testInfo, "homeworks/completion-error");
   });
 
-  test("查看详情链接到带作业锚点的班级页面", async ({ page }, testInfo) => {
+  test("作业详情链接到班级页面且不打开第二层详情", async ({
+    page,
+  }, testInfo) => {
     await signInAsDebugUser(page, "/workspace/homeworks");
     await ensureSeedSectionSubscription(page);
     await gotoAndWaitForReady(page, "/workspace/homeworks", {
@@ -561,16 +555,12 @@ test.describe("仪表盘作业", () => {
     const popout = page.locator('[data-slot="dialog-content"]').first();
     await expect(popout).toBeVisible();
     const sectionLink = popout
-      .locator(
-        `a[href*="/catalog/sections/${DEV_SEED.section.jwId}?homeworkId="][href$="#homework"]`,
-      )
+      .locator(`a[href="/catalog/sections/${DEV_SEED.section.jwId}"]`)
       .first();
     await expect(sectionLink).toBeVisible();
     await sectionLink.click();
 
-    await expect(page).toHaveURL(
-      /\/catalog\/sections\/\d+\?homeworkId=[^&#]+#homework$/,
-    );
+    await expect(page).toHaveURL(/\/catalog\/sections\/\d+$/);
     await captureStepScreenshot(page, testInfo, "homeworks/view-details");
   });
 

--- a/tests/e2e/src/app/dashboard/homeworks/test.ts
+++ b/tests/e2e/src/app/dashboard/homeworks/test.ts
@@ -759,14 +759,8 @@ test.describe("仪表盘作业", () => {
         "homeworks/created-full-fields",
       );
 
-      const sectionLink = detailDialog
-        .locator('a[href*="homeworkId="]')
-        .first();
-      const href = await sectionLink.getAttribute("href");
-      homeworkId = href
-        ? (new URL(href, "http://localhost").searchParams.get("homeworkId") ??
-          undefined)
-        : undefined;
+      homeworkId =
+        (await detailDialog.getAttribute("data-homework-id")) ?? undefined;
     } finally {
       await cleanupHomeworksForE2e([homeworkId]);
     }

--- a/tests/e2e/src/app/sections/[jwId]/test.ts
+++ b/tests/e2e/src/app/sections/[jwId]/test.ts
@@ -1098,9 +1098,9 @@ test.describe("/catalog/sections/[jwId] 班级详情页", () => {
       expect(footerBox).not.toBeNull();
       if (!dialogBox || !footerBox)
         throw new Error("Expected the mobile section homework dialog bounds");
-      expect(dialogBox.y).toBeGreaterThanOrEqual(16);
+      expect(dialogBox.y).toBeGreaterThanOrEqual(0);
       expect(dialogBox.y + dialogBox.height).toBeLessThanOrEqual(
-        viewportHeight - 16,
+        viewportHeight,
       );
       expect(footerBox.y + footerBox.height).toBeLessThanOrEqual(
         viewportHeight,


### PR DESCRIPTION
## Summary
- replace the nested-card homework pop-out with a focused, flat information hierarchy
- make homework detail full-screen on mobile and constrained on desktop, with sequential discussion and sticky actions
- remove the recursive dashboard “View details” action and align the section-detail workspace to the same composition
- keep audit history out of the layout when there is no history

## Validation
- `bunx svelte-check --tsconfig ./tsconfig.json` (0 errors; 5 pre-existing unused-export warnings)
- `bun run build`
- fresh Playwright Chromium visual QA at 1440×900 and 390×844 for dashboard and section homework detail
- no browser console errors during the captured flows

## Screenshots
Fresh captures are available locally in `/tmp/life-ustc-homework-audit/`.