### PR TITLE
fix(worker): refresh request IDs on cached SSR responses

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -86,6 +86,7 @@ function prepareCachedRepresentation(response) {
   headers.delete("Vary");
   headers.delete("Content-Length");
   headers.delete("x-request-id");
+  headers.delete(INTERNAL_REQUEST_ID_HEADER);
   return new Response(response.body, {
     headers,
     status: response.status,
@@ -128,7 +129,7 @@ class ScriptNonceRewriter {
   }
 }
 
-function personalizeCachedResponse(response) {
+function personalizeCachedResponse(response, requestId) {
   const nonce = createNonce();
   const headers = new Headers(response.headers);
   const csp = headers.get("Content-Security-Policy");
@@ -141,6 +142,8 @@ function personalizeCachedResponse(response) {
   headers.delete("Content-Length");
   headers.delete("ETag");
   headers.delete("Server-Timing");
+  headers.delete(INTERNAL_REQUEST_ID_HEADER);
+  headers.set("x-request-id", requestId);
   headers.set("Cache-Control", "private, no-store");
   headers.set("Cloudflare-CDN-Cache-Control", "no-store");
   headers.set("Vary", "Accept-Language, Cookie");
@@ -439,7 +442,7 @@ async function handleFetch(request, env, context, requestId, edgeObservation) {
       cf: { cacheKey: cacheUrl.pathname + cacheUrl.search },
     });
   return finish(
-    personalizeCachedResponse(response),
+    personalizeCachedResponse(response, requestId),
     "public-ssr-cache",
     normalizePublicSsrObservedRoute(new URL(request.url).pathname),
     resolveEdgeCacheOutcome(response),

--- a/tests/unit/worker-routing-entrypoint.test.ts
+++ b/tests/unit/worker-routing-entrypoint.test.ts
@@ -44,7 +44,7 @@ import {
   INTERNAL_REQUEST_ID_HEADER,
   normalizePublicSsrObservedRoute,
 } from "@/lib/log/worker-entrypoint-observability";
-import worker from "@/worker";
+import worker, { PublicSsr } from "@/worker";
 
 async function withHtmlRewriter<T>(callback: () => Promise<T>) {
   const globalScope = globalThis as typeof globalThis & {
@@ -250,6 +250,88 @@ describe("Worker routing entrypoint", () => {
         status: 200,
       }),
     );
+  });
+
+  it("does not store per-request ids in the shared cache representation", async () => {
+    appFetchMock.mockResolvedValue(
+      new Response(null, {
+        headers: {
+          "content-type": "text/html; charset=utf-8",
+          [INTERNAL_REQUEST_ID_HEADER]: "stale-internal-id",
+          "x-request-id": "stale-public-id",
+        },
+      }),
+    );
+
+    const cached = await new PublicSsr().fetch(
+      new Request("https://life-ustc.test/account/sign-in"),
+    );
+
+    expect(cached.headers.get("x-request-id")).toBeNull();
+    expect(cached.headers.get(INTERNAL_REQUEST_ID_HEADER)).toBeNull();
+  });
+
+  it("stamps each shared cache response with the current id and correlates one completion", async () => {
+    const cachedResponse = new Response(null, {
+      headers: {
+        "cf-cache-status": "HIT",
+        "content-type": "text/html; charset=utf-8",
+        [INTERNAL_REQUEST_ID_HEADER]: "stale-internal-id",
+        "x-request-id": "stale-public-id",
+      },
+    });
+    const publicSsrFetchMock = vi.fn().mockResolvedValue(cachedResponse);
+    const exports = {
+      PublicSsr: vi.fn(() => ({ fetch: publicSsrFetchMock })),
+    };
+    const context = { exports, waitUntil: vi.fn() };
+
+    const first = await withHtmlRewriter(() =>
+      worker.fetch(
+        new Request("https://life-ustc.test/account/sign-in", {
+          headers: {
+            accept: "text/html",
+            [INTERNAL_REQUEST_ID_HEADER]: "spoofed-internal-id",
+            "x-request-id": "spoofed-public-id",
+          },
+        }),
+        {},
+        context,
+      ),
+    );
+    const second = await withHtmlRewriter(() =>
+      worker.fetch(
+        new Request("https://life-ustc.test/account/sign-in", {
+          headers: {
+            accept: "text/html",
+            [INTERNAL_REQUEST_ID_HEADER]: "spoofed-internal-id-2",
+            "x-request-id": "spoofed-public-id-2",
+          },
+        }),
+        {},
+        context,
+      ),
+    );
+
+    const firstId = first.headers.get("x-request-id");
+    const secondId = second.headers.get("x-request-id");
+    expect(firstId).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(secondId).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(secondId).not.toBe(firstId);
+    expect(first.headers.get(INTERNAL_REQUEST_ID_HEADER)).toBeNull();
+    expect(second.headers.get(INTERNAL_REQUEST_ID_HEADER)).toBeNull();
+    expect(firstId).not.toMatch(/stale|spoofed/);
+    expect(secondId).not.toMatch(/stale|spoofed/);
+
+    const completions = logAppEventMock.mock.calls.filter(
+      ([, event]) => event === "edge.request.finish",
+    );
+    expect(completions).toHaveLength(2);
+    expect(completions.map(([, , fields]) => fields.requestId)).toEqual([
+      firstId,
+      secondId,
+    ]);
+    expect(publicSsrFetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("records one error completion before retaining the detailed worker error", async () => {


### PR DESCRIPTION
## Summary
- remove public and internal request IDs from cacheable SSR representations
- stamp each personalized cache HIT/MISS response with the current outer Worker request ID
- preserve CSP nonce replacement, locale/cache behavior, streaming, dynamic requests, and redirects
- cover shared-response reuse, stale/spoofed IDs, cache-boundary stripping, and one completion per request

## Validation
- bunx vitest run: 381 files / 2,385 tests passed
- focused Worker/observability tests: 21 tests passed
- svelte-check: 0 errors (5 existing warnings)
- all three TypeScript projects: passed
- biome check: passed (5 existing warnings)
- production build: passed
- wrangler deploy --dry-run: passed

No production logs, credentials, or raw request data are included.