### PR TITLE
fix(dev): load Prisma WASM through Vite

### DIFF
--- a/tests/unit/vite-prisma-wasm.test.ts
+++ b/tests/unit/vite-prisma-wasm.test.ts
@@ -11,7 +11,6 @@ describe("Vite Prisma WASM module handling", () => {
       {} as never,
       source,
       importer,
-      {} as never,
     );
 
     expect(resolved).toBe("\0life-ustc:prisma-wasm-module");
@@ -31,7 +30,6 @@ describe("Vite Prisma WASM module handling", () => {
         {} as never,
         "./query_compiler_fast_bg.wasm?module",
         "/workspace/src/generated/prisma/internal/class.ts",
-        {} as never,
       ),
     ).toEqual({
       id: "/workspace/src/generated/prisma/internal/query_compiler_fast_bg.wasm?module",

--- a/tests/unit/vite-prisma-wasm.test.ts
+++ b/tests/unit/vite-prisma-wasm.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { prismaWasmModulePlugin } from "../../vite.config";
+
+describe("Vite Prisma WASM module handling", () => {
+  test("serves the query compiler as a WebAssembly.Module in development", async () => {
+    const plugin = prismaWasmModulePlugin("serve");
+    const importer = "/workspace/src/generated/prisma/internal/class.ts";
+    const source = "./query_compiler_fast_bg.wasm?module";
+
+    const resolved = await plugin.resolveId?.call(
+      {} as never,
+      source,
+      importer,
+      {} as never,
+    );
+
+    expect(resolved).toBe("\0life-ustc:prisma-wasm-module");
+    const loaded = await plugin.load?.call({} as never, resolved as string);
+    expect(loaded).toContain('import { readFileSync } from "node:fs"');
+    expect(loaded).toContain("new WebAssembly.Module(readFileSync");
+    expect(loaded).toContain(
+      "/workspace/src/generated/prisma/internal/query_compiler_fast_bg.wasm",
+    );
+  });
+
+  test("leaves production WASM imports external for the Worker build", async () => {
+    const plugin = prismaWasmModulePlugin("build");
+
+    expect(
+      await plugin.resolveId?.call(
+        {} as never,
+        "./query_compiler_fast_bg.wasm?module",
+        "/workspace/src/generated/prisma/internal/class.ts",
+        {} as never,
+      ),
+    ).toEqual({
+      id: "/workspace/src/generated/prisma/internal/query_compiler_fast_bg.wasm?module",
+      external: true,
+    });
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,28 @@
 import "dotenv/config";
 import { copyFileSync, mkdirSync } from "node:fs";
 import { basename, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { rollupWasm } from "@ethercorps/sveltekit-og/plugin";
 import { sveltekit } from "@sveltejs/kit/vite";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 
-function prismaWasmModulePlugin() {
+const PRISMA_WASM_VIRTUAL_ID = "\0life-ustc:prisma-wasm-module";
+
+function prismaDevWasmModuleSource(wasmPath: string) {
+  return [
+    'import { readFileSync } from "node:fs";',
+    `export default new WebAssembly.Module(readFileSync(${JSON.stringify(wasmPath)}));`,
+  ].join("\n");
+}
+
+function resolvePrismaWasmPath(source: string, importer?: string) {
+  const withoutQuery = source.slice(0, -"?module".length);
+  if (!importer) return withoutQuery;
+  return fileURLToPath(new URL(withoutQuery, pathToFileURL(importer)));
+}
+
+export function prismaWasmModulePlugin(command: "build" | "serve"): Plugin {
   const wasmFile = "query_compiler_fast_bg.wasm";
   const wasmModuleSuffix = `${wasmFile}?module`;
   let resolvedWasmPath: string | null = null;
@@ -16,11 +32,16 @@ function prismaWasmModulePlugin() {
     enforce: "pre" as const,
     resolveId(source: string, importer?: string) {
       if (!source.endsWith(wasmModuleSuffix)) return null;
-      resolvedWasmPath = importer
-        ? new URL(source.slice(0, -"?module".length), `file://${importer}`)
-            .pathname
-        : source.slice(0, -"?module".length);
+      resolvedWasmPath = resolvePrismaWasmPath(source, importer);
+      if (command === "serve") {
+        return PRISMA_WASM_VIRTUAL_ID;
+      }
       return { id: `${resolvedWasmPath}?module`, external: true };
+    },
+    load(id: string) {
+      return id === PRISMA_WASM_VIRTUAL_ID && resolvedWasmPath
+        ? prismaDevWasmModuleSource(resolvedWasmPath)
+        : null;
     },
     generateBundle() {
       if (!resolvedWasmPath) return;
@@ -63,7 +84,7 @@ export default defineConfig(({ command }) => ({
     assetsInlineLimit: assetInlineDecision,
   },
   plugins: [
-    prismaWasmModulePlugin(),
+    prismaWasmModulePlugin(command),
     katexModernFontsPlugin(),
     rollupWasm(),
     tailwindcss(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { rollupWasm } from "@ethercorps/sveltekit-og/plugin";
 import { sveltekit } from "@sveltejs/kit/vite";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig, type Plugin } from "vite";
+import { defineConfig } from "vite";
 
 const PRISMA_WASM_VIRTUAL_ID = "\0life-ustc:prisma-wasm-module";
 
@@ -22,7 +22,7 @@ function resolvePrismaWasmPath(source: string, importer?: string) {
   return fileURLToPath(new URL(withoutQuery, pathToFileURL(importer)));
 }
 
-export function prismaWasmModulePlugin(command: "build" | "serve"): Plugin {
+export function prismaWasmModulePlugin(command: "build" | "serve") {
   const wasmFile = "query_compiler_fast_bg.wasm";
   const wasmModuleSuffix = `${wasmFile}?module`;
   let resolvedWasmPath: string | null = null;


### PR DESCRIPTION
Closes #873.

## Summary
- serve Prisma's generated query compiler as a dev-only virtual module that exports a compiled `WebAssembly.Module`
- retain the existing external/copy behavior for Cloudflare production builds
- cover development and production plugin resolution paths

## Verification
- `bunx biome check vite.config.ts tests/unit/vite-prisma-wasm.test.ts`
- `bunx vitest run tests/unit/vite-prisma-wasm.test.ts tests/unit/vite-font-assets.test.ts`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bun run build`
- actual Vite SSR load of `src/lib/db/prisma.ts` followed by `SELECT 1` returned `[{"ok":1}]`