### PR TITLE
fix(a11y): nest embedded Markdown headings

### DIFF
--- a/src/features/comments/server/serialized-comment-node.ts
+++ b/src/features/comments/server/serialized-comment-node.ts
@@ -1,5 +1,5 @@
 import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
-import { renderMarkdown } from "@/lib/components/markdown-preview-renderer";
+import { renderEmbeddedMarkdown } from "@/lib/components/markdown-preview-renderer";
 import { toShanghaiIsoString } from "@/lib/time/serialize-date-output";
 import { canViewerAccessCommentAttachment } from "./comment-attachment-access";
 import { canViewerWriteCommentInteraction } from "./comment-interaction-policy";
@@ -48,7 +48,7 @@ export function buildVisibleCommentNode({
   return {
     id: comment.id,
     body: comment.body,
-    renderedBody: renderMarkdown(comment.body, {
+    renderedBody: renderEmbeddedMarkdown(comment.body, {
       remarkPlugins: campusReferenceMarkdownPlugins,
     }),
     visibility: comment.visibility,

--- a/src/features/descriptions/server/description-payload.ts
+++ b/src/features/descriptions/server/description-payload.ts
@@ -8,7 +8,7 @@ import type {
   EditorSummary,
 } from "@/features/descriptions/lib/description-payload-types";
 import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
-import { renderMarkdown } from "@/lib/components/markdown-preview-renderer";
+import { renderEmbeddedMarkdown } from "@/lib/components/markdown-preview-renderer";
 
 export type {
   DescriptionData,
@@ -48,7 +48,7 @@ export function serializeDescriptionRecord(
   return {
     id: description.id,
     content: description.content ?? "",
-    renderedHtml: renderMarkdown(description.content ?? "", {
+    renderedHtml: renderEmbeddedMarkdown(description.content ?? "", {
       remarkPlugins: campusReferenceMarkdownPlugins,
     }),
     updatedAt: description.updatedAt

--- a/src/features/section-detail/server/section-detail-homework-data.ts
+++ b/src/features/section-detail/server/section-detail-homework-data.ts
@@ -1,7 +1,7 @@
 import { listSectionHomeworksWithAudit } from "@/features/homeworks/server/homework-list-read-model";
 import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import type { SectionDetailPageData } from "@/features/section-detail/lib/section-detail-controller-types";
-import { renderMarkdown } from "@/lib/components/markdown-preview-renderer";
+import { renderEmbeddedMarkdown } from "@/lib/components/markdown-preview-renderer";
 import {
   serializeDatesDeep,
   toShanghaiIsoString,
@@ -27,7 +27,7 @@ export async function getSectionHomeworkData(
         description: scopedHomework.description
           ? {
               ...scopedHomework.description,
-              renderedHtml: renderMarkdown(
+              renderedHtml: renderEmbeddedMarkdown(
                 scopedHomework.description.content ?? "",
                 { remarkPlugins: campusReferenceMarkdownPlugins },
               ),

--- a/src/lib/components/MarkdownPreview.svelte
+++ b/src/lib/components/MarkdownPreview.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { PluggableList } from "unified";
-import { renderMarkdown } from "$lib/components/markdown-preview-renderer";
+import { renderEmbeddedMarkdown } from "$lib/components/markdown-preview-renderer";
 import * as Empty from "$lib/components/ui/empty/index.js";
 import { cn } from "$lib/utils.js";
 import "$lib/components/markdown-preview.css";
@@ -14,7 +14,7 @@ let className = "";
 export { className as class };
 
 $: renderedHtml = content.trim()
-  ? renderMarkdown(content, { remarkPlugins })
+  ? renderEmbeddedMarkdown(content, { remarkPlugins })
   : "";
 </script>
 

--- a/src/lib/components/markdown-preview-heading-plugin.ts
+++ b/src/lib/components/markdown-preview-heading-plugin.ts
@@ -1,0 +1,10 @@
+import type { Heading, Root } from "mdast";
+import { visit } from "unist-util-visit";
+
+export function remarkShiftHeadings({ offset }: { offset: number }) {
+  return (tree: Root) => {
+    visit(tree, "heading", (node: Heading) => {
+      node.depth = Math.min(6, node.depth + offset) as Heading["depth"];
+    });
+  };
+}

--- a/src/lib/components/markdown-preview-plugins.ts
+++ b/src/lib/components/markdown-preview-plugins.ts
@@ -1,4 +1,5 @@
 export { remarkCalloutDirectives } from "./markdown-preview-directive-plugins";
+export { remarkShiftHeadings } from "./markdown-preview-heading-plugin";
 export {
   rehypeNormalizeMarkdownElements,
   remarkImageAttributes,

--- a/src/lib/components/markdown-preview-renderer.ts
+++ b/src/lib/components/markdown-preview-renderer.ts
@@ -13,6 +13,7 @@ import {
   remarkCalloutDirectives,
   remarkImageAttributes,
   remarkInlineExtensions,
+  remarkShiftHeadings,
 } from "./markdown-preview-plugins";
 import {
   markdownSanitizeSchema,
@@ -23,7 +24,12 @@ function normalizeMarkdownInput(value: string) {
   return value.replace(/^::::/gm, ":::");
 }
 
-function createProcessor(options: { remarkPlugins?: PluggableList } = {}) {
+type MarkdownRenderOptions = {
+  headingOffset?: number;
+  remarkPlugins?: PluggableList;
+};
+
+function createProcessor(options: MarkdownRenderOptions = {}) {
   const processor = unified()
     .use(remarkParse)
     .use(remarkGfm)
@@ -32,7 +38,8 @@ function createProcessor(options: { remarkPlugins?: PluggableList } = {}) {
     .use(remarkEmoji)
     .use(remarkCalloutDirectives)
     .use(remarkImageAttributes)
-    .use(remarkInlineExtensions);
+    .use(remarkInlineExtensions)
+    .use(remarkShiftHeadings, { offset: options.headingOffset ?? 0 });
 
   if (options.remarkPlugins?.length) {
     processor.use({ plugins: options.remarkPlugins });
@@ -51,14 +58,22 @@ const defaultProcessor = createProcessor();
 
 export function renderMarkdown(
   value: string,
-  options: { remarkPlugins?: PluggableList } = {},
+  options: MarkdownRenderOptions = {},
 ) {
   try {
-    const processor = options.remarkPlugins?.length
-      ? createProcessor(options)
-      : defaultProcessor;
+    const processor =
+      options.remarkPlugins?.length || options.headingOffset
+        ? createProcessor(options)
+        : defaultProcessor;
     return String(processor.processSync(normalizeMarkdownInput(value)));
   } catch {
     return "";
   }
+}
+
+export function renderEmbeddedMarkdown(
+  value: string,
+  options: Omit<MarkdownRenderOptions, "headingOffset"> = {},
+) {
+  return renderMarkdown(value, { ...options, headingOffset: 2 });
 }

--- a/tests/unit/markdown-renderer.test.ts
+++ b/tests/unit/markdown-renderer.test.ts
@@ -5,9 +5,24 @@ import {
   campusReferenceMarkdownPlugins,
   remarkCampusReferences,
 } from "@/features/markdown/lib/campus-reference-markdown";
-import { renderMarkdown } from "@/lib/components/markdown-preview-renderer";
+import {
+  renderEmbeddedMarkdown,
+  renderMarkdown,
+} from "@/lib/components/markdown-preview-renderer";
 
 describe("markdown 渲染器", () => {
+  it("preserves standalone headings and nests embedded headings below the host section", () => {
+    expect(renderMarkdown("# Page title")).toContain("<h1>Page title</h1>");
+
+    const embedded = renderEmbeddedMarkdown(
+      "# Embedded title\n\n## Subsection\n\n###### Deep heading",
+    );
+    expect(embedded).toContain("<h3>Embedded title</h3>");
+    expect(embedded).toContain("<h4>Subsection</h4>");
+    expect(embedded).toContain("<h6>Deep heading</h6>");
+    expect(embedded).not.toMatch(/<h1|<h2/);
+  });
+
   it("未注入特性插件时 campus 引用保持原样", () => {
     const html = renderMarkdown("See section#123 and teacher#456.");
 
@@ -50,5 +65,15 @@ describe("markdown 渲染器", () => {
     expect(description.content).toContain("<script>");
     expect(description.renderedHtml).toContain('href="/catalog/teachers/456"');
     expect(description.renderedHtml).not.toContain("<script>");
+  });
+
+  it("uses the embedded heading policy in serialized descriptions", () => {
+    const description = serializeDescriptionRecord({
+      id: "description-1",
+      content: "# Embedded title",
+    });
+
+    expect(description.renderedHtml).toContain("<h3>Embedded title</h3>");
+    expect(description.renderedHtml).not.toContain("<h1>");
   });
 });


### PR DESCRIPTION
Closes #872.

## Summary
- preserve standalone Markdown document heading levels
- shift headings in embedded descriptions, comments, homework content, and previews by two levels beneath their host section
- cap deeply nested headings at level six

## Verification
- `bunx biome check` on all touched files
- `bunx vitest run tests/unit` (381 files, 2385 tests)
- `bunx svelte-check --tsconfig ./tsconfig.json` (0 errors; 5 pre-existing warnings)
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`