### PR TITLE
chore(deps): upgrade Better Auth family to 1.7.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,11 +5,11 @@
     "": {
       "name": "life-ustc-server",
       "dependencies": {
-        "@better-auth/cimd": "1.7.0-rc.6",
-        "@better-auth/core": "1.7.0-rc.4",
-        "@better-auth/mcp": "1.7.0-rc.6",
-        "@better-auth/oauth-provider": "1.7.0-rc.4",
-        "@better-auth/passkey": "1.7.0-rc.6",
+        "@better-auth/cimd": "1.7.2",
+        "@better-auth/core": "1.7.2",
+        "@better-auth/mcp": "1.7.2",
+        "@better-auth/oauth-provider": "1.7.2",
+        "@better-auth/passkey": "1.7.2",
         "@escape.tech/graphql-armor": "3.2.0",
         "@ethercorps/sveltekit-og": "4.3.0",
         "@graphql-tools/executor": "1.5.7",
@@ -20,7 +20,7 @@
         "@prisma/adapter-pg": "7.9.1",
         "@prisma/client": "7.9.1",
         "@scalar/api-reference": "^1.66.1",
-        "better-auth": "1.7.0-rc.4",
+        "better-auth": "1.7.2",
         "clsx": "^2.1.1",
         "dataloader": "2.2.3",
         "dayjs": "^1.11.23",
@@ -85,13 +85,13 @@
     },
   },
   "patchedDependencies": {
-    "@better-auth/cimd@1.7.0-rc.6": "patches/@better-auth%2Fcimd@1.7.0-rc.6.patch",
+    "@better-auth/cimd@1.7.2": "patches/@better-auth%2Fcimd@1.7.2.patch",
   },
   "overrides": {
-    "@better-auth/core": "1.7.0-rc.4",
-    "@better-auth/oauth-provider": "1.7.0-rc.4",
+    "@better-auth/core": "1.7.2",
+    "@better-auth/oauth-provider": "1.7.2",
     "@hono/node-server": "1.19.15",
-    "better-auth": "1.7.0-rc.4",
+    "better-auth": "1.7.2",
     "body-parser": "2.3.0",
     "cookie": "0.7.2",
     "fast-uri": "3.1.5",
@@ -134,27 +134,27 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
-    "@better-auth/cimd": ["@better-auth/cimd@1.7.0-rc.6", "", { "peerDependencies": { "@better-auth/core": "^1.7.0-rc.6", "@better-auth/oauth-provider": "^1.7.0-rc.6", "better-auth": "^1.7.0-rc.6", "better-call": "1.4.0" } }, "sha512-+9Dzj5rKZswL8zlgtjcsh0YLOAtGcbqx7TDLk6sg5ipAvyzXW6/+vLmXSSmiRoURI0b37nffdHcTU1BvBm0Mnw=="],
+    "@better-auth/cimd": ["@better-auth/cimd@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/oauth-provider": "^1.7.2", "better-auth": "^1.7.2", "better-call": "1.4.0" } }, "sha512-kRp3EeQ58PODDR3udYM0tEhZdqckKBXMpDFkMJ/ykNlYCqSan9UHysM/JNHXio1QBrIGF437xmJYVLWSaQcagQ=="],
 
-    "@better-auth/core": ["@better-auth/core@1.7.0-rc.4", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.41.1", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.7", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-hkxBHcEXU6qxGd08ovBVuaSsENB78A45sclB5dEbohUMckkCbTab1eydGknsMF7SfE/vGcgPER5vzAQwNzP9oQ=="],
+    "@better-auth/core": ["@better-auth/core@1.7.2", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.41.1", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.4.0", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-j0nM4ygsWbF/fcYRoKtDn8gn8uLXkmC+075HqSqsJEAV828cJR9bvYBCUQ1zmxNyRBk6Iz/qXsA0Zm2oksiOTg=="],
 
-    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.7.0-rc.4", "", { "peerDependencies": { "@better-auth/core": "^1.7.0-rc.4", "@better-auth/utils": "0.4.2", "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0" }, "optionalPeers": ["drizzle-orm"] }, "sha512-UpBwR54jBJALnwqcezGS+CYj2i3qF6bl5PAzL8o0WDQleN6QHmqOC6fUHq8+las6R4Lj6BRozdUzbE4DaGusfg=="],
+    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0" }, "optionalPeers": ["drizzle-orm"] }, "sha512-A5wE10PIv3aS5LGePecEHntQylKy6OOF17B4dqlE0DwJeqU/IOBSd7/LZhMop9cNJ3WFjKMpazVSf91yYM/NFg=="],
 
-    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.7.0-rc.4", "", { "peerDependencies": { "@better-auth/core": "^1.7.0-rc.4", "@better-auth/utils": "0.4.2", "kysely": "^0.28.17 || ^0.29.0" }, "optionalPeers": ["kysely"] }, "sha512-JNApE34ATqfxMfOLyE+e4KwqZzg7ZkhcN4gnKNuLIQPq7ja/NTt5FnZCgbFCOviGmN5kfOWIvpRyp/hW+YjLjA=="],
+    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "kysely": "^0.28.17 || ^0.29.0" }, "optionalPeers": ["kysely"] }, "sha512-LYdSRLOvZiF+6S0UThu+wE/Qxsq9P2jQs7ZKkY6BIBJqUjYyxVDmi8HFcantBvWWW1/BeQCSsD7YVDG4gICMIQ=="],
 
-    "@better-auth/mcp": ["@better-auth/mcp@1.7.0-rc.6", "", { "dependencies": { "@better-auth/oauth-provider": "^1.7.0-rc.6", "jose": "^6.1.3" }, "peerDependencies": { "@better-auth/core": "^1.7.0-rc.6", "better-auth": "^1.7.0-rc.6", "better-call": "1.4.0" } }, "sha512-G7TDqRPpcsjqA9yHag326aka3fpuG0Z1IYyb9hWi/xx/EGW5wY1Hw05utHrUmTTx9DEaAXDmLBc5acgxuQZzTw=="],
+    "@better-auth/mcp": ["@better-auth/mcp@1.7.2", "", { "dependencies": { "@better-auth/oauth-provider": "^1.7.2", "jose": "^6.1.3" }, "peerDependencies": { "@better-auth/core": "^1.7.2", "better-auth": "^1.7.2", "better-call": "1.4.0" } }, "sha512-2Ge+r7OZyxHoZ+v5d7MBDaNhubNs8PW+HkIIrmb+zhIEqBZH47sqA1oGCbBXqVP4/J1ABei+mbF+uDumIOC39g=="],
 
-    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.7.0-rc.4", "", { "peerDependencies": { "@better-auth/core": "^1.7.0-rc.4", "@better-auth/utils": "0.4.2" } }, "sha512-/yIudwUCWRTEOyZteZ1dqa0cEk5/Dot4WiIw4TlMsGB2Rk0/HIVqtBULBWW551ihefWrz9AKGuFVtXQhRMXAZw=="],
+    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2" } }, "sha512-0q1SXMzm5esH9L0xVuM6IxCk59E4G+3HySX4My9gvEwqtmUobykn+iuc/si3Y4xwUO7JODqQ5o+/pPcLDDMIrA=="],
 
-    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.7.0-rc.4", "", { "peerDependencies": { "@better-auth/core": "^1.7.0-rc.4", "@better-auth/utils": "0.4.2", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-BRGwL0HfTa2hWW0WIHlsXpCBqwXVJUR6gQkaLA2Bm9a76KLaPVWLzigZJIfcVFZLaQJrFQ1ZdIh/zqbfC8m4Dw=="],
+    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-4879SmUWHUs0OYlvHoCFbycZ7i1bqytkcgAUdt9RLQMvZ5H3LRMTgax2YVlGZEXgwNjY/X7xAoXOecWLhlQWeA=="],
 
-    "@better-auth/oauth-provider": ["@better-auth/oauth-provider@1.7.0-rc.4", "", { "dependencies": { "jose": "^6.2.3", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.7.0-rc.4", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "better-auth": "^1.7.0-rc.4", "better-call": "1.3.7" } }, "sha512-7br1e+gJsFAC0EB4IDuEefF005CeaB8hbY59c8FMpcqiR5Vp+8mT2e8dmYSSjfH13Y34ObGR+ORI7mGQhzxlHQ=="],
+    "@better-auth/oauth-provider": ["@better-auth/oauth-provider@1.7.2", "", { "dependencies": { "jose": "^6.2.3", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "better-auth": "^1.7.2", "better-call": "1.4.0" } }, "sha512-td7FnUz3lLKXFXN+0RbZe3ygaHqxpRqDG+gxbfSZbztbVfG7vuZtR4ba3uccsodAw7anchhIg2xwVP1/zlcxcw=="],
 
-    "@better-auth/passkey": ["@better-auth/passkey@1.7.0-rc.6", "", { "dependencies": { "@simplewebauthn/browser": "^13.3.0", "@simplewebauthn/server": "^13.3.1", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.7.0-rc.6", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "better-auth": "^1.7.0-rc.6", "better-call": "1.4.0", "nanostores": "^1.0.1" } }, "sha512-a6m08OCO+1iG3BxBAk0/LAKeIN2Adev5bFoUCaSSbRH//ad11xkD1Kxsm3rhhuJeqbfe0M4GyMHLfHE56FPE1w=="],
+    "@better-auth/passkey": ["@better-auth/passkey@1.7.2", "", { "dependencies": { "@simplewebauthn/browser": "^13.3.0", "@simplewebauthn/server": "^13.3.1", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "better-auth": "^1.7.2", "better-call": "1.4.0", "nanostores": "^1.0.1" } }, "sha512-KBK852b+HsCdstVPPDHsuRa9Rc+7IEuRMPQboi/OXNOwgKL8GwHpzzWD2WhiT/FXJPrLCPh8vHJQfc1wdl5OZw=="],
 
-    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.7.0-rc.4", "", { "peerDependencies": { "@better-auth/core": "^1.7.0-rc.4", "@better-auth/utils": "0.4.2", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-SOmE17lirhGIXAJdvlThgNjt57Z98N5CewVFNRiPGHOv2w7llR3Fc6ASvoUTClB4pP0YyBjNZZwLVCwEoAKxwQ=="],
+    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-mXTr/83WrNWLrvzIjtgDgdu9iXhOcSG1+qBQOAKlbGSFiOB+z4IMRneQ2wmMOiB8mKY9qGkClVUjKRFXqtHnFQ=="],
 
-    "@better-auth/telemetry": ["@better-auth/telemetry@1.7.0-rc.4", "", { "peerDependencies": { "@better-auth/core": "^1.7.0-rc.4", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1" } }, "sha512-IZM3cDmLCbrmdRtBKEJtZ6Gqmfu2RBvai0DLEzXBs6/nTG5BVk3oz7JbcITAdE0AoMCV8rMdZJ3C1k/nIhZdDg=="],
+    "@better-auth/telemetry": ["@better-auth/telemetry@1.7.2", "", { "peerDependencies": { "@better-auth/core": "^1.7.2", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1" } }, "sha512-LcWu+O0zrxYDQj8E36vfkJwGPW4k9ZDA/rCo0zST6ihzL+juR7pBowoZIM9E6tK0Vit52mf6412bGT4XM4eTjQ=="],
 
     "@better-auth/utils": ["@better-auth/utils@0.4.2", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A=="],
 
@@ -986,9 +986,9 @@
 
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
-    "better-auth": ["better-auth@1.7.0-rc.4", "", { "dependencies": { "@better-auth/core": "1.7.0-rc.4", "@better-auth/drizzle-adapter": "1.7.0-rc.4", "@better-auth/kysely-adapter": "1.7.0-rc.4", "@better-auth/memory-adapter": "1.7.0-rc.4", "@better-auth/mongo-adapter": "1.7.0-rc.4", "@better-auth/prisma-adapter": "1.7.0-rc.4", "@better-auth/telemetry": "1.7.0-rc.4", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@noble/ciphers": "^2.2.0", "@noble/hashes": "^2.2.0", "better-call": "1.3.7", "defu": "^6.1.4", "jose": "^6.2.3", "kysely": "^0.28.17 || ^0.29.0", "nanostores": "^1.3.0", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4 || >=1.0.0-beta.1", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-1ONP6b9715zc/NqQV2LFpk7HYakjOUtPeXYuBI20ou6tY8zQ5VUYQYJ65GBXnDYDua9CSrre9CbuYkZ8FpnzfQ=="],
+    "better-auth": ["better-auth@1.7.2", "", { "dependencies": { "@better-auth/core": "1.7.2", "@better-auth/drizzle-adapter": "1.7.2", "@better-auth/kysely-adapter": "1.7.2", "@better-auth/memory-adapter": "1.7.2", "@better-auth/mongo-adapter": "1.7.2", "@better-auth/prisma-adapter": "1.7.2", "@better-auth/telemetry": "1.7.2", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@noble/ciphers": "^2.2.0", "@noble/hashes": "^2.2.0", "better-call": "1.4.0", "defu": "^6.1.4", "jose": "^6.2.3", "kysely": "^0.28.17 || ^0.29.0", "nanostores": "^1.3.0", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4 || >=1.0.0-beta.1", "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-gKapKBEvYIGcMxi74RjQ7EbFLiqyQt58vdoJmL1qAlWSkY1Bc2Vqshl524/3u1NxauiOU03M/Ebh762Brmac9A=="],
 
-    "better-call": ["better-call@1.3.7", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w=="],
+    "better-call": ["better-call@1.4.0", "", { "dependencies": { "@better-auth/utils": "^0.5.0", "@better-fetch/fetch": "^1.3.1", "rou3": "^0.9.1", "set-cookie-parser": "^3.1.2" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-bBKOT4vv1kZLDgxVePdilk/Jwkn+dtRRsmi3DzHcDP+WnswyVl6dR59l2HEeP/0cB+bDoopASAesWDPIdd/zZA=="],
 
     "better-result": ["better-result@2.9.2", "", {}, "sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q=="],
 
@@ -1970,7 +1970,7 @@
 
     "rolldown": ["rolldown@1.2.4", "", { "dependencies": { "@oxc-project/types": "=0.144.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.4", "@rolldown/binding-darwin-arm64": "1.2.4", "@rolldown/binding-darwin-x64": "1.2.4", "@rolldown/binding-freebsd-x64": "1.2.4", "@rolldown/binding-linux-arm-gnueabihf": "1.2.4", "@rolldown/binding-linux-arm64-gnu": "1.2.4", "@rolldown/binding-linux-arm64-musl": "1.2.4", "@rolldown/binding-linux-ppc64-gnu": "1.2.4", "@rolldown/binding-linux-s390x-gnu": "1.2.4", "@rolldown/binding-linux-x64-gnu": "1.2.4", "@rolldown/binding-linux-x64-musl": "1.2.4", "@rolldown/binding-openharmony-arm64": "1.2.4", "@rolldown/binding-win32-arm64-msvc": "1.2.4", "@rolldown/binding-win32-x64-msvc": "1.2.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w=="],
 
-    "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
+    "rou3": ["rou3@0.9.2", "", {}, "sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
@@ -2304,8 +2304,6 @@
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "@better-auth/oauth-provider/jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
-
     "@commitlint/is-ignored/semver": ["semver@7.8.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ=="],
 
     "@commitlint/parse/conventional-changelog-angular": ["conventional-changelog-angular@9.2.1", "", { "dependencies": { "@conventional-changelog/template": "^1.2.1" } }, "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw=="],
@@ -2400,7 +2398,9 @@
 
     "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
-    "better-auth/jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+    "better-call/@better-auth/utils": ["@better-auth/utils@0.5.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-BL8W4EfIZFwlu0r54m3v1ztjDhu6dDe/amLTm0xybmbZaNgYUqhD3SjpAsnq0q8YD6/ki4iwIgxJNLP/N3TxiA=="],
+
+    "better-call/set-cookie-parser": ["set-cookie-parser@3.1.2", "", {}, "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "bun": ">=1.3.13 <1.4"
   },
   "overrides": {
-    "@better-auth/core": "1.7.0-rc.4",
-    "@better-auth/oauth-provider": "1.7.0-rc.4",
+    "@better-auth/core": "1.7.2",
+    "@better-auth/oauth-provider": "1.7.2",
     "@hono/node-server": "1.19.15",
-    "better-auth": "1.7.0-rc.4",
+    "better-auth": "1.7.2",
     "body-parser": "2.3.0",
     "cookie": "0.7.2",
     "fast-uri": "3.1.5",
@@ -48,11 +48,11 @@
     "release": "semantic-release"
   },
   "dependencies": {
-    "@better-auth/cimd": "1.7.0-rc.6",
-    "@better-auth/core": "1.7.0-rc.4",
-    "@better-auth/mcp": "1.7.0-rc.6",
-    "@better-auth/oauth-provider": "1.7.0-rc.4",
-    "@better-auth/passkey": "1.7.0-rc.6",
+    "@better-auth/cimd": "1.7.2",
+    "@better-auth/core": "1.7.2",
+    "@better-auth/mcp": "1.7.2",
+    "@better-auth/oauth-provider": "1.7.2",
+    "@better-auth/passkey": "1.7.2",
     "@escape.tech/graphql-armor": "3.2.0",
     "@ethercorps/sveltekit-og": "4.3.0",
     "@graphql-tools/executor": "1.5.7",
@@ -63,7 +63,7 @@
     "@prisma/adapter-pg": "7.9.1",
     "@prisma/client": "7.9.1",
     "@scalar/api-reference": "^1.66.1",
-    "better-auth": "1.7.0-rc.4",
+    "better-auth": "1.7.2",
     "clsx": "^2.1.1",
     "dataloader": "2.2.3",
     "dayjs": "^1.11.23",
@@ -126,6 +126,6 @@
     "zod-openapi": "^6.0.1"
   },
   "patchedDependencies": {
-    "@better-auth/cimd@1.7.0-rc.6": "patches/@better-auth%2Fcimd@1.7.0-rc.6.patch"
+    "@better-auth/cimd@1.7.2": "patches/@better-auth%2Fcimd@1.7.2.patch"
   }
 }

--- a/patches/@better-auth%2Fcimd@1.7.2.patch
+++ b/patches/@better-auth%2Fcimd@1.7.2.patch
@@ -1,13 +1,8 @@
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 2b6db54..e9751ae 100644
+index ac68cec8c447860f5b9d6151152dd98351d10475..b85f9783e78aa5dac8fb891ad754cae7fa3862c7 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -102,10 +102,18 @@ function validateCimdMetadata(clientIdUrl, raw, options = {}) {
- 		valid: false,
- 		error: `client_id "${String(doc.client_id)}" does not match the metadata document URL`
- 	};
--	if (options.metadataProfile === "mcp-2026-07-28" && !doc.client_name?.trim()) return {
-+	if (!doc.client_name?.trim()) return {
+@@ -106,6 +106,14 @@ function validateCimdMetadata(clientIdUrl, raw, options = {}) {
  		valid: false,
  		error: "client_name must be a non-empty string"
  	};
@@ -22,8 +17,7 @@ index 2b6db54..e9751ae 100644
  	for (const field of ["backchannel_logout_uri", "backchannel_logout_session_required"]) if (doc[field] !== void 0) return {
  		valid: false,
  		error: `metadata document MUST NOT contain "${field}"`
-@@ -402,7 +410,9 @@ async function persistMetadataDocumentClient(ctx, clientIdUrl, metadata, cimdOpt
- 		clientId: clientIdUrl,
+@@ -403,6 +411,8 @@ async function persistMetadataDocumentClient(ctx, clientIdUrl, metadata, cimdOpt
  		clientDiscoveryId: CIMD_CLIENT_DISCOVERY_ID,
  		metadata: {
  			...metadata,

--- a/src/lib/auth/better-auth-oauth-provider-plugin.ts
+++ b/src/lib/auth/better-auth-oauth-provider-plugin.ts
@@ -49,10 +49,6 @@ export function buildOAuthProviderPlugin(input: { authPublicOrigin: string }) {
     resources,
     cachedResources: new Set(resources.map(({ identifier }) => identifier)),
     enforcePerClientResources: false,
-    silenceWarnings: {
-      oauthAuthServerConfig: true,
-      openidConfig: true,
-    },
     schema: {
       oauthClient: {
         modelName: "OAuthClient",

--- a/src/lib/auth/better-auth-security-hooks.ts
+++ b/src/lib/auth/better-auth-security-hooks.ts
@@ -346,7 +346,7 @@ async function auditEndpointResult(context: GenericEndpointContext) {
   const path = context.path;
   const action = actionForPath(path);
   if (!action) return;
-  const returned = context.context.returned;
+  const returned = (context.context as { returned?: unknown }).returned;
   const failed = isAPIError(returned);
 
   // Successful core mutations are emitted by committed database after hooks.

--- a/tests/unit/oauth-cimd-plugin.test.ts
+++ b/tests/unit/oauth-cimd-plugin.test.ts
@@ -1,6 +1,8 @@
 import { validateCimdMetadata } from "@better-auth/cimd";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const mcpMetadataOptions = { metadataProfile: "mcp-2026-07-28" } as const;
+
 describe("Better Auth CIMD plugin", () => {
   afterEach(() => {
     vi.resetModules();
@@ -11,21 +13,29 @@ describe("Better Auth CIMD plugin", () => {
     const clientId = "https://client.example/oauth.json";
 
     expect(
-      validateCimdMetadata(clientId, {
-        client_id: clientId,
-        redirect_uris: ["https://client.example/callback"],
-      }),
+      validateCimdMetadata(
+        clientId,
+        {
+          client_id: clientId,
+          redirect_uris: ["https://client.example/callback"],
+        },
+        mcpMetadataOptions,
+      ),
     ).toEqual({
       error: "client_name must be a non-empty string",
       valid: false,
     });
 
     expect(
-      validateCimdMetadata(clientId, {
-        client_id: clientId,
-        client_name: "Example MCP Client",
-        redirect_uris: ["https://client.example/callback"],
-      }),
+      validateCimdMetadata(
+        clientId,
+        {
+          client_id: clientId,
+          client_name: "Example MCP Client",
+          redirect_uris: ["https://client.example/callback"],
+        },
+        mcpMetadataOptions,
+      ),
     ).toMatchObject({ valid: true });
   });
 
@@ -33,12 +43,16 @@ describe("Better Auth CIMD plugin", () => {
     const clientId = "https://client.example/dpop-oauth.json";
 
     expect(
-      validateCimdMetadata(clientId, {
-        client_id: clientId,
-        client_name: "DPoP-only Client",
-        dpop_bound_access_tokens: true,
-        redirect_uris: ["https://client.example/callback"],
-      }),
+      validateCimdMetadata(
+        clientId,
+        {
+          client_id: clientId,
+          client_name: "DPoP-only Client",
+          dpop_bound_access_tokens: true,
+          redirect_uris: ["https://client.example/callback"],
+        },
+        mcpMetadataOptions,
+      ),
     ).toEqual({
       error:
         "DPoP-bound access tokens are not supported by this Bearer-only resource server",
@@ -50,26 +64,34 @@ describe("Better Auth CIMD plugin", () => {
     const clientId = "https://vscode.dev/oauth/client-metadata.json";
 
     expect(
-      validateCimdMetadata(clientId, {
-        client_id: clientId,
-        client_name: "Visual Studio Code",
-        redirect_uris: ["http://127.0.0.1:33418"],
-        grant_types: [
-          "authorization_code",
-          "refresh_token",
-          "urn:ietf:params:oauth:grant-type:device_code",
-        ],
-        response_types: ["code"],
-      }),
+      validateCimdMetadata(
+        clientId,
+        {
+          client_id: clientId,
+          client_name: "Visual Studio Code",
+          redirect_uris: ["http://127.0.0.1:33418"],
+          grant_types: [
+            "authorization_code",
+            "refresh_token",
+            "urn:ietf:params:oauth:grant-type:device_code",
+          ],
+          response_types: ["code"],
+        },
+        mcpMetadataOptions,
+      ),
     ).toMatchObject({ valid: true });
 
     expect(
-      validateCimdMetadata(clientId, {
-        client_id: clientId,
-        client_name: "Device-only client",
-        redirect_uris: ["http://127.0.0.1:33418"],
-        grant_types: ["urn:ietf:params:oauth:grant-type:device_code"],
-      }),
+      validateCimdMetadata(
+        clientId,
+        {
+          client_id: clientId,
+          client_name: "Device-only client",
+          redirect_uris: ["http://127.0.0.1:33418"],
+          grant_types: ["urn:ietf:params:oauth:grant-type:device_code"],
+        },
+        mcpMetadataOptions,
+      ),
     ).toMatchObject({
       error: 'grant_types must include "authorization_code"',
       valid: false,


### PR DESCRIPTION
## Summary
- upgrade the Better Auth core, OAuth provider, MCP, passkey, CIMD, and `better-auth` packages together to 1.7.2
- update the CIMD patch to the stable package while retaining the Bearer-only code-flow policy and persisted grant/response filtering
- make CIMD tests pass the explicit MCP metadata profile
- adapt the OAuth provider configuration and security hook typing to the 1.7.2 APIs

This supersedes Dependabot #918 and #911. The packages are kept on one release family because the stable packages require matching 1.7.2 peers.

## Validation
- `bun install --frozen-lockfile`
- `bun run app:prepare`
- `bunx wrangler types --include-runtime=false --check`
- `bunx biome check`
- `bunx svelte-check --tsconfig ./tsconfig.json` (0 errors; existing warnings only)
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx vitest run` (381 files, 2383 tests)
- Better Auth integration: `tests/integration/oauth-cimd-registration.test.ts` (5 tests)
- focused Better Auth unit suite (7 files, 44 tests)
- `bun run openapi:check`
- `git diff --check`
