### PR TITLE
fix(a11y): raise Bot bubble contrast

### DIFF
--- a/src/features/usage/components/UsageGuidePage.svelte
+++ b/src/features/usage/components/UsageGuidePage.svelte
@@ -73,8 +73,10 @@ $: iconTone =
   }
 
   .imessage-outgoing {
+    --imessage-outgoing-background: #0071e3;
+
     border-radius: 1.15rem 1.15rem 0.35rem 1.15rem;
-    background: #0a84ff;
+    background: var(--imessage-outgoing-background);
     color: white;
   }
 
@@ -84,7 +86,7 @@ $: iconTone =
     bottom: 0;
     width: 0.75rem;
     height: 0.85rem;
-    background: #0a84ff;
+    background: var(--imessage-outgoing-background);
     clip-path: polygon(0 0, 100% 100%, 0 100%);
     content: "";
   }


### PR DESCRIPTION
Closes #868.

## Summary
- darken the scoped iMessage-style outgoing bubble color from `#0a84ff` to `#0071e3`
- share the color through a component-scoped custom property so the bubble and tail cannot diverge

## Verification
- `bunx biome check src/features/usage/components/UsageGuidePage.svelte`
- `bunx svelte-check --tsconfig ./tsconfig.json` (0 errors; 5 pre-existing warnings)
- Playwright computed all four outgoing bubbles as white on `rgb(0, 113, 227)` in light and dark modes: 4.70:1 contrast, above the WCAG AA 4.5:1 threshold