### PR TITLE
chore(ci): update OpenAPI action contract

### DIFF
--- a/.github/workflows/openapi-compatibility.yml
+++ b/.github/workflows/openapi-compatibility.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Block unapproved breaking changes
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'api-breaking-approved') }}
-        uses: oasdiff/oasdiff-action/breaking@033c15c845bef10f148afb0fa781bf1b2a7fe1bf # v0.1.12
+        uses: oasdiff/oasdiff-action/breaking@2649ebe137aeb72a95707671204e829f86e091fc # v0.1.13
         with:
           base: origin/${{ github.base_ref }}:public/openapi.generated.json
           revision: HEAD:public/openapi.generated.json
@@ -32,7 +32,7 @@ jobs:
 
       - name: Report approved breaking changes
         if: ${{ contains(github.event.pull_request.labels.*.name, 'api-breaking-approved') }}
-        uses: oasdiff/oasdiff-action/breaking@033c15c845bef10f148afb0fa781bf1b2a7fe1bf # v0.1.12
+        uses: oasdiff/oasdiff-action/breaking@2649ebe137aeb72a95707671204e829f86e091fc # v0.1.13
         with:
           base: origin/${{ github.base_ref }}:public/openapi.generated.json
           revision: HEAD:public/openapi.generated.json

--- a/tests/unit/openapi-workflow-contract.test.ts
+++ b/tests/unit/openapi-workflow-contract.test.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 
 import { describe, expect, it } from "vitest";
 
-const actionRevision = "033c15c845bef10f148afb0fa781bf1b2a7fe1bf";
+const actionRevision = "2649ebe137aeb72a95707671204e829f86e091fc";
 
 async function readRepositoryFile(path: string) {
   return readFile(new URL(`../../${path}`, import.meta.url), "utf8");


### PR DESCRIPTION
## Summary
- update both oasdiff action pins to v0.1.13
- update the workflow contract test to assert the new immutable revision

This supersedes Dependabot #908. The action itself was already passing; the old in-repo SHA assertion caused the dependency PR's check failure.

## Validation
- `bun install --frozen-lockfile`
- `bun run app:prepare`
- `bunx vitest run tests/unit/openapi-workflow-contract.test.ts` (4 tests)
- `bunx biome check tests/unit/openapi-workflow-contract.test.ts`
- `bun run openapi:check`
- `git diff --check`
