### PR TITLE
perf(cache): activate catalog detail colo cache

### DIFF
--- a/docs/rendering-and-cache.md
+++ b/docs/rendering-and-cache.md
@@ -37,6 +37,11 @@ cache.
 ## Contributor notes
 
 - Don't put user-specific data into a payload you intend to cache anonymously.
+- Catalog detail core reads use isolate L1 → per-colo Cache API → revision-scoped
+  KV → origin. Cache API keys include the static-import revision, locale, entity
+  kind, ID, and payload shape; the revision changes the key space when static
+  data is rematerialized. Cache failures remain fail-open, and only validated
+  non-null public objects are retained.
 - Keep `/_internal` in the dynamic/private gateway roots even though the shell
   fetches JSON rather than HTML.
 - Client navigation may warm route code on hover; data preload waits for

--- a/src/lib/catalog-detail-runtime-cache.ts
+++ b/src/lib/catalog-detail-runtime-cache.ts
@@ -7,8 +7,10 @@ import {
 import {
   cachedPublicRuntimeData,
   type PublicDetailColoCacheKind,
+  publicDetailColoCacheKey,
   publicDetailKvCacheKey,
 } from "@/lib/public-runtime-cache";
+import { getCanonicalOrigin } from "@/lib/site-url";
 
 /** L1 isolate + colo Cache API TTL for anonymous catalog entity core. */
 export const PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS =
@@ -18,17 +20,24 @@ export const PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS =
 export const PUBLIC_DETAIL_KV_CACHE_TTL_MS = PUBLIC_CATALOG_KV_CACHE_TTL_MS;
 
 export async function buildPublicDetailRuntimeCacheOptions<T>(input: {
-  coloCacheKey?: string;
   id: number;
   kind: PublicDetailColoCacheKind;
   kvShape: string;
   locale: AppLocale;
+  origin?: string;
   shouldCacheResult?: (result: T) => boolean;
   validateColoCacheResult?: (result: unknown) => boolean;
 }) {
   const revision = await getCatalogDetailCacheRevision();
   return {
-    coloCacheKey: input.coloCacheKey,
+    coloCacheKey: publicDetailColoCacheKey(
+      input.origin ?? getCanonicalOrigin(),
+      revision,
+      input.kind,
+      input.locale,
+      input.id,
+      input.kvShape,
+    ),
     kvCacheKey: publicDetailKvCacheKey(
       revision,
       input.kind,

--- a/src/lib/public-runtime-cache.ts
+++ b/src/lib/public-runtime-cache.ts
@@ -64,14 +64,10 @@ const PUBLIC_DETAIL_COLO_CACHE_NAME = "life-ustc-public-detail-core-v2";
 const PUBLIC_DETAIL_COLO_CACHE_SCHEMA = "catalog-detail-core-v2";
 const PUBLIC_DETAIL_COLO_CACHE_PATH =
   "/_life-ustc-internal-cache/catalog-detail-core/v2";
-const publicDetailColoCacheShapes = {
-  course: "core-without-sections",
-  section: "core-without-exams-schedules-related",
-  teacher: "core-without-sections",
-} as const;
+const publicDetailColoCacheKinds = ["course", "section", "teacher"] as const;
 
 export type PublicDetailColoCacheKind =
-  keyof typeof publicDetailColoCacheShapes;
+  (typeof publicDetailColoCacheKinds)[number];
 
 const globalForPublicRuntimeCache = globalThis as typeof globalThis & {
   __lifeUstcPublicRuntimeCache?: Map<string, CacheEntry<unknown>>;
@@ -514,15 +510,16 @@ function resolvePublicDetailKvCacheKey(options: {
     const url = new URL(options.coloCacheKey);
     const parts = url.pathname.split("/").filter(Boolean);
     const versionIndex = parts.indexOf("v2");
-    if (versionIndex === -1 || parts.length < versionIndex + 5) {
+    if (versionIndex === -1 || parts.length < versionIndex + 6) {
       return undefined;
     }
-    const kind = parts[versionIndex + 1];
-    const shape = parts[versionIndex + 2];
-    const locale = parts[versionIndex + 3];
-    const id = decodeURIComponent(parts[versionIndex + 4] ?? "");
-    if (!kind || !shape || !locale || !id) return undefined;
-    return `v2:${kind}:${locale}:${id}:${shape}`;
+    const revision = decodeURIComponent(parts[versionIndex + 1] ?? "");
+    const kind = parts[versionIndex + 2];
+    const shape = decodeURIComponent(parts[versionIndex + 3] ?? "");
+    const locale = parts[versionIndex + 4];
+    const id = decodeURIComponent(parts[versionIndex + 5] ?? "");
+    if (!revision || !kind || !shape || !locale || !id) return undefined;
+    return `v2:${revision}:${kind}:${locale}:${id}:${shape}`;
   } catch {
     return undefined;
   }
@@ -530,13 +527,14 @@ function resolvePublicDetailKvCacheKey(options: {
 
 export function publicDetailColoCacheKey(
   origin: string,
+  revision: string,
   kind: PublicDetailColoCacheKind,
   locale: AppLocale,
   id: number,
+  shape: string,
 ) {
-  const shape = publicDetailColoCacheShapes[kind];
   return new URL(
-    `${PUBLIC_DETAIL_COLO_CACHE_PATH}/${kind}/${shape}/${locale}/${encodeURIComponent(String(id))}`,
+    `${PUBLIC_DETAIL_COLO_CACHE_PATH}/${encodeURIComponent(revision)}/${kind}/${encodeURIComponent(shape)}/${locale}/${encodeURIComponent(String(id))}`,
     origin,
   ).toString();
 }
@@ -580,33 +578,6 @@ export function cachedPublicRuntimeData<T>(
     const kvCacheKey =
       options.kvCacheKey ?? resolvePublicDetailKvCacheKey(options);
     const kvTtlMs = options.kvTtlMs ?? ttlMs;
-    const kvRead = kvCacheKey
-      ? await runCloudflareTraceSpan(
-          "cache.kv.read",
-          {
-            "cache.layer": "kv",
-            "cache.namespace": analyticsNamespace,
-          },
-          async (span) => {
-            const result = await readKvCache<T>(
-              kvCacheKey,
-              kvTtlMs,
-              analyticsNamespace,
-              initialStoreSize,
-              options.validateColoCacheResult,
-            );
-            span?.setAttribute("cache.outcome", result.outcome);
-            return result;
-          },
-        )
-      : undefined;
-    if (kvRead?.hit) {
-      if (value) {
-        shortenCurrentEntryExpiry(store, storeKey, value, kvRead.expiresAt);
-      }
-      return kvRead.value;
-    }
-
     const coloCacheKey = options.coloCacheKey;
     const coloRead = coloCacheKey
       ? await runCloudflareTraceSpan(
@@ -633,6 +604,44 @@ export function cachedPublicRuntimeData<T>(
         shortenCurrentEntryExpiry(store, storeKey, value, coloRead.expiresAt);
       }
       return coloRead.value;
+    }
+
+    const kvRead = kvCacheKey
+      ? await runCloudflareTraceSpan(
+          "cache.kv.read",
+          {
+            "cache.layer": "kv",
+            "cache.namespace": analyticsNamespace,
+          },
+          async (span) => {
+            const result = await readKvCache<T>(
+              kvCacheKey,
+              kvTtlMs,
+              analyticsNamespace,
+              initialStoreSize,
+              options.validateColoCacheResult,
+            );
+            span?.setAttribute("cache.outcome", result.outcome);
+            return result;
+          },
+        )
+      : undefined;
+    if (kvRead?.hit) {
+      if (value) {
+        shortenCurrentEntryExpiry(store, storeKey, value, kvRead.expiresAt);
+      }
+      if (coloRead?.cache && coloRead.request) {
+        scheduleColoCacheWrite(
+          coloRead.cache,
+          coloRead.request,
+          kvRead.value,
+          Math.min(expiresAt, kvRead.expiresAt),
+          ttlMs,
+          analyticsNamespace,
+          initialStoreSize,
+        );
+      }
+      return kvRead.value;
     }
 
     const loadStart = monotonicNowMs();

--- a/tests/unit/analytics-engine-runtime-events.test.ts
+++ b/tests/unit/analytics-engine-runtime-events.test.ts
@@ -24,8 +24,8 @@ import {
   writeWorkspaceRouteStageAnalytics,
 } from "@/lib/metrics/analytics-engine";
 import {
+  publicDetailColoCacheKey as buildPublicDetailColoCacheKey,
   cachedPublicRuntimeData,
-  publicDetailColoCacheKey,
 } from "@/lib/public-runtime-cache";
 import {
   getStorageObjectResponse,
@@ -61,6 +61,26 @@ function validatesSource(value: unknown) {
     typeof value === "object" &&
     "source" in value &&
     typeof value.source === "string"
+  );
+}
+
+function publicDetailColoCacheKey(
+  origin: string,
+  kind: "course" | "section" | "teacher",
+  locale: "en-us" | "zh-cn",
+  id: number,
+) {
+  const shape =
+    kind === "section"
+      ? "core-without-exams-schedules-related"
+      : "core-without-sections";
+  return buildPublicDetailColoCacheKey(
+    origin,
+    "revision-a",
+    kind,
+    locale,
+    id,
+    shape,
   );
 }
 

--- a/tests/unit/catalog-detail-read-cache.test.ts
+++ b/tests/unit/catalog-detail-read-cache.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runWithCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
+import { cachedPublicDetailRuntimeData } from "@/lib/catalog-detail-runtime-cache";
 import { resetPublicRuntimeCacheForTest } from "@/lib/public-runtime-cache";
 
 const {
@@ -101,6 +103,23 @@ const sectionDetailRecord = {
   adminClasses: [],
 };
 
+function detailCacheResponse(value: unknown, expiresAt = Date.now() + 60_000) {
+  return new Response(
+    JSON.stringify({
+      expiresAt,
+      schema: "catalog-detail-core-v2",
+      value,
+    }),
+  );
+}
+
+function detailCacheNamespace() {
+  return {
+    get: vi.fn(async () => null),
+    put: vi.fn(async () => undefined),
+  };
+}
+
 describe("shared public catalog detail cache", () => {
   beforeEach(() => {
     resetPublicRuntimeCacheForTest();
@@ -111,6 +130,11 @@ describe("shared public catalog detail cache", () => {
     teacherFindUniqueMock.mockReset();
     getCatalogDetailCacheRevisionMock.mockReset();
     getCatalogDetailCacheRevisionMock.mockResolvedValue("revision-a");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("shares course and teacher detail hits with single-id GraphQL batches", async () => {
@@ -255,5 +279,217 @@ describe("shared public catalog detail cache", () => {
     await expect(findTeacherDetailById(404, "zh-cn")).resolves.toBeNull();
 
     expect(teacherFindUniqueMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("serves a revision- and shape-scoped colo hit without waiting for KV", async () => {
+    vi.stubEnv("APP_CANONICAL_ORIGIN", "https://example.test");
+    const cached = { id: 1, source: "colo" };
+    const match = vi.fn(async (request: Request) => {
+      expect(request.url).toBe(
+        "https://example.test/_life-ustc-internal-cache/catalog-detail-core/v2/revision-a/course/detail-v1/en-us/101",
+      );
+      return detailCacheResponse(cached);
+    });
+    const put = vi.fn(
+      async (_request: Request, _response: Response) => undefined,
+    );
+    vi.stubGlobal("caches", {
+      open: vi.fn(async () => ({ match, put })),
+    });
+    const namespace = detailCacheNamespace();
+    const load = vi.fn(async () => ({ id: 1, source: "origin" }));
+
+    await expect(
+      runWithCloudflareRuntimeEnv({ CATALOG_DETAIL_CORE: namespace }, () =>
+        cachedPublicDetailRuntimeData({
+          id: 101,
+          kind: "course",
+          load,
+          locale: "en-us",
+          shape: "detail-v1",
+        }),
+      ),
+    ).resolves.toEqual(cached);
+
+    expect(match).toHaveBeenCalledOnce();
+    expect(namespace.get).not.toHaveBeenCalled();
+    expect(load).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it("writes a canonical origin result to colo and revision-scoped KV after misses", async () => {
+    vi.stubEnv("APP_CANONICAL_ORIGIN", "https://example.test");
+    const match = vi.fn(async () => undefined);
+    const put = vi.fn(
+      async (_request: Request, _response: Response) => undefined,
+    );
+    vi.stubGlobal("caches", {
+      open: vi.fn(async () => ({ match, put })),
+    });
+    const namespace = detailCacheNamespace();
+    const scheduled: Promise<unknown>[] = [];
+    const load = vi.fn(async () => ({ id: 101, source: "origin" }));
+    const context = {
+      waitUntil(promise: Promise<unknown>) {
+        scheduled.push(promise);
+      },
+    };
+
+    await runWithCloudflareRuntimeEnv(
+      { CATALOG_DETAIL_CORE: namespace },
+      async () => {
+        await expect(
+          cachedPublicDetailRuntimeData({
+            id: 101,
+            kind: "course",
+            load,
+            locale: "en-us",
+            shape: "detail-v1",
+          }),
+        ).resolves.toEqual({ id: 101, source: "origin" });
+        await Promise.all(scheduled);
+      },
+      context,
+    );
+
+    expect(match).toHaveBeenCalledOnce();
+    expect(namespace.get).toHaveBeenCalledWith(
+      "v2:revision-a:course:en-us:101:detail-v1",
+      { cacheTtl: 86_400, type: "json" },
+    );
+    expect(namespace.put).toHaveBeenCalledOnce();
+    expect(put).toHaveBeenCalledOnce();
+    const [writtenRequest] = put.mock.calls[0] ?? [];
+    expect((writtenRequest as Request).url).toBe(
+      "https://example.test/_life-ustc-internal-cache/catalog-detail-core/v2/revision-a/course/detail-v1/en-us/101",
+    );
+  });
+
+  it("keeps Cache API keys isolated by requested shape", async () => {
+    vi.stubEnv("APP_CANONICAL_ORIGIN", "https://example.test");
+    const requests: Request[] = [];
+    vi.stubGlobal("caches", {
+      open: vi.fn(async () => ({
+        match: vi.fn(async (request: Request) => {
+          requests.push(request);
+          return undefined;
+        }),
+        put: vi.fn(async () => undefined),
+      })),
+    });
+    const load = vi.fn(async () => ({ source: "origin" }));
+
+    await runWithCloudflareRuntimeEnv(
+      { CATALOG_DETAIL_CORE: detailCacheNamespace() },
+      async () => {
+        await cachedPublicDetailRuntimeData({
+          id: 101,
+          kind: "section",
+          load,
+          locale: "en-us",
+          shape: "detail-v1:exams=false",
+        });
+        await cachedPublicDetailRuntimeData({
+          id: 101,
+          kind: "section",
+          load,
+          locale: "en-us",
+          shape: "detail-v1:exams=true",
+        });
+      },
+    );
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.url).toContain(
+      "/v2/revision-a/section/detail-v1%3Aexams%3Dfalse/en-us/101",
+    );
+    expect(requests[1]?.url).toContain(
+      "/v2/revision-a/section/detail-v1%3Aexams%3Dtrue/en-us/101",
+    );
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps Cache API keys isolated by static import revision", async () => {
+    vi.stubEnv("APP_CANONICAL_ORIGIN", "https://example.test");
+    getCatalogDetailCacheRevisionMock
+      .mockResolvedValueOnce("revision-a")
+      .mockResolvedValueOnce("revision-b");
+    const requests: Request[] = [];
+    vi.stubGlobal("caches", {
+      open: vi.fn(async () => ({
+        match: vi.fn(async (request: Request) => {
+          requests.push(request);
+          return undefined;
+        }),
+        put: vi.fn(async () => undefined),
+      })),
+    });
+    const load = vi.fn(async () => ({ source: "origin" }));
+
+    await runWithCloudflareRuntimeEnv(
+      { CATALOG_DETAIL_CORE: detailCacheNamespace() },
+      async () => {
+        await cachedPublicDetailRuntimeData({
+          id: 101,
+          kind: "teacher",
+          load,
+          locale: "en-us",
+          shape: "detail-v1",
+        });
+        await cachedPublicDetailRuntimeData({
+          id: 101,
+          kind: "teacher",
+          load,
+          locale: "en-us",
+          shape: "detail-v1",
+        });
+      },
+    );
+
+    expect(requests.map((request) => request.url)).toEqual([
+      "https://example.test/_life-ustc-internal-cache/catalog-detail-core/v2/revision-a/teacher/detail-v1/en-us/101",
+      "https://example.test/_life-ustc-internal-cache/catalog-detail-core/v2/revision-b/teacher/detail-v1/en-us/101",
+    ]);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ["null", null],
+    ["primitive", "invalid"],
+  ])("does not cache %s detail results", async (_name, loadResult) => {
+    vi.stubEnv("APP_CANONICAL_ORIGIN", "https://example.test");
+    const match = vi.fn(async () => undefined);
+    const put = vi.fn(async () => undefined);
+    vi.stubGlobal("caches", {
+      open: vi.fn(async () => ({ match, put })),
+    });
+    const namespace = detailCacheNamespace();
+    const scheduled: Promise<unknown>[] = [];
+    const context = {
+      waitUntil(promise: Promise<unknown>) {
+        scheduled.push(promise);
+      },
+    };
+
+    await runWithCloudflareRuntimeEnv(
+      { CATALOG_DETAIL_CORE: namespace },
+      async () => {
+        await expect(
+          cachedPublicDetailRuntimeData<unknown>({
+            id: 101,
+            kind: "course",
+            load: async () => loadResult,
+            locale: "en-us",
+            shape: `invalid-${_name}`,
+          }),
+        ).resolves.toBe(loadResult);
+        await Promise.all(scheduled);
+      },
+      context,
+    );
+
+    expect(namespace.put).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
+    expect(scheduled).toHaveLength(0);
   });
 });

--- a/tests/unit/public-runtime-cache.test.ts
+++ b/tests/unit/public-runtime-cache.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runWithCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
 import {
+  publicDetailColoCacheKey as buildPublicDetailColoCacheKey,
   cachedPublicRuntimeData,
-  publicDetailColoCacheKey,
   publicDetailKvCacheKey,
 } from "@/lib/public-runtime-cache";
 import { createDeferred } from "../shared/deferred";
@@ -32,6 +32,26 @@ function validatesSource(value: unknown) {
     typeof value === "object" &&
     "source" in value &&
     typeof value.source === "string"
+  );
+}
+
+function publicDetailColoCacheKey(
+  origin: string,
+  kind: "course" | "section" | "teacher",
+  locale: "en-us" | "zh-cn",
+  id: number,
+) {
+  const shape =
+    kind === "section"
+      ? "core-without-exams-schedules-related"
+      : "core-without-sections";
+  return buildPublicDetailColoCacheKey(
+    origin,
+    "revision-a",
+    kind,
+    locale,
+    id,
+    shape,
   );
 }
 
@@ -206,13 +226,13 @@ describe("public runtime cache", () => {
 
     expect(new URL(course).origin).toBe("https://example.test");
     expect(new URL(course).pathname).toBe(
-      "/_life-ustc-internal-cache/catalog-detail-core/v2/course/core-without-sections/en-us/683001",
+      "/_life-ustc-internal-cache/catalog-detail-core/v2/revision-a/course/core-without-sections/en-us/683001",
     );
     expect(new URL(teacher).pathname).toContain(
-      "/v2/teacher/core-without-sections/en-us/683001",
+      "/v2/revision-a/teacher/core-without-sections/en-us/683001",
     );
     expect(new URL(section).pathname).toContain(
-      "/v2/section/core-without-exams-schedules-related/zh-cn/683002",
+      "/v2/revision-a/section/core-without-exams-schedules-related/zh-cn/683002",
     );
     expect(new Set([course, teacher, section]).size).toBe(3);
   });
@@ -240,7 +260,7 @@ describe("public runtime cache", () => {
     ).toBe("v2:abc123def4567890:course:en-us:683001:core-without-sections");
   });
 
-  it("uses a KV hit without loading or colo reads and then serves it from L1", async () => {
+  it("falls through a colo miss to a KV hit and then serves it from L1", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(10_000);
     const cached = { source: "kv" };
@@ -259,7 +279,7 @@ describe("public runtime cache", () => {
     });
     const { match, open, put } = installNamedCache();
     const load = vi.fn(async () => ({ source: "database" }));
-    const { context } = runtimeExecutionContext();
+    const { context, scheduled } = runtimeExecutionContext();
 
     await runWithCloudflareRuntimeEnv(
       { CATALOG_DETAIL_CORE: namespace },
@@ -299,6 +319,7 @@ describe("public runtime cache", () => {
 
         expect(first).toEqual(cached);
         expect(second).toBe(first);
+        await Promise.all(scheduled);
       },
       context,
     );
@@ -308,13 +329,13 @@ describe("public runtime cache", () => {
       cacheTtl: 60,
       type: "json",
     });
-    expect(open).not.toHaveBeenCalled();
-    expect(match).not.toHaveBeenCalled();
+    expect(open).toHaveBeenCalledOnce();
+    expect(match).toHaveBeenCalledOnce();
     expect(load).not.toHaveBeenCalled();
-    expect(put).not.toHaveBeenCalled();
+    expect(put).toHaveBeenCalledOnce();
   });
 
-  it("falls through KV miss to colo and schedules KV and colo writes", async () => {
+  it("falls through colo and KV misses and schedules KV and colo writes", async () => {
     const pending = createDeferred<{ source: string }>();
     const namespace = kvNamespace();
     const { match, put } = installNamedCache();
@@ -494,20 +515,20 @@ describe("public runtime cache", () => {
       writeDataPoint.mock.calls.find(
         ([dataPoint]) => dataPoint.blobs?.[1] === event,
       )?.[0].doubles?.[0];
-    expect(durationFor("kv_miss")).toBe(11);
     expect(durationFor("colo_miss")).toBe(23);
+    expect(durationFor("kv_miss")).toBe(11);
     expect(durationFor("load_success")).toBe(37);
     expect(match).toHaveBeenCalledOnce();
     expect(enterSpan.mock.calls.map(([name]) => name)).toEqual([
-      "cache.kv.read",
       "cache.colo.read",
+      "cache.kv.read",
       "cache.origin_load",
     ]);
     expect(setAttribute.mock.calls).toEqual([
-      ["cache.layer", "kv"],
+      ["cache.layer", "colo"],
       ["cache.namespace", "page:course-detail:en-us"],
       ["cache.outcome", "miss"],
-      ["cache.layer", "colo"],
+      ["cache.layer", "kv"],
       ["cache.namespace", "page:course-detail:en-us"],
       ["cache.outcome", "miss"],
       ["cache.layer", "origin"],


### PR DESCRIPTION
Closes #932

## What changed
- wire the anonymous catalog detail wrapper to revision-, kind-, locale-, ID-, and shape-scoped Cache API keys
- read the local colo cache before remote KV so a colo hit does not wait on KV
- warm a colo miss from a valid KV hit, while retaining fail-open and invalid-result safeguards
- add wrapper-level cache hit/miss/write, shape/revision isolation, and invalid-result tests
- document the cache consistency model

## Validation
- `bunx vitest run` (381 files, 2,391 tests)
- `bun run build`
- `bunx svelte-check --tsconfig ./tsconfig.json` (0 errors; existing warnings)
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx wrangler types --include-runtime=false --check`
- `bun run openapi:check`
- `bunx biome check` (existing warnings only)