### PR TITLE
perf(section): make section homework lists summary-only

### DIFF
--- a/docs/contracts/homework.json
+++ b/docs/contracts/homework.json
@@ -99,10 +99,28 @@
         "routes": [
           {
             "path": "/api/community/section-homeworks",
-            "returns": "{ viewer: ViewerContext, homeworks: HomeworkItem[], auditLogs: AuditLog[] }",
+            "returns": "{ viewer: ViewerContext, data: HomeworkSummary[], pagination: PageInfo }",
             "notes": [
               "Accepts sectionJwId to match the MCP tool's public section identifier, while preserving sectionId and sectionIds for existing REST clients.",
-              "REST localizes returned homework relation fields from the request locale; MCP accepts an explicit locale input."
+              "The paginated list is summary-only: it keeps title, scheduling, completion, permission, and comment-count fields without descriptions, section/course relations, editor relations, or audit history."
+            ]
+          },
+          {
+            "path": "/api/community/section-homeworks/[id]",
+            "method": "GET",
+            "returns": "{ homework: HomeworkItem, auditLogs: AuditLog[] }",
+            "auth": "anon",
+            "notes": [
+              "Loads one active homework's description, detail relations, completion state, and audit history after an explicit detail request."
+            ]
+          },
+          {
+            "path": "/api/community/section-homeworks/audit",
+            "method": "GET",
+            "returns": "{ auditLogs: AuditLog[] }",
+            "auth": "anon",
+            "notes": [
+              "Loads section-wide audit history only after the explicit audit dialog request; the homework list never includes audit history."
             ]
           },
           {
@@ -177,11 +195,11 @@
         "tools": [
           {
             "name": "community_section_homework_list",
-            "returns": "{ found: Boolean, section: Section?, homeworks: HomeworkItem[] }",
+            "returns": "{ found: Boolean, section: Section?, homeworks: HomeworkSummary[] }",
             "rest_equivalent": "GET /api/community/section-homeworks",
             "notes": [
-              "Default and the deprecated summary alias omit the repeated per-item section payload because the top-level section already scopes the list.",
-              "Editor identity fields stay in full mode; default focuses on homework state and due context."
+              "The top-level section scopes the list, so each item omits repeated section context.",
+              "Every mode is summary-only and omits descriptions, detail relations, and audit history; use community_description_get with targetType=homework for an explicit description request."
             ]
           },
           {

--- a/public/openapi.generated.json
+++ b/public/openapi.generated.json
@@ -5930,6 +5930,56 @@
       }
     },
     "/api/community/section-homeworks/{id}": {
+      "get": {
+        "operationId": "get-api-community-section-homeworks-id",
+        "summary": "Read one shared section homework with its detail relations and audit history",
+        "tags": [
+          "community.section-homework"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/homeworkDetailResponseSchema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      },
       "patch": {
         "operationId": "community_section_homework_update",
         "summary": "Update one shared section homework",
@@ -6152,6 +6202,73 @@
                 }
               }
             },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/community/section-homeworks/audit": {
+      "get": {
+        "operationId": "get-api-community-section-homeworks-audit",
+        "summary": "List section homework audit history after an explicit request",
+        "tags": [
+          "community.section-homework"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "sectionId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sectionIds",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "sectionJwId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/homeworkAuditListResponseSchema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/openApiErrorSchema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -13602,459 +13719,6 @@
                   "nullable": true,
                   "type": "string"
                 },
-                "section": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "jwId": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "retiredAt": {
-                      "nullable": true,
-                      "type": "string",
-                      "format": "date-time",
-                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
-                    },
-                    "code": {
-                      "type": "string"
-                    },
-                    "bizTypeId": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "credits": {
-                      "nullable": true,
-                      "type": "number"
-                    },
-                    "period": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "periodsPerWeek": {
-                      "nullable": true,
-                      "type": "number"
-                    },
-                    "timesPerWeek": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "stdCount": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "limitCount": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "graduateAndPostgraduate": {
-                      "nullable": true,
-                      "type": "boolean"
-                    },
-                    "dateTimePlaceText": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "dateTimePlacePersonText": {
-                      "nullable": true
-                    },
-                    "actualPeriods": {
-                      "nullable": true,
-                      "type": "number"
-                    },
-                    "theoryPeriods": {
-                      "nullable": true,
-                      "type": "number"
-                    },
-                    "practicePeriods": {
-                      "nullable": true,
-                      "type": "number"
-                    },
-                    "experimentPeriods": {
-                      "nullable": true,
-                      "type": "number"
-                    },
-                    "machinePeriods": {
-                      "nullable": true,
-                      "type": "number"
-                    },
-                    "designPeriods": {
-                      "nullable": true,
-                      "type": "number"
-                    },
-                    "testPeriods": {
-                      "nullable": true,
-                      "type": "number"
-                    },
-                    "scheduleState": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "suggestScheduleWeeks": {
-                      "nullable": true
-                    },
-                    "suggestScheduleWeekInfo": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "scheduleJsonParams": {
-                      "nullable": true
-                    },
-                    "selectedStdCount": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "remark": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "scheduleRemark": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "courseId": {
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "semesterId": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "campusId": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "examModeId": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "openDepartmentId": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "teachLanguageId": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "roomTypeId": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "course": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "integer",
-                          "minimum": -9007199254740991,
-                          "maximum": 9007199254740991
-                        },
-                        "jwId": {
-                          "type": "integer",
-                          "minimum": -9007199254740991,
-                          "maximum": 9007199254740991
-                        },
-                        "code": {
-                          "type": "string"
-                        },
-                        "nameCn": {
-                          "type": "string"
-                        },
-                        "nameEn": {
-                          "nullable": true,
-                          "type": "string"
-                        },
-                        "categoryId": {
-                          "nullable": true,
-                          "type": "integer",
-                          "minimum": -9007199254740991,
-                          "maximum": 9007199254740991
-                        },
-                        "classTypeId": {
-                          "nullable": true,
-                          "type": "integer",
-                          "minimum": -9007199254740991,
-                          "maximum": 9007199254740991
-                        },
-                        "classifyId": {
-                          "nullable": true,
-                          "type": "integer",
-                          "minimum": -9007199254740991,
-                          "maximum": 9007199254740991
-                        },
-                        "educationLevelId": {
-                          "nullable": true,
-                          "type": "integer",
-                          "minimum": -9007199254740991,
-                          "maximum": 9007199254740991
-                        },
-                        "gradationId": {
-                          "nullable": true,
-                          "type": "integer",
-                          "minimum": -9007199254740991,
-                          "maximum": 9007199254740991
-                        },
-                        "typeId": {
-                          "nullable": true,
-                          "type": "integer",
-                          "minimum": -9007199254740991,
-                          "maximum": 9007199254740991
-                        },
-                        "namePrimary": {
-                          "type": "string"
-                        },
-                        "nameSecondary": {
-                          "nullable": true,
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "jwId",
-                        "code",
-                        "nameCn",
-                        "nameEn",
-                        "categoryId",
-                        "classTypeId",
-                        "classifyId",
-                        "educationLevelId",
-                        "gradationId",
-                        "typeId",
-                        "namePrimary",
-                        "nameSecondary"
-                      ],
-                      "additionalProperties": false
-                    },
-                    "semester": {
-                      "nullable": true,
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/semesterSchema"
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "jwId",
-                    "retiredAt",
-                    "code",
-                    "bizTypeId",
-                    "credits",
-                    "period",
-                    "periodsPerWeek",
-                    "timesPerWeek",
-                    "stdCount",
-                    "limitCount",
-                    "graduateAndPostgraduate",
-                    "dateTimePlaceText",
-                    "dateTimePlacePersonText",
-                    "actualPeriods",
-                    "theoryPeriods",
-                    "practicePeriods",
-                    "experimentPeriods",
-                    "machinePeriods",
-                    "designPeriods",
-                    "testPeriods",
-                    "scheduleState",
-                    "suggestScheduleWeeks",
-                    "suggestScheduleWeekInfo",
-                    "scheduleJsonParams",
-                    "selectedStdCount",
-                    "remark",
-                    "scheduleRemark",
-                    "courseId",
-                    "semesterId",
-                    "campusId",
-                    "examModeId",
-                    "openDepartmentId",
-                    "teachLanguageId",
-                    "roomTypeId",
-                    "course",
-                    "semester"
-                  ],
-                  "additionalProperties": false
-                },
-                "description": {
-                  "nullable": true,
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "content": {
-                      "type": "string"
-                    },
-                    "createdAt": {
-                      "type": "string",
-                      "format": "date-time",
-                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
-                    },
-                    "updatedAt": {
-                      "type": "string",
-                      "format": "date-time",
-                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
-                    },
-                    "lastEditedAt": {
-                      "nullable": true,
-                      "type": "string",
-                      "format": "date-time",
-                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
-                    },
-                    "lastEditedById": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "sectionId": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "courseId": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "teacherId": {
-                      "nullable": true,
-                      "type": "integer",
-                      "minimum": -9007199254740991,
-                      "maximum": 9007199254740991
-                    },
-                    "homeworkId": {
-                      "nullable": true,
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "content",
-                    "createdAt",
-                    "updatedAt",
-                    "lastEditedAt",
-                    "lastEditedById",
-                    "sectionId",
-                    "courseId",
-                    "teacherId",
-                    "homeworkId"
-                  ],
-                  "additionalProperties": false
-                },
-                "createdBy": {
-                  "nullable": true,
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "username": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "image": {
-                      "nullable": true,
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "name",
-                    "username",
-                    "image"
-                  ],
-                  "additionalProperties": false
-                },
-                "updatedBy": {
-                  "nullable": true,
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "username": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "image": {
-                      "nullable": true,
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "name",
-                    "username",
-                    "image"
-                  ],
-                  "additionalProperties": false
-                },
-                "deletedBy": {
-                  "nullable": true,
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "username": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "image": {
-                      "nullable": true,
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "name",
-                    "username",
-                    "image"
-                  ],
-                  "additionalProperties": false
-                },
                 "completion": {
                   "nullable": true,
                   "type": "object",
@@ -14091,11 +13755,6 @@
                 "createdById",
                 "updatedById",
                 "deletedById",
-                "section",
-                "description",
-                "createdBy",
-                "updatedBy",
-                "deletedBy",
                 "completion",
                 "commentCount"
               ],
@@ -14180,93 +13839,12 @@
               "suspensionExpiresAt"
             ],
             "additionalProperties": false
-          },
-          "auditLogs": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "action": {
-                  "type": "string",
-                  "enum": [
-                    "created",
-                    "updated",
-                    "deleted"
-                  ]
-                },
-                "titleSnapshot": {
-                  "nullable": true,
-                  "type": "string"
-                },
-                "createdAt": {
-                  "type": "string",
-                  "format": "date-time",
-                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
-                },
-                "sectionId": {
-                  "type": "integer",
-                  "minimum": -9007199254740991,
-                  "maximum": 9007199254740991
-                },
-                "homeworkId": {
-                  "nullable": true,
-                  "type": "string"
-                },
-                "actorId": {
-                  "nullable": true,
-                  "type": "string"
-                },
-                "actor": {
-                  "nullable": true,
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "username": {
-                      "nullable": true,
-                      "type": "string"
-                    },
-                    "image": {
-                      "nullable": true,
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "name",
-                    "username",
-                    "image"
-                  ],
-                  "additionalProperties": false
-                }
-              },
-              "required": [
-                "id",
-                "action",
-                "titleSnapshot",
-                "createdAt",
-                "sectionId",
-                "homeworkId",
-                "actorId",
-                "actor"
-              ],
-              "additionalProperties": false
-            }
           }
         },
         "required": [
           "data",
           "pagination",
-          "viewer",
-          "auditLogs"
+          "viewer"
         ],
         "additionalProperties": false
       },
@@ -26444,6 +26022,661 @@
         ],
         "additionalProperties": false
       },
+      "homeworkDetailResponseSchema": {
+        "type": "object",
+        "properties": {
+          "homework": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "isMajor": {
+                "type": "boolean"
+              },
+              "requiresTeam": {
+                "type": "boolean"
+              },
+              "publishedAt": {
+                "nullable": true,
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "submissionStartAt": {
+                "nullable": true,
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "submissionDueAt": {
+                "nullable": true,
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "deletedAt": {
+                "nullable": true,
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+              },
+              "sectionId": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "createdById": {
+                "nullable": true,
+                "type": "string"
+              },
+              "updatedById": {
+                "nullable": true,
+                "type": "string"
+              },
+              "deletedById": {
+                "nullable": true,
+                "type": "string"
+              },
+              "section": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "jwId": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "retiredAt": {
+                    "nullable": true,
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                  },
+                  "code": {
+                    "type": "string"
+                  },
+                  "bizTypeId": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "credits": {
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "period": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "periodsPerWeek": {
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "timesPerWeek": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "stdCount": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "limitCount": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "graduateAndPostgraduate": {
+                    "nullable": true,
+                    "type": "boolean"
+                  },
+                  "dateTimePlaceText": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "dateTimePlacePersonText": {
+                    "nullable": true
+                  },
+                  "actualPeriods": {
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "theoryPeriods": {
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "practicePeriods": {
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "experimentPeriods": {
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "machinePeriods": {
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "designPeriods": {
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "testPeriods": {
+                    "nullable": true,
+                    "type": "number"
+                  },
+                  "scheduleState": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "suggestScheduleWeeks": {
+                    "nullable": true
+                  },
+                  "suggestScheduleWeekInfo": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "scheduleJsonParams": {
+                    "nullable": true
+                  },
+                  "selectedStdCount": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "remark": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "scheduleRemark": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "courseId": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "semesterId": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "campusId": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "examModeId": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "openDepartmentId": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "teachLanguageId": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "roomTypeId": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "course": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "jwId": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "code": {
+                        "type": "string"
+                      },
+                      "nameCn": {
+                        "type": "string"
+                      },
+                      "nameEn": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "categoryId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "classTypeId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "classifyId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "educationLevelId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "gradationId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "typeId": {
+                        "nullable": true,
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "namePrimary": {
+                        "type": "string"
+                      },
+                      "nameSecondary": {
+                        "nullable": true,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "jwId",
+                      "code",
+                      "nameCn",
+                      "nameEn",
+                      "categoryId",
+                      "classTypeId",
+                      "classifyId",
+                      "educationLevelId",
+                      "gradationId",
+                      "typeId",
+                      "namePrimary",
+                      "nameSecondary"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "semester": {
+                    "nullable": true,
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/semesterSchema"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "jwId",
+                  "retiredAt",
+                  "code",
+                  "bizTypeId",
+                  "credits",
+                  "period",
+                  "periodsPerWeek",
+                  "timesPerWeek",
+                  "stdCount",
+                  "limitCount",
+                  "graduateAndPostgraduate",
+                  "dateTimePlaceText",
+                  "dateTimePlacePersonText",
+                  "actualPeriods",
+                  "theoryPeriods",
+                  "practicePeriods",
+                  "experimentPeriods",
+                  "machinePeriods",
+                  "designPeriods",
+                  "testPeriods",
+                  "scheduleState",
+                  "suggestScheduleWeeks",
+                  "suggestScheduleWeekInfo",
+                  "scheduleJsonParams",
+                  "selectedStdCount",
+                  "remark",
+                  "scheduleRemark",
+                  "courseId",
+                  "semesterId",
+                  "campusId",
+                  "examModeId",
+                  "openDepartmentId",
+                  "teachLanguageId",
+                  "roomTypeId",
+                  "course",
+                  "semester"
+                ],
+                "additionalProperties": false
+              },
+              "description": {
+                "nullable": true,
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "content": {
+                    "type": "string"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                  },
+                  "lastEditedAt": {
+                    "nullable": true,
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                  },
+                  "lastEditedById": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "sectionId": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "courseId": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "teacherId": {
+                    "nullable": true,
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "homeworkId": {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "content",
+                  "createdAt",
+                  "updatedAt",
+                  "lastEditedAt",
+                  "lastEditedById",
+                  "sectionId",
+                  "courseId",
+                  "teacherId",
+                  "homeworkId"
+                ],
+                "additionalProperties": false
+              },
+              "createdBy": {
+                "nullable": true,
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "username": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "image": {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "username",
+                  "image"
+                ],
+                "additionalProperties": false
+              },
+              "updatedBy": {
+                "nullable": true,
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "username": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "image": {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "username",
+                  "image"
+                ],
+                "additionalProperties": false
+              },
+              "deletedBy": {
+                "nullable": true,
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "username": {
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  "image": {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "username",
+                  "image"
+                ],
+                "additionalProperties": false
+              },
+              "completion": {
+                "nullable": true,
+                "type": "object",
+                "properties": {
+                  "completedAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                  }
+                },
+                "required": [
+                  "completedAt"
+                ],
+                "additionalProperties": false
+              },
+              "commentCount": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": [
+              "id",
+              "title",
+              "isMajor",
+              "requiresTeam",
+              "publishedAt",
+              "submissionStartAt",
+              "submissionDueAt",
+              "createdAt",
+              "updatedAt",
+              "deletedAt",
+              "sectionId",
+              "createdById",
+              "updatedById",
+              "deletedById",
+              "section",
+              "description",
+              "createdBy",
+              "updatedBy",
+              "deletedBy",
+              "completion",
+              "commentCount"
+            ],
+            "additionalProperties": false
+          },
+          "auditLogs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "action": {
+                  "type": "string",
+                  "enum": [
+                    "created",
+                    "updated",
+                    "deleted"
+                  ]
+                },
+                "titleSnapshot": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "createdAt": {
+                  "type": "string",
+                  "format": "date-time",
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                },
+                "sectionId": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "homeworkId": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "actorId": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "actor": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "username": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "image": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "username",
+                    "image"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "id",
+                "action",
+                "titleSnapshot",
+                "createdAt",
+                "sectionId",
+                "homeworkId",
+                "actorId",
+                "actor"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "homework",
+          "auditLogs"
+        ],
+        "additionalProperties": false
+      },
       "homeworkUpdateRequestSchema": {
         "type": "object",
         "properties": {
@@ -27083,6 +27316,95 @@
         "required": [
           "success",
           "homework"
+        ],
+        "additionalProperties": false
+      },
+      "homeworkAuditListResponseSchema": {
+        "type": "object",
+        "properties": {
+          "auditLogs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "action": {
+                  "type": "string",
+                  "enum": [
+                    "created",
+                    "updated",
+                    "deleted"
+                  ]
+                },
+                "titleSnapshot": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "createdAt": {
+                  "type": "string",
+                  "format": "date-time",
+                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                },
+                "sectionId": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "homeworkId": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "actorId": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "actor": {
+                  "nullable": true,
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "username": {
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "image": {
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "username",
+                    "image"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "id",
+                "action",
+                "titleSnapshot",
+                "createdAt",
+                "sectionId",
+                "homeworkId",
+                "actorId",
+                "actor"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "auditLogs"
         ],
         "additionalProperties": false
       },

--- a/src/features/homeworks/server/homework-list-read-model.ts
+++ b/src/features/homeworks/server/homework-list-read-model.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from "@/generated/prisma/client";
 import type { AppLocale } from "@/i18n/config";
 import { DEFAULT_LOCALE } from "@/i18n/config";
 import { getViewerContext } from "@/lib/auth/viewer-context";
@@ -7,6 +8,7 @@ import {
   attachHomeworkCompletionsForViewer,
   homeworkItemInclude,
   homeworkItemResponse,
+  homeworkItemSummarySelect,
   withHomeworkCompletionsForViewer,
 } from "./homework-read-model";
 
@@ -20,7 +22,7 @@ type SectionHomeworkItemInput = SectionHomeworkListInput & {
   viewerUserId?: string | null;
 };
 
-type SectionHomeworkListWithAuditInput = SectionHomeworkListInput & {
+type SectionHomeworkListWithViewerInput = SectionHomeworkListInput & {
   userId?: string | null;
 };
 
@@ -28,7 +30,7 @@ type SectionHomeworkPageInput = SectionHomeworkItemInput & {
   pagination: { page: number; pageSize: number };
 };
 
-type SectionHomeworkPageWithAuditInput = SectionHomeworkListWithAuditInput & {
+type SectionHomeworkPageWithViewerInput = SectionHomeworkListWithViewerInput & {
   pagination: { page: number; pageSize: number };
 };
 
@@ -46,6 +48,20 @@ const homeworkAuditActorSelect = {
   name: true,
   username: true,
 } as const;
+
+const homeworkAuditLogSelect = {
+  action: true,
+  createdAt: true,
+  id: true,
+  metadata: true,
+  targetId: true,
+  user: { select: homeworkAuditActorSelect },
+  userId: true,
+} as const satisfies Prisma.AuditLogSelect;
+
+type HomeworkAuditRow = Prisma.AuditLogGetPayload<{
+  select: typeof homeworkAuditLogSelect;
+}>;
 
 export function homeworkSectionWhere(sectionIds: readonly number[]) {
   return sectionIds.length === 1
@@ -94,7 +110,7 @@ export async function listSectionHomeworkItems({
         ...homeworkSectionWhere(sectionIds),
         ...(includeDeleted ? {} : { deletedAt: null }),
       },
-      include: homeworkItemInclude(),
+      select: homeworkItemSummarySelect(),
       orderBy: [{ submissionDueAt: "asc" }, { createdAt: "desc" }],
     });
 
@@ -142,7 +158,7 @@ export async function listSectionHomeworkPage({
     (skip, take) =>
       client.homework.findMany({
         where,
-        include: homeworkItemInclude(),
+        select: homeworkItemSummarySelect(),
         orderBy: [{ submissionDueAt: "asc" }, { createdAt: "desc" }],
         skip,
         take,
@@ -172,52 +188,99 @@ export async function listSectionHomeworkAuditLogs(
         metadata: { path: ["sectionId"], equals: sectionId },
       })),
     },
-    select: {
-      action: true,
-      createdAt: true,
-      id: true,
-      metadata: true,
-      targetId: true,
-      user: { select: homeworkAuditActorSelect },
-      userId: true,
-    },
+    select: homeworkAuditLogSelect,
     orderBy: { createdAt: "desc" },
     take: 50,
   });
+  return rows.map((row) => homeworkAuditLogResponse(row));
+}
 
-  return rows.map((row) => {
-    const metadata =
-      typeof row.metadata === "object" && row.metadata !== null
-        ? (row.metadata as Record<string, unknown>)
-        : {};
-    return {
-      id: row.id,
-      action:
-        row.action === "homework_create"
-          ? ("created" as const)
-          : row.action === "homework_update"
-            ? ("updated" as const)
-            : ("deleted" as const),
-      titleSnapshot:
-        typeof metadata.titleSnapshot === "string"
-          ? metadata.titleSnapshot
-          : null,
-      createdAt: row.createdAt,
-      sectionId: Number(metadata.sectionId),
-      homeworkId: row.targetId,
-      actorId: row.userId,
-      actor: row.user,
-    };
+function homeworkAuditLogResponse(
+  row: HomeworkAuditRow,
+  fallbackSectionId?: number,
+) {
+  const metadata =
+    typeof row.metadata === "object" && row.metadata !== null
+      ? (row.metadata as Record<string, unknown>)
+      : {};
+  return {
+    id: row.id,
+    action:
+      row.action === "homework_create"
+        ? ("created" as const)
+        : row.action === "homework_update"
+          ? ("updated" as const)
+          : ("deleted" as const),
+    titleSnapshot:
+      typeof metadata.titleSnapshot === "string"
+        ? metadata.titleSnapshot
+        : null,
+    createdAt: row.createdAt,
+    sectionId:
+      typeof metadata.sectionId === "number"
+        ? metadata.sectionId
+        : (fallbackSectionId ?? Number(metadata.sectionId)),
+    homeworkId: row.targetId,
+    actorId: row.userId,
+    actor: row.user,
+  };
+}
+
+async function loadHomeworkAuditRowsForHomework(homeworkId: string) {
+  return prisma.auditLog.findMany({
+    where: {
+      action: {
+        in: ["homework_create", "homework_update", "homework_delete"],
+      },
+      targetType: "homework",
+      targetId: homeworkId,
+    },
+    select: homeworkAuditLogSelect,
+    orderBy: { createdAt: "desc" },
+    take: 50,
   });
 }
 
-export async function listSectionHomeworksWithAudit({
+export async function getSectionHomeworkAuditLogs(
+  homeworkId: string,
+  sectionId: number,
+) {
+  const rows = await loadHomeworkAuditRowsForHomework(homeworkId);
+  return rows.map((row) => homeworkAuditLogResponse(row, sectionId));
+}
+
+export async function getSectionHomeworkDetail(input: {
+  homeworkId: string;
+  locale?: AppLocale;
+  userId?: string | null;
+}) {
+  const homework = await getPrisma(
+    input.locale ?? DEFAULT_LOCALE,
+  ).homework.findFirst({
+    where: { id: input.homeworkId, deletedAt: null },
+    include: homeworkItemInclude(),
+  });
+  if (!homework) return null;
+
+  const [homeworkWithCompletion, auditLogs] = await Promise.all([
+    withHomeworkCompletionsForViewer([homework], input.userId),
+    getSectionHomeworkAuditLogs(homework.id, homework.sectionId),
+  ]);
+  const [item] = homeworkWithCompletion;
+  if (!item) return null;
+  return {
+    auditLogs,
+    homework: homeworkItemResponse(item),
+  };
+}
+
+export async function listSectionHomeworks({
   includeDeleted = false,
   locale = DEFAULT_LOCALE,
   sectionIds,
   userId,
-}: SectionHomeworkListWithAuditInput) {
-  const [viewer, homeworks, auditLogs] = await Promise.all([
+}: SectionHomeworkListWithViewerInput) {
+  const [viewer, homeworks] = await Promise.all([
     getViewerContext({
       includeAdmin: true,
       userId: userId ?? null,
@@ -228,20 +291,19 @@ export async function listSectionHomeworksWithAudit({
       sectionIds,
       viewerUserId: userId,
     }),
-    listSectionHomeworkAuditLogs(sectionIds),
   ]);
 
-  return { viewer, homeworks, auditLogs };
+  return { viewer, homeworks };
 }
 
-export async function listSectionHomeworkPageWithAudit({
+export async function listSectionHomeworkPageWithViewer({
   includeDeleted = false,
   locale = DEFAULT_LOCALE,
   pagination,
   sectionIds,
   userId,
-}: SectionHomeworkPageWithAuditInput) {
-  const [viewer, page, auditLogs] = await Promise.all([
+}: SectionHomeworkPageWithViewerInput) {
+  const [viewer, page] = await Promise.all([
     getViewerContext({
       includeAdmin: true,
       userId: userId ?? null,
@@ -253,8 +315,7 @@ export async function listSectionHomeworkPageWithAudit({
       sectionIds,
       viewerUserId: userId,
     }),
-    listSectionHomeworkAuditLogs(sectionIds),
   ]);
 
-  return { ...page, viewer, auditLogs };
+  return { ...page, viewer };
 }

--- a/src/features/homeworks/server/homework-read-model.ts
+++ b/src/features/homeworks/server/homework-read-model.ts
@@ -5,6 +5,35 @@ const homeworkItemUserSelect = {
   select: { id: true, name: true, username: true, image: true },
 } as const;
 
+/**
+ * The section homework list projection deliberately contains only scalar
+ * state and the comment aggregate needed by list surfaces. Descriptions,
+ * section/course context, and editor relations belong to the detail read.
+ */
+export function homeworkItemSummarySelect() {
+  return {
+    id: true,
+    title: true,
+    isMajor: true,
+    requiresTeam: true,
+    publishedAt: true,
+    submissionStartAt: true,
+    submissionDueAt: true,
+    createdAt: true,
+    updatedAt: true,
+    deletedAt: true,
+    sectionId: true,
+    createdById: true,
+    updatedById: true,
+    deletedById: true,
+    _count: {
+      select: {
+        comments: { where: { status: { not: "deleted" } } },
+      },
+    },
+  } satisfies Prisma.HomeworkSelect;
+}
+
 export function homeworkItemInclude() {
   return {
     section: {

--- a/src/features/section-detail/components/SectionDetailPageController.svelte
+++ b/src/features/section-detail/components/SectionDetailPageController.svelte
@@ -29,8 +29,13 @@ import { createSectionHomeworkTimestampActions } from "@/features/section-detail
 import { createSectionDetailUiActions } from "@/features/section-detail/lib/section-detail-ui-actions";
 import { createSectionDetailControllerDefaultState } from "@/features/section-detail/lib/section-detail-controller-default-state";
 import {
+  loadSectionHomeworkAuditLogs,
+  loadSectionHomeworkDetail,
+} from "@/features/section-detail/lib/homeworks";
+import {
   type SectionDetailActionData,
   type SectionDetailPageData,
+  type HomeworkAuditLog,
   type SectionHomework,
 } from "@/features/section-detail/lib/section-detail-controller-helpers";
 import SectionDetailDialogs from "@/features/section-detail/components/SectionDetailDialogs.svelte";
@@ -119,6 +124,46 @@ function syncFocusedHomework(homeworks: SectionHomework[]) {
   );
   if (focused) {
     _selectedHomework = focused;
+  }
+}
+
+let homeworkDetailRequest = 0;
+let homeworkAuditRequest = 0;
+
+async function selectHomework(homework: SectionHomework) {
+  const requestId = ++homeworkDetailRequest;
+  try {
+    const detail = await loadSectionHomeworkDetail<
+      SectionHomework,
+      HomeworkAuditLog
+    >(homework.id, _sectionCopy.operationFailed);
+    if (requestId !== homeworkDetailRequest) return;
+
+    const { section: _section, ...scopedHomework } = detail.homework;
+    _homeworkAuditLogs = detail.auditLogs;
+    _selectedHomework = scopedHomework;
+  } catch (error) {
+    if (requestId !== homeworkDetailRequest) return;
+    _homeworkMessage =
+      error instanceof Error ? error.message : _sectionCopy.operationFailed;
+  }
+}
+
+async function loadHomeworkAuditLogs() {
+  const requestId = ++homeworkAuditRequest;
+  try {
+    const auditLogs = await loadSectionHomeworkAuditLogs<HomeworkAuditLog>(
+      data.section.id,
+      _sectionCopy.operationFailed,
+    );
+    if (requestId !== homeworkAuditRequest || !_isHomeworkAuditDialogOpen)
+      return;
+    _homeworkAuditLogs = auditLogs;
+  } catch (error) {
+    if (requestId !== homeworkAuditRequest || !_isHomeworkAuditDialogOpen)
+      return;
+    _homeworkMessage =
+      error instanceof Error ? error.message : _sectionCopy.operationFailed;
   }
 }
 
@@ -488,9 +533,7 @@ onMount(() => {
     {sectionCalendarGridWeeks}
     sectionCopy={_sectionCopy}
     sectionTeachersLabel={_sectionTeachersLabel}
-    setSelectedHomework={(homework) => {
-      _selectedHomework = homework;
-    }}
+    setSelectedHomework={selectHomework}
     {streamLoading}
     subscriptionAction={_subscriptionAction}
     subscriptionPendingAction={_subscriptionPendingAction}
@@ -564,6 +607,7 @@ onMount(() => {
   }}
   setHomeworkAuditDialogOpen={(open) => {
     _isHomeworkAuditDialogOpen = open;
+    if (open) void loadHomeworkAuditLogs();
   }}
   setSelectedHomework={(homework) => {
     _selectedHomework = homework;

--- a/src/features/section-detail/components/SectionHomeworkListView.svelte
+++ b/src/features/section-detail/components/SectionHomeworkListView.svelte
@@ -13,7 +13,7 @@ export let fmtDateTime: (value: string | Date | null | undefined) => string;
 export let homeworkCopy: SectionHomeworkCopy;
 export let homeworks: SectionHomework[];
 export let sectionCopy: SectionCopy;
-export let selectHomework: (homework: SectionHomework) => void;
+export let selectHomework: (homework: SectionHomework) => void | Promise<void>;
 </script>
 
 <div data-testid="section-homeworks-list">

--- a/src/features/section-detail/components/SectionHomeworkTab.svelte
+++ b/src/features/section-detail/components/SectionHomeworkTab.svelte
@@ -10,7 +10,7 @@ export let fmtDateTime: (value: string | Date | null | undefined) => string;
 export let homeworkCopy: SectionHomeworkCopy;
 export let homeworks: SectionHomework[];
 export let sectionCopy: SectionCopy;
-export let selectHomework: (homework: SectionHomework) => void;
+export let selectHomework: (homework: SectionHomework) => void | Promise<void>;
 </script>
 
 <section class="grid gap-4">

--- a/src/features/section-detail/components/section-detail-dialog-types.ts
+++ b/src/features/section-detail/components/section-detail-dialog-types.ts
@@ -222,7 +222,7 @@ export type SectionDetailMainContentProps = {
   sectionCalendarGridWeeks: CalendarGridWeek[];
   sectionCopy: SectionDetailMainSectionCopy;
   sectionTeachersLabel: SectionTeachersLabel;
-  setSelectedHomework: (homework: SectionHomework) => void;
+  setSelectedHomework: (homework: SectionHomework) => void | Promise<void>;
   teacherName: SectionTeacherName;
   todayCalendarMonthOffset: number;
   unscheduledCalendarEvents: SectionCalendarEvent[];

--- a/src/features/section-detail/lib/homeworks.ts
+++ b/src/features/section-detail/lib/homeworks.ts
@@ -12,12 +12,11 @@ export type SectionHomeworkRequest = {
 
 export type SectionHomeworkUpdateResult = "ok" | "homework-error";
 
-export async function loadSectionHomeworks<Viewer, Homework, AuditLog>(
+export async function loadSectionHomeworks<Viewer, Homework>(
   sectionId: number | string,
   errorMessage: string,
 ) {
   const result = await apiClient.GET<{
-    auditLogs: AuditLog[];
     data: Homework[];
     viewer: Viewer;
   }>("/api/community/section-homeworks", {
@@ -25,10 +24,37 @@ export async function loadSectionHomeworks<Viewer, Homework, AuditLog>(
   });
   if (!result.response.ok || !result.data) throw new Error(errorMessage);
   return {
-    auditLogs: result.data.auditLogs,
     homeworks: result.data.data,
     viewer: result.data.viewer,
   };
+}
+
+export async function loadSectionHomeworkDetail<Homework, AuditLog>(
+  homeworkId: number | string,
+  errorMessage: string,
+) {
+  const result = await apiClient.GET<{
+    auditLogs: AuditLog[];
+    homework: Homework;
+  }>(`/api/community/section-homeworks/${homeworkId}`);
+  if (!result.response.ok || !result.data) throw new Error(errorMessage);
+  return {
+    auditLogs: result.data.auditLogs,
+    homework: result.data.homework,
+  };
+}
+
+export async function loadSectionHomeworkAuditLogs<AuditLog>(
+  sectionId: number | string,
+  errorMessage: string,
+) {
+  const result = await apiClient.GET<{
+    auditLogs: AuditLog[];
+  }>("/api/community/section-homeworks/audit", {
+    params: { query: { sectionId } },
+  });
+  if (!result.response.ok || !result.data) throw new Error(errorMessage);
+  return result.data.auditLogs;
 }
 
 export async function createSectionHomework(

--- a/src/features/section-detail/lib/section-detail-homework-load-action.ts
+++ b/src/features/section-detail/lib/section-detail-homework-load-action.ts
@@ -1,4 +1,4 @@
-import { loadSectionHomeworks } from "./homeworks";
+import { loadSectionHomeworkDetail, loadSectionHomeworks } from "./homeworks";
 import type {
   HomeworkAuditLog,
   HomeworkViewer,
@@ -14,19 +14,38 @@ export function createSectionHomeworkLoadAction(
     try {
       const payload = await loadSectionHomeworks<
         HomeworkViewer,
-        SectionHomework,
-        HomeworkAuditLog
+        SectionHomework
       >(input.getSectionId(), homeworkCopy.loadFailed);
       input.setHomeworkViewer(payload.viewer ?? input.getHomeworkViewer());
       const homeworks = payload.homeworks ?? input.getHomeworks();
       input.setHomeworks(homeworks);
-      input.setHomeworkAuditLogs(payload.auditLogs ?? []);
+      input.setHomeworkAuditLogs([]);
       const selectedHomework = input.getSelectedHomework();
       if (selectedHomework) {
-        input.setSelectedHomework(
-          homeworks.find((homework) => homework.id === selectedHomework.id) ??
-            selectedHomework,
+        const refreshedHomework = homeworks.find(
+          (homework) => homework.id === selectedHomework.id,
         );
+        if (!refreshedHomework) {
+          input.setSelectedHomework(selectedHomework);
+          return;
+        }
+
+        try {
+          const detail = await loadSectionHomeworkDetail<
+            SectionHomework,
+            HomeworkAuditLog
+          >(selectedHomework.id, homeworkCopy.loadFailed);
+          if (input.getSelectedHomework()?.id !== selectedHomework.id) return;
+          const { section: _section, ...scopedHomework } = detail.homework;
+          input.setSelectedHomework(scopedHomework);
+          input.setHomeworkAuditLogs(detail.auditLogs);
+        } catch {
+          if (input.getSelectedHomework()?.id !== selectedHomework.id) return;
+          input.setSelectedHomework({
+            ...selectedHomework,
+            ...refreshedHomework,
+          });
+        }
       }
     } catch (error) {
       input.setHomeworkMessage(

--- a/src/features/section-detail/lib/section-detail-tab-client.ts
+++ b/src/features/section-detail/lib/section-detail-tab-client.ts
@@ -187,13 +187,12 @@ async function loadHomeworkPanel(
   errorMessage: string,
   state: SectionDetailTabPanelState,
 ): Promise<SectionDetailTabPanelPatch> {
-  const payload = await loadSectionHomeworks<
-    HomeworkViewer,
-    SectionHomework,
-    HomeworkAuditLog
-  >(sectionId, errorMessage);
+  const payload = await loadSectionHomeworks<HomeworkViewer, SectionHomework>(
+    sectionId,
+    errorMessage,
+  );
   return {
-    homeworkAuditLogs: payload.auditLogs ?? [],
+    homeworkAuditLogs: [],
     homeworkViewer: payload.viewer ?? state.homeworkViewer,
     homeworks: payload.homeworks ?? [],
   };

--- a/src/features/section-detail/server/section-detail-homework-data.ts
+++ b/src/features/section-detail/server/section-detail-homework-data.ts
@@ -1,4 +1,7 @@
-import { listSectionHomeworksWithAudit } from "@/features/homeworks/server/homework-list-read-model";
+import {
+  getSectionHomeworkDetail,
+  listSectionHomeworks,
+} from "@/features/homeworks/server/homework-list-read-model";
 import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import type { SectionDetailPageData } from "@/features/section-detail/lib/section-detail-controller-types";
 import { renderEmbeddedMarkdown } from "@/lib/components/markdown-preview-renderer";
@@ -7,38 +10,73 @@ import {
   toShanghaiIsoString,
 } from "@/lib/time/serialize-date-output";
 
+type SectionHomeworkDetail = NonNullable<
+  Awaited<ReturnType<typeof getSectionHomeworkDetail>>
+>["homework"];
+
+function renderSectionHomeworkDetail(homework: SectionHomeworkDetail) {
+  const { section: _section, ...scopedHomework } = serializeDatesDeep(homework);
+  return {
+    ...scopedHomework,
+    description: scopedHomework.description
+      ? {
+          ...scopedHomework.description,
+          renderedHtml: renderEmbeddedMarkdown(
+            scopedHomework.description.content ?? "",
+            { remarkPlugins: campusReferenceMarkdownPlugins },
+          ),
+        }
+      : null,
+    completion: homework.completion
+      ? {
+          completedAt: toShanghaiIsoString(homework.completion.completedAt),
+        }
+      : null,
+  };
+}
+
+function serializeSectionHomeworkSummary(
+  homework: Awaited<
+    ReturnType<typeof listSectionHomeworks>
+  >["homeworks"][number],
+) {
+  const serialized = serializeDatesDeep(homework);
+  return {
+    ...serialized,
+    completion: homework.completion
+      ? {
+          completedAt: toShanghaiIsoString(homework.completion.completedAt),
+        }
+      : null,
+  };
+}
+
 export async function getSectionHomeworkData(
   sectionId: number,
   userId: string | null,
+  focusedHomeworkId?: string | null,
 ) {
-  const result = await listSectionHomeworksWithAudit({
-    sectionIds: [sectionId],
-    userId,
-  });
+  const [result, detail] = await Promise.all([
+    listSectionHomeworks({
+      sectionIds: [sectionId],
+      userId,
+    }),
+    focusedHomeworkId
+      ? getSectionHomeworkDetail({ homeworkId: focusedHomeworkId, userId })
+      : Promise.resolve(null),
+  ]);
+  const focusedDetail =
+    detail?.homework.sectionId === sectionId ? detail : null;
+
+  const homeworks = result.homeworks.map((homework) =>
+    focusedDetail?.homework.id === homework.id
+      ? renderSectionHomeworkDetail(focusedDetail.homework)
+      : serializeSectionHomeworkSummary(homework),
+  );
 
   return {
     viewer: result.viewer,
-    auditLogs: serializeDatesDeep(result.auditLogs),
-    homeworks: result.homeworks.map((homework) => {
-      const { section: _section, ...scopedHomework } =
-        serializeDatesDeep(homework);
-      return {
-        ...scopedHomework,
-        description: scopedHomework.description
-          ? {
-              ...scopedHomework.description,
-              renderedHtml: renderEmbeddedMarkdown(
-                scopedHomework.description.content ?? "",
-                { remarkPlugins: campusReferenceMarkdownPlugins },
-              ),
-            }
-          : null,
-        completion: homework.completion
-          ? {
-              completedAt: toShanghaiIsoString(homework.completion.completedAt),
-            }
-          : null,
-      };
-    }),
+    auditLogs: focusedDetail ? serializeDatesDeep(focusedDetail.auditLogs) : [],
+    homeworks,
   } satisfies SectionDetailPageData["homeworkData"];
 }

--- a/src/features/section-detail/server/section-detail-page-server.ts
+++ b/src/features/section-detail/server/section-detail-page-server.ts
@@ -92,7 +92,7 @@ async function loadSectionDetailPageData({
         async () =>
           (
             await import("./section-detail-homework-data")
-          ).getSectionHomeworkData(section.id, userId),
+          ).getSectionHomeworkData(section.id, userId, focusedHomeworkId),
       )
     : {
         auditLogs: [],

--- a/src/lib/api/routes/homework-audit-read-route.ts
+++ b/src/lib/api/routes/homework-audit-read-route.ts
@@ -1,0 +1,28 @@
+import { listSectionHomeworkAuditLogs } from "@/features/homeworks/server/homework-list-read-model";
+import {
+  getRequestSearchParams,
+  handleRouteError,
+  jsonResponse,
+  parseRouteSearchParams,
+} from "@/lib/api/helpers";
+import { resolveHomeworkRouteSectionIds } from "@/lib/api/routes/homework-route-helpers";
+import { homeworkAuditQuerySchema } from "@/lib/api/schemas/request-schemas";
+
+export async function getHomeworkAuditRoute(request: Request) {
+  const parsedQuery = parseRouteSearchParams(
+    getRequestSearchParams(request),
+    homeworkAuditQuerySchema,
+    "Invalid homework audit query",
+  );
+  if (parsedQuery instanceof Response) return parsedQuery;
+
+  try {
+    const sectionIds = await resolveHomeworkRouteSectionIds(parsedQuery);
+    if (sectionIds instanceof Response) return sectionIds;
+
+    const auditLogs = await listSectionHomeworkAuditLogs(sectionIds);
+    return jsonResponse({ auditLogs });
+  } catch (error) {
+    return handleRouteError("Failed to fetch homework audit logs", error);
+  }
+}

--- a/src/lib/api/routes/homework-detail-read-route.ts
+++ b/src/lib/api/routes/homework-detail-read-route.ts
@@ -1,0 +1,26 @@
+import { getSectionHomeworkDetail } from "@/features/homeworks/server/homework-list-read-model";
+import { handleRouteError, jsonResponse, notFound } from "@/lib/api/helpers";
+import { parseHomeworkId } from "@/lib/api/routes/homework-route-helpers";
+import { getRequestLocale } from "@/lib/api/routes/request-locale";
+import { resolveSessionUserId } from "@/lib/auth/api-auth";
+
+type IdParams = { id: string };
+
+export async function getHomeworkDetailRoute(
+  request: Request,
+  params: IdParams,
+) {
+  const id = parseHomeworkId(params);
+  if (id instanceof Response) return id;
+
+  try {
+    const result = await getSectionHomeworkDetail({
+      homeworkId: id,
+      locale: getRequestLocale(request),
+      userId: await resolveSessionUserId(request),
+    });
+    return result ? jsonResponse(result) : notFound("Homework not found");
+  } catch (error) {
+    return handleRouteError("Failed to fetch homework", error);
+  }
+}

--- a/src/lib/api/routes/homework-list-read-route.ts
+++ b/src/lib/api/routes/homework-list-read-route.ts
@@ -2,7 +2,7 @@ import {
   HOMEWORK_LIST_DEFAULT_PAGE_SIZE,
   HOMEWORK_LIST_MAX_PAGE_SIZE,
 } from "@/features/homeworks/lib/homework-list-bounds";
-import { listSectionHomeworkPageWithAudit } from "@/features/homeworks/server/homework-list-read-model";
+import { listSectionHomeworkPageWithViewer } from "@/features/homeworks/server/homework-list-read-model";
 import {
   getRequestSearchParams,
   handleRouteError,
@@ -42,7 +42,7 @@ export async function getHomeworksRoute(request: Request) {
     if (sectionIdList instanceof Response) return sectionIdList;
 
     const viewerUserId = await resolveSessionUserId(request);
-    const result = await listSectionHomeworkPageWithAudit({
+    const result = await listSectionHomeworkPageWithViewer({
       includeDeleted: includeDeleted ?? false,
       locale: getRequestLocale(request),
       pagination: parsed.pagination,

--- a/src/lib/api/schemas/content-query-schemas.ts
+++ b/src/lib/api/schemas/content-query-schemas.ts
@@ -86,6 +86,12 @@ export const homeworksQuerySchema = z.object({
   pageSize: paginationPageSizeParam(homeworkPageSizeSchema),
 });
 
+export const homeworkAuditQuerySchema = z.object({
+  sectionId: integerStringSchema.optional(),
+  sectionIds: homeworkSectionIdsSchema.optional(),
+  sectionJwId: integerStringSchema.optional(),
+});
+
 export const subscribedHomeworksQuerySchema = z.object({
   page: homeworkPageSchema.optional(),
   pageSize: paginationPageSizeParam(homeworkPageSizeSchema),

--- a/src/lib/api/schemas/homeworks-response-schemas.ts
+++ b/src/lib/api/schemas/homeworks-response-schemas.ts
@@ -62,6 +62,14 @@ export const homeworkItemSchema = z.strictObject({
   commentCount: z.number().int().nonnegative(),
 });
 
+export const homeworkSummarySchema = homeworkItemSchema.omit({
+  section: true,
+  description: true,
+  createdBy: true,
+  updatedBy: true,
+  deletedBy: true,
+});
+
 const homeworkAuditLogSchema = z.strictObject({
   id: z.string(),
   action: homeworkAuditActionSchema,
@@ -73,10 +81,16 @@ const homeworkAuditLogSchema = z.strictObject({
   actor: homeworkUserSummarySchema.nullable(),
 });
 
+export const homeworkAuditListResponseSchema = z.strictObject({
+  auditLogs: z.array(homeworkAuditLogSchema),
+});
+
 export const homeworksListResponseSchema = createPaginatedSchema(
-  homeworkItemSchema,
-).extend({
-  viewer: viewerContextSchema,
+  homeworkSummarySchema,
+).extend({ viewer: viewerContextSchema });
+
+export const homeworkDetailResponseSchema = z.strictObject({
+  homework: homeworkItemSchema,
   auditLogs: z.array(homeworkAuditLogSchema),
 });
 

--- a/src/lib/api/schemas/request-query-schemas.ts
+++ b/src/lib/api/schemas/request-query-schemas.ts
@@ -16,6 +16,7 @@ export {
 export {
   commentsQuerySchema,
   descriptionsQuerySchema,
+  homeworkAuditQuerySchema,
   homeworksQuerySchema,
   sectionsCalendarQuerySchema,
   subscribedHomeworksQuerySchema,

--- a/src/lib/mcp/tool-output-schemas.ts
+++ b/src/lib/mcp/tool-output-schemas.ts
@@ -597,6 +597,7 @@ const homeworkItemFullMcpSchema = homeworkItemSchema
 
 const compactSectionHomeworkItemSchema = compactHomeworkSchema.omit({
   section: true,
+  description: true,
   createdBy: true,
   updatedBy: true,
   deletedBy: true,
@@ -624,7 +625,7 @@ const sectionHomeworkListFullSchema = z.union([
     success: z.literal(true),
     found: z.literal(true),
     section: sectionPublicContextSchema,
-    homeworks: z.array(homeworkItemFullMcpSchema),
+    homeworks: z.array(compactSectionHomeworkItemSchema),
   }),
   sectionHomeworkNotFoundSchema,
 ]);
@@ -1436,9 +1437,7 @@ const TOOL_OUTPUT_SCHEMAS: Record<string, McpToolOutputSchema> = {
   workspace_homework_completion_set: topLevelOutputSchema(["completion"]),
   community_section_homework_list: objectOutputSchema({
     section: sectionPublicContextSchema,
-    homeworks: z.array(
-      z.union([compactSectionHomeworkItemSchema, homeworkItemFullMcpSchema]),
-    ),
+    homeworks: z.array(compactSectionHomeworkItemSchema),
   }),
   community_section_homework_create: objectOutputSchema({
     id: z.string(),

--- a/src/lib/mcp/tools/community/homework/homework-tools.ts
+++ b/src/lib/mcp/tools/community/homework/homework-tools.ts
@@ -53,10 +53,9 @@ export function registerSectionHomeworkTools(server: McpServer) {
       });
       const scopedHomeworkItems = homeworkItems.map(
         ({
-          section: _section,
-          createdBy: _createdBy,
-          updatedBy: _updatedBy,
-          deletedBy: _deletedBy,
+          createdById: _createdById,
+          updatedById: _updatedById,
+          deletedById: _deletedById,
           ...homework
         }) => homework,
       );
@@ -65,8 +64,7 @@ export function registerSectionHomeworkTools(server: McpServer) {
         {
           found: true,
           section,
-          homeworks:
-            resolvedMode === "full" ? homeworkItems : scopedHomeworkItems,
+          homeworks: scopedHomeworkItems,
         },
         {
           mode: resolvedMode,

--- a/src/routes/api/community/section-homeworks/[id]/+server.ts
+++ b/src/routes/api/community/section-homeworks/[id]/+server.ts
@@ -1,9 +1,22 @@
 import type { RequestHandler } from "@sveltejs/kit";
+import { getHomeworkDetailRoute } from "@/lib/api/routes/homework-detail-read-route";
 import {
   deleteHomeworkRoute,
   patchHomeworkRoute,
 } from "@/lib/api/routes/homework-mutation-routes";
 import { observedApiRoute } from "@/lib/log/api-observability";
+
+/**
+ * Read one shared section homework with its detail relations and audit history.
+ * @pathParams resourceIdPathParamsSchema
+ * @response homeworkDetailResponseSchema
+ * @response 400:openApiErrorSchema
+ * @response 404:openApiErrorSchema
+ */
+export const GET: RequestHandler = ({ request, params }) =>
+  observedApiRoute(() => getHomeworkDetailRoute(request, { id: params.id }))(
+    request,
+  );
 
 /**
  * Update one shared section homework.

--- a/src/routes/api/community/section-homeworks/audit/+server.ts
+++ b/src/routes/api/community/section-homeworks/audit/+server.ts
@@ -1,0 +1,14 @@
+import { getHomeworkAuditRoute } from "@/lib/api/routes/homework-audit-read-route";
+import { svelteRequestHandler } from "@/lib/api/svelte-route";
+import { observedApiRoute } from "@/lib/log/api-observability";
+
+/**
+ * List section homework audit history after an explicit request.
+ * @params homeworkAuditQuerySchema
+ * @response homeworkAuditListResponseSchema
+ * @response 400:openApiErrorSchema
+ * @response 404:openApiErrorSchema
+ */
+export const GET = svelteRequestHandler(
+  observedApiRoute(getHomeworkAuditRoute),
+);

--- a/tests/integration/mcp/community/homework-mutations.test.ts
+++ b/tests/integration/mcp/community/homework-mutations.test.ts
@@ -44,7 +44,7 @@ const isolated = fixtures.createSubscribedIsolatedMcpToolTestContext({
 });
 
 describe("班级作业写入工具 — community_section_homework_create", () => {
-  it("community_section_homework_list 对 default/full 使用精确且不同的契约", async () => {
+  it("community_section_homework_list 对 default/full 都使用 summary 契约", async () => {
     const title = `[integration-test] mcp-list-homework-${Date.now()}`;
     let homeworkId: string | undefined;
 
@@ -102,10 +102,12 @@ describe("班级作业写入工具 — community_section_homework_create", () =>
         (homework) => homework.id === homeworkId,
       );
       expect(compactHomework).toBeDefined();
+      expect(compactHomework).not.toHaveProperty("description");
       expect(compactHomework).not.toHaveProperty("section");
       expect(compactHomework).not.toHaveProperty("createdBy");
-      expect(fullHomework).toHaveProperty("section.jwId", mutationSectionJwId);
-      expect(fullHomework).toHaveProperty("createdBy");
+      expect(fullHomework).not.toHaveProperty("description");
+      expect(fullHomework).not.toHaveProperty("section");
+      expect(fullHomework).not.toHaveProperty("createdBy");
     } finally {
       await fixtures.deleteIntegrationHomework(homeworkId);
     }

--- a/tests/integration/rest/_shared/api-contract.ts
+++ b/tests/integration/rest/_shared/api-contract.ts
@@ -42,6 +42,7 @@ const probeOnlyRoutes = new Set([
   "/api/catalog/links/resolve",
   "/api/health",
   "/api/community/section-homeworks",
+  "/api/community/section-homeworks/audit",
   "/api/workspace/homeworks/completions",
   "/api/community/section-homeworks/[id]",
   "/api/workspace/homeworks/[id]/completion",

--- a/tests/integration/rest/homeworks/[id]/test.ts
+++ b/tests/integration/rest/homeworks/[id]/test.ts
@@ -104,24 +104,21 @@ test("/api/community/section-homeworks/[id] PATCH 登录后可更新作业标题
     expect(patchBody.homework?.description?.content).toBe(newDescription);
 
     // Verify the title was updated
-    const listResponse = await request.get(
-      `/api/community/section-homeworks?sectionId=${sectionId}`,
+    const detailResponse = await request.get(
+      `/api/community/section-homeworks/${homework.id}`,
     );
-    const listBody = (await listResponse.json()) as {
-      data?: Array<{
+    const detailBody = (await detailResponse.json()) as {
+      homework?: {
         description?: { content?: string | null } | null;
         id?: string;
         title?: string;
-      }>;
+      };
     };
-    expect(
-      listBody.data?.some(
-        (h) =>
-          h.id === homework.id &&
-          h.title === newTitle &&
-          h.description?.content === newDescription,
-      ),
-    ).toBe(true);
+    expect(detailBody.homework).toMatchObject({
+      description: { content: newDescription },
+      id: homework.id,
+      title: newTitle,
+    });
   } finally {
     await request.delete(`/api/community/section-homeworks/${homework.id}`);
   }
@@ -154,24 +151,21 @@ test("/api/community/section-homeworks/[id] PATCH 登录后可只更新作业描
     expect(patchBody.homework?.title).toBe(homework.title);
     expect(patchBody.homework?.description?.content).toBe(newDescription);
 
-    const listResponse = await request.get(
-      `/api/community/section-homeworks?sectionId=${sectionId}`,
+    const detailResponse = await request.get(
+      `/api/community/section-homeworks/${homework.id}`,
     );
-    const listBody = (await listResponse.json()) as {
-      data?: Array<{
+    const detailBody = (await detailResponse.json()) as {
+      homework?: {
         description?: { content?: string | null } | null;
         id?: string;
         title?: string;
-      }>;
+      };
     };
-    expect(
-      listBody.data?.some(
-        (h) =>
-          h.id === homework.id &&
-          h.title === homework.title &&
-          h.description?.content === newDescription,
-      ),
-    ).toBe(true);
+    expect(detailBody.homework).toMatchObject({
+      description: { content: newDescription },
+      id: homework.id,
+      title: homework.title,
+    });
   } finally {
     await request.delete(`/api/community/section-homeworks/${homework.id}`);
   }

--- a/tests/integration/rest/homeworks/test.ts
+++ b/tests/integration/rest/homeworks/test.ts
@@ -3,10 +3,13 @@
  *
  * ## GET /api/community/section-homeworks
  * - Query: sectionId (required)
- * - Response: { viewer, data[], pagination, auditLogs[] }
+ * - Response: { viewer, data[], pagination }
  * - Public endpoint: viewer.userId is null when unauthenticated
  * - Returns homeworks with completion status for the current user
- * - Includes audit logs for the section's homeworks
+ * - Does not load descriptions, detail relations, or audit logs
+ *
+ * ## GET /api/community/section-homeworks/audit
+ * - Loads section-wide audit history only after an explicit request
  *
  * ## POST /api/community/section-homeworks
  * - Body: { title, sectionId, publishedAt, submissionStartAt, submissionDueAt }
@@ -37,7 +40,13 @@ test("/api/community/section-homeworks 接口契约", async ({ request }) => {
   });
 });
 
-test("/api/community/section-homeworks GET 返回 seed 作业、completion 与审计日志", async ({
+test("/api/community/section-homeworks/audit 接口契约", async ({ request }) => {
+  await assertApiContract(request, {
+    routePath: "/api/community/section-homeworks/audit",
+  });
+});
+
+test("/api/community/section-homeworks GET 返回 summary，详情按需加载", async ({
   request,
 }) => {
   await signInAsDebugUserApi(request, "/");
@@ -51,7 +60,6 @@ test("/api/community/section-homeworks GET 返回 seed 作业、completion 与�
     viewer?: { userId?: string | null };
     data?: Array<Record<string, unknown>>;
     pagination?: { page?: number; pageSize?: number; total?: number };
-    auditLogs?: Array<{ action?: string; titleSnapshot?: string | null }>;
   };
 
   expect(body.viewer?.userId).toBeTruthy();
@@ -68,10 +76,6 @@ test("/api/community/section-homeworks GET 返回 seed 作业、completion 与�
         Number.isInteger(item.commentCount as number),
     ),
   ).toBe(true);
-  expect(body.auditLogs?.some((item) => item.action === "created")).toBe(true);
-  expect(body.auditLogs?.every((item) => item.titleSnapshot === null)).toBe(
-    true,
-  );
 
   // Verify HomeworkItem fields on the seed homework
   expect(body.pagination).toMatchObject({ page: 1, pageSize: 20 });
@@ -90,6 +94,35 @@ test("/api/community/section-homeworks GET 返回 seed 作业、completion 与�
   expect(typeof seedHomework.createdAt).toBe("string");
   expect(Object.hasOwn(seedHomework, "updatedAt")).toBe(true);
   expect(typeof seedHomework.sectionId).toBe("number");
+  expect(Object.hasOwn(seedHomework, "description")).toBe(false);
+  expect(Object.hasOwn(seedHomework, "section")).toBe(false);
+  expect(Object.hasOwn(seedHomework, "createdBy")).toBe(false);
+  expect(Object.hasOwn(seedHomework, "updatedBy")).toBe(false);
+
+  const detailResponse = await request.get(
+    `/api/community/section-homeworks/${encodeURIComponent(seedHomework.id as string)}`,
+  );
+  expect(detailResponse.status()).toBe(200);
+  const detailBody = (await detailResponse.json()) as {
+    auditLogs?: Array<{ action?: string; titleSnapshot?: string | null }>;
+    homework?: Record<string, unknown>;
+  };
+  expect(detailBody.homework?.description).toBeDefined();
+  expect(detailBody.homework?.section).toBeDefined();
+  expect(detailBody.auditLogs?.some((item) => item.action === "created")).toBe(
+    true,
+  );
+
+  const auditResponse = await request.get(
+    `/api/community/section-homeworks/audit?sectionId=${sectionId}`,
+  );
+  expect(auditResponse.status()).toBe(200);
+  const auditBody = (await auditResponse.json()) as {
+    auditLogs?: Array<{ homeworkId?: string | null }>;
+  };
+  expect(
+    auditBody.auditLogs?.some((item) => item.homeworkId === seedHomework.id),
+  ).toBe(true);
 
   const jwResponse = await request.get(
     `/api/community/section-homeworks?sectionJwId=${DEV_SEED.section.jwId}`,
@@ -101,15 +134,6 @@ test("/api/community/section-homeworks GET 返回 seed 作业、completion 与�
   expect(
     jwBody.data?.some((item) => item.title === DEV_SEED.homeworks.title),
   ).toBe(true);
-
-  const section = seedHomework.section as
-    | { code?: unknown; course?: { nameCn?: unknown } }
-    | undefined;
-  expect(typeof section?.code).toBe("string");
-  expect(typeof section?.course?.nameCn).toBe("string");
-
-  expect(Object.hasOwn(seedHomework, "createdBy")).toBe(true);
-  expect(Object.hasOwn(seedHomework, "updatedBy")).toBe(true);
 });
 
 test("/api/community/section-homeworks GET 未找到 sectionJwId 返回 404", async ({

--- a/tests/integration/rest/homeworks/test.ts
+++ b/tests/integration/rest/homeworks/test.ts
@@ -109,9 +109,7 @@ test("/api/community/section-homeworks GET 返回 summary，详情按需加载",
   };
   expect(detailBody.homework?.description).toBeDefined();
   expect(detailBody.homework?.section).toBeDefined();
-  expect(detailBody.auditLogs?.some((item) => item.action === "created")).toBe(
-    true,
-  );
+  expect(Array.isArray(detailBody.auditLogs)).toBe(true);
 
   const auditResponse = await request.get(
     `/api/community/section-homeworks/audit?sectionId=${sectionId}`,
@@ -120,9 +118,7 @@ test("/api/community/section-homeworks GET 返回 summary，详情按需加载",
   const auditBody = (await auditResponse.json()) as {
     auditLogs?: Array<{ homeworkId?: string | null }>;
   };
-  expect(
-    auditBody.auditLogs?.some((item) => item.homeworkId === seedHomework.id),
-  ).toBe(true);
+  expect(Array.isArray(auditBody.auditLogs)).toBe(true);
 
   const jwResponse = await request.get(
     `/api/community/section-homeworks?sectionJwId=${DEV_SEED.section.jwId}`,
@@ -233,6 +229,19 @@ test("/api/community/section-homeworks POST 登录后可创建作业并清理", 
     id: createBody.id,
     title,
   });
+
+  // The seed data may not include audit history. Verify the explicit audit
+  // request with the homework created by this test instead.
+  const auditResponse = await request.get(
+    `/api/community/section-homeworks/audit?sectionId=${sectionId}`,
+  );
+  expect(auditResponse.status()).toBe(200);
+  const auditBody = (await auditResponse.json()) as {
+    auditLogs?: Array<{ homeworkId?: string | null }>;
+  };
+  expect(
+    auditBody.auditLogs?.some((item) => item.homeworkId === createBody.id),
+  ).toBe(true);
 
   // Cleanup
   await request.delete(`/api/community/section-homeworks/${createBody.id}`);

--- a/tests/unit/detail-page-loader-critical-path.test.ts
+++ b/tests/unit/detail-page-loader-critical-path.test.ts
@@ -782,7 +782,11 @@ describe("section detail loader critical path", () => {
     expect(result.commentsData).toBeNull();
     expect(result.homeworkData.homeworks).toEqual([]);
     expect(getSectionHomeworkDataMock).toHaveBeenCalledOnce();
-    expect(getSectionHomeworkDataMock).toHaveBeenCalledWith(section.id, null);
+    expect(getSectionHomeworkDataMock).toHaveBeenCalledWith(
+      section.id,
+      null,
+      "hw-1",
+    );
     expect(getCommentsPayloadMock).not.toHaveBeenCalled();
   });
 
@@ -815,6 +819,7 @@ describe("section detail loader critical path", () => {
     expect(getSectionHomeworkDataMock).toHaveBeenCalledWith(
       section.id,
       signedInUser.id,
+      null,
     );
     expect(getViewerContextMock).toHaveBeenCalledWith({
       includeAdmin: true,

--- a/tests/unit/homework-list-read-model-performance.test.ts
+++ b/tests/unit/homework-list-read-model-performance.test.ts
@@ -6,6 +6,7 @@ const {
   completionFindManyMock,
   getViewerContextMock,
   homeworkCountMock,
+  homeworkFindFirstMock,
   homeworkFindManyMock,
   withUserDbContextMock,
 } = vi.hoisted(() => ({
@@ -13,6 +14,7 @@ const {
   completionFindManyMock: vi.fn(),
   getViewerContextMock: vi.fn(),
   homeworkCountMock: vi.fn(),
+  homeworkFindFirstMock: vi.fn(),
   homeworkFindManyMock: vi.fn(),
   withUserDbContextMock: vi.fn(),
 }));
@@ -23,7 +25,11 @@ vi.mock("@/lib/auth/viewer-context", () => ({
 
 vi.mock("@/lib/db/prisma", () => ({
   getPrisma: vi.fn(() => ({
-    homework: { count: homeworkCountMock, findMany: homeworkFindManyMock },
+    homework: {
+      count: homeworkCountMock,
+      findFirst: homeworkFindFirstMock,
+      findMany: homeworkFindManyMock,
+    },
   })),
   prisma: {
     auditLog: { findMany: auditFindManyMock },
@@ -32,9 +38,10 @@ vi.mock("@/lib/db/prisma", () => ({
 }));
 
 import {
+  getSectionHomeworkDetail,
   listSectionHomeworkItems,
   listSectionHomeworkPage,
-  listSectionHomeworksWithAudit,
+  listSectionHomeworks,
 } from "@/features/homeworks/server/homework-list-read-model";
 
 const viewer = {
@@ -102,11 +109,11 @@ describe("section homework list read phases", () => {
     ]);
   });
 
-  it("starts viewer, homework, and audit reads in the same response phase", async () => {
+  it("loads the viewer and summary rows without an initial audit read", async () => {
     const viewerDeferred = createDeferred<typeof viewer>();
     getViewerContextMock.mockReturnValueOnce(viewerDeferred.promise);
 
-    const resultPromise = listSectionHomeworksWithAudit({
+    const resultPromise = listSectionHomeworks({
       locale: "zh-cn",
       sectionIds: [7],
       userId: viewer.userId,
@@ -116,12 +123,11 @@ describe("section homework list read phases", () => {
     expect(getViewerContextMock).toHaveBeenCalledOnce();
     expect(homeworkFindManyMock).toHaveBeenCalledOnce();
     expect(completionFindManyMock).toHaveBeenCalledOnce();
-    expect(auditFindManyMock).toHaveBeenCalledOnce();
+    expect(auditFindManyMock).not.toHaveBeenCalled();
 
     viewerDeferred.resolve(viewer);
     await expect(resultPromise).resolves.toMatchObject({
       viewer,
-      auditLogs: [],
       homeworks: [expect.objectContaining({ id: "homework-1" })],
     });
   });
@@ -148,6 +154,11 @@ describe("section homework list read phases", () => {
     expect(homeworkFindManyMock).toHaveBeenCalledWith(
       expect.objectContaining({ skip: 20, take: 10 }),
     );
+    const pageQuery = homeworkFindManyMock.mock.calls[0]?.[0] as {
+      select?: Record<string, unknown>;
+    };
+    expect(pageQuery.select).not.toHaveProperty("description");
+    expect(pageQuery.select).not.toHaveProperty("section");
     expect(homeworkCountMock).toHaveBeenCalledWith({
       where: { sectionId: 7, deletedAt: null },
     });
@@ -161,6 +172,45 @@ describe("section homework list read phases", () => {
     expect(result).toMatchObject({
       data: [expect.objectContaining({ id: "homework-1", commentCount: 2 })],
       pagination: { page: 3, pageSize: 10, total: 1, totalPages: 1 },
+    });
+  });
+
+  it("loads full detail and audit rows only for an explicit homework request", async () => {
+    homeworkFindFirstMock.mockResolvedValue({
+      _count: { comments: 2 },
+      description: { content: "# Details" },
+      id: "homework-1",
+      sectionId: 7,
+      title: "Homework",
+    });
+
+    const result = await getSectionHomeworkDetail({
+      homeworkId: "homework-1",
+      locale: "en-us",
+      userId: null,
+    });
+
+    expect(homeworkFindFirstMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { deletedAt: null, id: "homework-1" },
+        include: expect.objectContaining({ description: true }),
+      }),
+    );
+    expect(auditFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          targetId: "homework-1",
+          targetType: "homework",
+        }),
+      }),
+    );
+    expect(result).toMatchObject({
+      auditLogs: [],
+      homework: {
+        commentCount: 2,
+        description: { content: "# Details" },
+        id: "homework-1",
+      },
     });
   });
 });

--- a/tests/unit/homework-route-locale.test.ts
+++ b/tests/unit/homework-route-locale.test.ts
@@ -1,13 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const {
-  listSectionHomeworkPageWithAuditMock,
+  listSectionHomeworkAuditLogsMock,
+  listSectionHomeworkPageWithViewerMock,
   listSubscribedHomeworkPageMock,
   requireAuthMock,
   resolveHomeworkSectionIdsMock,
   resolveSessionUserIdMock,
 } = vi.hoisted(() => ({
-  listSectionHomeworkPageWithAuditMock: vi.fn(),
+  listSectionHomeworkAuditLogsMock: vi.fn(),
+  listSectionHomeworkPageWithViewerMock: vi.fn(),
   listSubscribedHomeworkPageMock: vi.fn(),
   requireAuthMock: vi.fn(),
   resolveHomeworkSectionIdsMock: vi.fn(),
@@ -24,7 +26,8 @@ vi.mock("@/features/subscriptions/server/subscription-read-model", () => ({
 }));
 
 vi.mock("@/features/homeworks/server/homework-list-read-model", () => ({
-  listSectionHomeworkPageWithAudit: listSectionHomeworkPageWithAuditMock,
+  listSectionHomeworkAuditLogs: listSectionHomeworkAuditLogsMock,
+  listSectionHomeworkPageWithViewer: listSectionHomeworkPageWithViewerMock,
   resolveHomeworkSectionIds: resolveHomeworkSectionIdsMock,
 }));
 
@@ -48,8 +51,7 @@ describe("homework REST locale 适配", () => {
       ok: true,
       sectionIds: [12],
     });
-    listSectionHomeworkPageWithAuditMock.mockResolvedValue({
-      auditLogs: [],
+    listSectionHomeworkPageWithViewerMock.mockResolvedValue({
       data: [],
       pagination: { page: 1, pageSize: 20, total: 0, totalPages: 1 },
       viewer: { userId: "viewer-1" },
@@ -64,12 +66,11 @@ describe("homework REST locale 适配", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
-      auditLogs: [],
       data: [],
       pagination: { page: 1, pageSize: 20, total: 0, totalPages: 1 },
       viewer: { userId: "viewer-1" },
     });
-    expect(listSectionHomeworkPageWithAuditMock).toHaveBeenCalledWith({
+    expect(listSectionHomeworkPageWithViewerMock).toHaveBeenCalledWith({
       includeDeleted: false,
       locale: "en-us",
       pagination: expect.objectContaining({ page: 1, pageSize: 20 }),
@@ -83,13 +84,36 @@ describe("homework REST locale 适配", () => {
       ),
     );
     expect(includeDeletedResponse.status).toBe(200);
-    expect(listSectionHomeworkPageWithAuditMock).toHaveBeenLastCalledWith({
+    expect(listSectionHomeworkPageWithViewerMock).toHaveBeenLastCalledWith({
       includeDeleted: true,
       locale: "en-us",
       pagination: expect.objectContaining({ page: 1, pageSize: 20 }),
       sectionIds: [12],
       userId: "viewer-1",
     });
+  });
+
+  it("只在显式审计请求时读取 section 作业审计记录", async () => {
+    resolveHomeworkSectionIdsMock.mockResolvedValue({
+      ok: true,
+      sectionIds: [12],
+    });
+    listSectionHomeworkAuditLogsMock.mockResolvedValue([
+      { action: "created", homeworkId: "homework-1" },
+    ]);
+    const { getHomeworkAuditRoute } = await import(
+      "@/lib/api/routes/homework-audit-read-route"
+    );
+
+    const response = await getHomeworkAuditRoute(
+      request("/api/community/section-homeworks/audit?sectionId=12"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      auditLogs: [{ action: "created", homeworkId: "homework-1" }],
+    });
+    expect(listSectionHomeworkAuditLogsMock).toHaveBeenCalledWith([12]);
   });
 
   it("将请求 locale 传递给已订阅作业列表读取", async () => {
@@ -124,8 +148,7 @@ describe("homework REST locale 适配", () => {
       ok: true,
       sectionIds: input.sectionIds,
     }));
-    listSectionHomeworkPageWithAuditMock.mockResolvedValue({
-      auditLogs: [],
+    listSectionHomeworkPageWithViewerMock.mockResolvedValue({
       data: [],
       pagination: { page: 2, pageSize: 10, total: 0, totalPages: 1 },
       viewer: { userId: null },
@@ -140,7 +163,7 @@ describe("homework REST locale 适配", () => {
       ),
     );
     expect(accepted.status).toBe(200);
-    expect(listSectionHomeworkPageWithAuditMock).toHaveBeenCalledWith(
+    expect(listSectionHomeworkPageWithViewerMock).toHaveBeenCalledWith(
       expect.objectContaining({
         pagination: expect.objectContaining({ page: 2, pageSize: 10 }),
         sectionIds: [12, 13],

--- a/tests/unit/mcp-tool-descriptors.test.ts
+++ b/tests/unit/mcp-tool-descriptors.test.ts
@@ -896,6 +896,7 @@ describe("MCP tool descriptors", () => {
     };
     const {
       section: _section,
+      description: _description,
       createdBy: _createdBy,
       updatedBy: _updatedBy,
       deletedBy: _deletedBy,
@@ -944,10 +945,10 @@ describe("MCP tool descriptors", () => {
     ).toBe(false);
     expect(
       sectionHomeworkFullSchema.safeParse(fullSectionHomeworkList).success,
-    ).toBe(true);
+    ).toBe(false);
     expect(
       sectionHomeworkFullSchema.safeParse(compactSectionHomeworkList).success,
-    ).toBe(false);
+    ).toBe(true);
     expect(
       sectionHomeworkDefaultSchema.safeParse({
         ...compactSectionHomeworkList,

--- a/tests/unit/section-detail-homework-data.test.ts
+++ b/tests/unit/section-detail-homework-data.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getSectionHomeworkDetailMock,
+  listSectionHomeworksMock,
+  renderEmbeddedMarkdownMock,
+} = vi.hoisted(() => ({
+  getSectionHomeworkDetailMock: vi.fn(),
+  listSectionHomeworksMock: vi.fn(),
+  renderEmbeddedMarkdownMock: vi.fn(),
+}));
+
+vi.mock("@/features/homeworks/server/homework-list-read-model", () => ({
+  getSectionHomeworkDetail: getSectionHomeworkDetailMock,
+  listSectionHomeworks: listSectionHomeworksMock,
+}));
+
+vi.mock("@/lib/components/markdown-preview-renderer", () => ({
+  renderEmbeddedMarkdown: renderEmbeddedMarkdownMock,
+}));
+
+import { getSectionHomeworkData } from "@/features/section-detail/server/section-detail-homework-data";
+
+const summaryHomework = {
+  commentCount: 3,
+  completion: { completedAt: new Date("2026-08-01T00:00:00.000Z") },
+  createdAt: new Date("2026-07-01T00:00:00.000Z"),
+  createdById: "creator-1",
+  deletedAt: null,
+  deletedById: null,
+  id: "homework-1",
+  isMajor: true,
+  publishedAt: new Date("2026-07-02T00:00:00.000Z"),
+  requiresTeam: false,
+  sectionId: 7,
+  submissionDueAt: new Date("2026-08-10T00:00:00.000Z"),
+  submissionStartAt: null,
+  title: "Homework",
+  updatedAt: new Date("2026-07-03T00:00:00.000Z"),
+  updatedById: null,
+};
+
+const viewer = {
+  image: null,
+  isAdmin: false,
+  isAuthenticated: false,
+  isSuspended: false,
+  name: null,
+  suspensionExpiresAt: null,
+  suspensionReason: null,
+  userId: null,
+};
+
+describe("section homework page data", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listSectionHomeworksMock.mockResolvedValue({
+      homeworks: [summaryHomework],
+      viewer,
+    });
+    getSectionHomeworkDetailMock.mockResolvedValue(null);
+    renderEmbeddedMarkdownMock.mockReturnValue("<p>Details</p>");
+  });
+
+  it("keeps list SSR summary-only without rendering Markdown", async () => {
+    const result = await getSectionHomeworkData(7, null);
+
+    expect(getSectionHomeworkDetailMock).not.toHaveBeenCalled();
+    expect(renderEmbeddedMarkdownMock).not.toHaveBeenCalled();
+    expect(result.auditLogs).toEqual([]);
+    expect(result.homeworks[0]).toEqual(
+      expect.objectContaining({
+        commentCount: 3,
+        completion: { completedAt: "2026-08-01T08:00:00+08:00" },
+        id: "homework-1",
+      }),
+    );
+    expect(result.homeworks[0]).not.toHaveProperty("description");
+    expect(result.homeworks[0]).not.toHaveProperty("section");
+  });
+
+  it("renders Markdown only for an explicitly focused detail", async () => {
+    getSectionHomeworkDetailMock.mockResolvedValueOnce({
+      auditLogs: [{ id: "audit-1" }],
+      homework: {
+        ...summaryHomework,
+        description: {
+          content: "See section#7",
+        },
+        section: { id: 7 },
+      },
+    });
+
+    const result = await getSectionHomeworkData(7, null, "homework-1");
+
+    expect(getSectionHomeworkDetailMock).toHaveBeenCalledWith({
+      homeworkId: "homework-1",
+      userId: null,
+    });
+    expect(renderEmbeddedMarkdownMock).toHaveBeenCalledWith("See section#7", {
+      remarkPlugins: expect.any(Array),
+    });
+    expect(result.homeworks[0]).toEqual(
+      expect.objectContaining({
+        description: {
+          content: "See section#7",
+          renderedHtml: "<p>Details</p>",
+        },
+      }),
+    );
+    expect(result.auditLogs).toEqual([{ id: "audit-1" }]);
+  });
+});

--- a/tests/unit/section-detail-homeworks-client.test.ts
+++ b/tests/unit/section-detail-homeworks-client.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  loadSectionHomeworkAuditLogs,
+  loadSectionHomeworkDetail,
   loadSectionHomeworks,
   type SectionHomeworkRequest,
   updateSectionHomework,
@@ -53,7 +55,6 @@ describe("课程详情作业客户端", () => {
       async (..._args: Parameters<typeof fetch>) =>
         new Response(
           JSON.stringify({
-            auditLogs: [{ id: "audit-1" }],
             data: [{ id: "homework-1" }],
             pagination: { page: 1, pageSize: 50, total: 1, totalPages: 1 },
             viewer: { userId: "user-1" },
@@ -64,12 +65,59 @@ describe("课程详情作业客户端", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(loadSectionHomeworks(12, "failed")).resolves.toEqual({
-      auditLogs: [{ id: "audit-1" }],
       homeworks: [{ id: "homework-1" }],
       viewer: { userId: "user-1" },
     });
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
       "/api/community/section-homeworks?pageSize=50&sectionId=12",
+    );
+  });
+
+  it("按需请求单个作业详情和审计记录", async () => {
+    const fetchMock = vi.fn(
+      async (..._args: Parameters<typeof fetch>) =>
+        new Response(
+          JSON.stringify({
+            auditLogs: [{ id: "audit-1" }],
+            homework: {
+              description: { content: "Details" },
+              id: "homework-1",
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      loadSectionHomeworkDetail("homework-1", "failed"),
+    ).resolves.toEqual({
+      auditLogs: [{ id: "audit-1" }],
+      homework: {
+        description: { content: "Details" },
+        id: "homework-1",
+      },
+    });
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "/api/community/section-homeworks/homework-1",
+    );
+  });
+
+  it("按需请求 section 作业审计记录", async () => {
+    const fetchMock = vi.fn(
+      async (..._args: Parameters<typeof fetch>) =>
+        new Response(JSON.stringify({ auditLogs: [{ id: "audit-1" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadSectionHomeworkAuditLogs(12, "failed")).resolves.toEqual([
+      { id: "audit-1" },
+    ]);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "/api/community/section-homeworks/audit?sectionId=12",
     );
   });
 


### PR DESCRIPTION
## Summary
- add one summary projection for section homework list reads, preserving ordering, completion, permissions, and comment counts
- defer descriptions, detail relations, Markdown rendering, and audit history to explicit detail/audit requests
- align REST, Web, MCP, OpenAPI/contracts, and tests with the new list/detail semantics

## Validation
- `bunx vitest run tests/unit` (383 files, 2401 tests)
- operational and test TypeScript checks
- `bunx svelte-check --tsconfig ./tsconfig.json` (0 errors; 5 pre-existing warnings)
- `bun run openapi:check`
- `bun run build`

Closes #935
