### PR TITLE
ci(release): gate publishing on current main CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,17 @@ on:
     branches:
       - main
 
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
 jobs:
   semantic-release:
     name: Semantic
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' && github.repository == 'Life-USTC/server' && !contains(github.event.workflow_run.head_commit.message || '', '[skip ci]')
     permissions:
+      actions: read
       contents: write
       issues: write
       pull-requests: write
@@ -25,13 +30,63 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve current main
+        id: current-main
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --prune --tags origin main
+          git checkout -B main origin/main
+          current_sha="$(git rev-parse HEAD)"
+          echo "sha=${current_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify current main has a successful full CI run
+        id: ci-gate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_SHA: ${{ steps.current-main.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          if ! ci_runs="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?branch=main&event=push&head_sha=${CURRENT_SHA}&status=completed&per_page=100")"; then
+            echo "verified=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Release skipped"
+              echo
+              echo "GitHub Actions API lookup failed for current main ${CURRENT_SHA}; waiting for its CI completion event."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if jq -e --arg sha "$CURRENT_SHA" \
+            'any(.workflow_runs[]?; .head_sha == $sha and .head_branch == "main" and .event == "push" and .status == "completed" and .conclusion == "success")' \
+            <<<"$ci_runs" >/dev/null; then
+            echo "verified=true" >> "$GITHUB_OUTPUT"
+            echo "Verified successful full CI run for current main ${CURRENT_SHA}."
+          else
+            echo "verified=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Release skipped"
+              echo
+              echo "No completed successful full CI run was found for current main ${CURRENT_SHA}; waiting for its CI completion event."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Setup workspace
+        if: steps.ci-gate.outputs.verified == 'true'
         uses: ./.github/actions/setup-bun-env
 
+      - name: Refresh main before release
+        if: steps.ci-gate.outputs.verified == 'true'
+        shell: bash
+        run: git fetch --prune --tags origin main
+
       - name: Run semantic-release
+        if: steps.ci-gate.outputs.verified == 'true'
         run: bun run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/unit/release-workflow-contract.test.ts
+++ b/tests/unit/release-workflow-contract.test.ts
@@ -1,0 +1,32 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+describe("release workflow contract", () => {
+  it("serializes releases and gates the current main tip on full CI", async () => {
+    const workflow = await readFile(
+      new URL("../../.github/workflows/release.yml", import.meta.url),
+      "utf8",
+    );
+
+    expect(workflow).toMatch(
+      /concurrency:\n {2}group: release-main\n {2}cancel-in-progress: false/,
+    );
+    expect(workflow).toContain("actions: read");
+    expect(workflow).toContain("ref: main");
+    expect(workflow).not.toContain(
+      "ref: ${{ github.event.workflow_run.head_sha " + "}}",
+    );
+    expect(workflow).toContain(
+      "actions/workflows/ci.yml/runs?branch=main&event=push&head_sha=$" +
+        "{CURRENT_SHA}&status=completed",
+    );
+    expect(workflow).toContain(
+      '.head_branch == "main" and .event == "push" and .status == "completed" and .conclusion == "success"',
+    );
+    expect(workflow).toMatch(
+      /name: Run semantic-release\n\s+if: steps\.ci-gate\.outputs\.verified == 'true'/,
+    );
+    expect(workflow).toContain("git fetch --prune --tags origin main");
+  });
+});


### PR DESCRIPTION
## Summary

- Serialize release runs with the `release-main` concurrency group.
- Checkout and fetch the current `main` tip instead of the triggering run's stale SHA.
- Use the workflow token with `actions: read` to require a completed successful `CI` push run for that exact `main` SHA.
- Safely skip semantic-release when the API lookup fails or no matching full CI run exists; that SHA's later CI completion event will retry the workflow.
- Refresh `origin/main` immediately before semantic-release so its existing branch-ahead safety check handles a main advance after verification.

## Validation

- `actionlint .github/workflows/release.yml`
- Ruby YAML parse, `yq`, `git diff --check`
- `bun run app:prepare`
- `bunx vitest run tests/unit` (383 files, 2396 tests passed)
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx biome check`
- `bunx wrangler types --include-runtime=false --check`

Full-repository actionlint still reports the pre-existing `ci.yml:215 queue: max` contract; this PR does not alter that workflow.