### PR TITLE
feat(observability): integrate runtime telemetry and catalog/calendar optimizations

### DIFF
--- a/src/features/calendar/server/calendar-export-rebuild.ts
+++ b/src/features/calendar/server/calendar-export-rebuild.ts
@@ -45,26 +45,26 @@ async function listSectionSubscriberUserIds(sectionId: number) {
 
 type CalendarExportRebuildTargets = {
   noSubscriberMessageCount: number;
+  userContributionCounts: ReadonlyMap<string, number>;
   userIds: string[];
-  userMessageCounts: ReadonlyMap<string, number>;
 };
 
-function incrementCount<TKey>(map: Map<TKey, number>, key: TKey) {
-  map.set(key, (map.get(key) ?? 0) + 1);
+function incrementCount<TKey>(map: Map<TKey, number>, key: TKey, amount = 1) {
+  map.set(key, (map.get(key) ?? 0) + amount);
 }
 
 async function collectCalendarExportRebuildTargets(
   messages: CalendarExportRebuildMessage[],
 ): Promise<CalendarExportRebuildTargets> {
   const userIds = new Set<string>();
-  const userMessageCounts = new Map<string, number>();
+  const userContributionCounts = new Map<string, number>();
   const sectionIds = new Set<number>();
   const sectionMessageCounts = new Map<number, number>();
 
   for (const message of messages) {
     if (message.type === "user") {
       userIds.add(message.userId);
-      incrementCount(userMessageCounts, message.userId);
+      incrementCount(userContributionCounts, message.userId);
       continue;
     }
     sectionIds.add(message.sectionId);
@@ -77,15 +77,22 @@ async function collectCalendarExportRebuildTargets(
     if (subscribers.length === 0) {
       noSubscriberMessageCount += sectionMessageCounts.get(sectionId) ?? 0;
     }
-    for (const userId of subscribers) {
+    // A section message contributes once for each distinct current subscriber.
+    // Keep duplicate subscription rows from inflating original-message counts.
+    for (const userId of new Set(subscribers)) {
       userIds.add(userId);
+      incrementCount(
+        userContributionCounts,
+        userId,
+        sectionMessageCounts.get(sectionId) ?? 0,
+      );
     }
   }
 
   return {
     noSubscriberMessageCount,
+    userContributionCounts,
     userIds: [...userIds],
-    userMessageCounts,
   };
 }
 
@@ -98,7 +105,9 @@ export async function collectCalendarExportRebuildUserIds(
 export type CalendarExportRebuildProcessingReport = {
   noOpMessageCount: number;
   noSubscriberMessageCount: number;
+  /** Completed rebuild attempts for distinct users, including deleted users. */
   processedUserCount: number;
+  /** Distinct users coalesced from direct messages and section fan-out. */
   uniqueUserRebuildCount: number;
 };
 
@@ -124,9 +133,13 @@ export async function processCalendarExportRebuildMessages(
   for (const userId of targets.userIds) {
     try {
       const calendar = await rebuildUserCalendarExport(userId);
+      // Coalescing intentionally runs one rebuild per distinct user. Keep
+      // this count user-based; no-op messages are expanded separately from
+      // the original direct/section contributions below.
       report.processedUserCount += 1;
       if (calendar === null) {
-        report.noOpMessageCount += targets.userMessageCounts.get(userId) ?? 0;
+        report.noOpMessageCount +=
+          targets.userContributionCounts.get(userId) ?? 0;
       }
       if (progress) Object.assign(progress, report);
       writeCalendarExportRebuildAnalytics({ status: "ok" });

--- a/src/features/calendar/server/calendar-export-rebuild.ts
+++ b/src/features/calendar/server/calendar-export-rebuild.ts
@@ -5,8 +5,13 @@ import {
   parseCalendarExportRebuildMessage,
 } from "@/features/calendar/server/calendar-export-queue";
 import { buildUserCalendarExport } from "@/features/calendar/server/calendar-export-service";
+import {
+  type CalendarQueueBatchOutcome,
+  writeCalendarQueueBatchAnalytics,
+} from "@/features/calendar/server/calendar-queue-batch-analytics";
 import { prisma } from "@/lib/db/prisma";
 import { logAppEvent } from "@/lib/log/app-logger";
+import { elapsedMs, monotonicNowMs } from "@/lib/log/observability-clock";
 import { writeCalendarExportRebuildAnalytics } from "@/lib/metrics/analytics-engine";
 
 export async function rebuildUserCalendarExport(userId: string) {
@@ -38,28 +43,64 @@ async function listSectionSubscriberUserIds(sectionId: number) {
   return subscribers.map((subscriber) => subscriber.userId);
 }
 
-export async function collectCalendarExportRebuildUserIds(
+type CalendarExportRebuildTargets = {
+  noSubscriberMessageCount: number;
+  userIds: string[];
+  userMessageCounts: ReadonlyMap<string, number>;
+};
+
+function incrementCount<TKey>(map: Map<TKey, number>, key: TKey) {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+async function collectCalendarExportRebuildTargets(
   messages: CalendarExportRebuildMessage[],
-) {
+): Promise<CalendarExportRebuildTargets> {
   const userIds = new Set<string>();
+  const userMessageCounts = new Map<string, number>();
   const sectionIds = new Set<number>();
+  const sectionMessageCounts = new Map<number, number>();
 
   for (const message of messages) {
     if (message.type === "user") {
       userIds.add(message.userId);
+      incrementCount(userMessageCounts, message.userId);
       continue;
     }
     sectionIds.add(message.sectionId);
+    incrementCount(sectionMessageCounts, message.sectionId);
   }
 
+  let noSubscriberMessageCount = 0;
   for (const sectionId of sectionIds) {
-    for (const userId of await listSectionSubscriberUserIds(sectionId)) {
+    const subscribers = await listSectionSubscriberUserIds(sectionId);
+    if (subscribers.length === 0) {
+      noSubscriberMessageCount += sectionMessageCounts.get(sectionId) ?? 0;
+    }
+    for (const userId of subscribers) {
       userIds.add(userId);
     }
   }
 
-  return [...userIds];
+  return {
+    noSubscriberMessageCount,
+    userIds: [...userIds],
+    userMessageCounts,
+  };
 }
+
+export async function collectCalendarExportRebuildUserIds(
+  messages: CalendarExportRebuildMessage[],
+) {
+  return (await collectCalendarExportRebuildTargets(messages)).userIds;
+}
+
+export type CalendarExportRebuildProcessingReport = {
+  noOpMessageCount: number;
+  noSubscriberMessageCount: number;
+  processedUserCount: number;
+  uniqueUserRebuildCount: number;
+};
 
 export async function processCalendarExportRebuildMessage(
   message: CalendarExportRebuildMessage,
@@ -69,13 +110,28 @@ export async function processCalendarExportRebuildMessage(
 
 export async function processCalendarExportRebuildMessages(
   messages: CalendarExportRebuildMessage[],
+  progress?: CalendarExportRebuildProcessingReport,
 ) {
-  const userIds = await collectCalendarExportRebuildUserIds(messages);
-  for (const userId of userIds) {
+  const targets = await collectCalendarExportRebuildTargets(messages);
+  const report: CalendarExportRebuildProcessingReport = {
+    noOpMessageCount: targets.noSubscriberMessageCount,
+    noSubscriberMessageCount: targets.noSubscriberMessageCount,
+    processedUserCount: 0,
+    uniqueUserRebuildCount: targets.userIds.length,
+  };
+  if (progress) Object.assign(progress, report);
+
+  for (const userId of targets.userIds) {
     try {
-      await rebuildUserCalendarExport(userId);
+      const calendar = await rebuildUserCalendarExport(userId);
+      report.processedUserCount += 1;
+      if (calendar === null) {
+        report.noOpMessageCount += targets.userMessageCounts.get(userId) ?? 0;
+      }
+      if (progress) Object.assign(progress, report);
       writeCalendarExportRebuildAnalytics({ status: "ok" });
     } catch (error) {
+      if (progress) Object.assign(progress, report);
       writeCalendarExportRebuildAnalytics({ status: "error" });
       throw error;
     }
@@ -84,8 +140,10 @@ export async function processCalendarExportRebuildMessages(
 
 export type CalendarExportRebuildQueueMessage = {
   ack(): void;
+  attempts?: number;
   body: unknown;
   retry(): void;
+  timestamp?: Date;
 };
 
 export type CalendarExportRebuildQueueBatch = {
@@ -93,8 +151,45 @@ export type CalendarExportRebuildQueueBatch = {
 };
 
 export type CalendarExportRebuildQueueBatchReport = {
-  outcome: "partial" | "retry" | "success";
+  outcome: CalendarQueueBatchOutcome;
 };
+
+type CalendarExportRebuildBatchCounters = {
+  ackedMessageCount: number;
+  inputMessageCount: number;
+  invalidMessageCount: number;
+  maxAgeMs: number;
+  maxAttempts: number;
+  noOpMessageCount: number;
+  noSubscriberMessageCount: number;
+  processedUserCount: number;
+  retriedMessageCount: number;
+  sectionMessageCount: number;
+  uniqueUserRebuildCount: number;
+  userMessageCount: number;
+};
+
+function recordQueueMessageMetadata(
+  counters: CalendarExportRebuildBatchCounters,
+  message: CalendarExportRebuildQueueMessage,
+  now: number,
+) {
+  if (message.timestamp instanceof Date) {
+    const ageMs = now - message.timestamp.getTime();
+    if (Number.isFinite(ageMs)) {
+      counters.maxAgeMs = Math.max(counters.maxAgeMs, Math.max(0, ageMs));
+    }
+  }
+  if (
+    typeof message.attempts === "number" &&
+    Number.isFinite(message.attempts)
+  ) {
+    counters.maxAttempts = Math.max(
+      counters.maxAttempts,
+      Math.max(0, message.attempts),
+    );
+  }
+}
 
 /**
  * Worker queue entrypoint: parse, coalesce, rebuild, ack/retry per message.
@@ -102,56 +197,104 @@ export type CalendarExportRebuildQueueBatchReport = {
 export async function handleCalendarExportRebuildBatch(
   batch: CalendarExportRebuildQueueBatch,
 ): Promise<CalendarExportRebuildQueueBatchReport> {
-  const parsed: CalendarExportRebuildMessage[] = [];
-  const validMessages: CalendarExportRebuildQueueMessage[] = [];
-
-  for (const message of batch.messages) {
-    const body = parseCalendarExportRebuildMessage(message.body);
-    if (!body) {
-      logAppEvent("error", "calendar-export-rebuild.invalid-message", {
-        event: "calendar-export-rebuild.invalid-message",
-        phase: "consumer",
-        reason: "invalid_envelope",
-        source: "calendar-export-rebuild",
-      });
-      // Keep the body out of logs. Retrying lets the configured DLQ retain the
-      // invalid envelope for bounded operational inspection.
-      message.retry();
-      continue;
-    }
-    parsed.push(body);
-    validMessages.push(message);
-  }
-
-  if (batch.messages.length === 0) return { outcome: "success" };
-  if (parsed.length === 0) return { outcome: "retry" };
-
+  const start = monotonicNowMs();
+  const counters: CalendarExportRebuildBatchCounters = {
+    ackedMessageCount: 0,
+    inputMessageCount: batch.messages.length,
+    invalidMessageCount: 0,
+    maxAgeMs: 0,
+    maxAttempts: 0,
+    noOpMessageCount: 0,
+    noSubscriberMessageCount: 0,
+    processedUserCount: 0,
+    retriedMessageCount: 0,
+    sectionMessageCount: 0,
+    uniqueUserRebuildCount: 0,
+    userMessageCount: 0,
+  };
+  const processingProgress: CalendarExportRebuildProcessingReport = {
+    noOpMessageCount: 0,
+    noSubscriberMessageCount: 0,
+    processedUserCount: 0,
+    uniqueUserRebuildCount: 0,
+  };
+  let outcome: CalendarQueueBatchOutcome = "error";
   try {
-    await processCalendarExportRebuildMessages(parsed);
-    for (const message of validMessages) {
-      message.ack();
+    const now = Date.now();
+    const parsed: CalendarExportRebuildMessage[] = [];
+    const validMessages: CalendarExportRebuildQueueMessage[] = [];
+
+    for (const message of batch.messages) {
+      recordQueueMessageMetadata(counters, message, now);
+      const body = parseCalendarExportRebuildMessage(message.body);
+      if (!body) {
+        counters.invalidMessageCount += 1;
+        logAppEvent("error", "calendar-export-rebuild.invalid-message", {
+          event: "calendar-export-rebuild.invalid-message",
+          phase: "consumer",
+          reason: "invalid_envelope",
+          source: "calendar-export-rebuild",
+        });
+        // Keep the body out of logs. Retrying lets the configured DLQ retain the
+        // invalid envelope for bounded operational inspection.
+        counters.retriedMessageCount += 1;
+        message.retry();
+        continue;
+      }
+      parsed.push(body);
+      validMessages.push(message);
+      if (body.type === "user") {
+        counters.userMessageCount += 1;
+      } else {
+        counters.sectionMessageCount += 1;
+      }
     }
-    return {
-      outcome:
-        validMessages.length < batch.messages.length ? "partial" : "success",
-    };
-  } catch (error) {
-    logAppEvent(
-      "error",
-      "calendar-export-rebuild.retry",
-      {
-        batchMessageCount: batch.messages.length,
-        event: "calendar-export-rebuild.retry",
-        messageType: "calendar-export-rebuild",
-        retryCount: validMessages.length,
-        source: "calendar-export-rebuild",
-        validMessageCount: validMessages.length,
-      },
-      error,
-    );
-    for (const message of validMessages) {
-      message.retry();
+
+    if (batch.messages.length === 0) {
+      outcome = "success";
+      return { outcome };
     }
-    return { outcome: "retry" };
+    if (parsed.length === 0) {
+      outcome = "retry";
+      return { outcome };
+    }
+
+    try {
+      await processCalendarExportRebuildMessages(parsed, processingProgress);
+      for (const message of validMessages) {
+        message.ack();
+        counters.ackedMessageCount += 1;
+      }
+      outcome =
+        validMessages.length < batch.messages.length ? "partial" : "success";
+      return { outcome };
+    } catch (error) {
+      logAppEvent(
+        "error",
+        "calendar-export-rebuild.retry",
+        {
+          batchMessageCount: batch.messages.length,
+          event: "calendar-export-rebuild.retry",
+          messageType: "calendar-export-rebuild",
+          retryCount: validMessages.length,
+          source: "calendar-export-rebuild",
+          validMessageCount: validMessages.length,
+        },
+        error,
+      );
+      for (const message of validMessages) {
+        counters.retriedMessageCount += 1;
+        message.retry();
+      }
+      outcome = "retry";
+      return { outcome };
+    }
+  } finally {
+    Object.assign(counters, processingProgress);
+    writeCalendarQueueBatchAnalytics({
+      ...counters,
+      durationMs: elapsedMs(start),
+      outcome,
+    });
   }
 }

--- a/src/features/calendar/server/calendar-queue-batch-analytics.ts
+++ b/src/features/calendar/server/calendar-queue-batch-analytics.ts
@@ -1,0 +1,128 @@
+import { getCloudflareAnalyticsEngineDataset } from "@/lib/adapters/cloudflare-runtime";
+import { logAppEvent } from "@/lib/log/app-logger";
+import { getSafeErrorName } from "@/lib/log/safe-error-name";
+
+export type CalendarQueueBatchOutcome =
+  | "error"
+  | "partial"
+  | "retry"
+  | "success";
+
+/**
+ * The numeric field order is part of the Analytics Engine contract. Keep this
+ * list in sync with the doubles array in writeCalendarQueueBatchAnalytics.
+ */
+export const CALENDAR_QUEUE_BATCH_ANALYTICS_DOUBLE_FIELDS = [
+  "durationMs",
+  "inputMessageCount",
+  "userMessageCount",
+  "sectionMessageCount",
+  "uniqueUserRebuildCount",
+  "noSubscriberMessageCount",
+  "noOpMessageCount",
+  "processedUserCount",
+  "ackedMessageCount",
+  "retriedMessageCount",
+  "invalidMessageCount",
+  "maxAgeMs",
+  "maxAttempts",
+] as const;
+
+export type CalendarQueueBatchAnalyticsInput = {
+  ackedMessageCount: number;
+  durationMs: number;
+  inputMessageCount: number;
+  invalidMessageCount: number;
+  maxAgeMs: number;
+  maxAttempts: number;
+  noOpMessageCount: number;
+  noSubscriberMessageCount: number;
+  outcome: CalendarQueueBatchOutcome;
+  processedUserCount: number;
+  retriedMessageCount: number;
+  sectionMessageCount: number;
+  uniqueUserRebuildCount: number;
+  userMessageCount: number;
+};
+
+const CALENDAR_QUEUE_NAME = "calendar";
+const CALENDAR_QUEUE_BATCH_EVENT = "calendar_queue_batch_v1";
+const CALENDAR_QUEUE_BATCH_EVENT_PHASE = "finish";
+const MAX_COUNT = 1_000_000;
+
+function boundedMetric(value: number) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.min(Math.max(0, value), MAX_COUNT);
+}
+
+function normalizeOutcome(value: unknown): CalendarQueueBatchOutcome {
+  return value === "error" ||
+    value === "partial" ||
+    value === "retry" ||
+    value === "success"
+    ? value
+    : "error";
+}
+
+function logAnalyticsFailure(error: unknown) {
+  try {
+    logAppEvent("error", "calendar-queue-batch.analytics-failed", {
+      errorName: getSafeErrorName(error),
+      event: "calendar-queue-batch.analytics-failed",
+      source: "calendar-export-rebuild",
+    });
+  } catch {
+    // Analytics diagnostics must never affect queue processing.
+  }
+}
+
+/**
+ * Write one fixed, low-cardinality datapoint for one calendar consumer batch.
+ *
+ * The writer is deliberately feature-owned instead of extending the shared
+ * queue schema: calendar fan-out counts describe users, while queue ack/retry
+ * counts describe messages. Keeping both in one versioned datapoint prevents
+ * the per-user `calendar_export_rebuild.ok` event from being misread as a
+ * message completion counter.
+ */
+export function writeCalendarQueueBatchAnalytics(
+  input: CalendarQueueBatchAnalyticsInput,
+) {
+  try {
+    const dataset = getCloudflareAnalyticsEngineDataset();
+    if (
+      !dataset ||
+      typeof dataset !== "object" ||
+      typeof dataset.writeDataPoint !== "function"
+    ) {
+      return;
+    }
+
+    dataset.writeDataPoint({
+      indexes: ["queue:calendar"],
+      blobs: [
+        CALENDAR_QUEUE_BATCH_EVENT,
+        CALENDAR_QUEUE_BATCH_EVENT_PHASE,
+        CALENDAR_QUEUE_NAME,
+        normalizeOutcome(input.outcome),
+      ],
+      doubles: [
+        boundedMetric(input.durationMs),
+        boundedMetric(input.inputMessageCount),
+        boundedMetric(input.userMessageCount),
+        boundedMetric(input.sectionMessageCount),
+        boundedMetric(input.uniqueUserRebuildCount),
+        boundedMetric(input.noSubscriberMessageCount),
+        boundedMetric(input.noOpMessageCount),
+        boundedMetric(input.processedUserCount),
+        boundedMetric(input.ackedMessageCount),
+        boundedMetric(input.retriedMessageCount),
+        boundedMetric(input.invalidMessageCount),
+        boundedMetric(input.maxAgeMs),
+        boundedMetric(input.maxAttempts),
+      ],
+    });
+  } catch (error) {
+    logAnalyticsFailure(error);
+  }
+}

--- a/src/features/calendar/server/calendar-queue-batch-analytics.ts
+++ b/src/features/calendar/server/calendar-queue-batch-analytics.ts
@@ -38,9 +38,11 @@ export type CalendarQueueBatchAnalyticsInput = {
   noOpMessageCount: number;
   noSubscriberMessageCount: number;
   outcome: CalendarQueueBatchOutcome;
+  /** Completed rebuild attempts for distinct users, including deleted users. */
   processedUserCount: number;
   retriedMessageCount: number;
   sectionMessageCount: number;
+  /** Distinct users coalesced from direct messages and section fan-out. */
   uniqueUserRebuildCount: number;
   userMessageCount: number;
 };

--- a/src/features/catalog/server/catalog-detail-cache-validation.ts
+++ b/src/features/catalog/server/catalog-detail-cache-validation.ts
@@ -1,0 +1,188 @@
+type UnknownRecord = Record<string, unknown>;
+
+function isPlainRecord(value: unknown): value is UnknownRecord {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function hasExactKeys(value: UnknownRecord, expectedKeys: readonly string[]) {
+  const keys = Object.keys(value);
+  if (keys.length !== expectedKeys.length) return false;
+  const expected = new Set(expectedKeys);
+  return keys.every((key) => expected.has(key));
+}
+
+function isFiniteNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isSafeInteger(value: unknown) {
+  return typeof value === "number" && Number.isSafeInteger(value);
+}
+
+function isNullableString(value: unknown) {
+  return value === null || typeof value === "string";
+}
+
+function isLocalizedName(value: unknown) {
+  if (
+    !isPlainRecord(value) ||
+    !hasExactKeys(value, ["nameCn", "nameEn", "namePrimary", "nameSecondary"])
+  ) {
+    return false;
+  }
+
+  return (
+    typeof value.nameCn === "string" &&
+    isNullableString(value.nameEn) &&
+    typeof value.namePrimary === "string" &&
+    isNullableString(value.nameSecondary)
+  );
+}
+
+function isNullableLocalizedName(value: unknown) {
+  return value === null || isLocalizedName(value);
+}
+
+function isSemesterName(value: unknown) {
+  return (
+    isPlainRecord(value) &&
+    hasExactKeys(value, ["nameCn"]) &&
+    typeof value.nameCn === "string"
+  );
+}
+
+function isCoursePageSection(value: unknown) {
+  if (
+    !isPlainRecord(value) ||
+    !hasExactKeys(value, [
+      "jwId",
+      "code",
+      "stdCount",
+      "limitCount",
+      "semester",
+      "campus",
+      "teachers",
+    ])
+  ) {
+    return false;
+  }
+
+  return (
+    isSafeInteger(value.jwId) &&
+    typeof value.code === "string" &&
+    (value.stdCount === null || isFiniteNumber(value.stdCount)) &&
+    (value.limitCount === null || isFiniteNumber(value.limitCount)) &&
+    (value.semester === null || isSemesterName(value.semester)) &&
+    (value.campus === null || isLocalizedName(value.campus)) &&
+    Array.isArray(value.teachers) &&
+    value.teachers.every(isLocalizedName)
+  );
+}
+
+function isTeacherPageSection(value: unknown) {
+  if (
+    !isPlainRecord(value) ||
+    !hasExactKeys(value, ["jwId", "code", "credits", "course", "semester"])
+  ) {
+    return false;
+  }
+
+  return (
+    isSafeInteger(value.jwId) &&
+    typeof value.code === "string" &&
+    (value.credits === null || isFiniteNumber(value.credits)) &&
+    isLocalizedName(value.course) &&
+    (value.semester === null || isSemesterName(value.semester))
+  );
+}
+
+/**
+ * Validates the exact public course page core shape before it can be served
+ * from an anonymous cache. Mutable/user-specific fields are rejected by the
+ * exact root and nested key checks.
+ */
+export function isCoursePageCore(value: unknown) {
+  if (
+    !isPlainRecord(value) ||
+    !hasExactKeys(value, [
+      "id",
+      "jwId",
+      "code",
+      "nameCn",
+      "nameEn",
+      "namePrimary",
+      "nameSecondary",
+      "educationLevel",
+      "category",
+      "classType",
+      "type",
+      "sections",
+    ])
+  ) {
+    return false;
+  }
+
+  return (
+    isSafeInteger(value.id) &&
+    isSafeInteger(value.jwId) &&
+    typeof value.code === "string" &&
+    typeof value.nameCn === "string" &&
+    isNullableString(value.nameEn) &&
+    typeof value.namePrimary === "string" &&
+    isNullableString(value.nameSecondary) &&
+    isNullableLocalizedName(value.educationLevel) &&
+    isNullableLocalizedName(value.category) &&
+    isNullableLocalizedName(value.classType) &&
+    isNullableLocalizedName(value.type) &&
+    Array.isArray(value.sections) &&
+    value.sections.every(isCoursePageSection)
+  );
+}
+
+/**
+ * Validates the exact public teacher page core shape before it can be served
+ * from an anonymous cache. Contact fields are public page fields; viewer,
+ * description, subscription, and comment fields are intentionally excluded.
+ */
+export function isTeacherPageCore(value: unknown) {
+  if (
+    !isPlainRecord(value) ||
+    !hasExactKeys(value, [
+      "id",
+      "nameCn",
+      "nameEn",
+      "namePrimary",
+      "nameSecondary",
+      "email",
+      "telephone",
+      "mobile",
+      "address",
+      "department",
+      "teacherTitle",
+      "sections",
+    ])
+  ) {
+    return false;
+  }
+
+  return (
+    isSafeInteger(value.id) &&
+    typeof value.nameCn === "string" &&
+    isNullableString(value.nameEn) &&
+    typeof value.namePrimary === "string" &&
+    isNullableString(value.nameSecondary) &&
+    isNullableString(value.email) &&
+    isNullableString(value.telephone) &&
+    isNullableString(value.mobile) &&
+    isNullableString(value.address) &&
+    isNullableLocalizedName(value.department) &&
+    isNullableLocalizedName(value.teacherTitle) &&
+    Array.isArray(value.sections) &&
+    value.sections.every(isTeacherPageSection)
+  );
+}

--- a/src/features/catalog/server/course-page-data.ts
+++ b/src/features/catalog/server/course-page-data.ts
@@ -1,7 +1,9 @@
 import type { CourseDetailSection } from "@/features/catalog/components/catalog-detail-component-types";
 import { PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT } from "@/features/catalog/server/academic-query-includes";
 import { localizedNameSelect } from "@/features/section-detail/server/section-page-name-selects";
+import type { AppLocale } from "@/i18n/config";
 import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
+import { cachedPublicDetailRuntimeData } from "@/lib/catalog-detail-runtime-cache";
 import { getPrisma } from "@/lib/db/prisma";
 import { toLoadData } from "@/lib/load-data-utils";
 
@@ -23,59 +25,73 @@ const coursePageSectionsSelect = {
   },
 } as const;
 
-export async function getCoursePage(jwId: number, locale = "zh-cn") {
-  const prisma = getPrisma(locale);
-  const course = await runCloudflareTraceSpan(
-    "catalog.detail.course.query",
-    { "catalog.detail.kind": "course" },
-    async () =>
-      await prisma.course.findUnique({
-        where: { jwId },
-        select: {
-          id: true,
-          jwId: true,
-          code: true,
-          ...localizedNameSelect,
-          educationLevel: {
+const COURSE_PAGE_CORE_CACHE_SHAPE = "page-core-v1";
+
+/**
+ * Loads the immutable public course core. Viewer, description, and comments
+ * are assembled by catalog-detail-page-server outside this cache boundary.
+ */
+export async function getCoursePage(jwId: number, locale: AppLocale = "zh-cn") {
+  return cachedPublicDetailRuntimeData({
+    id: jwId,
+    kind: "course",
+    locale,
+    shape: COURSE_PAGE_CORE_CACHE_SHAPE,
+    load: async () => {
+      const prisma = getPrisma(locale);
+      const course = await runCloudflareTraceSpan(
+        "catalog.detail.course.query",
+        { "catalog.detail.kind": "course" },
+        async () =>
+          await prisma.course.findUnique({
+            where: { jwId },
             select: {
+              id: true,
+              jwId: true,
+              code: true,
               ...localizedNameSelect,
+              educationLevel: {
+                select: {
+                  ...localizedNameSelect,
+                },
+              },
+              category: {
+                select: {
+                  ...localizedNameSelect,
+                },
+              },
+              classType: {
+                select: {
+                  ...localizedNameSelect,
+                },
+              },
+              type: {
+                select: {
+                  ...localizedNameSelect,
+                },
+              },
+              sections: {
+                orderBy: [{ semester: { jwId: "desc" } }, { code: "asc" }],
+                take: PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
+                select: coursePageSectionsSelect,
+              },
             },
-          },
-          category: {
-            select: {
-              ...localizedNameSelect,
-            },
-          },
-          classType: {
-            select: {
-              ...localizedNameSelect,
-            },
-          },
-          type: {
-            select: {
-              ...localizedNameSelect,
-            },
-          },
-          sections: {
-            orderBy: [{ semester: { jwId: "desc" } }, { code: "asc" }],
-            take: PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
-            select: coursePageSectionsSelect,
-          },
+          }),
+      );
+
+      if (!course) return null;
+
+      return runCloudflareTraceSpan(
+        "catalog.detail.course.transform",
+        { "catalog.detail.kind": "course" },
+        () => {
+          const { sections, ...data } = course;
+          return toLoadData({
+            ...data,
+            sections: sections as unknown as CourseDetailSection[],
+          });
         },
-      }),
-  );
-
-  if (!course) return null;
-
-  return runCloudflareTraceSpan(
-    "catalog.detail.course.transform",
-    { "catalog.detail.kind": "course" },
-    () => {
-      const { sections, ...data } = course;
-      return toLoadData({
-        ...data,
-        sections: sections as unknown as CourseDetailSection[],
-      });
+      );
     },
-  );
+  });
 }

--- a/src/features/catalog/server/course-page-data.ts
+++ b/src/features/catalog/server/course-page-data.ts
@@ -6,6 +6,7 @@ import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import { cachedPublicDetailRuntimeData } from "@/lib/catalog-detail-runtime-cache";
 import { getPrisma } from "@/lib/db/prisma";
 import { toLoadData } from "@/lib/load-data-utils";
+import { isCoursePageCore } from "./catalog-detail-cache-validation";
 
 const coursePageSectionsSelect = {
   jwId: true,
@@ -37,6 +38,7 @@ export async function getCoursePage(jwId: number, locale: AppLocale = "zh-cn") {
     kind: "course",
     locale,
     shape: COURSE_PAGE_CORE_CACHE_SHAPE,
+    validateResult: isCoursePageCore,
     load: async () => {
       const prisma = getPrisma(locale);
       const course = await runCloudflareTraceSpan(

--- a/src/features/catalog/server/teacher-page-data.ts
+++ b/src/features/catalog/server/teacher-page-data.ts
@@ -6,6 +6,7 @@ import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import { cachedPublicDetailRuntimeData } from "@/lib/catalog-detail-runtime-cache";
 import { getPrisma } from "@/lib/db/prisma";
 import { toLoadData } from "@/lib/load-data-utils";
+import { isTeacherPageCore } from "./catalog-detail-cache-validation";
 
 const teacherPageSectionsSelect = {
   jwId: true,
@@ -31,6 +32,7 @@ export async function getTeacherPage(id: number, locale: AppLocale = "zh-cn") {
     kind: "teacher",
     locale,
     shape: TEACHER_PAGE_CORE_CACHE_SHAPE,
+    validateResult: isTeacherPageCore,
     load: async () => {
       const prisma = getPrisma(locale);
       const teacher = await runCloudflareTraceSpan(

--- a/src/features/catalog/server/teacher-page-data.ts
+++ b/src/features/catalog/server/teacher-page-data.ts
@@ -1,7 +1,9 @@
 import type { TeacherDetailSection } from "@/features/catalog/components/catalog-detail-component-types";
 import { PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT } from "@/features/catalog/server/academic-query-includes";
 import { localizedNameSelect } from "@/features/section-detail/server/section-page-name-selects";
+import type { AppLocale } from "@/i18n/config";
 import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
+import { cachedPublicDetailRuntimeData } from "@/lib/catalog-detail-runtime-cache";
 import { getPrisma } from "@/lib/db/prisma";
 import { toLoadData } from "@/lib/load-data-utils";
 
@@ -17,54 +19,68 @@ const teacherPageSectionsSelect = {
   semester: { select: { nameCn: true } },
 } as const;
 
-export async function getTeacherPage(id: number, locale = "zh-cn") {
-  const prisma = getPrisma(locale);
-  const teacher = await runCloudflareTraceSpan(
-    "catalog.detail.teacher.query",
-    { "catalog.detail.kind": "teacher" },
-    async () =>
-      await prisma.teacher.findUnique({
-        where: { id },
-        select: {
-          id: true,
-          ...localizedNameSelect,
-          email: true,
-          telephone: true,
-          mobile: true,
-          address: true,
-          department: {
+const TEACHER_PAGE_CORE_CACHE_SHAPE = "page-core-v1";
+
+/**
+ * Loads the immutable public teacher core. Viewer, description, and comments
+ * are assembled by catalog-detail-page-server outside this cache boundary.
+ */
+export async function getTeacherPage(id: number, locale: AppLocale = "zh-cn") {
+  return cachedPublicDetailRuntimeData({
+    id,
+    kind: "teacher",
+    locale,
+    shape: TEACHER_PAGE_CORE_CACHE_SHAPE,
+    load: async () => {
+      const prisma = getPrisma(locale);
+      const teacher = await runCloudflareTraceSpan(
+        "catalog.detail.teacher.query",
+        { "catalog.detail.kind": "teacher" },
+        async () =>
+          await prisma.teacher.findUnique({
+            where: { id },
             select: {
+              id: true,
               ...localizedNameSelect,
+              email: true,
+              telephone: true,
+              mobile: true,
+              address: true,
+              department: {
+                select: {
+                  ...localizedNameSelect,
+                },
+              },
+              teacherTitle: {
+                select: {
+                  ...localizedNameSelect,
+                },
+              },
+              sections: {
+                orderBy: [
+                  { semester: { jwId: "desc" } },
+                  { course: { nameCn: "asc" } },
+                ],
+                take: PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
+                select: teacherPageSectionsSelect,
+              },
             },
-          },
-          teacherTitle: {
-            select: {
-              ...localizedNameSelect,
-            },
-          },
-          sections: {
-            orderBy: [
-              { semester: { jwId: "desc" } },
-              { course: { nameCn: "asc" } },
-            ],
-            take: PUBLIC_DETAIL_SECTION_PREVIEW_LIMIT,
-            select: teacherPageSectionsSelect,
-          },
+          }),
+      );
+
+      if (!teacher) return null;
+
+      return runCloudflareTraceSpan(
+        "catalog.detail.teacher.transform",
+        { "catalog.detail.kind": "teacher" },
+        () => {
+          const { sections, ...data } = teacher;
+          return toLoadData({
+            ...data,
+            sections: sections as unknown as TeacherDetailSection[],
+          });
         },
-      }),
-  );
-
-  if (!teacher) return null;
-
-  return runCloudflareTraceSpan(
-    "catalog.detail.teacher.transform",
-    { "catalog.detail.kind": "teacher" },
-    () => {
-      const { sections, ...data } = teacher;
-      return toLoadData({
-        ...data,
-        sections: sections as unknown as TeacherDetailSection[],
-      });
+      );
     },
-  );
+  });
 }

--- a/src/features/comments/server/comment-read-model.ts
+++ b/src/features/comments/server/comment-read-model.ts
@@ -3,6 +3,7 @@ import { runCloudflareTraceSpan } from "@/lib/adapters/cloudflare-runtime";
 import {
   getViewerContext,
   type ViewerContext,
+  type ViewerContextInstrumentation,
 } from "@/lib/auth/viewer-context";
 import { authPrisma } from "@/lib/db/auth-prisma";
 import { prisma, withUserDbContext } from "@/lib/db/prisma";
@@ -75,6 +76,32 @@ type CommentDescendantWindowRow = {
   createdAt: Date;
   rowNumber: bigint | null;
 };
+
+function observeCommentViewerContext(input: {
+  viewer?: ViewerContext;
+  viewerUserId: string | null;
+}) {
+  const counter = createCommentStageCounter({
+    dbContext: "none",
+    dbLabel: "app",
+  });
+  const instrumentation: ViewerContextInstrumentation = {
+    onQuery: () => countCommentStageQuery(counter),
+  };
+
+  return observeCommentStage({
+    counter,
+    stage: "viewer.context",
+    work: () =>
+      input.viewer
+        ? Promise.resolve(input.viewer)
+        : getViewerContext({
+            includeAdmin: false,
+            userId: input.viewerUserId,
+            instrumentation,
+          }),
+  });
+}
 
 export async function withCommentAuthorProviders(
   comments: RawComment[],
@@ -746,39 +773,14 @@ export async function loadCommentThread(input: {
   viewerUserId: string | null;
 }) {
   if (input.target.empty) {
-    const viewer = await observeCommentStage({
-      counter: input.viewer
-        ? createCommentStageCounter({ dbContext: "none", dbLabel: "app" })
-        : undefined,
-      stage: "viewer.context",
-      work: () =>
-        input.viewer
-          ? Promise.resolve(input.viewer)
-          : getViewerContext({
-              includeAdmin: false,
-              userId: input.viewerUserId,
-            }),
-    });
+    const viewer = await observeCommentViewerContext(input);
     return { comments: [], hiddenCount: 0, total: 0, viewer };
   }
 
   const viewer = await runCloudflareTraceSpan(
     "viewer.context",
     { source: "comments" },
-    () =>
-      observeCommentStage({
-        counter: input.viewer
-          ? createCommentStageCounter({ dbContext: "none", dbLabel: "app" })
-          : undefined,
-        stage: "viewer.context",
-        work: () =>
-          input.viewer
-            ? Promise.resolve(input.viewer)
-            : getViewerContext({
-                includeAdmin: false,
-                userId: input.viewerUserId,
-              }),
-      }),
+    () => observeCommentViewerContext(input),
   );
   const pagination = input.pagination ?? { pageSize: 20, skip: 0 };
   const rootCounter = createCommentStageCounter({
@@ -890,9 +892,8 @@ export async function loadCommentReplies(input: {
   pageSize?: number;
   viewerUserId: string | null;
 }) {
-  const viewer = await getViewerContext({
-    includeAdmin: false,
-    userId: input.viewerUserId,
+  const viewer = await observeCommentViewerContext({
+    viewerUserId: input.viewerUserId,
   });
   const pageSize = Math.min(
     Math.max(input.pageSize ?? COMMENT_REPLY_PAGE_SIZE, 1),
@@ -978,10 +979,7 @@ export async function loadFocusedCommentThread(input: {
         select: commentTargetLookupSelect,
       }),
     ),
-    getViewerContext({
-      includeAdmin: false,
-      userId: input.viewerUserId,
-    }),
+    observeCommentViewerContext({ viewerUserId: input.viewerUserId }),
   ]);
 
   if (!comment) {

--- a/src/features/comments/server/comment-read-model.ts
+++ b/src/features/comments/server/comment-read-model.ts
@@ -78,13 +78,16 @@ type CommentDescendantWindowRow = {
 };
 
 function observeCommentViewerContext(input: {
+  counter?: CommentStageCounter;
   viewer?: ViewerContext;
   viewerUserId: string | null;
 }) {
-  const counter = createCommentStageCounter({
-    dbContext: "none",
-    dbLabel: "app",
-  });
+  const counter =
+    input.counter ??
+    createCommentStageCounter({
+      dbContext: "none",
+      dbLabel: "app",
+    });
   const instrumentation: ViewerContextInstrumentation = {
     onQuery: () => countCommentStageQuery(counter),
   };
@@ -770,18 +773,25 @@ export async function loadCommentThread(input: {
   pagination?: { pageSize: number; skip: number };
   target: ResolvedCommentTarget;
   viewer?: ViewerContext;
+  viewerContextStageRecorded?: boolean;
   viewerUserId: string | null;
 }) {
   if (input.target.empty) {
-    const viewer = await observeCommentViewerContext(input);
+    const viewer =
+      input.viewerContextStageRecorded && input.viewer
+        ? input.viewer
+        : await observeCommentViewerContext(input);
     return { comments: [], hiddenCount: 0, total: 0, viewer };
   }
 
-  const viewer = await runCloudflareTraceSpan(
-    "viewer.context",
-    { source: "comments" },
-    () => observeCommentViewerContext(input),
-  );
+  const viewer =
+    input.viewerContextStageRecorded && input.viewer
+      ? input.viewer
+      : await runCloudflareTraceSpan(
+          "viewer.context",
+          { source: "comments" },
+          () => observeCommentViewerContext(input),
+        );
   const pagination = input.pagination ?? { pageSize: 20, skip: 0 };
   const rootCounter = createCommentStageCounter({
     dbContext: input.viewerUserId ? "rls" : "none",

--- a/src/features/comments/server/comments-server.ts
+++ b/src/features/comments/server/comments-server.ts
@@ -1,5 +1,10 @@
 import { getViewerContext } from "@/lib/auth/viewer-context";
 import { loadCommentThread } from "./comment-read-model";
+import {
+  countCommentStageQuery,
+  createCommentStageCounter,
+  observeCommentStage,
+} from "./comment-stage-analytics";
 import type {
   CommentNode,
   CommentTarget,
@@ -19,8 +24,23 @@ export async function getCommentsPayload(
   viewerOverride?: CommentViewer,
   options: { pageSize?: number } = {},
 ): Promise<CommentsPayload> {
-  const viewer =
-    viewerOverride ?? (await getViewerContext({ includeAdmin: false }));
+  const viewerStageCounter = createCommentStageCounter({
+    dbContext: "none",
+    dbLabel: "app",
+  });
+  const viewer = await observeCommentStage({
+    counter: viewerStageCounter,
+    stage: "viewer.context",
+    work: () =>
+      viewerOverride
+        ? Promise.resolve(viewerOverride)
+        : getViewerContext({
+            includeAdmin: false,
+            instrumentation: {
+              onQuery: () => countCommentStageQuery(viewerStageCounter),
+            },
+          }),
+  });
   const resolvedTarget = await resolveCommentTarget({
     allowDirectSectionTeacherId: true,
     rawTargetId:
@@ -41,6 +61,7 @@ export async function getCommentsPayload(
     pagination: { pageSize, skip: 0 },
     target: resolvedTarget,
     viewer,
+    viewerContextStageRecorded: true,
     viewerUserId: viewer.userId,
   });
   return {

--- a/src/features/dashboard/server/dashboard-page-load-signed.ts
+++ b/src/features/dashboard/server/dashboard-page-load-signed.ts
@@ -4,7 +4,10 @@ import {
   loadSignedDashboardTabData,
   timeDashboardStage,
 } from "@/features/dashboard/server/dashboard-page-tab-data";
-import { createDashboardStageCounter } from "@/features/dashboard/server/dashboard-stage-analytics";
+import {
+  createDashboardStageCounter,
+  markDashboardStageCountsUnknown,
+} from "@/features/dashboard/server/dashboard-stage-analytics";
 import type { AppLocale } from "@/i18n/config";
 import { toShanghaiIsoString } from "@/lib/time/serialize-date-output";
 
@@ -49,6 +52,11 @@ export async function loadSignedDashboardPageData(input: {
     };
   }
 
+  const tabCounter = createDashboardStageCounter({
+    dbContext: "mixed",
+    dbLabel: "app",
+  });
+  markDashboardStageCountsUnknown(tabCounter);
   const {
     bus,
     calendarSubscriptionUrl,
@@ -77,6 +85,7 @@ export async function loadSignedDashboardPageData(input: {
         tab: input.tab,
         userId: input.userId,
       }),
+    tabCounter,
   );
 
   return {

--- a/src/features/dashboard/server/dashboard-stage-analytics.ts
+++ b/src/features/dashboard/server/dashboard-stage-analytics.ts
@@ -1,7 +1,8 @@
 import { elapsedMs, monotonicNowMs } from "@/lib/log/observability-clock";
 import {
+  type DashboardDbStageContext,
   type DashboardStage,
-  type DbStageContext,
+  type DashboardStageCountState,
   type DbStageLabel,
   writeDashboardStageAnalytics,
 } from "@/lib/metrics/analytics-engine";
@@ -9,19 +10,19 @@ import {
 export type { DashboardStage };
 
 export type DashboardStageCounter = {
-  complete: boolean;
-  dbContext: DbStageContext;
+  countState: DashboardStageCountState;
+  dbContext: DashboardDbStageContext;
   dbLabel: DbStageLabel;
   dbQueryCount: number;
   dbTransactionCount: number;
 };
 
 export function createDashboardStageCounter(input: {
-  dbContext: DbStageContext;
+  dbContext: DashboardDbStageContext;
   dbLabel: DbStageLabel;
 }): DashboardStageCounter {
   return {
-    complete: true,
+    countState: "known",
     dbContext: input.dbContext,
     dbLabel: input.dbLabel,
     dbQueryCount: 0,
@@ -50,7 +51,7 @@ export function markDashboardStageCountsUnknown(
   counter?: DashboardStageCounter,
 ) {
   if (!counter) return;
-  counter.complete = false;
+  counter.countState = "unknown";
 }
 
 export function recordDashboardStageAnalytics(input: {
@@ -65,10 +66,11 @@ export function recordDashboardStageAnalytics(input: {
   stage: DashboardStage;
 }) {
   const counter = input.counter;
-  if (!counter?.complete) return;
+  if (!counter) return;
 
   try {
     writeDashboardStageAnalytics({
+      countState: counter.countState,
       dbContext: counter.dbContext,
       dbLabel: counter.dbLabel,
       dbQueryCount: counter.dbQueryCount,

--- a/src/features/dashboard/server/dashboard-stage-analytics.ts
+++ b/src/features/dashboard/server/dashboard-stage-analytics.ts
@@ -10,6 +10,7 @@ import {
 export type { DashboardStage };
 
 export type DashboardStageCounter = {
+  analyticsRecorded: boolean;
   countState: DashboardStageCountState;
   dbContext: DashboardDbStageContext;
   dbLabel: DbStageLabel;
@@ -22,6 +23,7 @@ export function createDashboardStageCounter(input: {
   dbLabel: DbStageLabel;
 }): DashboardStageCounter {
   return {
+    analyticsRecorded: false,
     countState: "known",
     dbContext: input.dbContext,
     dbLabel: input.dbLabel,
@@ -66,7 +68,13 @@ export function recordDashboardStageAnalytics(input: {
   stage: DashboardStage;
 }) {
   const counter = input.counter;
-  if (!counter) return;
+  if (!counter || counter.analyticsRecorded) return;
+
+  // A read model may publish the precise stage result while a page
+  // orchestrator also wraps the same operation for request-level timing.
+  // The counter is the ownership token: only the first completion may emit
+  // the datapoint, preventing duplicate nav_stats records.
+  counter.analyticsRecorded = true;
 
   try {
     writeDashboardStageAnalytics({

--- a/src/lib/auth/viewer-context.ts
+++ b/src/lib/auth/viewer-context.ts
@@ -13,6 +13,10 @@ export type ViewerContext = {
   suspensionExpiresAt: string | null;
 };
 
+export interface ViewerContextInstrumentation {
+  onQuery?: () => void;
+}
+
 type ViewerAuthData = {
   user: {
     id: string;
@@ -38,7 +42,21 @@ function getRequestViewerCache() {
   return cache;
 }
 
-export async function findActiveSuspension(userId: string) {
+function notifyViewerContextQuery(
+  instrumentation?: ViewerContextInstrumentation,
+): void {
+  try {
+    instrumentation?.onQuery?.();
+  } catch {
+    // Instrumentation must never change authentication behavior.
+  }
+}
+
+export async function findActiveSuspension(
+  userId: string,
+  instrumentation?: ViewerContextInstrumentation,
+) {
+  notifyViewerContextQuery(instrumentation);
   const now = new Date();
   return prisma.userSuspension.findFirst({
     where: {
@@ -50,7 +68,11 @@ export async function findActiveSuspension(userId: string) {
   });
 }
 
-async function findViewerUser(userId: string) {
+async function findViewerUser(
+  userId: string,
+  instrumentation?: ViewerContextInstrumentation,
+) {
+  notifyViewerContextQuery(instrumentation);
   return prisma.user.findUnique({
     where: { id: userId },
     select: { id: true, name: true, image: true, isAdmin: true },
@@ -59,10 +81,11 @@ async function findViewerUser(userId: string) {
 
 export async function getViewerAuthDataForUserId(
   userId: string,
+  instrumentation?: ViewerContextInstrumentation,
 ): Promise<ViewerAuthData | null> {
   const [user, suspension] = await Promise.all([
-    findViewerUser(userId),
-    findActiveSuspension(userId),
+    findViewerUser(userId, instrumentation),
+    findActiveSuspension(userId, instrumentation),
   ]);
 
   if (!user) {
@@ -73,11 +96,18 @@ export async function getViewerAuthDataForUserId(
 }
 
 async function loadViewerContext(
-  options: { includeAdmin?: boolean; userId?: string | null } = {},
+  options: {
+    includeAdmin?: boolean;
+    userId?: string | null;
+    instrumentation?: ViewerContextInstrumentation;
+  } = {},
 ): Promise<ViewerContext> {
   const data =
     typeof options.userId === "string"
-      ? await getViewerAuthDataForUserId(options.userId)
+      ? await getViewerAuthDataForUserId(
+          options.userId,
+          options.instrumentation,
+        )
       : null;
 
   if (!data) {
@@ -111,7 +141,11 @@ async function loadViewerContext(
 }
 
 export function getViewerContext(
-  options: { includeAdmin?: boolean; userId?: string | null } = {},
+  options: {
+    includeAdmin?: boolean;
+    userId?: string | null;
+    instrumentation?: ViewerContextInstrumentation;
+  } = {},
 ): Promise<ViewerContext> {
   const cache = getRequestViewerCache();
   if (!cache) return loadViewerContext(options);

--- a/src/lib/catalog-detail-runtime-cache.ts
+++ b/src/lib/catalog-detail-runtime-cache.ts
@@ -12,6 +12,8 @@ import {
 } from "@/lib/public-runtime-cache";
 import { getCanonicalOrigin } from "@/lib/site-url";
 
+export type PublicDetailCacheResultValidator = (result: unknown) => boolean;
+
 /** L1 isolate + colo Cache API TTL for anonymous catalog entity core. */
 export const PUBLIC_DETAIL_RUNTIME_CACHE_TTL_MS =
   PUBLIC_CATALOG_RUNTIME_CACHE_TTL_MS;
@@ -61,14 +63,19 @@ export async function cachedPublicDetailRuntimeData<T>(input: {
   load: () => Promise<T | null>;
   locale: AppLocale;
   shape: string;
+  validateResult?: PublicDetailCacheResultValidator;
 }) {
+  const validateResult = input.validateResult ?? isPublicDetailResult;
+  const isValidResult = (result: unknown) =>
+    isPublicDetailResult(result) && validateResult(result);
+
   const options = await buildPublicDetailRuntimeCacheOptions<T | null>({
     id: input.id,
     kind: input.kind,
     kvShape: input.shape,
     locale: input.locale,
-    shouldCacheResult: isPublicDetailResult,
-    validateColoCacheResult: isPublicDetailResult,
+    shouldCacheResult: isValidResult,
+    validateColoCacheResult: validateResult,
   });
 
   return cachedPublicRuntimeData(

--- a/src/lib/log/api-observability-path.ts
+++ b/src/lib/log/api-observability-path.ts
@@ -3,6 +3,38 @@ const UUID_SEGMENT =
 const NUMERIC_SEGMENT = /^\d+$/;
 const OPAQUE_ID_SEGMENT = /^(?=.*\d)[A-Za-z0-9_-]{16,}$/;
 
+export const API_ROUTE_FAMILY_NAMES = [
+  "account",
+  "admin",
+  "auth",
+  "calendar-feeds",
+  "catalog",
+  "community",
+  "graphql",
+  "health",
+  "mcp",
+  "openapi",
+  "search",
+  "users",
+  "workspace",
+] as const;
+
+export type ApiRouteFamily = (typeof API_ROUTE_FAMILY_NAMES)[number] | "other";
+
+const API_ROUTE_FAMILY_SET = new Set<string>(API_ROUTE_FAMILY_NAMES);
+
+export function resolveApiRouteFamily(pathname: string): ApiRouteFamily {
+  const path = pathname.split(/[?#]/, 1)[0] ?? pathname;
+  const segment = path.startsWith("/api/") ? path.split("/", 3)[2] : undefined;
+  return segment && API_ROUTE_FAMILY_SET.has(segment)
+    ? (segment as ApiRouteFamily)
+    : "other";
+}
+
+export function normalizeApiRouteFamilyPath(pathname: string) {
+  return `/api/${resolveApiRouteFamily(pathname)}`;
+}
+
 export function normalizeApiRoutePath(pathname: string) {
   return pathname
     .split("/")

--- a/src/lib/log/worker-entrypoint-observability.ts
+++ b/src/lib/log/worker-entrypoint-observability.ts
@@ -1,3 +1,4 @@
+import { normalizeApiRouteFamilyPath } from "@/lib/log/api-observability-path";
 import { logAppEvent } from "@/lib/log/app-logger";
 import { elapsedMs } from "@/lib/log/observability-clock";
 import { shouldLogSuccessfulRequest } from "@/lib/log/request-log-sampling";
@@ -91,7 +92,11 @@ export function normalizePublicSsrObservedRoute(pathname: string) {
  * dynamic-vs-cache attribution explicit without ever retaining path IDs.
  */
 export function normalizeWorkerObservedRoute(pathname: string) {
-  return normalizePublicSsrObservedRoute(pathname);
+  const path = pathname.split(/[?#]/, 1)[0] ?? pathname;
+  if (path === "/api" || path.startsWith("/api/")) {
+    return normalizeApiRouteFamilyPath(path);
+  }
+  return normalizePublicSsrObservedRoute(path);
 }
 
 export function resolveEdgeCacheOutcome(response: Response): EdgeCacheOutcome {

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -3,6 +3,7 @@ import {
   getCloudflareAnalyticsEngineDataset,
   getCloudflareRuntimeEnvInput,
 } from "@/lib/adapters/cloudflare-runtime";
+import { resolveApiRouteFamily } from "@/lib/log/api-observability-path";
 import { emitLog } from "@/lib/log/app-log-emitter";
 import { getSafeErrorName } from "@/lib/log/safe-error-name";
 import type {
@@ -252,7 +253,9 @@ export type DashboardStage =
   | "tab";
 
 export type DbStageContext = "none" | "rls";
+export type DashboardDbStageContext = DbStageContext | "mixed";
 export type DbStageLabel = "app" | "auth" | "maintenance";
+export type DashboardStageCountState = "known" | "unknown";
 
 export type CommentsStageAnalyticsInput = {
   dbContext: DbStageContext;
@@ -267,7 +270,8 @@ export type CommentsStageAnalyticsInput = {
 };
 
 export type DashboardStageAnalyticsInput = {
-  dbContext: DbStageContext;
+  countState: DashboardStageCountState;
+  dbContext: DashboardDbStageContext;
   dbQueryCount: number;
   dbTransactionCount: number;
   durationMs: number;
@@ -382,21 +386,6 @@ const MCP_ERROR_NAMES = new Set([
   "SyntaxError",
   "TimeoutError",
   "TypeError",
-]);
-const API_ROUTE_FAMILIES = new Set([
-  "account",
-  "admin",
-  "auth",
-  "calendar-feeds",
-  "catalog",
-  "community",
-  "graphql",
-  "health",
-  "mcp",
-  "openapi",
-  "search",
-  "users",
-  "workspace",
 ]);
 const API_AUTH_MODES = new Set([
   "anonymous",
@@ -593,6 +582,8 @@ const DASHBOARD_STAGES = new Set([
   "tab",
 ]);
 const DB_STAGE_CONTEXTS = new Set(["none", "rls"]);
+const DASHBOARD_DB_STAGE_CONTEXTS = new Set(["none", "rls", "mixed"]);
+const DASHBOARD_STAGE_COUNT_STATES = new Set(["known", "unknown"]);
 const DB_STAGE_LABELS = new Set(["app", "auth", "maintenance"]);
 const DB_STAGE_OUTCOMES = new Set(["error", "success"]);
 const OAUTH_EVENTS = new Set([
@@ -728,7 +719,9 @@ function boundedCount(value: number | undefined | null, max = 1_000_000) {
 function workerRouteFamily(route: string) {
   const pathname = route.split(/[?#]/, 1)[0] ?? route;
   if (pathname === "/account/sign-in") return "account-sign-in";
-  if (pathname.startsWith("/api/")) return "api";
+  if (pathname === "/api" || pathname.startsWith("/api/")) {
+    return `api:${resolveApiRouteFamily(pathname)}`;
+  }
   if (pathname.startsWith("/catalog/")) return "catalog";
   if (pathname === "public-page" || pathname === "public-not-found") {
     return "public";
@@ -738,11 +731,7 @@ function workerRouteFamily(route: string) {
 }
 
 function apiRouteFamily(route: string) {
-  const pathname = route.split(/[?#]/, 1)[0] ?? route;
-  const segment = pathname.startsWith("/api/")
-    ? pathname.split("/", 3)[2]
-    : undefined;
-  return segment && API_ROUTE_FAMILIES.has(segment) ? segment : "other";
+  return resolveApiRouteFamily(route);
 }
 
 function pageRouteId(route: string) {
@@ -907,7 +896,7 @@ export function writeWorkerRequestAnalytics(
   writeAnalyticsDataPoint({
     indexes: [`worker:${routeFamily}`],
     blobs: [
-      "worker_request_v1",
+      "worker_request_v2",
       "finish",
       routeFamily,
       requestClass,
@@ -1166,20 +1155,31 @@ export function writeDashboardStageAnalytics(
   input: DashboardStageAnalyticsInput,
 ) {
   const stage = finiteEnum(input.stage, DASHBOARD_STAGES);
-  const dbContext = finiteEnum(input.dbContext, DB_STAGE_CONTEXTS);
+  const countState = finiteEnum(input.countState, DASHBOARD_STAGE_COUNT_STATES);
+  const dbContext = finiteEnum(input.dbContext, DASHBOARD_DB_STAGE_CONTEXTS);
   const dbLabel = finiteEnum(input.dbLabel, DB_STAGE_LABELS);
   const outcome = finiteEnum(input.outcome, DB_STAGE_OUTCOMES);
+  const counts =
+    countState === "unknown"
+      ? [0, 0, 0, 0, 0]
+      : [
+          boundedCount(input.dbQueryCount),
+          boundedCount(input.dbTransactionCount),
+          boundedCount(input.loadedCount),
+          boundedCount(input.rootCount),
+          boundedCount(input.subscribedSectionCount),
+        ];
   writeAnalyticsDataPoint({
     indexes: [`dashboard:${stage}`],
-    blobs: ["dashboard_stage_v1", stage, dbContext, dbLabel, outcome],
-    doubles: [
-      finiteNumber(input.durationMs),
-      boundedCount(input.dbQueryCount),
-      boundedCount(input.dbTransactionCount),
-      boundedCount(input.loadedCount),
-      boundedCount(input.rootCount),
-      boundedCount(input.subscribedSectionCount),
+    blobs: [
+      "dashboard_stage_v2",
+      stage,
+      dbContext,
+      dbLabel,
+      outcome,
+      countState,
     ],
+    doubles: [finiteNumber(input.durationMs), ...counts],
   });
 }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -52,6 +52,7 @@ import {
   logWorkerQueueError,
   logWorkerQueueFinish,
   normalizePublicSsrObservedRoute,
+  normalizeWorkerObservedRoute,
   observedEdgeResponse,
   resolveEdgeCacheOutcome,
   resolveWorkerQueue,
@@ -402,9 +403,7 @@ async function handleFetch(request, env, context, requestId, edgeObservation) {
   }
   const mode = resolvePublicSsrMode(request, resolveCatalogListPublicSsrMode);
   if (!shouldRoutePublicSsrCache(request, mode)) {
-    const route = normalizePublicSsrObservedRoute(
-      new URL(request.url).pathname,
-    );
+    const route = normalizeWorkerObservedRoute(new URL(request.url).pathname);
     edgeObservation.cacheOutcome = "dynamic";
     edgeObservation.requestClass = "dynamic";
     edgeObservation.route = route;

--- a/tests/unit/analytics-engine-runtime-events.test.ts
+++ b/tests/unit/analytics-engine-runtime-events.test.ts
@@ -528,6 +528,7 @@ describe("Cloudflare Analytics Engine runtime events", () => {
       stage: "comments.descendants",
     });
     writeDashboardStageAnalytics({
+      countState: "known",
       dbContext: "rls",
       dbLabel: "app",
       dbQueryCount: 3,
@@ -543,7 +544,7 @@ describe("Cloudflare Analytics Engine runtime events", () => {
     expect(writeDataPoint).toHaveBeenNthCalledWith(1, {
       indexes: ["worker:account-sign-in"],
       blobs: [
-        "worker_request_v1",
+        "worker_request_v2",
         "finish",
         "account-sign-in",
         "dynamic",
@@ -577,8 +578,64 @@ describe("Cloudflare Analytics Engine runtime events", () => {
     });
     expect(writeDataPoint).toHaveBeenNthCalledWith(4, {
       indexes: ["dashboard:nav_stats"],
-      blobs: ["dashboard_stage_v1", "nav_stats", "rls", "app", "success"],
+      blobs: [
+        "dashboard_stage_v2",
+        "nav_stats",
+        "rls",
+        "app",
+        "success",
+        "known",
+      ],
       doubles: [50, 3, 1, 4, 0, 4],
+    });
+    expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain("private");
+  });
+
+  it("maps worker API telemetry to finite route families", () => {
+    const writeDataPoint = installAnalyticsBinding();
+
+    writeWorkerRequestAnalytics({
+      cacheOutcome: "dynamic",
+      durationMs: 3,
+      method: "GET",
+      requestClass: "dynamic",
+      route: "/api/catalog/courses/123?token=private",
+      status: 200,
+    });
+    writeWorkerRequestAnalytics({
+      cacheOutcome: "dynamic",
+      durationMs: 4,
+      method: "GET",
+      requestClass: "dynamic",
+      route: "/api/secret-endpoint/user-123?token=private",
+      status: 404,
+    });
+
+    expect(writeDataPoint).toHaveBeenNthCalledWith(1, {
+      indexes: ["worker:api:catalog"],
+      blobs: [
+        "worker_request_v2",
+        "finish",
+        "api:catalog",
+        "dynamic",
+        "GET",
+        "2xx",
+        "dynamic",
+      ],
+      doubles: [3, 200],
+    });
+    expect(writeDataPoint).toHaveBeenNthCalledWith(2, {
+      indexes: ["worker:api:other"],
+      blobs: [
+        "worker_request_v2",
+        "finish",
+        "api:other",
+        "dynamic",
+        "GET",
+        "4xx",
+        "dynamic",
+      ],
+      doubles: [4, 404],
     });
     expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain("private");
   });
@@ -612,6 +669,7 @@ describe("Cloudflare Analytics Engine runtime events", () => {
       stage: secret as never,
     });
     writeDashboardStageAnalytics({
+      countState: "unknown",
       dbContext: secret as never,
       dbLabel: secret as never,
       dbQueryCount: 1,
@@ -662,12 +720,14 @@ describe("Cloudflare Analytics Engine runtime events", () => {
       expect.objectContaining({
         indexes: ["dashboard:unknown"],
         blobs: [
-          "dashboard_stage_v1",
+          "dashboard_stage_v2",
+          "unknown",
           "unknown",
           "unknown",
           "unknown",
           "unknown",
         ],
+        doubles: [1, 0, 0, 0, 0, 0],
       }),
     );
     expect(JSON.stringify(writeDataPoint.mock.calls)).not.toContain(secret);

--- a/tests/unit/calendar-export-rebuild.test.ts
+++ b/tests/unit/calendar-export-rebuild.test.ts
@@ -203,6 +203,117 @@ describe("calendar export rebuild fan-out", () => {
     );
   });
 
+  it("counts a user deleted after section fan-out as a no-op for every contribution", async () => {
+    findManyMock.mockResolvedValue([{ userId: "user-1" }]);
+    getUserCalendarRecordMock.mockResolvedValue(null);
+    const direct = {
+      ack: vi.fn(),
+      body: { type: "user", userId: "user-1" },
+      retry: vi.fn(),
+    };
+    const section = {
+      ack: vi.fn(),
+      body: { type: "section", sectionId: 10 },
+      retry: vi.fn(),
+    };
+
+    await expect(
+      handleCalendarExportRebuildBatch({ messages: [direct, section] }),
+    ).resolves.toEqual({ outcome: "success" });
+
+    expect(getUserCalendarRecordMock).toHaveBeenCalledOnce();
+    expect(writeCalendarQueueBatchAnalyticsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputMessageCount: 2,
+        noOpMessageCount: 2,
+        noSubscriberMessageCount: 0,
+        // One coalesced user was attempted; the no-op count remains at the
+        // original direct-message plus section-fan-out contribution level.
+        processedUserCount: 1,
+        sectionMessageCount: 1,
+        uniqueUserRebuildCount: 1,
+        userMessageCount: 1,
+      }),
+    );
+  });
+
+  it("preserves duplicate section-message contributions for a deleted user", async () => {
+    findManyMock.mockResolvedValue([{ userId: "user-1" }]);
+    getUserCalendarRecordMock.mockResolvedValue(null);
+    const first = {
+      ack: vi.fn(),
+      body: { type: "section", sectionId: 10 },
+      retry: vi.fn(),
+    };
+    const second = {
+      ack: vi.fn(),
+      body: { type: "section", sectionId: 10 },
+      retry: vi.fn(),
+    };
+
+    await expect(
+      handleCalendarExportRebuildBatch({ messages: [first, second] }),
+    ).resolves.toEqual({ outcome: "success" });
+
+    expect(findManyMock).toHaveBeenCalledOnce();
+    expect(getUserCalendarRecordMock).toHaveBeenCalledOnce();
+    expect(first.ack).toHaveBeenCalledOnce();
+    expect(second.ack).toHaveBeenCalledOnce();
+    expect(writeCalendarQueueBatchAnalyticsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputMessageCount: 2,
+        noOpMessageCount: 2,
+        noSubscriberMessageCount: 0,
+        // The two source messages still result in one coalesced user attempt.
+        processedUserCount: 1,
+        sectionMessageCount: 2,
+        uniqueUserRebuildCount: 1,
+        userMessageCount: 0,
+      }),
+    );
+  });
+
+  it("sums overlapping section contributions for one deleted user", async () => {
+    findManyMock.mockResolvedValue([{ userId: "user-1" }]);
+    getUserCalendarRecordMock.mockResolvedValue(null);
+    const first = {
+      ack: vi.fn(),
+      body: { type: "section", sectionId: 10 },
+      retry: vi.fn(),
+    };
+    const second = {
+      ack: vi.fn(),
+      body: { type: "section", sectionId: 11 },
+      retry: vi.fn(),
+    };
+
+    await expect(
+      handleCalendarExportRebuildBatch({ messages: [first, second] }),
+    ).resolves.toEqual({ outcome: "success" });
+
+    expect(findManyMock).toHaveBeenCalledTimes(2);
+    expect(findManyMock).toHaveBeenNthCalledWith(1, {
+      where: { sectionId: 10 },
+      select: { userId: true },
+    });
+    expect(findManyMock).toHaveBeenNthCalledWith(2, {
+      where: { sectionId: 11 },
+      select: { userId: true },
+    });
+    expect(getUserCalendarRecordMock).toHaveBeenCalledOnce();
+    expect(writeCalendarQueueBatchAnalyticsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputMessageCount: 2,
+        noOpMessageCount: 2,
+        noSubscriberMessageCount: 0,
+        processedUserCount: 1,
+        sectionMessageCount: 2,
+        uniqueUserRebuildCount: 1,
+        userMessageCount: 0,
+      }),
+    );
+  });
+
   it("acks valid messages and sends invalid envelopes toward the DLQ", async () => {
     findManyMock.mockResolvedValue([]);
     getUserCalendarRecordMock.mockResolvedValue(null);

--- a/tests/unit/calendar-export-rebuild.test.ts
+++ b/tests/unit/calendar-export-rebuild.test.ts
@@ -6,12 +6,14 @@ const {
   buildUserCalendarExportMock,
   logAppEventMock,
   storeBuiltUserCalendarExportMock,
+  writeCalendarQueueBatchAnalyticsMock,
 } = vi.hoisted(() => ({
   findManyMock: vi.fn(),
   getUserCalendarRecordMock: vi.fn(),
   buildUserCalendarExportMock: vi.fn(),
   logAppEventMock: vi.fn(),
   storeBuiltUserCalendarExportMock: vi.fn(),
+  writeCalendarQueueBatchAnalyticsMock: vi.fn(),
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
@@ -38,6 +40,10 @@ vi.mock("@/lib/log/app-logger", () => ({
   logAppEvent: logAppEventMock,
 }));
 
+vi.mock("@/features/calendar/server/calendar-queue-batch-analytics", () => ({
+  writeCalendarQueueBatchAnalytics: writeCalendarQueueBatchAnalyticsMock,
+}));
+
 import {
   collectCalendarExportRebuildUserIds,
   handleCalendarExportRebuildBatch,
@@ -47,6 +53,7 @@ import {
 describe("calendar export rebuild fan-out", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it("coalesces duplicate user ids across user and section messages", async () => {
@@ -106,6 +113,96 @@ describe("calendar export rebuild fan-out", () => {
     expect(storeBuiltUserCalendarExportMock).toHaveBeenCalledTimes(2);
   });
 
+  it("records coalescing-aware counts once for a successful batch", async () => {
+    findManyMock.mockResolvedValue([
+      { userId: "user-1" },
+      { userId: "user-2" },
+    ]);
+    getUserCalendarRecordMock.mockResolvedValue({
+      id: "user-1",
+      sectionSubscriptions: [],
+      todos: [],
+    });
+    buildUserCalendarExportMock.mockResolvedValue({
+      cacheControl: "private, max-age=1800",
+      filename: "life-ustc-subscriptions.ics",
+      text: "BEGIN:VCALENDAR\nEND:VCALENDAR",
+    });
+    storeBuiltUserCalendarExportMock.mockResolvedValue({});
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-27T00:00:10.000Z"));
+
+    const user = {
+      ack: vi.fn(),
+      attempts: 2,
+      body: { type: "user", userId: "user-1" },
+      retry: vi.fn(),
+      timestamp: new Date("2026-08-27T00:00:00.000Z"),
+    };
+    const section = {
+      ack: vi.fn(),
+      attempts: 1,
+      body: { type: "section", sectionId: 5 },
+      retry: vi.fn(),
+      timestamp: new Date("2026-08-27T00:00:05.000Z"),
+    };
+
+    await expect(
+      handleCalendarExportRebuildBatch({ messages: [user, section] }),
+    ).resolves.toEqual({ outcome: "success" });
+
+    expect(writeCalendarQueueBatchAnalyticsMock).toHaveBeenCalledOnce();
+    expect(writeCalendarQueueBatchAnalyticsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ackedMessageCount: 2,
+        inputMessageCount: 2,
+        invalidMessageCount: 0,
+        maxAgeMs: 10_000,
+        maxAttempts: 2,
+        noOpMessageCount: 0,
+        noSubscriberMessageCount: 0,
+        outcome: "success",
+        processedUserCount: 2,
+        retriedMessageCount: 0,
+        sectionMessageCount: 1,
+        uniqueUserRebuildCount: 2,
+        userMessageCount: 1,
+        durationMs: expect.any(Number),
+      }),
+    );
+  });
+
+  it("counts each no-subscriber section message as a no-op", async () => {
+    findManyMock.mockResolvedValue([]);
+    const first = {
+      ack: vi.fn(),
+      body: { type: "section", sectionId: 99 },
+      retry: vi.fn(),
+    };
+    const second = {
+      ack: vi.fn(),
+      body: { type: "section", sectionId: 99 },
+      retry: vi.fn(),
+    };
+
+    await expect(
+      handleCalendarExportRebuildBatch({ messages: [first, second] }),
+    ).resolves.toEqual({ outcome: "success" });
+
+    expect(writeCalendarQueueBatchAnalyticsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ackedMessageCount: 2,
+        inputMessageCount: 2,
+        noOpMessageCount: 2,
+        noSubscriberMessageCount: 2,
+        processedUserCount: 0,
+        sectionMessageCount: 2,
+        uniqueUserRebuildCount: 0,
+        userMessageCount: 0,
+      }),
+    );
+  });
+
   it("acks valid messages and sends invalid envelopes toward the DLQ", async () => {
     findManyMock.mockResolvedValue([]);
     getUserCalendarRecordMock.mockResolvedValue(null);
@@ -141,6 +238,16 @@ describe("calendar export rebuild fan-out", () => {
       },
     );
     expect(JSON.stringify(logAppEventMock.mock.calls)).not.toContain("nope");
+    expect(writeCalendarQueueBatchAnalyticsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ackedMessageCount: 1,
+        inputMessageCount: 2,
+        invalidMessageCount: 1,
+        outcome: "partial",
+        retriedMessageCount: 1,
+        userMessageCount: 1,
+      }),
+    );
   });
 
   it("logs safe batch context before retrying a failed batch", async () => {
@@ -184,6 +291,19 @@ describe("calendar export rebuild fan-out", () => {
     );
     expect(logAppEventMock.mock.calls[0]?.[2]).not.toHaveProperty("userId");
     expect(logAppEventMock.mock.calls[0]?.[2]).not.toHaveProperty("sectionId");
+    expect(writeCalendarQueueBatchAnalyticsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ackedMessageCount: 0,
+        inputMessageCount: 2,
+        invalidMessageCount: 0,
+        outcome: "retry",
+        processedUserCount: 0,
+        retriedMessageCount: 2,
+        uniqueUserRebuildCount: 2,
+        userMessageCount: 1,
+        sectionMessageCount: 1,
+      }),
+    );
   });
 
   it("classifies an all-invalid batch as retry without sampling it as success", async () => {
@@ -198,6 +318,18 @@ describe("calendar export rebuild fan-out", () => {
     ).resolves.toEqual({ outcome: "retry" });
     expect(invalid.ack).not.toHaveBeenCalled();
     expect(invalid.retry).toHaveBeenCalledOnce();
+    expect(writeCalendarQueueBatchAnalyticsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ackedMessageCount: 0,
+        inputMessageCount: 1,
+        invalidMessageCount: 1,
+        noOpMessageCount: 0,
+        noSubscriberMessageCount: 0,
+        outcome: "retry",
+        processedUserCount: 0,
+        retriedMessageCount: 1,
+      }),
+    );
   });
 
   it("classifies an all-valid batch as success after acknowledging once", async () => {
@@ -214,11 +346,36 @@ describe("calendar export rebuild fan-out", () => {
     ).resolves.toEqual({ outcome: "success" });
     expect(valid.ack).toHaveBeenCalledOnce();
     expect(valid.retry).not.toHaveBeenCalled();
+    expect(writeCalendarQueueBatchAnalyticsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ackedMessageCount: 1,
+        inputMessageCount: 1,
+        invalidMessageCount: 0,
+        noOpMessageCount: 1,
+        noSubscriberMessageCount: 0,
+        outcome: "success",
+        processedUserCount: 1,
+        retriedMessageCount: 0,
+        uniqueUserRebuildCount: 1,
+        userMessageCount: 1,
+      }),
+    );
   });
 
   it("classifies an empty batch as a successful no-op", async () => {
     await expect(
       handleCalendarExportRebuildBatch({ messages: [] }),
     ).resolves.toEqual({ outcome: "success" });
+    expect(writeCalendarQueueBatchAnalyticsMock).toHaveBeenCalledOnce();
+    expect(writeCalendarQueueBatchAnalyticsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ackedMessageCount: 0,
+        inputMessageCount: 0,
+        invalidMessageCount: 0,
+        outcome: "success",
+        processedUserCount: 0,
+        retriedMessageCount: 0,
+      }),
+    );
   });
 });

--- a/tests/unit/calendar-queue-batch-analytics.test.ts
+++ b/tests/unit/calendar-queue-batch-analytics.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CALENDAR_QUEUE_BATCH_ANALYTICS_DOUBLE_FIELDS,
+  writeCalendarQueueBatchAnalytics,
+} from "@/features/calendar/server/calendar-queue-batch-analytics";
+import { setCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
+
+const { emitLogMock } = vi.hoisted(() => ({
+  emitLogMock: vi.fn(),
+}));
+
+vi.mock("@/lib/log/app-log-emitter", () => ({
+  emitLog: emitLogMock,
+}));
+
+const baseInput = {
+  ackedMessageCount: 2,
+  durationMs: 17.5,
+  inputMessageCount: 3,
+  invalidMessageCount: 1,
+  maxAgeMs: 125,
+  maxAttempts: 2,
+  noOpMessageCount: 1,
+  noSubscriberMessageCount: 1,
+  outcome: "partial" as const,
+  processedUserCount: 2,
+  retriedMessageCount: 1,
+  sectionMessageCount: 1,
+  uniqueUserRebuildCount: 2,
+  userMessageCount: 1,
+};
+
+describe("calendar queue batch analytics", () => {
+  afterEach(() => {
+    setCloudflareRuntimeEnv(undefined);
+    emitLogMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("writes one fixed low-cardinality datapoint with the documented field order", () => {
+    const writeDataPoint = vi.fn();
+    setCloudflareRuntimeEnv({ ANALYTICS: { writeDataPoint } });
+
+    writeCalendarQueueBatchAnalytics(baseInput);
+
+    expect(writeDataPoint).toHaveBeenCalledOnce();
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      indexes: ["queue:calendar"],
+      blobs: ["calendar_queue_batch_v1", "finish", "calendar", "partial"],
+      doubles: [17.5, 3, 1, 1, 2, 1, 1, 2, 2, 1, 1, 125, 2],
+    });
+    expect(CALENDAR_QUEUE_BATCH_ANALYTICS_DOUBLE_FIELDS).toEqual([
+      "durationMs",
+      "inputMessageCount",
+      "userMessageCount",
+      "sectionMessageCount",
+      "uniqueUserRebuildCount",
+      "noSubscriberMessageCount",
+      "noOpMessageCount",
+      "processedUserCount",
+      "ackedMessageCount",
+      "retriedMessageCount",
+      "invalidMessageCount",
+      "maxAgeMs",
+      "maxAttempts",
+    ]);
+  });
+
+  it("keeps untrusted values out of the finite schema and datapoint limits", () => {
+    const writeDataPoint = vi.fn();
+    setCloudflareRuntimeEnv({ ANALYTICS: { writeDataPoint } });
+    const secret = "user-secret-or-section-secret";
+
+    writeCalendarQueueBatchAnalytics({
+      ...baseInput,
+      ackedMessageCount: Number.NaN,
+      durationMs: Number.POSITIVE_INFINITY,
+      inputMessageCount: 2_000_000,
+      invalidMessageCount: -10,
+      maxAgeMs: Number.NEGATIVE_INFINITY,
+      maxAttempts: Number.NaN,
+      noOpMessageCount: 2_000_000,
+      noSubscriberMessageCount: 2_000_000,
+      outcome: secret as never,
+      processedUserCount: 2_000_000,
+      retriedMessageCount: 2_000_000,
+      sectionMessageCount: 2_000_000,
+      uniqueUserRebuildCount: 2_000_000,
+      userMessageCount: 2_000_000,
+    });
+
+    const [dataPoint] = writeDataPoint.mock.calls[0] ?? [];
+    expect(dataPoint.indexes).toHaveLength(1);
+    expect(dataPoint.blobs).toHaveLength(4);
+    expect(dataPoint.doubles).toHaveLength(
+      CALENDAR_QUEUE_BATCH_ANALYTICS_DOUBLE_FIELDS.length,
+    );
+    expect(dataPoint.blobs).toEqual([
+      "calendar_queue_batch_v1",
+      "finish",
+      "calendar",
+      "error",
+    ]);
+    expect(dataPoint.doubles.every(Number.isFinite)).toBe(true);
+    expect(dataPoint.doubles.every((value: number) => value >= 0)).toBe(true);
+    expect(dataPoint.doubles).toContain(1_000_000);
+    expect(JSON.stringify(dataPoint)).not.toContain(secret);
+  });
+
+  it("fails open when the Analytics Engine binding throws without logging the error body", () => {
+    const writeDataPoint = vi.fn(() => {
+      throw new Error("private analytics transport detail");
+    });
+    setCloudflareRuntimeEnv({ ANALYTICS: { writeDataPoint } });
+
+    expect(() => writeCalendarQueueBatchAnalytics(baseInput)).not.toThrow();
+    expect(emitLogMock).toHaveBeenCalledWith(
+      "[app]",
+      "error",
+      expect.objectContaining({
+        errorName: "Error",
+        event: "calendar-queue-batch.analytics-failed",
+        source: "calendar-export-rebuild",
+      }),
+      undefined,
+    );
+    expect(JSON.stringify(emitLogMock.mock.calls)).not.toContain(
+      "private analytics transport detail",
+    );
+  });
+
+  it("does nothing when Analytics Engine is unavailable", () => {
+    expect(() => writeCalendarQueueBatchAnalytics(baseInput)).not.toThrow();
+    expect(emitLogMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/catalog-detail-page-data.test.ts
+++ b/tests/unit/catalog-detail-page-data.test.ts
@@ -1,12 +1,18 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runWithCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
+import { resetPublicRuntimeCacheForTest } from "@/lib/public-runtime-cache";
 
-const { courseFindManyMock, courseFindUniqueMock, teacherFindUniqueMock } =
-  vi.hoisted(() => ({
-    courseFindManyMock: vi.fn(),
-    courseFindUniqueMock: vi.fn(),
-    teacherFindUniqueMock: vi.fn(),
-  }));
+const {
+  courseFindManyMock,
+  courseFindUniqueMock,
+  getCatalogDetailCacheRevisionMock,
+  teacherFindUniqueMock,
+} = vi.hoisted(() => ({
+  courseFindManyMock: vi.fn(),
+  courseFindUniqueMock: vi.fn(),
+  getCatalogDetailCacheRevisionMock: vi.fn(),
+  teacherFindUniqueMock: vi.fn(),
+}));
 
 vi.mock("@/lib/db/prisma", () => ({
   getPrisma: () => ({
@@ -16,6 +22,10 @@ vi.mock("@/lib/db/prisma", () => ({
     },
     teacher: { findUnique: teacherFindUniqueMock },
   }),
+}));
+
+vi.mock("@/lib/catalog-detail-cache-revision", () => ({
+  getCatalogDetailCacheRevision: getCatalogDetailCacheRevisionMock,
 }));
 
 function prismaThenable<T>(value: T): PromiseLike<T> {
@@ -29,7 +39,13 @@ function prismaThenable<T>(value: T): PromiseLike<T> {
 
 describe("catalog detail page data", () => {
   beforeEach(() => {
+    resetPublicRuntimeCacheForTest();
     vi.clearAllMocks();
+    getCatalogDetailCacheRevisionMock.mockResolvedValue("test-revision");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("loads a course without unused comment queries", async () => {
@@ -88,6 +104,107 @@ describe("catalog detail page data", () => {
     expect(teacherSelect?.sections?.take).toBe(20);
     expect(result).not.toHaveProperty("commentCount");
     expect(result).not.toHaveProperty("latestComments");
+  });
+
+  it("coalesces concurrent course core misses within the isolate", async () => {
+    let resolveCourse: ((value: unknown) => void) | undefined;
+    const course = { code: "MATH1001", id: 11, jwId: 101, sections: [] };
+    courseFindUniqueMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCourse = resolve;
+      }),
+    );
+
+    const { getCoursePage } = await import(
+      "@/features/catalog/server/course-page-data"
+    );
+    const first = getCoursePage(course.jwId, "zh-cn");
+    const second = getCoursePage(course.jwId, "zh-cn");
+
+    await vi.waitFor(() => {
+      expect(courseFindUniqueMock).toHaveBeenCalledOnce();
+    });
+    resolveCourse?.(course);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      course,
+      course,
+    ]);
+    expect(courseFindUniqueMock).toHaveBeenCalledOnce();
+  });
+
+  it("reuses the immutable teacher core without caching request data", async () => {
+    const teacher = {
+      address: "Campus",
+      email: "teacher@example.test",
+      id: 21,
+      namePrimary: "Ada",
+      sections: [],
+    };
+    teacherFindUniqueMock.mockResolvedValue(teacher);
+
+    const { getTeacherPage } = await import(
+      "@/features/catalog/server/teacher-page-data"
+    );
+    const first = await getTeacherPage(teacher.id, "zh-cn");
+    const second = await getTeacherPage(teacher.id, "zh-cn");
+
+    expect(second).toEqual(first);
+    expect(teacherFindUniqueMock).toHaveBeenCalledOnce();
+    expect(first).not.toHaveProperty("viewer");
+    expect(first).not.toHaveProperty("description");
+    expect(first).not.toHaveProperty("comments");
+  });
+
+  it("isolates course core entries by locale and static revision", async () => {
+    courseFindUniqueMock.mockResolvedValue({
+      code: "MATH1001",
+      id: 11,
+      jwId: 101,
+      sections: [],
+    });
+    const { getCoursePage } = await import(
+      "@/features/catalog/server/course-page-data"
+    );
+
+    await getCoursePage(101, "zh-cn");
+    await getCoursePage(101, "en-us");
+    await getCoursePage(101, "zh-cn");
+    expect(courseFindUniqueMock).toHaveBeenCalledTimes(2);
+
+    getCatalogDetailCacheRevisionMock.mockResolvedValue("next-revision");
+    await getCoursePage(101, "zh-cn");
+    expect(courseFindUniqueMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("uses a distinct bounded page-core cache shape", async () => {
+    vi.stubEnv("APP_CANONICAL_ORIGIN", "https://example.test");
+    const requests: Request[] = [];
+    vi.stubGlobal("caches", {
+      open: vi.fn(async () => ({
+        match: vi.fn(async (request: Request) => {
+          requests.push(request);
+          return undefined;
+        }),
+        put: vi.fn(async () => undefined),
+      })),
+    });
+    courseFindUniqueMock.mockResolvedValue({
+      code: "MATH1001",
+      id: 11,
+      jwId: 101,
+      sections: [],
+    });
+
+    const { getCoursePage } = await import(
+      "@/features/catalog/server/course-page-data"
+    );
+    await runWithCloudflareRuntimeEnv({}, () => getCoursePage(101, "en-us"));
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe(
+      "https://example.test/_life-ustc-internal-cache/catalog-detail-core/v2/test-revision/course/page-core-v1/en-us/101",
+    );
   });
 
   it("strips Prisma extension symbols before returning load data", async () => {
@@ -188,29 +305,47 @@ describe("catalog detail page data", () => {
       },
     );
 
-    expect(spans).toEqual([
-      {
-        attributes: { "catalog.detail.kind": "course" },
-        name: "catalog.detail.course.query",
-      },
-      {
-        attributes: { "catalog.detail.kind": "course" },
-        name: "catalog.detail.course.transform",
-      },
-      {
-        attributes: { "catalog.detail.kind": "teacher" },
-        name: "catalog.detail.teacher.query",
-      },
-      {
-        attributes: { "catalog.detail.kind": "teacher" },
-        name: "catalog.detail.teacher.transform",
-      },
-    ]);
+    expect(spans).toEqual(
+      expect.arrayContaining([
+        {
+          attributes: expect.objectContaining({
+            "cache.layer": "colo",
+            "cache.namespace": "catalog:course-detail:zh-cn",
+          }),
+          name: "cache.colo.read",
+        },
+        {
+          attributes: { "catalog.detail.kind": "course" },
+          name: "catalog.detail.course.query",
+        },
+        {
+          attributes: { "catalog.detail.kind": "course" },
+          name: "catalog.detail.course.transform",
+        },
+        {
+          attributes: expect.objectContaining({
+            "cache.layer": "colo",
+            "cache.namespace": "catalog:teacher-detail:zh-cn",
+          }),
+          name: "cache.colo.read",
+        },
+        {
+          attributes: { "catalog.detail.kind": "teacher" },
+          name: "catalog.detail.teacher.query",
+        },
+        {
+          attributes: { "catalog.detail.kind": "teacher" },
+          name: "catalog.detail.teacher.transform",
+        },
+      ]),
+    );
     expect(JSON.stringify(spans)).not.toContain("101");
     expect(JSON.stringify(spans)).not.toContain("21");
-    expect(nativePromiseSpans).toEqual([
-      "catalog.detail.course.query",
-      "catalog.detail.teacher.query",
-    ]);
+    expect(nativePromiseSpans).toEqual(
+      expect.arrayContaining([
+        "catalog.detail.course.query",
+        "catalog.detail.teacher.query",
+      ]),
+    );
   });
 });

--- a/tests/unit/catalog-detail-page-data.test.ts
+++ b/tests/unit/catalog-detail-page-data.test.ts
@@ -37,6 +37,78 @@ function prismaThenable<T>(value: T): PromiseLike<T> {
   };
 }
 
+function localizedName(nameCn: string) {
+  const nameEn = `${nameCn} EN`;
+  return {
+    nameCn,
+    nameEn,
+    namePrimary: nameCn,
+    nameSecondary: nameEn,
+  };
+}
+
+function coursePageSection(overrides: object = {}) {
+  return {
+    jwId: 301,
+    code: "001",
+    stdCount: null,
+    limitCount: null,
+    semester: null,
+    campus: null,
+    teachers: [],
+    ...overrides,
+  };
+}
+
+function teacherPageSection(overrides: object = {}) {
+  return {
+    jwId: 302,
+    code: "002",
+    credits: null,
+    course: localizedName("Course"),
+    semester: null,
+    ...overrides,
+  };
+}
+
+function coursePage(overrides: object = {}) {
+  return {
+    id: 11,
+    jwId: 101,
+    code: "MATH1001",
+    ...localizedName("Calculus"),
+    educationLevel: null,
+    category: null,
+    classType: null,
+    type: null,
+    sections: [],
+    ...overrides,
+  };
+}
+
+function teacherPage(overrides: object = {}) {
+  return {
+    id: 21,
+    ...localizedName("Ada"),
+    email: null,
+    telephone: null,
+    mobile: null,
+    address: null,
+    department: null,
+    teacherTitle: null,
+    sections: [],
+    ...overrides,
+  };
+}
+
+function detailCacheEnvelope(value: unknown) {
+  return {
+    expiresAt: Date.now() + 60_000,
+    schema: "catalog-detail-core-v2",
+    value,
+  };
+}
+
 describe("catalog detail page data", () => {
   beforeEach(() => {
     resetPublicRuntimeCacheForTest();
@@ -49,12 +121,7 @@ describe("catalog detail page data", () => {
   });
 
   it("loads a course without unused comment queries", async () => {
-    const course = {
-      code: "MATH1001",
-      id: 11,
-      jwId: 101,
-      sections: [],
-    };
+    const course = coursePage();
     courseFindUniqueMock.mockResolvedValue(course);
 
     const { getCoursePage } = await import(
@@ -62,12 +129,7 @@ describe("catalog detail page data", () => {
     );
     const result = await getCoursePage(course.jwId, "zh-cn");
 
-    expect(result).toEqual({
-      code: course.code,
-      id: course.id,
-      jwId: course.jwId,
-      sections: [],
-    });
+    expect(result).toEqual(course);
     expect(courseFindUniqueMock).toHaveBeenCalledTimes(1);
     expect(courseFindUniqueMock).toHaveBeenCalledWith(
       expect.objectContaining({ where: { jwId: course.jwId } }),
@@ -81,11 +143,7 @@ describe("catalog detail page data", () => {
   });
 
   it("loads a teacher without unused comment queries", async () => {
-    const teacher = {
-      id: 21,
-      namePrimary: "Ada",
-      sections: [],
-    };
+    const teacher = teacherPage();
     teacherFindUniqueMock.mockResolvedValue(teacher);
 
     const { getTeacherPage } = await import(
@@ -93,11 +151,7 @@ describe("catalog detail page data", () => {
     );
     const result = await getTeacherPage(teacher.id, "zh-cn");
 
-    expect(result).toEqual({
-      id: teacher.id,
-      namePrimary: teacher.namePrimary,
-      sections: [],
-    });
+    expect(result).toEqual(teacher);
     const teacherSelect = teacherFindUniqueMock.mock.calls[0]?.[0]?.select;
     expect(teacherSelect).not.toHaveProperty("description");
     expect(teacherSelect).not.toHaveProperty("_count");
@@ -108,7 +162,7 @@ describe("catalog detail page data", () => {
 
   it("coalesces concurrent course core misses within the isolate", async () => {
     let resolveCourse: ((value: unknown) => void) | undefined;
-    const course = { code: "MATH1001", id: 11, jwId: 101, sections: [] };
+    const course = coursePage();
     courseFindUniqueMock.mockReturnValue(
       new Promise((resolve) => {
         resolveCourse = resolve;
@@ -134,13 +188,10 @@ describe("catalog detail page data", () => {
   });
 
   it("reuses the immutable teacher core without caching request data", async () => {
-    const teacher = {
+    const teacher = teacherPage({
       address: "Campus",
       email: "teacher@example.test",
-      id: 21,
-      namePrimary: "Ada",
-      sections: [],
-    };
+    });
     teacherFindUniqueMock.mockResolvedValue(teacher);
 
     const { getTeacherPage } = await import(
@@ -157,12 +208,7 @@ describe("catalog detail page data", () => {
   });
 
   it("isolates course core entries by locale and static revision", async () => {
-    courseFindUniqueMock.mockResolvedValue({
-      code: "MATH1001",
-      id: 11,
-      jwId: 101,
-      sections: [],
-    });
+    courseFindUniqueMock.mockResolvedValue(coursePage());
     const { getCoursePage } = await import(
       "@/features/catalog/server/course-page-data"
     );
@@ -189,12 +235,7 @@ describe("catalog detail page data", () => {
         put: vi.fn(async () => undefined),
       })),
     });
-    courseFindUniqueMock.mockResolvedValue({
-      code: "MATH1001",
-      id: 11,
-      jwId: 101,
-      sections: [],
-    });
+    courseFindUniqueMock.mockResolvedValue(coursePage());
 
     const { getCoursePage } = await import(
       "@/features/catalog/server/course-page-data"
@@ -207,20 +248,197 @@ describe("catalog detail page data", () => {
     );
   });
 
+  it("reloads a course when KV contains a corrupt page core", async () => {
+    const course = coursePage();
+    const namespace = {
+      get: vi.fn(async () =>
+        detailCacheEnvelope(
+          coursePage({
+            viewer: { userId: "must-not-be-cached" },
+          }),
+        ),
+      ),
+      put: vi.fn(async () => undefined),
+    };
+    const match = vi.fn(async () => undefined);
+    vi.stubGlobal("caches", {
+      open: vi.fn(async () => ({
+        match,
+        put: vi.fn(async () => undefined),
+      })),
+    });
+    courseFindUniqueMock.mockResolvedValue(course);
+
+    const { getCoursePage } = await import(
+      "@/features/catalog/server/course-page-data"
+    );
+    const result = await runWithCloudflareRuntimeEnv(
+      { CATALOG_DETAIL_CORE: namespace },
+      () => getCoursePage(course.jwId, "zh-cn"),
+    );
+
+    expect(result).toEqual(course);
+    expect(courseFindUniqueMock).toHaveBeenCalledOnce();
+    expect(namespace.get).toHaveBeenCalledOnce();
+    expect(match).toHaveBeenCalledOnce();
+  });
+
+  it("reloads a course when Cache API contains a corrupt nested core", async () => {
+    const course = coursePage();
+    const match = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify(
+            detailCacheEnvelope(
+              coursePage({
+                sections: [
+                  coursePageSection({
+                    teachers: [
+                      { ...localizedName("Teacher"), email: "private" },
+                    ],
+                  }),
+                ],
+              }),
+            ),
+          ),
+        ),
+    );
+    vi.stubGlobal("caches", {
+      open: vi.fn(async () => ({
+        match,
+        put: vi.fn(async () => undefined),
+      })),
+    });
+    courseFindUniqueMock.mockResolvedValue(course);
+
+    const { getCoursePage } = await import(
+      "@/features/catalog/server/course-page-data"
+    );
+    const result = await runWithCloudflareRuntimeEnv({}, () =>
+      getCoursePage(course.jwId, "zh-cn"),
+    );
+
+    expect(result).toEqual(course);
+    expect(courseFindUniqueMock).toHaveBeenCalledOnce();
+    expect(match).toHaveBeenCalledOnce();
+  });
+
+  it("reloads a teacher when Cache API contains a corrupt nested core", async () => {
+    const teacher = teacherPage();
+    const match = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify(
+            detailCacheEnvelope(
+              teacherPage({
+                sections: [
+                  teacherPageSection({
+                    course: {
+                      ...localizedName("Course"),
+                      viewer: { userId: "must-not-be-cached" },
+                    },
+                  }),
+                ],
+              }),
+            ),
+          ),
+        ),
+    );
+    vi.stubGlobal("caches", {
+      open: vi.fn(async () => ({
+        match,
+        put: vi.fn(async () => undefined),
+      })),
+    });
+    teacherFindUniqueMock.mockResolvedValue(teacher);
+
+    const { getTeacherPage } = await import(
+      "@/features/catalog/server/teacher-page-data"
+    );
+    const result = await runWithCloudflareRuntimeEnv({}, () =>
+      getTeacherPage(teacher.id, "zh-cn"),
+    );
+
+    expect(result).toEqual(teacher);
+    expect(teacherFindUniqueMock).toHaveBeenCalledOnce();
+    expect(match).toHaveBeenCalledOnce();
+  });
+
+  it("reloads a teacher when KV contains a corrupt page core", async () => {
+    const teacher = teacherPage();
+    const namespace = {
+      get: vi.fn(async () =>
+        detailCacheEnvelope(
+          teacherPage({
+            email: { leaked: true },
+          }),
+        ),
+      ),
+      put: vi.fn(async () => undefined),
+    };
+    const match = vi.fn(async () => undefined);
+    vi.stubGlobal("caches", {
+      open: vi.fn(async () => ({
+        match,
+        put: vi.fn(async () => undefined),
+      })),
+    });
+    teacherFindUniqueMock.mockResolvedValue(teacher);
+
+    const { getTeacherPage } = await import(
+      "@/features/catalog/server/teacher-page-data"
+    );
+    const result = await runWithCloudflareRuntimeEnv(
+      { CATALOG_DETAIL_CORE: namespace },
+      () => getTeacherPage(teacher.id, "zh-cn"),
+    );
+
+    expect(result).toEqual(teacher);
+    expect(teacherFindUniqueMock).toHaveBeenCalledOnce();
+    expect(namespace.get).toHaveBeenCalledOnce();
+    expect(match).toHaveBeenCalledOnce();
+  });
+
+  it("keeps representative page-core cache envelopes below the payload guard", () => {
+    const course = coursePage({
+      sections: Array.from({ length: 20 }, (_, index) =>
+        coursePageSection({
+          code: `COURSE-${index + 1}`,
+          jwId: 301 + index,
+          teachers: [localizedName(`Teacher ${index + 1}`)],
+        }),
+      ),
+    });
+    const teacher = teacherPage({
+      sections: Array.from({ length: 20 }, (_, index) =>
+        teacherPageSection({
+          code: `SECTION-${index + 1}`,
+          jwId: 401 + index,
+          course: localizedName(`Course ${index + 1}`),
+        }),
+      ),
+    });
+    const maxPayloadBytes = 256 * 1024;
+
+    for (const value of [course, teacher]) {
+      const serialized = JSON.stringify(detailCacheEnvelope(value));
+      expect(new TextEncoder().encode(serialized).byteLength).toBeLessThan(
+        maxPayloadBytes,
+      );
+    }
+  });
+
   it("strips Prisma extension symbols before returning load data", async () => {
     const localizedNameSymbol = Symbol("localizedName");
-    const courseSections = [{ code: "001", jwId: 301 }];
+    const courseSections = [coursePageSection()];
     courseFindUniqueMock.mockResolvedValue({
-      id: 11,
-      jwId: 101,
+      ...coursePage({ sections: courseSections }),
       [localizedNameSymbol]: "course",
-      sections: courseSections,
     });
-    const teacherSections = [{ code: "002", jwId: 302 }];
+    const teacherSections = [teacherPageSection()];
     teacherFindUniqueMock.mockResolvedValue({
-      id: 21,
+      ...teacherPage({ sections: teacherSections }),
       [localizedNameSymbol]: "teacher",
-      sections: teacherSections,
     });
 
     const [{ getCoursePage }, { getTeacherPage }] = await Promise.all([
@@ -249,16 +467,8 @@ describe("catalog detail page data", () => {
   });
 
   it("traces bounded course and teacher query phases", async () => {
-    courseFindUniqueMock.mockReturnValue(
-      prismaThenable({
-        id: 11,
-        jwId: 101,
-        sections: [],
-      }),
-    );
-    teacherFindUniqueMock.mockReturnValue(
-      prismaThenable({ id: 21, sections: [] }),
-    );
+    courseFindUniqueMock.mockReturnValue(prismaThenable(coursePage()));
+    teacherFindUniqueMock.mockReturnValue(prismaThenable(teacherPage()));
     const [{ getCoursePage }, { getTeacherPage }] = await Promise.all([
       import("@/features/catalog/server/course-page-data"),
       import("@/features/catalog/server/teacher-page-data"),

--- a/tests/unit/comment-read-model-pagination.test.ts
+++ b/tests/unit/comment-read-model-pagination.test.ts
@@ -13,6 +13,8 @@ const {
   publicReactionSummaryQueryMock,
   reactionSummaryQueryMock,
   rootPageQueryMock,
+  suspensionFindFirstMock,
+  userFindUniqueMock,
   withUserDbContextMock,
   writeCommentsStageAnalyticsMock,
 } = vi.hoisted(() => ({
@@ -28,6 +30,8 @@ const {
   publicReactionSummaryQueryMock: vi.fn(),
   reactionSummaryQueryMock: vi.fn(),
   rootPageQueryMock: vi.fn(),
+  suspensionFindFirstMock: vi.fn(),
+  userFindUniqueMock: vi.fn(),
   withUserDbContextMock: vi.fn(),
   writeCommentsStageAnalyticsMock: vi.fn(),
 }));
@@ -47,6 +51,8 @@ vi.mock("@/lib/db/prisma", () => ({
       count: commentCountMock,
       findMany: commentFindManyMock,
     },
+    user: { findUnique: userFindUniqueMock },
+    userSuspension: { findFirst: suspensionFindFirstMock },
   },
   withUserDbContext: withUserDbContextMock,
 }));
@@ -143,11 +149,20 @@ describe("loadCommentThread pagination", () => {
     descendantQueryMock.mockResolvedValue([]);
     rootPageQueryMock.mockReset();
     commentFindManyMock.mockReset();
+    suspensionFindFirstMock.mockReset();
+    userFindUniqueMock.mockReset();
     accountFindManyMock.mockResolvedValue([]);
     logAppEventMock.mockReset();
     publicReactionSummaryQueryMock.mockResolvedValue([]);
     publicAttachmentSummaryQueryMock.mockResolvedValue([]);
     rootPageQueryMock.mockResolvedValue([{ id: "root-2", total: 3n }]);
+    suspensionFindFirstMock.mockResolvedValue(null);
+    userFindUniqueMock.mockResolvedValue({
+      id: viewer.userId,
+      image: viewer.image,
+      isAdmin: viewer.isAdmin,
+      name: viewer.name,
+    });
     reactionSummaryQueryMock.mockResolvedValue([]);
     attachmentSummaryQueryMock.mockResolvedValue([]);
     writeCommentsStageAnalyticsMock.mockReset();
@@ -340,6 +355,51 @@ describe("loadCommentThread pagination", () => {
             },
           ],
         },
+      }),
+    );
+  });
+
+  it("records two uncached viewer reads once without counting a transaction", async () => {
+    commentFindManyMock.mockResolvedValueOnce([]);
+
+    await loadCommentThread({
+      target: target({ sectionId: 7 }),
+      viewerUserId: viewer.userId,
+    });
+
+    expect(userFindUniqueMock).toHaveBeenCalledOnce();
+    expect(suspensionFindFirstMock).toHaveBeenCalledOnce();
+    expect(
+      writeCommentsStageAnalyticsMock.mock.calls.filter(
+        ([input]) => (input as { stage: string }).stage === "viewer.context",
+      ),
+    ).toEqual([
+      [
+        expect.objectContaining({
+          dbContext: "none",
+          dbQueryCount: 2,
+          dbTransactionCount: 0,
+          stage: "viewer.context",
+        }),
+      ],
+    ]);
+  });
+
+  it("records anonymous viewer context without a database read", async () => {
+    commentFindManyMock.mockResolvedValueOnce([]);
+
+    await loadCommentThread({
+      target: target({ sectionId: 7 }),
+      viewerUserId: null,
+    });
+
+    expect(userFindUniqueMock).not.toHaveBeenCalled();
+    expect(suspensionFindFirstMock).not.toHaveBeenCalled();
+    expect(writeCommentsStageAnalyticsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dbQueryCount: 0,
+        dbTransactionCount: 0,
+        stage: "viewer.context",
       }),
     );
   });

--- a/tests/unit/comments-server-pagination.test.ts
+++ b/tests/unit/comments-server-pagination.test.ts
@@ -1,15 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { loadCommentThread, resolveCommentTarget } = vi.hoisted(() => ({
+const {
+  getViewerContextMock,
+  loadCommentThread,
+  resolveCommentTarget,
+  writeCommentsStageAnalyticsMock,
+} = vi.hoisted(() => ({
+  getViewerContextMock: vi.fn(),
   loadCommentThread: vi.fn(),
   resolveCommentTarget: vi.fn(),
+  writeCommentsStageAnalyticsMock: vi.fn(),
 }));
 
+vi.mock("@/lib/auth/viewer-context", () => ({
+  getViewerContext: getViewerContextMock,
+}));
 vi.mock("@/features/comments/server/comment-read-model", () => ({
   loadCommentThread,
 }));
 vi.mock("@/features/comments/server/comment-utils", () => ({
   resolveCommentTarget,
+}));
+vi.mock("@/lib/metrics/analytics-engine", () => ({
+  writeCommentsStageAnalytics: writeCommentsStageAnalyticsMock,
 }));
 
 const viewer = {
@@ -26,6 +39,7 @@ const viewer = {
 describe("comments SSR payload", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getViewerContextMock.mockReset();
     resolveCommentTarget.mockResolvedValue({
       empty: false,
       whereTarget: { courseId: 1 },
@@ -36,6 +50,8 @@ describe("comments SSR payload", () => {
       total: 21,
       viewer,
     });
+    getViewerContextMock.mockResolvedValue(viewer);
+    writeCommentsStageAnalyticsMock.mockReset();
   });
 
   it("loads one bounded root page and marks it for CSR completion", async () => {
@@ -50,8 +66,82 @@ describe("comments SSR payload", () => {
     );
 
     expect(loadCommentThread).toHaveBeenCalledWith(
-      expect.objectContaining({ pagination: { pageSize: 20, skip: 0 } }),
+      expect.objectContaining({
+        pagination: { pageSize: 20, skip: 0 },
+        viewerContextStageRecorded: true,
+      }),
     );
     expect(result.complete).toBe(false);
+  });
+
+  it("counts two cold authenticated viewer reads in one SSR stage", async () => {
+    const authenticatedViewer = {
+      ...viewer,
+      isAuthenticated: true,
+      userId: "user-1",
+    };
+    getViewerContextMock.mockImplementation(async ({ instrumentation }) => {
+      instrumentation?.onQuery?.();
+      instrumentation?.onQuery?.();
+      return authenticatedViewer;
+    });
+
+    const { getCommentsPayload } = await import(
+      "@/features/comments/server/comments-server"
+    );
+    await getCommentsPayload({ targetId: 1, type: "course" });
+
+    expect(getViewerContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeAdmin: false,
+        instrumentation: expect.any(Object),
+      }),
+    );
+    expect(writeCommentsStageAnalyticsMock).toHaveBeenCalledOnce();
+    expect(writeCommentsStageAnalyticsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dbContext: "none",
+        dbQueryCount: 2,
+        dbTransactionCount: 0,
+        outcome: "success",
+        stage: "viewer.context",
+      }),
+    );
+    expect(loadCommentThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        viewer: authenticatedViewer,
+        viewerContextStageRecorded: true,
+      }),
+    );
+  });
+
+  it("records anonymous and preloaded viewer contexts with zero reads", async () => {
+    const { getCommentsPayload } = await import(
+      "@/features/comments/server/comments-server"
+    );
+
+    await getCommentsPayload({ targetId: 1, type: "course" });
+    expect(writeCommentsStageAnalyticsMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        dbQueryCount: 0,
+        dbTransactionCount: 0,
+        stage: "viewer.context",
+      }),
+    );
+
+    writeCommentsStageAnalyticsMock.mockReset();
+    getViewerContextMock.mockClear();
+    await getCommentsPayload({ targetId: 1, type: "course" }, viewer);
+
+    expect(getViewerContextMock).not.toHaveBeenCalled();
+    expect(writeCommentsStageAnalyticsMock).toHaveBeenCalledOnce();
+    expect(writeCommentsStageAnalyticsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dbQueryCount: 0,
+        dbTransactionCount: 0,
+        stage: "viewer.context",
+      }),
+    );
   });
 });

--- a/tests/unit/dashboard-nav-stats.test.ts
+++ b/tests/unit/dashboard-nav-stats.test.ts
@@ -240,6 +240,7 @@ describe("仪表盘导航统计", () => {
           undefined,
           counter,
         ),
+      counter,
     );
 
     expect(writeDashboardStageAnalyticsMock).toHaveBeenCalledOnce();

--- a/tests/unit/dashboard-nav-stats.test.ts
+++ b/tests/unit/dashboard-nav-stats.test.ts
@@ -29,6 +29,10 @@ vi.mock("@/lib/metrics/analytics-engine", () => ({
   writeDashboardStageAnalytics: writeDashboardStageAnalyticsMock,
 }));
 
+vi.mock("@/lib/log/app-logger", () => ({
+  logAppEvent: vi.fn(),
+}));
+
 describe("仪表盘导航统计", () => {
   afterEach(() => {
     countIncompleteTodosMock.mockReset();
@@ -191,5 +195,56 @@ describe("仪表盘导航统计", () => {
     await expect(resultPromise).resolves.toMatchObject({
       pendingTodosCount: 5,
     });
+  });
+
+  it("emits one nav datapoint when the page stage wraps the aggregate", async () => {
+    getWorkspaceNavigationAggregateMock.mockResolvedValue({
+      calendarItemsCount: 9,
+      examsCount: 3,
+      highlightPendingHomeworks: false,
+      pendingHomeworksCount: 2,
+      pendingTodosCount: 4,
+      subscribedSectionCount: 1,
+    });
+    withUserDbContextMock.mockImplementation(
+      async (_userId: string, action: (tx: object) => unknown) => action({}),
+    );
+
+    const { getDashboardNavStats } = await import(
+      "@/features/dashboard/server/dashboard-nav-stats"
+    );
+    const { timeDashboardStage } = await import(
+      "@/features/dashboard/server/dashboard-page-tab-data"
+    );
+    const { createDashboardStageCounter } = await import(
+      "@/features/dashboard/server/dashboard-stage-analytics"
+    );
+    const counter = createDashboardStageCounter({
+      dbContext: "rls",
+      dbLabel: "app",
+    });
+
+    await timeDashboardStage(
+      "nav_stats",
+      {
+        requestId: "dashboard-nav-stage-test",
+        subscribedSectionCount: 1,
+        tab: "overview",
+      },
+      () =>
+        getDashboardNavStats(
+          { id: "user-1", name: "User", username: "user" },
+          [{ id: 12, semesterId: 1 }],
+          new Date("2026-05-22T10:30:00.000Z"),
+          undefined,
+          undefined,
+          counter,
+        ),
+    );
+
+    expect(writeDashboardStageAnalyticsMock).toHaveBeenCalledOnce();
+    expect(writeDashboardStageAnalyticsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: "nav_stats" }),
+    );
   });
 });

--- a/tests/unit/dashboard-page-load-signed.test.ts
+++ b/tests/unit/dashboard-page-load-signed.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getDashboardUserContextMock,
+  loadSignedDashboardTabDataMock,
+  serializeDashboardOverviewMock,
+  timeDashboardStageMock,
+} = vi.hoisted(() => ({
+  getDashboardUserContextMock: vi.fn(),
+  loadSignedDashboardTabDataMock: vi.fn(),
+  serializeDashboardOverviewMock: vi.fn(),
+  timeDashboardStageMock: vi.fn(
+    async (...args: [string, unknown, () => Promise<unknown>, unknown?]) =>
+      args[2](),
+  ),
+}));
+
+vi.mock("@/features/dashboard/server/dashboard-overview-data", () => ({
+  getDashboardUserContext: getDashboardUserContextMock,
+}));
+
+vi.mock("@/features/dashboard/server/dashboard-overview-serialization", () => ({
+  serializeDashboardOverview: serializeDashboardOverviewMock,
+}));
+
+vi.mock("@/features/dashboard/server/dashboard-page-tab-data", () => ({
+  loadSignedDashboardTabData: loadSignedDashboardTabDataMock,
+  timeDashboardStage: timeDashboardStageMock,
+}));
+
+import { loadSignedDashboardPageData } from "@/features/dashboard/server/dashboard-page-load-signed";
+
+describe("signed dashboard tab observability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getDashboardUserContextMock.mockResolvedValue({
+      sectionIds: [12, 34],
+    });
+    loadSignedDashboardTabDataMock.mockResolvedValue({
+      bus: null,
+      calendarSubscriptionUrl: null,
+      homeworks: null,
+      links: null,
+      navStats: null,
+      overview: null,
+      subscriptions: null,
+      todos: null,
+    });
+  });
+
+  it("records one unknown mixed-context tab stage for fan-out data", async () => {
+    await loadSignedDashboardPageData({
+      calendarSemesterId: undefined,
+      locale: "en-us",
+      overviewWeek: null,
+      pageCopy: {} as never,
+      referenceNow: new Date("2026-05-22T10:30:00.000Z"),
+      requestId: "request-1",
+      tab: "overview",
+      userId: "user-1",
+    });
+
+    const tabCall = timeDashboardStageMock.mock.calls.find(
+      ([stage]) => stage === "tab",
+    );
+    expect(tabCall?.[3]).toEqual(
+      expect.objectContaining({
+        countState: "unknown",
+        dbContext: "mixed",
+        dbLabel: "app",
+      }),
+    );
+    expect(
+      timeDashboardStageMock.mock.calls.filter(([stage]) => stage === "tab"),
+    ).toHaveLength(1);
+  });
+});

--- a/tests/unit/dashboard-stage-analytics.test.ts
+++ b/tests/unit/dashboard-stage-analytics.test.ts
@@ -40,6 +40,7 @@ describe("dashboard stage analytics", () => {
     ).resolves.toBe("ok");
 
     expect(writeDashboardStageAnalyticsMock).toHaveBeenCalledWith({
+      countState: "known",
       dbContext: "rls",
       dbLabel: "app",
       dbQueryCount: 1,
@@ -51,7 +52,7 @@ describe("dashboard stage analytics", () => {
     });
   });
 
-  it("does not publish a partial counter", async () => {
+  it("publishes an explicitly unknown partial counter without numeric counts", async () => {
     writeDashboardStageAnalyticsMock.mockReset();
     const counter = createDashboardStageCounter({
       dbContext: "none",
@@ -66,7 +67,16 @@ describe("dashboard stage analytics", () => {
         work: async () => ({ ok: true }),
       }),
     ).resolves.toEqual({ ok: true });
-    expect(writeDashboardStageAnalyticsMock).not.toHaveBeenCalled();
+    expect(writeDashboardStageAnalyticsMock).toHaveBeenCalledWith({
+      countState: "unknown",
+      dbContext: "none",
+      dbLabel: "auth",
+      dbQueryCount: 0,
+      dbTransactionCount: 0,
+      durationMs: 9,
+      outcome: "success",
+      stage: "tab",
+    });
   });
 
   it("keeps the dashboard result when the writer throws", async () => {

--- a/tests/unit/dashboard-todo-nav-reuse.test.ts
+++ b/tests/unit/dashboard-todo-nav-reuse.test.ts
@@ -155,7 +155,7 @@ describe("dashboard todo count reuse and RLS fan-out", () => {
       undefined,
       expect.any(Array),
       expect.objectContaining({
-        complete: true,
+        countState: "known",
         dbContext: "rls",
         dbLabel: "app",
       }),
@@ -178,7 +178,7 @@ describe("dashboard todo count reuse and RLS fan-out", () => {
       expect.any(Promise),
       semesters,
       expect.objectContaining({
-        complete: true,
+        countState: "known",
         dbContext: "rls",
         dbLabel: "app",
       }),

--- a/tests/unit/viewer-context-cache.test.ts
+++ b/tests/unit/viewer-context-cache.test.ts
@@ -40,6 +40,34 @@ describe("viewer context request cache", () => {
     expect(findSuspension).toHaveBeenCalledOnce();
   });
 
+  it("counts uncached reads but leaves request-cache hits and anonymous reads at zero", async () => {
+    const { getViewerContext } = await import("@/lib/auth/viewer-context");
+    let uncachedQueryCount = 0;
+    let cachedQueryCount = 0;
+    let anonymousQueryCount = 0;
+
+    await runWithCloudflareRuntimeEnv({}, async () => {
+      await getViewerContext({
+        userId: "user-1",
+        instrumentation: { onQuery: () => (uncachedQueryCount += 1) },
+      });
+      await getViewerContext({
+        userId: "user-1",
+        instrumentation: { onQuery: () => (cachedQueryCount += 1) },
+      });
+    });
+    await runWithCloudflareRuntimeEnv({}, () =>
+      getViewerContext({
+        userId: null,
+        instrumentation: { onQuery: () => (anonymousQueryCount += 1) },
+      }),
+    );
+
+    expect(uncachedQueryCount).toBe(2);
+    expect(cachedQueryCount).toBe(0);
+    expect(anonymousQueryCount).toBe(0);
+  });
+
   it("does not share viewer data across requests or admin modes", async () => {
     const { getViewerContext } = await import("@/lib/auth/viewer-context");
 

--- a/tests/unit/worker-entrypoint-observability.test.ts
+++ b/tests/unit/worker-entrypoint-observability.test.ts
@@ -22,6 +22,7 @@ import {
   logWorkerQueueError,
   logWorkerQueueFinish,
   normalizePublicSsrObservedRoute,
+  normalizeWorkerObservedRoute,
   observedEdgeResponse,
   resolveEdgeCacheOutcome,
   resolveWorkerQueue,
@@ -52,6 +53,24 @@ describe("worker entrypoint observability", () => {
     );
     expect(normalizePublicSsrObservedRoute("/users/user-secret")).toBe(
       "public-page",
+    );
+  });
+
+  it("normalizes dynamic API routes to finite families without queries or IDs", () => {
+    expect(
+      normalizeWorkerObservedRoute(
+        "/api/catalog/courses/123?token=private-value",
+      ),
+    ).toBe("/api/catalog");
+    expect(normalizeWorkerObservedRoute("/api/mcp/tools/call")).toBe(
+      "/api/mcp",
+    );
+    expect(
+      normalizeWorkerObservedRoute("/api/not-allowlisted/user-secret"),
+    ).toBe("/api/other");
+    expect(normalizeWorkerObservedRoute("/api")).toBe("/api/other");
+    expect(normalizeWorkerObservedRoute("/catalog/courses/course-secret")).toBe(
+      "/catalog/courses/:id",
     );
   });
 

--- a/tests/unit/worker-routing-entrypoint.test.ts
+++ b/tests/unit/worker-routing-entrypoint.test.ts
@@ -252,6 +252,30 @@ describe("Worker routing entrypoint", () => {
     );
   });
 
+  it("attributes dynamic API requests to a finite route family", async () => {
+    const response = await worker.fetch(
+      new Request(
+        "https://life-ustc.test/api/catalog/courses/123?token=private-value",
+      ),
+      {},
+      { waitUntil: vi.fn() },
+    );
+
+    expect(response.status).toBe(200);
+    const completion = logAppEventMock.mock.calls.find(
+      ([, event]) => event === "edge.request.finish",
+    );
+    expect(completion?.[2]).toEqual(
+      expect.objectContaining({
+        cacheOutcome: "dynamic",
+        requestClass: "dynamic",
+        route: "/api/catalog",
+        status: 200,
+      }),
+    );
+    expect(JSON.stringify(completion)).not.toContain("private-value");
+  });
+
   it("does not store per-request ids in the shared cache representation", async () => {
     appFetchMock.mockResolvedValue(
       new Response(null, {


### PR DESCRIPTION
## Summary

- cache validated public catalog detail page cores with mutable/viewer data isolated from cache
- add versioned stage-aware worker/API/OAuth/MCP/dashboard telemetry with bounded cardinality and truthful viewer/navigation counts
- add calendar export queue batch telemetry, fan-out no-op counts, and ack/retry accounting
- recover invalid catalog cache entries by falling back to origin data

## Validation

- full unit: 392 files / 2461 tests passed
- TypeScript (application, tests, operational), Svelte check, Biome, production build, OpenAPI parity, GraphQL snapshot
- clean CI-mirror DB integration: 46 files / 268 tests passed; RLS/auth/function-owner/maintenance contracts passed
- REST comments: 18 tests passed; focused catalog/cache/comments/dashboard/calendar/worker tests passed
- CLI and Bot vendored OpenAPI specs match the integrated server spec; relevant Go tests and command builds passed
- commitlint and git diff --check passed

No Prisma schema, OpenAPI, or GraphQL contract changes are included, so CLI/Bot generation is not required.

## Residual risk

- P3: local Playwright Worker teardown can emit a harmless status-file race warning after an otherwise passing REST run; application behavior and test assertions remain green.