### PR TITLE
fix(observability): preserve Worker response metadata

### DIFF
--- a/.github/workflows/db-backed-bun-job.yml
+++ b/.github/workflows/db-backed-bun-job.yml
@@ -157,6 +157,7 @@ jobs:
               bash tests/ci/seed-guard.test.sh
               bash tests/ci/e2e-full-suite-parity.test.sh
               bash tests/ci/e2e-worker-server.test.sh
+              bash tests/ci/worker-request-id-platform.test.sh
               bun run app:prepare
               bunx wrangler types --include-runtime=false --check
               bunx biome check

--- a/src/lib/log/worker-entrypoint-observability.ts
+++ b/src/lib/log/worker-entrypoint-observability.ts
@@ -138,6 +138,65 @@ function logEdgeObservationFailure(
   }
 }
 
+type ResponseHeadersWithCookieAccess = Headers & {
+  getAll?: (name: string) => string[];
+  getSetCookie?: () => string[];
+};
+type ResponseWithOptionalWebSocket = Response & {
+  readonly webSocket?: unknown;
+};
+type ResponseInitWithOptionalWebSocket = ResponseInit & {
+  webSocket?: unknown;
+};
+
+function copyResponseHeaders(response: Response) {
+  const headers = new Headers(response.headers);
+  const sourceHeaders = response.headers as ResponseHeadersWithCookieAccess;
+  const setCookieValues =
+    typeof sourceHeaders.getSetCookie === "function"
+      ? sourceHeaders.getSetCookie()
+      : typeof sourceHeaders.getAll === "function"
+        ? sourceHeaders.getAll("set-cookie")
+        : undefined;
+
+  if (setCookieValues) {
+    headers.delete("set-cookie");
+    for (const value of setCookieValues) {
+      headers.append("set-cookie", value);
+    }
+  }
+
+  return headers;
+}
+
+function isImmutableResponseHeadersError(error: unknown) {
+  return (
+    error instanceof TypeError &&
+    error.message.toLowerCase().includes("immutable")
+  );
+}
+
+function responseWithRequestId(response: Response, requestId: string) {
+  try {
+    response.headers.set("x-request-id", requestId);
+    return response;
+  } catch (error) {
+    if (!isImmutableResponseHeadersError(error)) throw error;
+    const headers = copyResponseHeaders(response);
+    headers.set("x-request-id", requestId);
+    const init: ResponseInitWithOptionalWebSocket = {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    };
+    const webSocket = (response as ResponseWithOptionalWebSocket).webSocket;
+    if (webSocket) {
+      init.webSocket = webSocket;
+    }
+    return new Response(response.body, init);
+  }
+}
+
 export function observedEdgeResponse(input: {
   cacheOutcome: EdgeCacheOutcome;
   request: Request;
@@ -150,11 +209,12 @@ export function observedEdgeResponse(input: {
   // Keep ownership of the body with the response returned by the application.
   // Constructing another Response around an already wrapped SvelteKit body can
   // make the runtime cancel/restart a valid response while edge telemetry is
-  // being recorded. Headers are mutable on the responses produced by this
-  // Worker; if a platform response is immutable, retain it unchanged.
-  const response = input.response;
+  // being recorded. Keep the mutable-response fast path; if a platform
+  // response is immutable, the fallback transfers the original body stream
+  // without cloning or teeing it.
+  let response = input.response;
   try {
-    response.headers.set("x-request-id", input.requestId);
+    response = responseWithRequestId(response, input.requestId);
   } catch (error) {
     logEdgeObservationFailure(input, "request-id", error);
   }

--- a/src/lib/log/worker-entrypoint-observability.ts
+++ b/src/lib/log/worker-entrypoint-observability.ts
@@ -138,62 +138,38 @@ function logEdgeObservationFailure(
   }
 }
 
-type ResponseHeadersWithCookieAccess = Headers & {
-  getAll?: (name: string) => string[];
-  getSetCookie?: () => string[];
-};
-type ResponseWithOptionalWebSocket = Response & {
-  readonly webSocket?: unknown;
-};
-type ResponseInitWithOptionalWebSocket = ResponseInit & {
-  webSocket?: unknown;
-};
-
-function copyResponseHeaders(response: Response) {
-  const headers = new Headers(response.headers);
-  const sourceHeaders = response.headers as ResponseHeadersWithCookieAccess;
-  const setCookieValues =
-    typeof sourceHeaders.getSetCookie === "function"
-      ? sourceHeaders.getSetCookie()
-      : typeof sourceHeaders.getAll === "function"
-        ? sourceHeaders.getAll("set-cookie")
-        : undefined;
-
-  if (setCookieValues) {
-    headers.delete("set-cookie");
-    for (const value of setCookieValues) {
-      headers.append("set-cookie", value);
-    }
-  }
-
-  return headers;
-}
-
 function isImmutableResponseHeadersError(error: unknown) {
+  // Workers does not expose a structured error code for immutable Headers.
+  // Match the runtime's TypeError name and stable message fragment, including
+  // errors crossing an isolate/realm boundary where instanceof is false.
+  const message =
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as { message?: unknown }).message === "string"
+      ? (error as { message: string }).message
+      : undefined;
   return (
-    error instanceof TypeError &&
-    error.message.toLowerCase().includes("immutable")
+    getSafeErrorName(error) === "TypeError" &&
+    message?.toLowerCase().includes("immutable") === true
   );
 }
 
-function responseWithRequestId(response: Response, requestId: string) {
+export function responseWithRequestId(response: Response, requestId: string) {
   try {
     response.headers.set("x-request-id", requestId);
     return response;
   } catch (error) {
     if (!isImmutableResponseHeadersError(error)) throw error;
-    const headers = copyResponseHeaders(response);
-    headers.set("x-request-id", requestId);
-    const init: ResponseInitWithOptionalWebSocket = {
-      headers,
-      status: response.status,
-      statusText: response.statusText,
-    };
-    const webSocket = (response as ResponseWithOptionalWebSocket).webSocket;
-    if (webSocket) {
-      init.webSocket = webSocket;
+    if (response.body?.locked || response.bodyUsed) {
+      throw new TypeError("Response body is locked or disturbed.");
     }
-    return new Response(response.body, init);
+    // Passing the original Response as init is the Workers-supported way to
+    // retain platform fields (cf, encodeBody, webSocket) and multi-value
+    // Set-Cookie headers while transferring ownership of the same body stream.
+    const wrapped = new Response(response.body, response);
+    wrapped.headers.set("x-request-id", requestId);
+    return wrapped;
   }
 }
 

--- a/tests/ci/fixtures/worker-request-id-observability.ts
+++ b/tests/ci/fixtures/worker-request-id-observability.ts
@@ -1,0 +1,194 @@
+import { responseWithRequestId } from "../../../src/lib/log/worker-entrypoint-observability";
+
+const REQUEST_IDS = {
+  disturbed: "33333333-3333-4333-8333-333333333333",
+  encoding: "44444444-4444-4444-8444-444444444444",
+  locked: "22222222-2222-4222-8222-222222222222",
+  metadata: "11111111-1111-4111-8111-111111111111",
+  nonImmutable: "55555555-5555-4555-8555-555555555555",
+  redirect: "66666666-6666-4666-8666-666666666666",
+  websocket: "77777777-7777-4777-8777-777777777777",
+};
+
+function forceImmutable(response: Response) {
+  response.headers.set = () => {
+    throw new TypeError("Can't modify immutable headers.");
+  };
+  return response;
+}
+
+function responseCf(response: Response) {
+  if (!("cf" in response)) return undefined;
+  return (response as Response & { readonly cf?: unknown }).cf;
+}
+
+function responseCookies(response: Response) {
+  return (
+    response.headers as Headers & {
+      getAll(name: string): string[];
+    }
+  ).getAll("set-cookie");
+}
+
+function errorDescription(error: unknown) {
+  if (error instanceof Error) return `${error.name}:${error.message}`;
+  return String(error);
+}
+
+async function compressedBody(value: string) {
+  const source = new Response(value);
+  const compressed = source.body?.pipeThrough(new CompressionStream("gzip"));
+  if (!compressed) throw new Error("Expected a source response body");
+  return new Response(compressed).arrayBuffer();
+}
+
+async function metadataResponse() {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("streamed"));
+      controller.close();
+    },
+  });
+  const original = forceImmutable(
+    new Response(stream, {
+      status: 206,
+      statusText: "Partial Content",
+      headers: {
+        "Content-Encoding": "gzip",
+        "Set-Cookie": "session=one",
+      },
+      cf: { cacheStatus: "HIT" },
+      encodeBody: "manual",
+    }),
+  );
+  original.headers.append("Set-Cookie", "theme=dark");
+  const observed = responseWithRequestId(original, REQUEST_IDS.metadata);
+  const bodySame = observed.body === original.body;
+  const body = await observed.text();
+  return Response.json({
+    body,
+    bodySame,
+    cf: responseCf(observed),
+    contentEncoding: observed.headers.get("content-encoding"),
+    cookies: responseCookies(observed),
+    requestId: observed.headers.get("x-request-id"),
+    status: observed.status,
+    statusText: observed.statusText,
+  });
+}
+
+async function encodingResponse() {
+  const original = forceImmutable(
+    new Response(await compressedBody("encoded"), {
+      headers: { "Content-Encoding": "gzip" },
+      encodeBody: "manual",
+    }),
+  );
+  return responseWithRequestId(original, REQUEST_IDS.encoding);
+}
+
+function websocketResponse() {
+  const pair = new WebSocketPair();
+  pair[1].accept();
+  const original = forceImmutable(
+    new Response(null, { status: 101, webSocket: pair[0] }),
+  );
+  try {
+    const observed = responseWithRequestId(original, REQUEST_IDS.websocket);
+    return Response.json({
+      hasWebSocket:
+        "webSocket" in observed &&
+        Boolean(
+          (observed as Response & { readonly webSocket?: unknown }).webSocket,
+        ),
+      requestId: observed.headers.get("x-request-id"),
+      status: observed.status,
+    });
+  } finally {
+    pair[0].accept();
+    pair[0].close();
+    pair[1].close();
+  }
+}
+
+function lockedResponse() {
+  const original = forceImmutable(new Response("locked"));
+  const reader = original.body?.getReader();
+  let error = "none";
+  try {
+    responseWithRequestId(original, REQUEST_IDS.locked);
+  } catch (caught) {
+    error = errorDescription(caught);
+  } finally {
+    reader?.releaseLock();
+  }
+  return Response.json({ error });
+}
+
+async function disturbedResponse() {
+  const original = forceImmutable(new Response("disturbed"));
+  await original.text();
+  let error = "none";
+  try {
+    responseWithRequestId(original, REQUEST_IDS.disturbed);
+  } catch (caught) {
+    error = errorDescription(caught);
+  }
+  return Response.json({ error });
+}
+
+function nonImmutableResponse() {
+  const original = new Response("unavailable");
+  original.headers.set = () => {
+    throw new TypeError("header sink unavailable");
+  };
+  let error = "none";
+  try {
+    responseWithRequestId(original, REQUEST_IDS.nonImmutable);
+  } catch (caught) {
+    error = errorDescription(caught);
+  }
+  return Response.json({ error });
+}
+
+function redirectResponse() {
+  const original = Response.redirect("https://example.test/target", 302);
+  let immutableError = "none";
+  try {
+    original.headers.set("x-test", "value");
+  } catch (error) {
+    immutableError = errorDescription(error);
+  }
+  const observed = responseWithRequestId(original, REQUEST_IDS.redirect);
+  return Response.json({
+    immutableError,
+    location: observed.headers.get("location"),
+    requestId: observed.headers.get("x-request-id"),
+    same: observed === original,
+    status: observed.status,
+    statusText: observed.statusText,
+  });
+}
+
+export default {
+  async fetch(request: Request) {
+    switch (new URL(request.url).pathname) {
+      case "/disturbed":
+        return disturbedResponse();
+      case "/encoding":
+        return encodingResponse();
+      case "/locked":
+        return lockedResponse();
+      case "/metadata":
+        return metadataResponse();
+      case "/non-immutable":
+        return nonImmutableResponse();
+      case "/redirect":
+        return redirectResponse();
+      case "/websocket":
+        return websocketResponse();
+      default:
+        return new Response("Not found", { status: 404 });
+    }
+  },
+};

--- a/tests/ci/worker-request-id-platform.test.sh
+++ b/tests/ci/worker-request-id-platform.test.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$repo_root"
 
-for command in bun curl node rg; do
+for command in bun curl node grep; do
   command -v "$command" >/dev/null 2>&1 || {
     echo "$command is required" >&2
     exit 1
@@ -136,7 +136,7 @@ grep -qi '^x-request-id: 44444444-4444-4444-8444-444444444444' \
   exit 1
 }
 
-if rg -n 'edge\.request\.observation\.error|Uncaught Error' "$temp_dir/wrangler.log"; then
+if grep -En 'edge\.request\.observation\.error|Uncaught Error' "$temp_dir/wrangler.log"; then
   echo "unexpected platform response observation failure" >&2
   exit 1
 fi

--- a/tests/ci/worker-request-id-platform.test.sh
+++ b/tests/ci/worker-request-id-platform.test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Run request-id response ownership checks inside the real Wrangler/workerd
+# runtime. This covers platform behavior that Node/Bun's Response polyfills do
+# not reproduce, including immutable redirect headers and Workers extensions.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+for command in bun curl node rg; do
+  command -v "$command" >/dev/null 2>&1 || {
+    echo "$command is required" >&2
+    exit 1
+  }
+done
+
+temp_dir="$(mktemp -d)"
+worker_pid=""
+cleanup() {
+  if [[ -n "$worker_pid" ]] && kill -0 "$worker_pid" >/dev/null 2>&1; then
+    kill -TERM "$worker_pid" >/dev/null 2>&1 || true
+    wait "$worker_pid" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$temp_dir"
+}
+trap cleanup EXIT
+
+port="$(bun -e '
+  const listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: { data() {} },
+  });
+  console.log(listener.port);
+  listener.stop(true);
+')"
+base_url="http://127.0.0.1:${port}"
+
+bunx wrangler dev \
+  --config wrangler.observability.jsonc \
+  --ip 127.0.0.1 \
+  --port "$port" \
+  --local >"$temp_dir/wrangler.log" 2>&1 &
+worker_pid="$!"
+
+for _ in $(seq 1 60); do
+  if curl --silent --show-error --fail --max-time 2 --noproxy '*' \
+    "$base_url/redirect" >"$temp_dir/redirect.json" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "$worker_pid" >/dev/null 2>&1; then
+    sed -n '1,240p' "$temp_dir/wrangler.log" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+test -s "$temp_dir/redirect.json" || {
+  echo "platform Worker did not become ready" >&2
+  sed -n '1,240p' "$temp_dir/wrangler.log" >&2
+  exit 1
+}
+
+fetch_json() {
+  local path="$1"
+  local output="$2"
+  curl --silent --show-error --fail --max-time 10 --noproxy '*' \
+    "$base_url/$path" >"$output"
+}
+
+fetch_json metadata "$temp_dir/metadata.json"
+fetch_json websocket "$temp_dir/websocket.json"
+fetch_json locked "$temp_dir/locked.json"
+fetch_json disturbed "$temp_dir/disturbed.json"
+fetch_json non-immutable "$temp_dir/non-immutable.json"
+
+node - "$temp_dir/redirect.json" "$temp_dir/metadata.json" \
+  "$temp_dir/websocket.json" "$temp_dir/locked.json" \
+  "$temp_dir/disturbed.json" "$temp_dir/non-immutable.json" <<'NODE'
+const fs = require("node:fs");
+const [redirect, metadata, websocket, locked, disturbed, nonImmutable] =
+  process.argv.slice(2).map((path) => JSON.parse(fs.readFileSync(path, "utf8")));
+
+if (redirect.immutableError !== "TypeError:Can't modify immutable headers.") {
+  throw new Error(`workerd did not expose immutable headers: ${redirect.immutableError}`);
+}
+if (
+  redirect.same ||
+  redirect.status !== 302 ||
+  redirect.statusText !== "Found" ||
+  redirect.location !== "https://example.test/target" ||
+  redirect.requestId !== "66666666-6666-4666-8666-666666666666"
+) {
+  throw new Error(`redirect semantics changed: ${JSON.stringify(redirect)}`);
+}
+if (
+  metadata.body !== "streamed" ||
+  !metadata.bodySame ||
+  metadata.status !== 206 ||
+  metadata.statusText !== "Partial Content" ||
+  metadata.requestId !== "11111111-1111-4111-8111-111111111111" ||
+  JSON.stringify(metadata.cookies) !== JSON.stringify(["session=one", "theme=dark"]) ||
+  metadata.cf?.cacheStatus !== "HIT" ||
+  metadata.contentEncoding !== "gzip"
+) {
+  throw new Error(`metadata semantics changed: ${JSON.stringify(metadata)}`);
+}
+if (
+  websocket.status !== 101 ||
+  !websocket.hasWebSocket ||
+  websocket.requestId !== "77777777-7777-4777-8777-777777777777"
+) {
+  throw new Error(`WebSocket semantics changed: ${JSON.stringify(websocket)}`);
+}
+if (locked.error !== "TypeError:Response body is locked or disturbed.") {
+  throw new Error(`locked body was not rejected: ${locked.error}`);
+}
+if (disturbed.error !== "TypeError:Response body is locked or disturbed.") {
+  throw new Error(`disturbed body was not rejected: ${disturbed.error}`);
+}
+if (nonImmutable.error !== "TypeError:header sink unavailable") {
+  throw new Error(`non-immutable TypeError was misclassified: ${nonImmutable.error}`);
+}
+NODE
+
+curl --silent --show-error --fail --max-time 10 --noproxy '*' \
+  --compressed -D "$temp_dir/encoding.headers" \
+  "$base_url/encoding" >"$temp_dir/encoding.body"
+test "$(<"$temp_dir/encoding.body")" = "encoded" || {
+  echo "encodeBody manual semantics were not preserved" >&2
+  exit 1
+}
+grep -qi '^x-request-id: 44444444-4444-4444-8444-444444444444' \
+  "$temp_dir/encoding.headers" || {
+  echo "encoding response request ID was not injected" >&2
+  exit 1
+}
+
+if rg -n 'edge\.request\.observation\.error|Uncaught Error' "$temp_dir/wrangler.log"; then
+  echo "unexpected platform response observation failure" >&2
+  exit 1
+fi
+
+echo "request-id response platform regression passed"

--- a/tests/ci/worker-request-id-platform.test.sh
+++ b/tests/ci/worker-request-id-platform.test.sh
@@ -14,6 +14,11 @@ for command in bun curl node grep; do
   }
 done
 
+# The production helper uses the project's `@` alias, which SvelteKit writes
+# to `.svelte-kit/tsconfig.json`. Keep this fixture runnable from a fresh
+# checkout instead of relying on an earlier CI phase having generated it.
+bun run svelte:sync >/dev/null
+
 temp_dir="$(mktemp -d)"
 worker_pid=""
 cleanup() {

--- a/tests/unit/worker-entrypoint-observability.test.ts
+++ b/tests/unit/worker-entrypoint-observability.test.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from "node:vm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { logAppEventMock, writeWorkerRequestAnalyticsMock } = vi.hoisted(() => ({
@@ -26,6 +27,7 @@ import {
   observedEdgeResponse,
   resolveEdgeCacheOutcome,
   resolveWorkerQueue,
+  responseWithRequestId,
   setTrustedRequestIdHeader,
 } from "@/lib/log/worker-entrypoint-observability";
 
@@ -295,7 +297,7 @@ describe("worker entrypoint observability", () => {
   it("does not hide non-immutability request-id injection failures", () => {
     const response = new Response("unavailable");
     vi.spyOn(response.headers, "set").mockImplementation(() => {
-      throw new Error("header sink unavailable");
+      throw new TypeError("header sink unavailable");
     });
 
     const observed = observedEdgeResponse({
@@ -313,10 +315,25 @@ describe("worker entrypoint observability", () => {
       "error",
       "edge.request.observation.error",
       expect.objectContaining({
-        errorName: "Error",
+        errorName: "TypeError",
         failurePhase: "request-id",
       }),
     );
+  });
+
+  it("recognizes an immutable TypeError across realms", () => {
+    const response = new Response("cross-realm");
+    const foreignTypeError = runInNewContext(
+      'new TypeError("Can\'t modify immutable headers.")',
+    );
+    vi.spyOn(response.headers, "set").mockImplementation(() => {
+      throw foreignTypeError;
+    });
+
+    const observed = responseWithRequestId(response, "request-1");
+
+    expect(observed).not.toBe(response);
+    expect(observed.headers.get("x-request-id")).toBe("request-1");
   });
 
   it("only accepts the internal UUID header and strips external request ids", () => {

--- a/tests/unit/worker-entrypoint-observability.test.ts
+++ b/tests/unit/worker-entrypoint-observability.test.ts
@@ -173,8 +173,11 @@ describe("worker entrypoint observability", () => {
     );
   });
 
-  it("does not wrap an immutable response while recording telemetry failure", () => {
+  it("wraps immutable redirects without changing response semantics", () => {
     const response = Response.redirect("https://example.test/login", 302);
+    vi.spyOn(response.headers, "set").mockImplementation(() => {
+      throw new TypeError("Can't modify immutable headers.");
+    });
 
     const observed = observedEdgeResponse({
       cacheOutcome: "bypass",
@@ -186,8 +189,134 @@ describe("worker entrypoint observability", () => {
       startMs: performance.now(),
     });
 
+    expect(observed).not.toBe(response);
+    expect(observed.status).toBe(302);
+    expect(observed.statusText).toBe(response.statusText);
+    expect(observed.headers.get("location")).toBe("https://example.test/login");
+    expect(observed.headers.get("x-request-id")).toBe("request-1");
+    expect(
+      logAppEventMock.mock.calls.some(
+        ([, event, fields]) =>
+          event === "edge.request.observation.error" &&
+          (fields as { failurePhase?: string })?.failurePhase === "request-id",
+      ),
+    ).toBe(false);
+  });
+
+  it("transfers streaming bodies and preserves multiple Set-Cookie headers", async () => {
+    const cancelMock = vi.fn();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("streamed"));
+        controller.close();
+      },
+      cancel: cancelMock,
+    });
+    const headers = new Headers();
+    headers.append("Set-Cookie", "session=one");
+    headers.append("Set-Cookie", "theme=dark");
+    headers.set("x-request-id", "stale-response-id");
+    const response = new Response(stream, {
+      headers,
+      status: 206,
+      statusText: "Partial Content",
+    });
+    vi.spyOn(response.headers, "set").mockImplementation(() => {
+      throw new TypeError("Can't modify immutable headers.");
+    });
+
+    const observed = observedEdgeResponse({
+      cacheOutcome: "dynamic",
+      request: new Request("https://example.test/stream", {
+        headers: {
+          [INTERNAL_REQUEST_ID_HEADER]: "spoofed-inbound-id",
+          "x-request-id": "spoofed-public-id",
+        },
+      }),
+      requestClass: "dynamic",
+      requestId: "request-1",
+      response,
+      route: "public-page",
+      startMs: performance.now(),
+    });
+
+    expect(observed).not.toBe(response);
+    expect(observed.body).toBe(response.body);
+    expect(observed.status).toBe(206);
+    expect(observed.statusText).toBe("Partial Content");
+    expect(observed.headers.get("x-request-id")).toBe("request-1");
+    expect(JSON.stringify(logAppEventMock.mock.calls)).not.toContain(
+      "spoofed-inbound-id",
+    );
+    expect(JSON.stringify(logAppEventMock.mock.calls)).not.toContain(
+      "spoofed-public-id",
+    );
+    const observedHeaders = observed.headers as Headers & {
+      getAll?: (name: string) => string[];
+      getSetCookie?: () => string[];
+    };
+    expect(
+      observedHeaders.getSetCookie?.() ??
+        observedHeaders.getAll?.("set-cookie"),
+    ).toEqual(["session=one", "theme=dark"]);
+    await expect(observed.text()).resolves.toBe("streamed");
+    expect(cancelMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a real request-id fallback failure and returns the original response", () => {
+    const response = new Response("locked");
+    vi.spyOn(response.headers, "set").mockImplementation(() => {
+      throw new TypeError("Can't modify immutable headers.");
+    });
+    const reader = response.body?.getReader();
+
+    const observed = observedEdgeResponse({
+      cacheOutcome: "dynamic",
+      request: new Request("https://example.test/locked"),
+      requestClass: "dynamic",
+      requestId: "request-1",
+      response,
+      route: "public-page",
+      startMs: performance.now(),
+    });
+    reader?.releaseLock();
+
     expect(observed).toBe(response);
-    expect(observed.headers.get("x-request-id")).toBeNull();
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "error",
+      "edge.request.observation.error",
+      expect.objectContaining({
+        errorName: "TypeError",
+        failurePhase: "request-id",
+      }),
+    );
+  });
+
+  it("does not hide non-immutability request-id injection failures", () => {
+    const response = new Response("unavailable");
+    vi.spyOn(response.headers, "set").mockImplementation(() => {
+      throw new Error("header sink unavailable");
+    });
+
+    const observed = observedEdgeResponse({
+      cacheOutcome: "dynamic",
+      request: new Request("https://example.test/header-failure"),
+      requestClass: "dynamic",
+      requestId: "request-1",
+      response,
+      route: "public-page",
+      startMs: performance.now(),
+    });
+
+    expect(observed).toBe(response);
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "error",
+      "edge.request.observation.error",
+      expect.objectContaining({
+        errorName: "Error",
+        failurePhase: "request-id",
+      }),
+    );
   });
 
   it("only accepts the internal UUID header and strips external request ids", () => {

--- a/wrangler.observability.jsonc
+++ b/wrangler.observability.jsonc
@@ -1,0 +1,10 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "life-ustc-observability-platform-test",
+  "main": "tests/ci/fixtures/worker-request-id-observability.ts",
+  "compatibility_date": "2026-08-20",
+  "compatibility_flags": ["nodejs_compat"],
+  "alias": {
+    "@": "./src"
+  }
+}


### PR DESCRIPTION
## Summary

Production v1.96 tail showed `edge.request.observation.error` with `failurePhase=request-id` on `dynamic/public-page` responses. Cloudflare workerd throws `TypeError: Can't modify immutable headers.` for immutable response headers.

This PR:

- preserves the original Worker `Response` metadata by using `new Response(response.body, response)` when injecting the request ID, retaining `cf`, `encodeBody`, WebSocket/upgrade metadata, duplicate `Set-Cookie` values, status/statusText, and the original streaming body ownership;
- rejects locked or disturbed bodies explicitly so a broken wrapper is never returned;
- recognizes the workerd immutable-header TypeError across realms while allowing unrelated TypeErrors to surface and be logged;
- adds a real Wrangler/workerd regression covering immutable redirects, streaming, `cf`, manual encoding, multi-value cookies, WebSocket, locked/disturbed bodies, cross-realm errors, and non-immutable errors;
- runs that platform regression in CI.

## Validation

- Full unit: 392 files / 2465 tests
- Focused observability/routing/lifecycle: 38 tests
- Wrangler/workerd platform regression: passed
- TypeScript (3 configs), Svelte check, Biome, build: passed
- Wrangler types and production deploy dry-run: passed
- OpenAPI and GraphQL snapshots: passed
- commitlint and diff check: passed

No Prisma, OpenAPI, GraphQL, CLI, or Bot contract changes. Residual P3: the Workers runtime exposes no structured immutable-header error code, so the narrow TypeError name plus stable `immutable` message fragment is used; unrelated TypeErrors are not classified as immutable.
