### PR TITLE
fix(admin): return 403 for non-admin access to /admin

### DIFF
--- a/src/features/admin/server/admin-page-auth.ts
+++ b/src/features/admin/server/admin-page-auth.ts
@@ -37,7 +37,7 @@ export async function requireAdminPage(
 
   if (!user?.isAdmin) {
     logAdminSecurityEvent(request, "not_admin");
-    error(404, "Not found");
+    error(403, "Forbidden");
   }
   if (options.requireActive) {
     const suspension = await findActiveSuspension(user.id);

--- a/tests/e2e/src/app/admin/audit/test.ts
+++ b/tests/e2e/src/app/admin/audit/test.ts
@@ -13,9 +13,9 @@ for (const path of ["/admin/audit", "/admin/analytics"] as const) {
     await expectRequiresSignIn(page, path);
   });
 
-  test(`${path} 普通用户访问返回 404`, async ({ page }) => {
+  test(`${path} 普通用户访问返回 403`, async ({ page }) => {
     await signInAsDebugUser(page, path, path);
-    await expect(page.getByText("404").first()).toBeVisible();
+    await expect(page.getByText("403").first()).toBeVisible();
   });
 }
 

--- a/tests/e2e/src/app/admin/bus/test.ts
+++ b/tests/e2e/src/app/admin/bus/test.ts
@@ -17,7 +17,7 @@
  *
  * ## Edge Cases
  * - Unauthenticated → redirect to /signin
- * - Non-admin → 404
+ * - Non-admin → 403
  * - Seed version from DEV_SEED.bus always present
  */
 import { expect, test } from "@playwright/test";
@@ -39,13 +39,11 @@ test("/admin/bus 未登录重定向到登录页", async ({ page }, testInfo) => 
   await captureStepScreenshot(page, testInfo, "admin-bus/unauthorized");
 });
 
-test("/admin/bus 普通用户访问返回 404", async ({ page }, testInfo) => {
+test("/admin/bus 普通用户访问返回 403", async ({ page }, testInfo) => {
   await signInAsDebugUser(page, "/admin/bus", "/admin/bus");
-  await expect(page.getByText("404").first()).toBeVisible();
-  await expect(
-    page.getByRole("heading", { name: /页面不存在|Page Not Found/i }),
-  ).toBeVisible();
-  await captureStepScreenshot(page, testInfo, "admin-bus/404");
+  await expect(page.getByText("403").first()).toBeVisible();
+  await expect(page.getByText("Forbidden").first()).toBeVisible();
+  await captureStepScreenshot(page, testInfo, "admin-bus/403");
 });
 
 test("/admin/bus 显示所有必需的版本字段", async ({ page }, testInfo) => {

--- a/tests/e2e/src/app/admin/moderation/test.ts
+++ b/tests/e2e/src/app/admin/moderation/test.ts
@@ -81,13 +81,11 @@ test("/admin/moderation 未登录重定向到登录页", async ({ page }, testIn
   await captureStepScreenshot(page, testInfo, "admin-moderation-unauthorized");
 });
 
-test("/admin/moderation 普通用户访问返回 404", async ({ page }, testInfo) => {
+test("/admin/moderation 普通用户访问返回 403", async ({ page }, testInfo) => {
   await signInAsDebugUser(page, "/admin/moderation", "/admin/moderation");
-  await expect(page.getByText("404").first()).toBeVisible();
-  await expect(
-    page.getByRole("heading", { name: /页面不存在|Page Not Found/i }),
-  ).toBeVisible();
-  await captureStepScreenshot(page, testInfo, "admin-moderation-404");
+  await expect(page.getByText("403").first()).toBeVisible();
+  await expect(page.getByText("Forbidden").first()).toBeVisible();
+  await captureStepScreenshot(page, testInfo, "admin-moderation-403");
 });
 
 test("/admin/moderation 管理员访问成功", async ({ page }, testInfo) => {

--- a/tests/e2e/src/app/admin/oauth/test.ts
+++ b/tests/e2e/src/app/admin/oauth/test.ts
@@ -105,13 +105,11 @@ test("/admin/oauth 未登录重定向到登录页", async ({ page }, testInfo) =
   await captureStepScreenshot(page, testInfo, "admin-oauth-unauthorized");
 });
 
-test("/admin/oauth 普通用户访问返回 404", async ({ page }, testInfo) => {
+test("/admin/oauth 普通用户访问返回 403", async ({ page }, testInfo) => {
   await signInAsDebugUser(page, "/admin/oauth", "/admin/oauth");
-  await expect(page.getByText("404").first()).toBeVisible();
-  await expect(
-    page.getByRole("heading", { name: /页面不存在|Page Not Found/i }),
-  ).toBeVisible();
-  await captureStepScreenshot(page, testInfo, "admin-oauth-404");
+  await expect(page.getByText("403").first()).toBeVisible();
+  await expect(page.getByText("Forbidden").first()).toBeVisible();
+  await captureStepScreenshot(page, testInfo, "admin-oauth-403");
 });
 
 test("/admin/oauth 可创建三种固定客户端且密钥只显示一次", async ({

--- a/tests/e2e/src/app/admin/test.ts
+++ b/tests/e2e/src/app/admin/test.ts
@@ -2,7 +2,7 @@
  * E2E tests for /admin — Admin entry + primary navigation
  *
  * ## Features
- * - Admin-only: unauthenticated → /signin, non-admin → 404
+ * - Admin-only: unauthenticated → /signin, non-admin → 403
  * - /admin redirects to /admin/users
  * - Admin tools live in the primary sidebar (no secondary admin nav)
  */
@@ -29,10 +29,10 @@ test("/admin 未登录重定向到登录页", async ({ page }, testInfo) => {
   await captureStepScreenshot(page, testInfo, "admin/unauthorized");
 });
 
-test("/admin 普通用户访问返回 404", async ({ page }, testInfo) => {
+test("/admin 普通用户访问返回 403", async ({ page }, testInfo) => {
   await signInAsDebugUser(page, "/admin", "/admin");
-  await expect(page.locator("h1")).toHaveText("404");
-  await captureStepScreenshot(page, testInfo, "admin/404");
+  await expect(page.locator("h1")).toHaveText("403");
+  await captureStepScreenshot(page, testInfo, "admin/403");
 });
 
 test("/admin 重定向到用户管理", async ({ page }, testInfo) => {

--- a/tests/e2e/src/app/admin/users/test.ts
+++ b/tests/e2e/src/app/admin/users/test.ts
@@ -50,10 +50,10 @@ test("/admin/users 未登录重定向到登录页", async ({ page }, testInfo) =
   await captureStepScreenshot(page, testInfo, "admin-users-unauthorized");
 });
 
-test("/admin/users 普通用户访问返回 404", async ({ page }, testInfo) => {
+test("/admin/users 普通用户访问返回 403", async ({ page }, testInfo) => {
   await signInAsDebugUser(page, "/admin/users", "/admin/users");
-  await expect(page.locator("h1")).toHaveText("404");
-  await captureStepScreenshot(page, testInfo, "admin-users-404");
+  await expect(page.locator("h1")).toHaveText("403");
+  await captureStepScreenshot(page, testInfo, "admin-users-403");
 });
 
 test("/admin/users 管理员可看到 seed 用户", async ({ page }, testInfo) => {

--- a/tests/unit/admin-page-auth.test.ts
+++ b/tests/unit/admin-page-auth.test.ts
@@ -121,7 +121,7 @@ describe("admin 页面认证", () => {
 
     await expect(
       requireAdminPage(new Request("https://example.test/admin/users")),
-    ).rejects.toMatchObject({ status: 404 });
+    ).rejects.toMatchObject({ status: 403 });
     expect(logAppEventMock).toHaveBeenCalledWith(
       "warn",
       "admin.authorization.denied",


### PR DESCRIPTION
Closes #963.

Previously, authenticated non-admin users hitting any /admin page got a 404 response. This change makes the admin page guard return **403 Forbidden** instead, which more accurately reflects that the request failed authorization.

Rationale:
- The route is literally "/admin", so returning 403 does not meaningfully reveal the existence of admin functionality.
- 404 masked the real failure mode, making monitoring and debugging harder.
- Unauthenticated users still redirect to sign-in; suspended admins still get 403 as before.

Changed files:
- src/features/admin/server/admin-page-auth.ts: error(404) → error(403) for the not_admin case.
- tests/unit/admin-page-auth.test.ts: updated expected status.
- tests/e2e/src/app/admin/**/*.ts: updated non-admin access assertions from 404 to 403.