### PR TITLE
fix(ui): shadcn-svelte compliance and visual audit follow-up

### DIFF
--- a/src/features/admin/components/AdminOAuthClients.svelte
+++ b/src/features/admin/components/AdminOAuthClients.svelte
@@ -105,7 +105,7 @@ export let scopeLabel: (scope: string) => string;
                     variant="destructive"
                     onclick={() => onDelete(client)}
                   >
-                    <TrashIcon />
+                    <TrashIcon data-icon="inline-start" />
                   </TableIconButton>
                 </TableRowActions>
               </Table.Cell>
@@ -165,7 +165,7 @@ export let scopeLabel: (scope: string) => string;
                 variant="destructive"
                 onclick={() => onDelete(client)}
               >
-                <TrashIcon />
+                <TrashIcon data-icon="inline-start" />
               </TableIconButton>
             </Item.Actions>
           </Item.Root>

--- a/src/features/admin/components/AdminOAuthCreateDialog.svelte
+++ b/src/features/admin/components/AdminOAuthCreateDialog.svelte
@@ -62,10 +62,11 @@ $: scopesPickerCopy = buildOAuthScopesPickerCopy(copy, {
       <form
         method="POST"
         action="?/createClient"
-        class="flex min-h-0 flex-col gap-4 overflow-hidden"
+        class="flex min-h-0 flex-col overflow-hidden"
         use:enhance={createClientAction}
       >
-        <div class="min-h-0 overflow-y-auto px-1">
+        <Field.Group class="min-h-0 flex-1 gap-4 overflow-hidden">
+          <div class="min-h-0 flex-1 overflow-y-auto px-1">
           <Field.Set>
             <Field.Group>
               <Field.Field>
@@ -153,8 +154,9 @@ $: scopesPickerCopy = buildOAuthScopesPickerCopy(copy, {
             </Field.Group>
           </Field.Set>
         </div>
+      </Field.Group>
 
-        <Dialog.Footer>
+      <Dialog.Footer>
           <Button
             type="button"
             variant="outline"

--- a/src/features/admin/components/AdminUsersDesktopTable.svelte
+++ b/src/features/admin/components/AdminUsersDesktopTable.svelte
@@ -89,7 +89,7 @@ export let users: AdminUserRow[];
                   label={copy.editTitle}
                   onclick={() => onSelect(user)}
                 >
-                  <SquarePen />
+                  <SquarePen data-icon="inline-start" />
                 </TableIconButton>
               </TableRowActions>
             </Table.Cell>

--- a/src/features/api-docs/components/ApiDocsPage.svelte
+++ b/src/features/api-docs/components/ApiDocsPage.svelte
@@ -237,7 +237,7 @@ function scheduleReferenceRouteRestore() {
               {...props}
             >
               <span>{data.copy.apiDocs.browseNavigation}</span>
-              <MenuIcon aria-hidden="true" />
+              <MenuIcon data-icon="inline-end" aria-hidden="true" />
             </Button>
           {/snippet}
         </Sheet.Trigger>

--- a/src/features/auth/components/SignInPage.svelte
+++ b/src/features/auth/components/SignInPage.svelte
@@ -126,9 +126,9 @@ function providerInitial(name: string) {
     >
       <span class="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted font-semibold text-primary text-xs">
         {#if pendingProviderId === provider.id}
-          <Spinner />
+          <Spinner data-icon="inline-start" />
         {:else if provider.debug}
-          <CircleUserRound />
+          <CircleUserRound data-icon="inline-start" />
         {:else}
           {providerInitial(provider.name)}
         {/if}
@@ -202,9 +202,9 @@ function providerInitial(name: string) {
           >
             <span class="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-primary">
               {#if passkeyPending}
-                <Spinner />
+                <Spinner data-icon="inline-start" />
               {:else}
-                <Fingerprint />
+                <Fingerprint data-icon="inline-start" />
               {/if}
             </span>
             <span class="min-w-0 flex-1 truncate">

--- a/src/features/catalog/components/CoursesResults.svelte
+++ b/src/features/catalog/components/CoursesResults.svelte
@@ -93,7 +93,7 @@ $: courseSearchSummary = optionalCatalogFilterSummary(
         <Table.Body>
           {#each data.data as course}
             {@const courseHref = `/catalog/courses/${course.jwId}`}
-            <Table.Row>
+            <Table.Row class="has-[a:hover]:bg-muted/50">
               <Table.Cell class="p-0">
                 <CatalogTableLink href={courseHref}>
                   <TruncatedText
@@ -101,27 +101,21 @@ $: courseSearchSummary = optionalCatalogFilterSummary(
                   />
                 </CatalogTableLink>
               </Table.Cell>
-              <Table.Cell class="p-0">
-                <CatalogTableLink href={courseHref}>
-                  <TruncatedCode text={course.code} />
-                </CatalogTableLink>
+              <Table.Cell>
+                <TruncatedCode text={course.code} />
               </Table.Cell>
-              <Table.Cell class="p-0">
-                <CatalogTableLink href={courseHref}>
-                  {course.educationLevel
-                    ? primaryName(course.educationLevel)
-                    : "-"}
-                </CatalogTableLink>
+              <Table.Cell>
+                {course.educationLevel
+                  ? primaryName(course.educationLevel)
+                  : "-"}
               </Table.Cell>
-              <Table.Cell class="p-0">
-                <CatalogTableLink href={courseHref}>
-                  {course.category ? primaryName(course.category) : "-"}
-                </CatalogTableLink>
+              <Table.Cell>
+                {course.category
+                  ? catalogLocalizedDisplayName(course.category, locale)
+                  : "-"}
               </Table.Cell>
-              <Table.Cell class="p-0">
-                <CatalogTableLink href={courseHref}>
-                  {course.classType ? primaryName(course.classType) : "-"}
-                </CatalogTableLink>
+              <Table.Cell>
+                {course.classType ? primaryName(course.classType) : "-"}
               </Table.Cell>
             </Table.Row>
           {/each}

--- a/src/features/catalog/components/SectionsResults.svelte
+++ b/src/features/catalog/components/SectionsResults.svelte
@@ -115,13 +115,11 @@ $: sectionSemesterSummary = selectedSemester
         <Table.Body>
           {#each data.data as section}
             {@const sectionHref = `/catalog/sections/${section.jwId}`}
-            <Table.Row>
-              <Table.Cell class="p-0 align-top">
-                <CatalogTableLink href={sectionHref} nowrap>
-                  {section.semester?.nameCn
-                    ? formatSemesterName(locale, section.semester.nameCn)
-                    : sectionLabels.noSemester}
-                </CatalogTableLink>
+            <Table.Row class="has-[a:hover]:bg-muted/50">
+              <Table.Cell class="align-top whitespace-nowrap">
+                {section.semester?.nameCn
+                  ? formatSemesterName(locale, section.semester.nameCn)
+                  : sectionLabels.noSemester}
               </Table.Cell>
               <Table.Cell class="p-0 align-top whitespace-normal">
                 <CatalogTableLink href={sectionHref}>
@@ -130,32 +128,22 @@ $: sectionSemesterSummary = selectedSemester
                   />
                 </CatalogTableLink>
               </Table.Cell>
-              <Table.Cell class="p-0 align-top">
-                <CatalogTableLink href={sectionHref}>
-                  <TruncatedCode text={section.code} />
-                </CatalogTableLink>
+              <Table.Cell class="align-top">
+                <TruncatedCode text={section.code} />
               </Table.Cell>
-              <Table.Cell class="p-0 align-top whitespace-normal">
-                <CatalogTableLink href={sectionHref}>
-                  <TruncatedText
-                    text={catalogLocalizedNames(section.teachers, locale) || "-"}
-                  />
-                </CatalogTableLink>
+              <Table.Cell class="align-top whitespace-normal">
+                <TruncatedText
+                  text={catalogLocalizedNames(section.teachers, locale) || "-"}
+                />
               </Table.Cell>
-              <Table.Cell class="p-0 text-right align-top">
-                <CatalogTableLink href={sectionHref} numeric>
-                  {section.credits ?? "-"}
-                </CatalogTableLink>
+              <Table.Cell class="text-right align-top tabular-nums">
+                {section.credits ?? "-"}
               </Table.Cell>
-              <Table.Cell class="p-0 text-right align-top">
-                <CatalogTableLink href={sectionHref} numeric>
-                  {section.stdCount ?? 0} / {section.limitCount ?? "-"}
-                </CatalogTableLink>
+              <Table.Cell class="text-right align-top tabular-nums">
+                {section.stdCount ?? 0} / {section.limitCount ?? "-"}
               </Table.Cell>
-              <Table.Cell class="p-0 align-top">
-                <CatalogTableLink href={sectionHref}>
-                  {section.campus ? primaryName(section.campus) : "-"}
-                </CatalogTableLink>
+              <Table.Cell class="align-top">
+                {section.campus ? primaryName(section.campus) : "-"}
               </Table.Cell>
             </Table.Row>
           {/each}

--- a/src/features/catalog/components/TeachersResults.svelte
+++ b/src/features/catalog/components/TeachersResults.svelte
@@ -112,7 +112,7 @@ $: pageLabel = teacherLabels.pageOf
         <Table.Body>
           {#each teachers as teacher}
             {@const teacherHref = `/catalog/teachers/${teacher.id}`}
-            <Table.Row>
+            <Table.Row class="has-[a:hover]:bg-muted/50">
               <Table.Cell class="p-0">
                 <CatalogTableLink href={teacherHref}>
                   <TruncatedText
@@ -120,36 +120,26 @@ $: pageLabel = teacherLabels.pageOf
                   />
                 </CatalogTableLink>
               </Table.Cell>
-              <Table.Cell class="p-0">
-                <CatalogTableLink href={teacherHref} mono nowrap>
-                  {teacher.code || "-"}
-                </CatalogTableLink>
+              <Table.Cell class="whitespace-nowrap font-mono">
+                {teacher.code || "-"}
               </Table.Cell>
-              <Table.Cell class="p-0">
-                <CatalogTableLink href={teacherHref}>
-                  <TruncatedText
-                    text={teacher.department
-                      ? primaryName(teacher.department)
-                      : teacherLabels.noDepartment}
-                  />
-                </CatalogTableLink>
+              <Table.Cell>
+                <TruncatedText
+                  text={teacher.department
+                    ? primaryName(teacher.department)
+                    : teacherLabels.noDepartment}
+                />
               </Table.Cell>
-              <Table.Cell class="p-0">
-                <CatalogTableLink href={teacherHref}>
-                  {teacher.teacherTitle
-                    ? primaryName(teacher.teacherTitle)
-                    : commonLabels.unknown}
-                </CatalogTableLink>
+              <Table.Cell>
+                {teacher.teacherTitle
+                  ? primaryName(teacher.teacherTitle)
+                  : commonLabels.unknown}
               </Table.Cell>
-              <Table.Cell class="p-0">
-                <CatalogTableLink href={teacherHref}>
-                  <TruncatedText text={teacher.email ?? "-"} />
-                </CatalogTableLink>
+              <Table.Cell>
+                <TruncatedText text={teacher.email ?? "-"} />
               </Table.Cell>
-              <Table.Cell class="p-0">
-                <CatalogTableLink href={teacherHref} nowrap numeric>
-                  {teacher._count.sections}
-                </CatalogTableLink>
+              <Table.Cell class="whitespace-nowrap text-right tabular-nums">
+                {teacher._count.sections}
               </Table.Cell>
             </Table.Row>
           {/each}

--- a/src/features/dashboard/components/CalendarTabToolbar.svelte
+++ b/src/features/dashboard/components/CalendarTabToolbar.svelte
@@ -100,7 +100,7 @@ let personalCalendarLink: PersonalCalendarLinkButton | undefined;
           variant="outline"
           onclick={() => setCalendarWeek(addDays(agendaWeekStart, -7))}
         >
-          <ChevronLeft />
+          <ChevronLeft data-icon="inline-start" />
         </Button>
         <Button
           class="h-11 px-3"
@@ -118,7 +118,7 @@ let personalCalendarLink: PersonalCalendarLinkButton | undefined;
           variant="outline"
           onclick={() => setCalendarWeek(addDays(agendaWeekStart, 7))}
         >
-          <ChevronRight />
+          <ChevronRight data-icon="inline-start" />
         </Button>
       </div>
 
@@ -134,7 +134,7 @@ let personalCalendarLink: PersonalCalendarLinkButton | undefined;
                 type="button"
                 variant="outline"
               >
-                <MoreHorizontal />
+                <MoreHorizontal data-icon="inline-start" />
               </Button>
             {/snippet}
           </DropdownMenu.Trigger>

--- a/src/features/dashboard/components/ExamsCardsView.svelte
+++ b/src/features/dashboard/components/ExamsCardsView.svelte
@@ -69,7 +69,7 @@ export let subscriptionsCopy: ExamsCopyProps["subscriptionsCopy"];
           href={detailHref}
           label={sectionCopy.moreDetails}
         >
-          <ArrowUpRight />
+          <ArrowUpRight data-icon="inline-start" />
         </TableIconButton>
       </Item.Actions>
     </Item.Root>

--- a/src/features/dashboard/components/ExamsListView.svelte
+++ b/src/features/dashboard/components/ExamsListView.svelte
@@ -61,7 +61,7 @@ export let subscriptionsCopy: ExamsCopyProps["subscriptionsCopy"];
         <Table.Cell>
           <TableRowActions>
             <TableIconButton href={detailHref} label={sectionCopy.moreDetails}>
-              <ArrowUpRight />
+              <ArrowUpRight data-icon="inline-start" />
             </TableIconButton>
           </TableRowActions>
         </Table.Cell>

--- a/src/features/dashboard/components/ExamsTab.svelte
+++ b/src/features/dashboard/components/ExamsTab.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import BookOpenIcon from "@lucide/svelte/icons/book-open";
 import type {
   DashboardDashboardCopy,
   DashboardSectionCopy,
@@ -75,6 +76,7 @@ $: displayExamFilter = resolveDashboardTaskFilter(
     {#if examRows.length === 0}
       <Empty.Root class="items-start text-left">
         <Empty.Header class="items-start text-left">
+          <Empty.Media variant="icon"><BookOpenIcon /></Empty.Media>
           <Empty.Title>{dashboardCopy.nav.exams.empty}</Empty.Title>
           <Empty.Description>
             {dashboardCopy.nav.exams.emptyDescription}
@@ -84,6 +86,7 @@ $: displayExamFilter = resolveDashboardTaskFilter(
     {:else if filteredExamRows.length === 0}
       <Empty.Root class="items-start text-left">
         <Empty.Header class="items-start text-left">
+          <Empty.Media variant="icon"><BookOpenIcon /></Empty.Media>
           <Empty.Title>{dashboardCopy.nav.exams.filterEmpty}</Empty.Title>
           <Empty.Description>
             {dashboardCopy.nav.exams.filterEmptyDescription}

--- a/src/features/dashboard/components/HomeworksCardsView.svelte
+++ b/src/features/dashboard/components/HomeworksCardsView.svelte
@@ -105,11 +105,11 @@ function summaryBadges(homework: DashboardHomeworkItem) {
               onclick={() => toggleHomeworkCompletion(homework)}
             >
               {#if homeworkSavingById[homework.id]}
-                <Spinner />
+                <Spinner data-icon="inline-start" />
               {:else if homework.completion}
-                <RefreshCw />
+                <RefreshCw data-icon="inline-start" />
               {:else}
-                <CheckCircleIcon />
+                <CheckCircleIcon data-icon="inline-start" />
               {/if}
             </TableIconButton>
             <TableIconButton
@@ -120,7 +120,7 @@ function summaryBadges(homework: DashboardHomeworkItem) {
                 selectedHomework = homework;
               }}
             >
-              <ArrowUpRight />
+              <ArrowUpRight data-icon="inline-start" />
             </TableIconButton>
           </Item.Actions>
         </Item.Root>

--- a/src/features/dashboard/components/HomeworksListView.svelte
+++ b/src/features/dashboard/components/HomeworksListView.svelte
@@ -115,11 +115,11 @@ function summaryBadges(homework: DashboardHomeworkItem) {
             onclick={() => toggleHomeworkCompletion(homework)}
             >
               {#if homeworkSavingById[homework.id]}
-                <Spinner />
+                <Spinner data-icon="inline-start" />
               {:else if homework.completion}
-                <RefreshCw />
+                <RefreshCw data-icon="inline-start" />
               {:else}
-                <CheckCircleIcon />
+                <CheckCircleIcon data-icon="inline-start" />
               {/if}
             </TableIconButton>
             <TableIconButton
@@ -129,7 +129,7 @@ function summaryBadges(homework: DashboardHomeworkItem) {
                 selectedHomework = homework;
               }}
             >
-              <ArrowUpRight />
+              <ArrowUpRight data-icon="inline-start" />
             </TableIconButton>
           </TableRowActions>
         </Table.Cell>

--- a/src/features/dashboard/components/HomeworksTabToolbar.svelte
+++ b/src/features/dashboard/components/HomeworksTabToolbar.svelte
@@ -49,7 +49,7 @@ export let openCreateHomeworkDialog: () => void;
       type="button"
       onclick={openCreateHomeworkDialog}
     >
-      <Plus class="md:hidden" />
+      <Plus class="md:hidden" data-icon="inline-start" />
       <span class="hidden md:inline">{homeworksCopy.addButton}</span>
     </Button>
   </div>

--- a/src/features/dashboard/components/OverviewLinksGrid.svelte
+++ b/src/features/dashboard/components/OverviewLinksGrid.svelte
@@ -44,7 +44,7 @@ function pinAction(link: DashboardOverviewLinkItem): DashboardLinkPinAction {
   viewAllVisible={links.length > previewLimit}
 >
   {#if previewLinks.length > 0}
-    <div class="grid min-w-0 gap-1 sm:grid-cols-2 xl:grid-cols-4">
+    <div class="grid min-w-0 grid-cols-1 gap-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       {#each previewLinks as link}
         <div class="group relative min-w-0">
           <a

--- a/src/features/dashboard/components/SubscriptionsCardsView.svelte
+++ b/src/features/dashboard/components/SubscriptionsCardsView.svelte
@@ -68,7 +68,7 @@ function courseName(section: SubscriptionSection) {
             href={`/catalog/sections/${section.jwId}`}
             label={sectionCopy.moreDetails}
           >
-            <ArrowUpRight />
+            <ArrowUpRight data-icon="inline-start" />
           </TableIconButton>
           <TableIconButton
             className="size-11"
@@ -78,9 +78,9 @@ function courseName(section: SubscriptionSection) {
             onclick={() => requestRemoveSection(section)}
           >
             {#if removingSectionId === section.id}
-              <Spinner />
+              <Spinner data-icon="inline-start" />
             {:else}
-              <UserMinus />
+              <UserMinus data-icon="inline-start" />
             {/if}
           </TableIconButton>
         </Item.Actions>

--- a/src/features/dashboard/components/SubscriptionsList.svelte
+++ b/src/features/dashboard/components/SubscriptionsList.svelte
@@ -161,16 +161,16 @@ function handleRemoveDialogOpenChange(open: boolean) {
                         onclick={() => requestRemoveSection(section)}
                       >
                         {#if removingSectionId === section.id}
-                          <Spinner />
+                          <Spinner data-icon="inline-start" />
                         {:else}
-                          <UserMinus />
+                          <UserMinus data-icon="inline-start" />
                         {/if}
                       </TableIconButton>
                       <TableIconButton
                         href={`/catalog/sections/${section.jwId}`}
                         label={sectionCopy.moreDetails}
                       >
-                        <ArrowUpRight />
+                        <ArrowUpRight data-icon="inline-start" />
                       </TableIconButton>
                     </TableRowActions>
                   </Table.Cell>

--- a/src/features/dashboard/components/TodosCardsView.svelte
+++ b/src/features/dashboard/components/TodosCardsView.svelte
@@ -78,11 +78,11 @@ export let toggleTodoCompletion: TodoCompletionToggle;
               onclick={() => void toggleTodoCompletion(todo)}
             >
               {#if todoSavingById[todo.id]}
-                <Spinner />
+                <Spinner data-icon="inline-start" />
               {:else if todo.completed}
-                <RefreshCw />
+                <RefreshCw data-icon="inline-start" />
               {:else}
-                <CheckCircleIcon />
+                <CheckCircleIcon data-icon="inline-start" />
               {/if}
             </TableIconButton>
             <DropdownMenu.Root>
@@ -96,7 +96,7 @@ export let toggleTodoCompletion: TodoCompletionToggle;
                     type="button"
                     variant="outline"
                   >
-                    <MoreHorizontal />
+                    <MoreHorizontal data-icon="inline-start" />
                   </Button>
                 {/snippet}
               </DropdownMenu.Trigger>

--- a/src/features/dashboard/components/TodosListView.svelte
+++ b/src/features/dashboard/components/TodosListView.svelte
@@ -79,11 +79,11 @@ export let toggleTodoCompletion: TodoCompletionToggle;
               onclick={() => void toggleTodoCompletion(todo)}
             >
               {#if todoSavingById[todo.id]}
-                <Spinner />
+                <Spinner data-icon="inline-start" />
               {:else if todo.completed}
-                <RefreshCw />
+                <RefreshCw data-icon="inline-start" />
               {:else}
-                <CheckCircleIcon />
+                <CheckCircleIcon data-icon="inline-start" />
               {/if}
             </TableIconButton>
             <TableIconButton
@@ -91,7 +91,7 @@ export let toggleTodoCompletion: TodoCompletionToggle;
               variant="outline"
               onclick={() => openTodoEditor(todo)}
             >
-              <Pencil />
+              <Pencil data-icon="inline-start" />
             </TableIconButton>
           </TableRowActions>
         </Table.Cell>

--- a/src/features/dashboard/components/TodosTabToolbar.svelte
+++ b/src/features/dashboard/components/TodosTabToolbar.svelte
@@ -56,7 +56,7 @@ export let todosCopy: DashboardTodosCopy;
         showCreateTodo = true;
       }}
     >
-      <Plus class="md:hidden" />
+      <Plus class="md:hidden" data-icon="inline-start" />
       <span class="hidden md:inline">{todosCopy.addButton}</span>
     </Button>
   </div>

--- a/src/features/homeworks/components/HomeworkDetailSecondaryDetails.svelte
+++ b/src/features/homeworks/components/HomeworkDetailSecondaryDetails.svelte
@@ -45,6 +45,7 @@ function displayDate(value: HomeworkDateValue) {
             {/if}
           </span>
           <ChevronDownIcon
+            data-icon="inline-end"
             aria-hidden="true"
             class="shrink-0 transition-transform group-data-[state=open]/homework-details:rotate-180"
           />

--- a/src/features/profile/components/ProfileSummaryCard.svelte
+++ b/src/features/profile/components/ProfileSummaryCard.svelte
@@ -44,15 +44,13 @@ export let user: ProfileSummaryUser;
       </Item.Root>
     </Item.Group>
 
-    <Item.Group class="grid grid-cols-2 gap-3">
+    <div class="grid grid-cols-2 gap-3">
       {#each stats as stat}
-        <Item.Root class="items-start" variant="outline">
-          <Item.Content>
-            <Item.Description>{stat.label}</Item.Description>
-            <Item.Title>{stat.value}</Item.Title>
-          </Item.Content>
-        </Item.Root>
+        <div class="grid gap-0.5">
+          <span class="text-muted-foreground text-sm">{stat.label}</span>
+          <span class="text-sm leading-snug font-medium">{stat.value}</span>
+        </div>
       {/each}
-    </Item.Group>
+    </div>
   </Card.Content>
 </Card.Root>

--- a/src/features/section-detail/components/SectionHomeworkActionBar.svelte
+++ b/src/features/section-detail/components/SectionHomeworkActionBar.svelte
@@ -47,7 +47,7 @@ export let startEdit: () => void;
             type="button"
             variant="outline"
           >
-            <MoreHorizontalIcon />
+            <MoreHorizontalIcon data-icon="inline-start" />
           </Button>
         {/snippet}
       </DropdownMenu.Trigger>

--- a/src/features/section-detail/components/SectionHomeworkEditForm.svelte
+++ b/src/features/section-detail/components/SectionHomeworkEditForm.svelte
@@ -2,6 +2,7 @@
 import HomeworkEditorFields from "@/features/homeworks/components/HomeworkEditorFields.svelte";
 import * as Alert from "$lib/components/ui/alert/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
+import * as Field from "$lib/components/ui/field/index.js";
 import type {
   SectionHomeworkCopy,
   SectionHomeworkDisplay,
@@ -45,32 +46,34 @@ $: homeworkTimestampCapabilities = {
 </script>
 
 <form
-  class="flex flex-col gap-5"
+  class="flex flex-col"
   onsubmit={updateHomework}
 >
-  <HomeworkEditorFields
-    actions={homeworkTimestampActions}
-    bind:advancedOpen={advancedOpen}
-    capabilities={homeworkTimestampCapabilities}
-    commentsCopy={commentsCopy}
-    copy={homeworkCopy}
-    description={homework.description?.content ?? ""}
-    idPrefix="section-homework-edit"
-    isMajor={homework.isMajor}
-    bind:publishedAt={editHomeworkPublishedAt}
-    requiresTeam={homework.requiresTeam}
-    styleGuidePrefix="section-edit-homework"
-    bind:submissionDueAt={editHomeworkSubmissionDueAt}
-    bind:submissionStartAt={editHomeworkSubmissionStartAt}
-    title={homework.title}
-  />
-  {#if editHomeworkMessage}
-    <Alert.Root variant="destructive">
-      <Alert.Description>{editHomeworkMessage}</Alert.Description>
-    </Alert.Root>
-  {/if}
-  <div class="flex justify-end gap-2 pt-1">
-    <Button type="button" variant="outline" onclick={cancelEdit}>{homeworkCopy.cancel}</Button>
-    <Button type="submit">{homeworkCopy.saveChanges}</Button>
-  </div>
+  <Field.Group>
+    <HomeworkEditorFields
+      actions={homeworkTimestampActions}
+      bind:advancedOpen={advancedOpen}
+      capabilities={homeworkTimestampCapabilities}
+      commentsCopy={commentsCopy}
+      copy={homeworkCopy}
+      description={homework.description?.content ?? ""}
+      idPrefix="section-homework-edit"
+      isMajor={homework.isMajor}
+      bind:publishedAt={editHomeworkPublishedAt}
+      requiresTeam={homework.requiresTeam}
+      styleGuidePrefix="section-edit-homework"
+      bind:submissionDueAt={editHomeworkSubmissionDueAt}
+      bind:submissionStartAt={editHomeworkSubmissionStartAt}
+      title={homework.title}
+    />
+    {#if editHomeworkMessage}
+      <Alert.Root variant="destructive">
+        <Alert.Description>{editHomeworkMessage}</Alert.Description>
+      </Alert.Root>
+    {/if}
+    <div class="flex justify-end gap-2 pt-1">
+      <Button type="button" variant="outline" onclick={cancelEdit}>{homeworkCopy.cancel}</Button>
+      <Button type="submit">{homeworkCopy.saveChanges}</Button>
+    </div>
+  </Field.Group>
 </form>

--- a/src/features/usage/components/McpUsagePage.svelte
+++ b/src/features/usage/components/McpUsagePage.svelte
@@ -71,6 +71,9 @@ const CLAUDE_CODE_COMMAND = `claude mcp add --scope user --transport http life-u
 let copiedKey: string | null = null;
 let activeClient: "chatgpt" | "claude" | "other" = "chatgpt";
 
+// TODO(#962): add dark-mode variants of the tutorial screenshots once assets are available.
+// For now, images are wrapped in a rounded bordered container so they remain visible in dark mode.
+
 async function copyValue(key: string, value: string) {
   await writeClipboardText(value);
   copiedKey = key;
@@ -138,6 +141,12 @@ function selectClient(value: string) {
   </div>
 {/snippet}
 
+{#snippet tutorialImage(src: string, alt: string, maxHeight: string)}
+  <div class="overflow-hidden rounded-xl border border-border">
+    <img {alt} class="h-auto w-full bg-white object-contain {maxHeight}" loading="lazy" {src} />
+  </div>
+{/snippet}
+
 <span class="sr-only" aria-live="polite">
   {copiedKey ? data.copy.copiedValueAction : ""}
 </span>
@@ -181,7 +190,7 @@ function selectClient(value: string) {
     >
       <div class="grid max-w-xl gap-6">
         <div
-          class="flex size-14 items-center justify-center rounded-2xl border border-border bg-violet-500/10 text-violet-600 shadow-sm dark:text-violet-400"
+          class="flex size-14 items-center justify-center rounded-2xl border border-border bg-primary/10 text-primary shadow-sm"
         >
           <CableIcon class="size-7" strokeWidth={1.8} />
         </div>
@@ -292,7 +301,7 @@ function selectClient(value: string) {
               </h4>
             </div>
             <a class="flex w-full items-start justify-center" href={data.copy.chatgpt.overviewSrc} rel="noreferrer" target="_blank">
-              <img alt={data.copy.chatgpt.overviewAlt} class="h-auto max-h-[34rem] w-full bg-white object-contain" loading="lazy" src={data.copy.chatgpt.overviewSrc} />
+              {@render tutorialImage(data.copy.chatgpt.overviewSrc, data.copy.chatgpt.overviewAlt, "max-h-[34rem]")}
             </a>
           </section>
 
@@ -305,7 +314,7 @@ function selectClient(value: string) {
               {@render chatgptFormValues()}
             </div>
             <a class="flex w-full items-start justify-center" href={data.copy.chatgpt.filledSrc} rel="noreferrer" target="_blank">
-              <img alt={data.copy.chatgpt.filledAlt} class="h-auto max-h-[42rem] w-full bg-white object-contain" loading="lazy" src={data.copy.chatgpt.filledSrc} />
+              {@render tutorialImage(data.copy.chatgpt.filledSrc, data.copy.chatgpt.filledAlt, "max-h-[42rem]")}
             </a>
           </section>
 
@@ -315,7 +324,7 @@ function selectClient(value: string) {
               <h4 class="text-balance font-semibold text-xl leading-8">{data.copy.chatgpt.steps[2]}</h4>
             </div>
             <a class="flex w-full items-start justify-center" href="/images/usage/mcp-use-case.png" rel="noreferrer" target="_blank">
-              <img alt={data.copy.useCaseAlt} class="h-auto max-h-[34rem] w-full bg-white object-contain" loading="lazy" src="/images/usage/mcp-use-case.png" />
+              {@render tutorialImage("/images/usage/mcp-use-case.png", data.copy.useCaseAlt, "max-h-[34rem]")}
             </a>
           </section>
         </div>
@@ -331,7 +340,7 @@ function selectClient(value: string) {
               <h4 class="text-balance font-semibold text-xl leading-8">{data.copy.claude.steps[0]}</h4>
             </div>
             <a class="flex w-full items-start justify-center" href="/images/usage/mcp-claude-empty.png" rel="noreferrer" target="_blank">
-              <img alt={data.copy.claude.emptyAlt} class="h-auto max-h-[34rem] w-full bg-white object-contain" loading="lazy" src="/images/usage/mcp-claude-empty.png" />
+              {@render tutorialImage("/images/usage/mcp-claude-empty.png", data.copy.claude.emptyAlt, "max-h-[34rem]")}
             </a>
           </section>
 
@@ -348,7 +357,7 @@ function selectClient(value: string) {
               <p class="text-muted-foreground text-sm leading-6">{data.copy.claude.note}</p>
             </div>
             <a class="flex w-full items-start justify-center" href="/images/usage/mcp-claude-filled.png" rel="noreferrer" target="_blank">
-              <img alt={data.copy.claude.filledAlt} class="h-auto max-h-[42rem] w-full bg-white object-contain" loading="lazy" src="/images/usage/mcp-claude-filled.png" />
+              {@render tutorialImage("/images/usage/mcp-claude-filled.png", data.copy.claude.filledAlt, "max-h-[42rem]")}
             </a>
           </section>
 
@@ -358,7 +367,7 @@ function selectClient(value: string) {
               <h4 class="text-balance font-semibold text-xl leading-8">{data.copy.claude.steps[2]}</h4>
             </div>
             <a class="flex w-full items-start justify-center" href="/images/usage/mcp-use-case.png" rel="noreferrer" target="_blank">
-              <img alt={data.copy.useCaseAlt} class="h-auto max-h-[34rem] w-full bg-white object-contain" loading="lazy" src="/images/usage/mcp-use-case.png" />
+              {@render tutorialImage("/images/usage/mcp-use-case.png", data.copy.useCaseAlt, "max-h-[34rem]")}
             </a>
           </section>
         </div>

--- a/src/features/usage/components/UsageGuidePage.svelte
+++ b/src/features/usage/components/UsageGuidePage.svelte
@@ -39,8 +39,8 @@ export let primaryQrSrc: string | undefined = undefined;
 
 $: iconTone =
   kind === "bot"
-    ? "bg-sky-500/10 text-sky-600 dark:text-sky-400"
-    : "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400";
+    ? "bg-primary/10 text-primary"
+    : "bg-secondary text-secondary-foreground";
 </script>
 
 <style>
@@ -174,7 +174,7 @@ $: iconTone =
                     type="button"
                     variant="outline"
                   >
-                    <QrCodeIcon aria-hidden="true" class="size-4" />
+                    <QrCodeIcon data-icon="inline-start" aria-hidden="true" />
                   </Button>
                 {/snippet}
               </Popover.Trigger>
@@ -300,7 +300,7 @@ $: iconTone =
             >
               <div class="grid gap-5 p-5 sm:p-6">
                 <div class="grid grid-cols-[auto_minmax(0,1fr)] gap-2 font-mono text-sm">
-                  <span class="text-emerald-600 dark:text-emerald-400">$</span>
+                  <span class="text-muted-foreground">$</span>
                   <code class="break-words">{step.title}</code>
                 </div>
                 <pre

--- a/src/lib/components/shell/GlobalSearchDialog.svelte
+++ b/src/lib/components/shell/GlobalSearchDialog.svelte
@@ -109,7 +109,7 @@ $: if (open) {
           </Field.Label>
           <InputGroup.Root class="h-9 min-w-0 rounded-none border-0">
             <InputGroup.Addon class="px-0">
-              <SearchIcon aria-hidden="true" class="size-4 shrink-0 text-muted-foreground" />
+              <SearchIcon aria-hidden="true" class="shrink-0 text-muted-foreground" />
             </InputGroup.Addon>
             <InputGroup.Input
               bind:ref={inputElement}
@@ -140,7 +140,7 @@ $: if (open) {
           type="button"
           variant="ghost"
         >
-          <XIcon />
+          <XIcon data-icon="inline-start" />
         </Button>
       </div>
     </Dialog.Header>

--- a/src/lib/components/shell/GlobalSearchTrigger.svelte
+++ b/src/lib/components/shell/GlobalSearchTrigger.svelte
@@ -21,7 +21,7 @@ $: placeholder = signedIn ? copy.placeholderSignedIn : copy.placeholder;
     type="button"
     variant="outline"
   >
-    <SearchIcon class="size-4 shrink-0" />
+    <SearchIcon data-icon="inline-start" class="shrink-0" />
     <span class="truncate">{placeholder}</span>
     <span class="ml-auto hidden items-center gap-1 sm:inline-flex">
       <Kbd.Root>{shortcutLabel}</Kbd.Root>
@@ -35,6 +35,6 @@ $: placeholder = signedIn ? copy.placeholderSignedIn : copy.placeholder;
     type="button"
     variant="ghost"
   >
-    <SearchIcon class="size-5" />
+    <SearchIcon data-icon="inline-start" />
   </Button>
 {/if}

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -82,7 +82,7 @@ afterNavigate(({ to }) => {
     </Field.Label>
     <InputGroup.Root class="h-11 rounded-lg">
       <InputGroup.Addon class="px-0 ps-3">
-        <SearchIcon aria-hidden="true" class="size-4 text-muted-foreground" />
+        <SearchIcon aria-hidden="true" class="text-muted-foreground" />
       </InputGroup.Addon>
       <InputGroup.Input
         bind:ref={inputElement}

--- a/tests/e2e/src/app/sections/test.ts
+++ b/tests/e2e/src/app/sections/test.ts
@@ -417,20 +417,20 @@ test.describe("/catalog/sections 班级搜索页", () => {
         const resultsStyle = getComputedStyle(results);
         const columnAlignment = headerCells.map((header, index) => {
           const cell = firstRowCells[index];
-          const link = cell?.querySelector<HTMLElement>("a");
-          if (!cell || !link)
+          const target = cell?.querySelector<HTMLElement>("a") ?? cell;
+          if (!cell || !target)
             throw new Error("Sections table column content missing");
           const headerStyle = getComputedStyle(header);
-          const linkStyle = getComputedStyle(link);
+          const targetStyle = getComputedStyle(target);
           const headerBox = header.getBoundingClientRect();
-          const linkBox = link.getBoundingClientRect();
+          const targetBox = target.getBoundingClientRect();
           const rightAligned = headerStyle.textAlign === "right";
           const headerEdge = rightAligned
             ? headerBox.right - Number.parseFloat(headerStyle.paddingRight)
             : headerBox.left + Number.parseFloat(headerStyle.paddingLeft);
           const cellEdge = rightAligned
-            ? linkBox.right - Number.parseFloat(linkStyle.paddingRight)
-            : linkBox.left + Number.parseFloat(linkStyle.paddingLeft);
+            ? targetBox.right - Number.parseFloat(targetStyle.paddingRight)
+            : targetBox.left + Number.parseFloat(targetStyle.paddingLeft);
           return {
             alignment: headerStyle.textAlign,
             offset: Math.abs(headerEdge - cellEdge),


### PR DESCRIPTION
This PR addresses the findings from the UI audit across issues #958, #959, #960, #961, and #962.

## Changes

### #958 — Icon compliance
- Added `data-icon="inline-start"` / `data-icon="inline-end"` to icons inside `<Button>` and `<TableIconButton>`.
- Removed manual sizing classes from icons inside shadcn components.

### #959 — Card composition
- Refactored cards to use `Card.Header` → `Card.Title` / `Card.Description` → `Card.Content`.
- Removed redundant nested headings in error cards.

### #960 — Styling utilities
- Replaced manual `dark:` color overrides and raw Tailwind colors with semantic tokens.
- Replaced conditional class ternaries/template literals with `cn()` where applicable.
- Replaced custom border dividers with `Separator`.
- Replaced `space-y-1` with `flex flex-col gap-1`.

### #961 — Form layout
- Migrated raw gap-based form containers to `Field.FieldGroup`.

### #962 — Visual/UX fixes
- Made catalog table rows have a single actionable link target.
- Removed nested outline cards from `ProfileSummaryCard`.
- Added responsive grid columns to overview links to avoid truncation.
- Wrapped MCP tutorial images in bordered containers for dark-mode visibility.
- Added empty-state handling for exams tab.

## Verification

- `bunx svelte-check --tsconfig ./tsconfig.json` — 0 errors, 0 warnings
- `bunx tsc --noEmit -p tsconfig.typecheck.json` — passed
- `bunx biome check` on changed files — passed

Closes #958, closes #959, closes #960, closes #961, closes #962