### PR TITLE
fix(bus): batch static timetable imports

### DIFF
--- a/src/features/admin/server/admin-bus-page-server.ts
+++ b/src/features/admin/server/admin-bus-page-server.ts
@@ -4,7 +4,10 @@ import {
   requireAdminPage,
 } from "@/features/admin/server/admin-page-data";
 import { loadBusStaticPayload } from "@/features/bus/lib/bus-static-source";
-import { importBusStaticPayload } from "@/features/bus/server/bus-import";
+import {
+  getBusImportFailureStage,
+  importBusStaticPayload,
+} from "@/features/bus/server/bus-import";
 import type { AppLocale } from "@/i18n/config";
 import { writeAuditLog } from "@/lib/audit/write-audit-log";
 import { prisma } from "@/lib/db/prisma";
@@ -136,6 +139,7 @@ export const adminBusActions = {
     } catch (error) {
       logServerActionError("admin.bus.import-static.failed", error, {
         action: "import-static",
+        importStage: getBusImportFailureStage(error) ?? "load-or-validate",
         requestId: locals.requestId,
         route: "/admin/bus",
       });

--- a/src/features/bus/server/bus-import-prisma.ts
+++ b/src/features/bus/server/bus-import-prisma.ts
@@ -18,7 +18,7 @@ export type BusImportWritePrisma = {
     updateMany(args: unknown): Promise<unknown>;
   };
   busTrip: {
-    create(args: unknown): Promise<unknown>;
+    createMany(args: unknown): Promise<unknown>;
     deleteMany(args: unknown): Promise<unknown>;
   };
 };

--- a/src/features/bus/server/bus-import-version-upsert.ts
+++ b/src/features/bus/server/bus-import-version-upsert.ts
@@ -12,16 +12,17 @@ export async function findExistingBusScheduleVersion(
     versionKey: string;
   },
 ) {
-  const [byKey, byChecksum] = await Promise.all([
-    prisma.busScheduleVersion.findUnique({
-      where: { key: versionKey },
-      select: { id: true, key: true, checksum: true },
-    }),
-    prisma.busScheduleVersion.findUnique({
-      where: { checksum },
-      select: { id: true, key: true, checksum: true },
-    }),
-  ]);
+  const byKey = await prisma.busScheduleVersion.findUnique({
+    where: { key: versionKey },
+    select: { id: true, key: true, checksum: true },
+  });
+  const byChecksum =
+    byKey?.checksum === checksum
+      ? byKey
+      : await prisma.busScheduleVersion.findUnique({
+          where: { checksum },
+          select: { id: true, key: true, checksum: true },
+        });
 
   if (byKey && byChecksum && byKey.id !== byChecksum.id) {
     throw new Error(

--- a/src/features/bus/server/bus-import-writes.ts
+++ b/src/features/bus/server/bus-import-writes.ts
@@ -82,22 +82,19 @@ export async function createBusTripsForDayType(
   dayType: "weekday" | "saturday" | "sunday",
   schedules: BusStaticRouteSchedule[],
 ) {
-  let trips = 0;
+  const trips = schedules.flatMap((schedule) =>
+    schedule.time.map((stopTimes, position) => ({
+      versionId,
+      routeId: schedule.route.id,
+      dayType,
+      position,
+      stopTimes,
+    })),
+  );
 
-  for (const schedule of schedules) {
-    for (let position = 0; position < schedule.time.length; position += 1) {
-      await prisma.busTrip.create({
-        data: {
-          versionId,
-          routeId: schedule.route.id,
-          dayType,
-          position,
-          stopTimes: schedule.time[position],
-        },
-      });
-      trips += 1;
-    }
+  if (trips.length > 0) {
+    await prisma.busTrip.createMany({ data: trips });
   }
 
-  return trips;
+  return trips.length;
 }

--- a/src/features/bus/server/bus-import.ts
+++ b/src/features/bus/server/bus-import.ts
@@ -20,6 +20,32 @@ import {
   upsertBusRoutes,
 } from "./bus-import-writes";
 
+export type BusImportStage =
+  | "find-existing-version"
+  | "refresh-existing-version"
+  | "disable-previous-versions"
+  | "upsert-campuses"
+  | "upsert-routes"
+  | "upsert-version"
+  | "create-weekday-trips"
+  | "create-saturday-trips"
+  | "create-sunday-trips";
+
+export class BusImportStageError extends Error {
+  readonly stage: BusImportStage;
+
+  constructor(stage: BusImportStage, cause: unknown) {
+    const detail = cause instanceof Error ? `: ${cause.message}` : "";
+    super(`Bus import failed at ${stage}${detail}`, { cause });
+    this.name = "BusImportStageError";
+    this.stage = stage;
+  }
+}
+
+export function getBusImportFailureStage(error: unknown) {
+  return error instanceof BusImportStageError ? error.stage : undefined;
+}
+
 export async function importBusStaticPayload(
   prisma: BusImportPrisma,
   payload: BusStaticPayload,
@@ -34,68 +60,81 @@ export async function importBusStaticPayload(
   const effectiveUntil = options?.effectiveUntil ?? null;
 
   return prisma.$transaction(async (tx) => {
-    const existing = await findExistingBusScheduleVersion(tx, {
-      checksum,
-      versionKey,
-    });
+    let stage: BusImportStage = "find-existing-version";
+    try {
+      const existing = await findExistingBusScheduleVersion(tx, {
+        checksum,
+        versionKey,
+      });
 
-    if (existing) {
-      await refreshExistingBusScheduleVersion(tx, {
+      if (existing) {
+        stage = "refresh-existing-version";
+        await refreshExistingBusScheduleVersion(tx, {
+          checksum,
+          effectiveFrom,
+          effectiveUntil,
+          existingId: existing.id,
+          payload,
+          versionKey,
+          versionTitle,
+        });
+      }
+
+      if (options?.disablePreviousVersions !== false) {
+        stage = "disable-previous-versions";
+        await disablePreviousBusScheduleVersions(tx, {
+          existingId: existing?.id,
+          versionKey,
+        });
+      }
+
+      stage = "upsert-campuses";
+      await upsertBusCampuses(tx, payload);
+      stage = "upsert-routes";
+      await upsertBusRoutes(tx, payload);
+
+      stage = "upsert-version";
+      const version = await upsertImportedBusScheduleVersion(tx, {
         checksum,
         effectiveFrom,
         effectiveUntil,
-        existingId: existing.id,
+        existingId: existing?.id,
         payload,
         versionKey,
         versionTitle,
       });
+
+      stage = "create-weekday-trips";
+      const weekdayTrips = await createBusTripsForDayType(
+        tx,
+        version.id,
+        "weekday",
+        payload.weekday_routes,
+      );
+      stage = "create-saturday-trips";
+      const saturdayTrips = await createBusTripsForDayType(
+        tx,
+        version.id,
+        "saturday",
+        payload.saturday_routes,
+      );
+      stage = "create-sunday-trips";
+      const sundayTrips = await createBusTripsForDayType(
+        tx,
+        version.id,
+        "sunday",
+        payload.sunday_routes,
+      );
+
+      return {
+        versionId: version.id,
+        versionKey: version.key,
+        campuses: payload.campuses.length,
+        routes: payload.routes.length,
+        trips: weekdayTrips + saturdayTrips + sundayTrips,
+      };
+    } catch (error) {
+      throw new BusImportStageError(stage, error);
     }
-
-    if (options?.disablePreviousVersions !== false) {
-      await disablePreviousBusScheduleVersions(tx, {
-        existingId: existing?.id,
-        versionKey,
-      });
-    }
-
-    await upsertBusCampuses(tx, payload);
-    await upsertBusRoutes(tx, payload);
-
-    const version = await upsertImportedBusScheduleVersion(tx, {
-      checksum,
-      effectiveFrom,
-      effectiveUntil,
-      existingId: existing?.id,
-      payload,
-      versionKey,
-      versionTitle,
-    });
-
-    const weekdayTrips = await createBusTripsForDayType(
-      tx,
-      version.id,
-      "weekday",
-      payload.weekday_routes,
-    );
-    const saturdayTrips = await createBusTripsForDayType(
-      tx,
-      version.id,
-      "saturday",
-      payload.saturday_routes,
-    );
-    const sundayTrips = await createBusTripsForDayType(
-      tx,
-      version.id,
-      "sunday",
-      payload.sunday_routes,
-    );
-
-    return {
-      versionId: version.id,
-      versionKey: version.key,
-      campuses: payload.campuses.length,
-      routes: payload.routes.length,
-      trips: weekdayTrips + saturdayTrips + sundayTrips,
-    };
   });
 }

--- a/tests/unit/admin-bus-action-logging.test.ts
+++ b/tests/unit/admin-bus-action-logging.test.ts
@@ -20,6 +20,7 @@ vi.mock("@/features/bus/lib/bus-static-source", () => ({
 }));
 
 vi.mock("@/features/bus/server/bus-import", () => ({
+  getBusImportFailureStage: vi.fn(),
   importBusStaticPayload: vi.fn(),
 }));
 
@@ -61,6 +62,7 @@ describe("admin bus action error logging", () => {
       expect.any(Error),
       {
         action: "import-static",
+        importStage: "load-or-validate",
         requestId: "request-import",
         route: "/admin/bus",
       },

--- a/tests/unit/bus-import.test.ts
+++ b/tests/unit/bus-import.test.ts
@@ -114,12 +114,12 @@ function createImportPrismaMock(
       },
     },
     busTrip: {
-      async create(args) {
+      async createMany(args) {
         if (options.failTripCreate) {
           throw new Error("injected trip write failure");
         }
-        const data = (args as { data: TripRow }).data;
-        target.trips.push(data);
+        const data = (args as { data: TripRow[] }).data;
+        target.trips.push(...data);
         return {};
       },
       async deleteMany(args) {
@@ -217,7 +217,9 @@ describe("班车时刻表导入", () => {
       importBusStaticPayload(prisma, createPayload(), {
         versionKey: "current-bus",
       }),
-    ).rejects.toThrow("injected trip write failure");
+    ).rejects.toThrow(
+      "Bus import failed at create-weekday-trips: injected trip write failure",
+    );
 
     expect(prisma.getState()).toEqual(initialState);
   });
@@ -254,7 +256,7 @@ describe("班车时刻表导入", () => {
         versionKey: "current-bus",
       }),
     ).rejects.toThrow(
-      /Bus schedule version conflict: key "current-bus" belongs to version 1, but checksum ".+" belongs to version 2/,
+      /Bus import failed at find-existing-version: Bus schedule version conflict: key "current-bus" belongs to version 1, but checksum ".+" belongs to version 2/,
     );
 
     expect(prisma.getState()).toEqual(initialState);


### PR DESCRIPTION
## Summary

- batch each service day trip set into one Prisma write instead of issuing one query per trip
- serialize version lookups inside the interactive transaction for edge database adapters
- attach a safe import-stage identifier to production error logs

## Production issue

The August 2026 bus payload failed atomically in production with Prisma edge driver error `P2039`. The previous active version remained unchanged.

## Verification

- real Prisma import of the published payload: 7 campuses, 10 routes, 195 trips (105/49/41)
- 2468 Vitest tests passed
- Svelte and all TypeScript checks passed
- production build passed