### PR TITLE
fix(bus): avoid edge upserts during import

### DIFF
--- a/src/features/bus/server/bus-import-prisma.ts
+++ b/src/features/bus/server/bus-import-prisma.ts
@@ -1,9 +1,11 @@
 export type BusImportWritePrisma = {
   busCampus: {
-    upsert(args: unknown): Promise<unknown>;
+    create(args: unknown): Promise<unknown>;
+    updateMany(args: unknown): Promise<{ count: number }>;
   };
   busRoute: {
-    upsert(args: unknown): Promise<unknown>;
+    create(args: unknown): Promise<unknown>;
+    updateMany(args: unknown): Promise<{ count: number }>;
   };
   busRouteStop: {
     createMany(args: unknown): Promise<unknown>;

--- a/src/features/bus/server/bus-import-writes.ts
+++ b/src/features/bus/server/bus-import-writes.ts
@@ -30,20 +30,23 @@ export async function upsertBusCampuses(
 ) {
   for (const campus of payload.campuses) {
     const { latitude, longitude } = normalizeBusCampusCoordinates(campus);
-    await prisma.busCampus.upsert({
+    const data = {
+      nameCn: normalizeBusCampusName(campus.name),
+      latitude,
+      longitude,
+    };
+    const updated = await prisma.busCampus.updateMany({
       where: { id: campus.id },
-      update: {
-        nameCn: normalizeBusCampusName(campus.name),
-        latitude,
-        longitude,
-      },
-      create: {
-        id: campus.id,
-        nameCn: normalizeBusCampusName(campus.name),
-        latitude,
-        longitude,
-      },
+      data,
     });
+    if (updated.count === 0) {
+      await prisma.busCampus.create({
+        data: {
+          id: campus.id,
+          ...data,
+        },
+      });
+    }
   }
 }
 
@@ -53,14 +56,18 @@ export async function upsertBusRoutes(
 ) {
   for (const route of payload.routes) {
     const routeNameData = buildBusRouteNameData(route.campuses);
-    await prisma.busRoute.upsert({
+    const updated = await prisma.busRoute.updateMany({
       where: { id: route.id },
-      update: routeNameData,
-      create: {
-        id: route.id,
-        ...routeNameData,
-      },
+      data: routeNameData,
     });
+    if (updated.count === 0) {
+      await prisma.busRoute.create({
+        data: {
+          id: route.id,
+          ...routeNameData,
+        },
+      });
+    }
 
     await prisma.busRouteStop.deleteMany({
       where: { routeId: route.id },

--- a/tests/unit/bus-import.test.ts
+++ b/tests/unit/bus-import.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { checksumBusPayload } from "@/features/bus/lib/bus-import-metadata";
 import type { BusStaticPayload } from "@/features/bus/lib/bus-types";
 import { importBusStaticPayload } from "@/features/bus/server/bus-import";
@@ -6,6 +6,10 @@ import type {
   BusImportPrisma,
   BusImportWritePrisma,
 } from "@/features/bus/server/bus-import-prisma";
+import {
+  upsertBusCampuses,
+  upsertBusRoutes,
+} from "@/features/bus/server/bus-import-writes";
 
 type VersionRow = {
   id: number;
@@ -46,13 +50,19 @@ function createImportPrismaMock(
 
   const createDelegates = (target: ImportState): BusImportWritePrisma => ({
     busCampus: {
-      async upsert() {
+      async create() {
         return {};
+      },
+      async updateMany() {
+        return { count: 1 };
       },
     },
     busRoute: {
-      async upsert() {
+      async create() {
         return {};
+      },
+      async updateMany() {
+        return { count: 1 };
       },
     },
     busRouteStop: {
@@ -167,6 +177,41 @@ function createPayload(): BusStaticPayload {
 }
 
 describe("班车时刻表导入", () => {
+  it("未命中的园区和路线更新会创建新记录", async () => {
+    const campusCreate = vi.fn().mockResolvedValue({});
+    const routeCreate = vi.fn().mockResolvedValue({});
+    const routeStopCreateMany = vi.fn().mockResolvedValue({});
+    const prisma = {
+      busCampus: {
+        create: campusCreate,
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      busRoute: {
+        create: routeCreate,
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      busRouteStop: {
+        createMany: routeStopCreateMany,
+        deleteMany: vi.fn().mockResolvedValue({}),
+      },
+    } as unknown as BusImportWritePrisma;
+    const payload = createPayload();
+
+    await upsertBusCampuses(prisma, payload);
+    await upsertBusRoutes(prisma, payload);
+
+    expect(campusCreate).toHaveBeenCalledTimes(2);
+    expect(routeCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({ id: 8, nameCn: "东区 -> 西区" }),
+    });
+    expect(routeStopCreateMany).toHaveBeenCalledWith({
+      data: [
+        { routeId: 8, campusId: 1, stopOrder: 0 },
+        { routeId: 8, campusId: 2, stopOrder: 1 },
+      ],
+    });
+  });
+
   it("分别导入工作日、周六和周日班次", async () => {
     const prisma = createImportPrismaMock({
       nextVersionId: 1,


### PR DESCRIPTION
## Summary

- replace Prisma `upsert` for bus campuses and routes with explicit update-or-create operations
- preserve the same atomic import semantics
- add regression coverage for the create path

## Production evidence

The staged production log from PR #968 localized the edge driver `P2039` failure to `upsert-campuses`, before any trip writes.

## Verification

- real Prisma import of the published payload succeeded: 7 campuses, 10 routes, 195 trips
- 2468 Vitest tests passed
- TypeScript checks and production build passed