### PR TITLE
fix(bus): grant runtime import writes

### DIFF
--- a/prisma/migrations/20260831130000_grant_bus_catalog_import/migration.sql
+++ b/prisma/migrations/20260831130000_grant_bus_catalog_import/migration.sql
@@ -1,0 +1,19 @@
+-- The authenticated admin import runs through the unprivileged app role.
+-- Grant only the catalog writes performed by importBusStaticPayload.
+DO $grant_bus_catalog_import$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_roles WHERE rolname = 'life_ustc_runtime'
+  ) THEN
+    RAISE NOTICE 'Skipping bus import grants; role life_ustc_runtime does not exist.';
+    RETURN;
+  END IF;
+
+  GRANT INSERT, UPDATE ON TABLE "BusCampus", "BusRoute"
+  TO life_ustc_runtime;
+  GRANT INSERT, DELETE ON TABLE "BusRouteStop", "BusTrip"
+  TO life_ustc_runtime;
+  GRANT USAGE, SELECT ON SEQUENCE "BusRouteStop_id_seq", "BusTrip_id_seq"
+  TO life_ustc_runtime;
+END
+$grant_bus_catalog_import$;

--- a/prisma/roles/app-runtime-table-grants.sql
+++ b/prisma/roles/app-runtime-table-grants.sql
@@ -62,5 +62,9 @@ GRANT INSERT ON TABLE "AuditLog" TO life_ustc_runtime;
 GRANT SELECT, INSERT, UPDATE ON TABLE "UserSuspension" TO life_ustc_runtime;
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "BusScheduleVersion"
 TO life_ustc_runtime;
+GRANT INSERT, UPDATE ON TABLE "BusCampus", "BusRoute"
+TO life_ustc_runtime;
+GRANT INSERT, DELETE ON TABLE "BusRouteStop", "BusTrip"
+TO life_ustc_runtime;
 GRANT UPDATE ("name", "username", "isAdmin", "calendarFeedToken", "updatedAt") ON TABLE "User"
 TO life_ustc_runtime;

--- a/src/features/bus/server/bus-import-prisma.ts
+++ b/src/features/bus/server/bus-import-prisma.ts
@@ -1,11 +1,9 @@
 export type BusImportWritePrisma = {
   busCampus: {
-    create(args: unknown): Promise<unknown>;
-    updateMany(args: unknown): Promise<{ count: number }>;
+    upsert(args: unknown): Promise<unknown>;
   };
   busRoute: {
-    create(args: unknown): Promise<unknown>;
-    updateMany(args: unknown): Promise<{ count: number }>;
+    upsert(args: unknown): Promise<unknown>;
   };
   busRouteStop: {
     createMany(args: unknown): Promise<unknown>;

--- a/src/features/bus/server/bus-import-writes.ts
+++ b/src/features/bus/server/bus-import-writes.ts
@@ -30,23 +30,20 @@ export async function upsertBusCampuses(
 ) {
   for (const campus of payload.campuses) {
     const { latitude, longitude } = normalizeBusCampusCoordinates(campus);
-    const data = {
-      nameCn: normalizeBusCampusName(campus.name),
-      latitude,
-      longitude,
-    };
-    const updated = await prisma.busCampus.updateMany({
+    await prisma.busCampus.upsert({
       where: { id: campus.id },
-      data,
+      update: {
+        nameCn: normalizeBusCampusName(campus.name),
+        latitude,
+        longitude,
+      },
+      create: {
+        id: campus.id,
+        nameCn: normalizeBusCampusName(campus.name),
+        latitude,
+        longitude,
+      },
     });
-    if (updated.count === 0) {
-      await prisma.busCampus.create({
-        data: {
-          id: campus.id,
-          ...data,
-        },
-      });
-    }
   }
 }
 
@@ -56,18 +53,14 @@ export async function upsertBusRoutes(
 ) {
   for (const route of payload.routes) {
     const routeNameData = buildBusRouteNameData(route.campuses);
-    const updated = await prisma.busRoute.updateMany({
+    await prisma.busRoute.upsert({
       where: { id: route.id },
-      data: routeNameData,
+      update: routeNameData,
+      create: {
+        id: route.id,
+        ...routeNameData,
+      },
     });
-    if (updated.count === 0) {
-      await prisma.busRoute.create({
-        data: {
-          id: route.id,
-          ...routeNameData,
-        },
-      });
-    }
 
     await prisma.busRouteStop.deleteMany({
       where: { routeId: route.id },

--- a/tests/unit/bus-import.test.ts
+++ b/tests/unit/bus-import.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { checksumBusPayload } from "@/features/bus/lib/bus-import-metadata";
 import type { BusStaticPayload } from "@/features/bus/lib/bus-types";
 import { importBusStaticPayload } from "@/features/bus/server/bus-import";
@@ -6,10 +6,6 @@ import type {
   BusImportPrisma,
   BusImportWritePrisma,
 } from "@/features/bus/server/bus-import-prisma";
-import {
-  upsertBusCampuses,
-  upsertBusRoutes,
-} from "@/features/bus/server/bus-import-writes";
 
 type VersionRow = {
   id: number;
@@ -50,19 +46,13 @@ function createImportPrismaMock(
 
   const createDelegates = (target: ImportState): BusImportWritePrisma => ({
     busCampus: {
-      async create() {
+      async upsert() {
         return {};
-      },
-      async updateMany() {
-        return { count: 1 };
       },
     },
     busRoute: {
-      async create() {
+      async upsert() {
         return {};
-      },
-      async updateMany() {
-        return { count: 1 };
       },
     },
     busRouteStop: {
@@ -177,41 +167,6 @@ function createPayload(): BusStaticPayload {
 }
 
 describe("班车时刻表导入", () => {
-  it("未命中的园区和路线更新会创建新记录", async () => {
-    const campusCreate = vi.fn().mockResolvedValue({});
-    const routeCreate = vi.fn().mockResolvedValue({});
-    const routeStopCreateMany = vi.fn().mockResolvedValue({});
-    const prisma = {
-      busCampus: {
-        create: campusCreate,
-        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
-      },
-      busRoute: {
-        create: routeCreate,
-        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
-      },
-      busRouteStop: {
-        createMany: routeStopCreateMany,
-        deleteMany: vi.fn().mockResolvedValue({}),
-      },
-    } as unknown as BusImportWritePrisma;
-    const payload = createPayload();
-
-    await upsertBusCampuses(prisma, payload);
-    await upsertBusRoutes(prisma, payload);
-
-    expect(campusCreate).toHaveBeenCalledTimes(2);
-    expect(routeCreate).toHaveBeenCalledWith({
-      data: expect.objectContaining({ id: 8, nameCn: "东区 -> 西区" }),
-    });
-    expect(routeStopCreateMany).toHaveBeenCalledWith({
-      data: [
-        { routeId: 8, campusId: 1, stopOrder: 0 },
-        { routeId: 8, campusId: 2, stopOrder: 1 },
-      ],
-    });
-  });
-
   it("分别导入工作日、周六和周日班次", async () => {
     const prisma = createImportPrismaMock({
       nextVersionId: 1,


### PR DESCRIPTION
## Summary
- grant the production runtime role the minimal writes required by the authenticated bus timetable importer
- grant sequence access for route stops and trips
- restore straightforward Prisma upserts now that the production P2039 root cause is identified as database privileges

## Production evidence
- import failed atomically at `upsert-campuses` with Prisma P2039
- the canonical runtime grants allowed writes to `BusScheduleVersion`, but none to `BusCampus`, `BusRoute`, `BusRouteStop`, or `BusTrip`

## Verification
- `bun run db:migrate:deploy`
- TypeScript checks for app, scripts, and tests
- full Vitest suite
- `bun run build`
- `git diff --check`