### PR TITLE
fix(bus): refresh cache after timetable imports

### DIFF
--- a/src/features/bus/server/bus-timetable-data.ts
+++ b/src/features/bus/server/bus-timetable-data.ts
@@ -17,6 +17,7 @@ import type {
 import { getBusPreference } from "./bus-preferences";
 import { getBusVersionTopology } from "./bus-route-records";
 import {
+  type BusVersionRuntime,
   findEffectiveBusVersion,
   findEffectiveBusVersionFromRecords,
   listEnabledBusVersionRecords,
@@ -43,6 +44,7 @@ function busVersionNotice(version: {
 function getStaticBusTimetableCacheKey(input: {
   dateKey: string;
   locale: string;
+  version: BusVersionRuntime;
   versionKey?: string | null;
 }) {
   return JSON.stringify([
@@ -51,31 +53,22 @@ function getStaticBusTimetableCacheKey(input: {
     input.versionKey == null
       ? { type: "auto" }
       : { key: input.versionKey, type: "explicit" },
+    {
+      id: input.version.id,
+      importedAt: input.version.importedAt.toISOString(),
+    },
   ]);
 }
 
 async function loadStaticBusTimetableData(input: {
-  dateKey: string;
   locale: BusTimetableInput["locale"];
-  versionKey?: string | null;
+  version: BusVersionRuntime;
+  versionRecords: BusVersionRuntime[];
 }): Promise<CachedStaticBusTimetableData | null> {
-  const versionRecordsPromise = listEnabledBusVersionRecords();
-  const explicitVersionPromise = input.versionKey
-    ? findEffectiveBusVersion(input.dateKey, input.versionKey)
-    : Promise.resolve(null);
-  const [versionRecords, explicitVersion] = await Promise.all([
-    versionRecordsPromise,
-    explicitVersionPromise,
-  ]);
-  const version = input.versionKey
-    ? explicitVersion
-    : findEffectiveBusVersionFromRecords(versionRecords, input.dateKey);
-  if (!version) return null;
-
   const [topology, tripRows] = await Promise.all([
-    getBusVersionTopology(input.locale ?? "zh-cn", version.id),
+    getBusVersionTopology(input.locale ?? "zh-cn", input.version.id),
     prisma.busTrip.findMany({
-      where: { versionId: version.id },
+      where: { versionId: input.version.id },
       orderBy: [{ dayType: "asc" }, { routeId: "asc" }, { position: "asc" }],
     }),
   ]);
@@ -100,19 +93,19 @@ async function loadStaticBusTimetableData(input: {
   return {
     locale,
     version: {
-      id: version.id,
-      key: version.key,
-      title: version.title,
-      effectiveFrom: version.effectiveFrom?.toISOString() ?? null,
-      effectiveUntil: version.effectiveUntil?.toISOString() ?? null,
-      importedAt: version.importedAt.toISOString(),
-      notice: busVersionNotice(version),
+      id: input.version.id,
+      key: input.version.key,
+      title: input.version.title,
+      effectiveFrom: input.version.effectiveFrom?.toISOString() ?? null,
+      effectiveUntil: input.version.effectiveUntil?.toISOString() ?? null,
+      importedAt: input.version.importedAt.toISOString(),
+      notice: busVersionNotice(input.version),
     },
     campuses: topology.campuses,
     routes,
     trips,
-    availableVersions: summarizeBusVersions(versionRecords),
-    notice: busVersionNotice(version),
+    availableVersions: summarizeBusVersions(input.versionRecords),
+    notice: busVersionNotice(input.version),
   };
 }
 
@@ -122,9 +115,23 @@ export async function getStaticBusTimetableData(
   const locale = input.locale ?? "zh-cn";
   const now = input.now ? shanghaiDayjs(input.now) : shanghaiDayjs();
   const dateKey = now.format("YYYY-MM-DD");
+  const versionRecordsPromise = listEnabledBusVersionRecords();
+  const explicitVersionPromise = input.versionKey
+    ? findEffectiveBusVersion(dateKey, input.versionKey)
+    : Promise.resolve(null);
+  const [versionRecords, explicitVersion] = await Promise.all([
+    versionRecordsPromise,
+    explicitVersionPromise,
+  ]);
+  const version = input.versionKey
+    ? explicitVersion
+    : findEffectiveBusVersionFromRecords(versionRecords, dateKey);
+  if (!version) return null;
+
   const cacheKey = getStaticBusTimetableCacheKey({
     dateKey,
     locale,
+    version,
     versionKey: input.versionKey,
   });
 
@@ -134,9 +141,9 @@ export async function getStaticBusTimetableData(
     getCanonicalOrigin(),
     () =>
       loadStaticBusTimetableData({
-        dateKey,
         locale,
-        versionKey: input.versionKey,
+        version,
+        versionRecords,
       }),
     {
       shouldCacheResult: (result) => result !== null,

--- a/tests/unit/bus-timetable-data.test.ts
+++ b/tests/unit/bus-timetable-data.test.ts
@@ -234,8 +234,8 @@ describe("getBusTimetableData 班车时刻表数据", () => {
 
     expect(data?.departures[0]?.departureTime).toBe("08:00");
     expect(db.busTripFindMany).not.toHaveBeenCalled();
-    expect(db.busScheduleVersionFindMany).not.toHaveBeenCalled();
-    expect(db.busScheduleVersionFindUnique).not.toHaveBeenCalled();
+    expect(db.busScheduleVersionFindMany).toHaveBeenCalledTimes(1);
+    expect(versionLookupCount("old-bus")).toBe(1);
     expect(db.busCampusFindMany).not.toHaveBeenCalled();
     expect(db.busRouteFindMany).not.toHaveBeenCalled();
   });
@@ -259,8 +259,8 @@ describe("getBusTimetableData 班车时刻表数据", () => {
       expect.objectContaining({ routeId: 8, status: "en-route" }),
     ]);
     expect(db.busTripFindMany).not.toHaveBeenCalled();
-    expect(db.busScheduleVersionFindMany).not.toHaveBeenCalled();
-    expect(db.busScheduleVersionFindUnique).not.toHaveBeenCalled();
+    expect(db.busScheduleVersionFindMany).toHaveBeenCalledTimes(1);
+    expect(versionLookupCount("old-bus")).toBe(1);
   });
 
   it("为每次调用刷新 fetchedAt 而不重新加载静态数据", async () => {
@@ -277,8 +277,47 @@ describe("getBusTimetableData 班车时刻表数据", () => {
 
     expect(first?.fetchedAt).toBe("2026-02-01T00:00:00.000Z");
     expect(second?.fetchedAt).toBe("2026-02-01T01:00:00.000Z");
-    expect(versionLookupCount("old-bus")).toBe(1);
+    expect(versionLookupCount("old-bus")).toBe(2);
     expect(db.busTripFindMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("同一版本重新导入后按 importedAt 刷新静态数据", async () => {
+    const input = {
+      locale: "zh-cn" as const,
+      now: "2026-02-01T00:00:00.000Z",
+      versionKey: "old-bus",
+    };
+    const first = await timetable.getStaticBusTimetableData(input);
+
+    db.busScheduleVersionFindUnique.mockImplementation(
+      async (args: unknown) => {
+        const where = (args as { where: { id?: number; key?: string } }).where;
+        if (where.id === db.oldVersion.id) return { rawJson: db.oldPayload };
+        if (where.key === "old-bus") {
+          return {
+            ...db.oldVersion,
+            importedAt: new Date("2026-07-30T00:01:00.000Z"),
+          };
+        }
+        return null;
+      },
+    );
+    db.busTripFindMany.mockResolvedValue([
+      {
+        id: 102,
+        versionId: db.oldVersion.id,
+        routeId: 8,
+        dayType: "weekday" as const,
+        position: 0,
+        stopTimes: ["09:00", "09:20"],
+      },
+    ]);
+
+    const second = await timetable.getStaticBusTimetableData(input);
+
+    expect(first?.trips[0]?.departureTime).toBe("08:00");
+    expect(second?.trips[0]?.departureTime).toBe("09:00");
+    expect(db.busTripFindMany).toHaveBeenCalledTimes(2);
   });
 
   it("不把调用者偏好放进静态缓存", async () => {
@@ -309,7 +348,7 @@ describe("getBusTimetableData 班车时刻表数据", () => {
       preferredOriginCampusId: 2,
       showDepartedTrips: true,
     });
-    expect(versionLookupCount("old-bus")).toBe(1);
+    expect(versionLookupCount("old-bus")).toBe(2);
     expect(db.busPreferenceFindUnique).toHaveBeenCalledTimes(2);
   });
 
@@ -388,7 +427,7 @@ describe("getBusTimetableData 班车时刻表数据", () => {
     });
   });
 
-  it("合并同 key 并发加载，并从成功时刻开始 24 小时 TTL", async () => {
+  it("版本检查后合并同 key 并发静态加载", async () => {
     vi.useRealTimers();
     const explicitVersion = createDeferred<unknown>();
     db.busScheduleVersionFindUnique.mockReturnValueOnce(
@@ -407,7 +446,7 @@ describe("getBusTimetableData 班车时刻表数据", () => {
     });
     await flushAsyncWork();
 
-    expect(versionLookupCount("old-bus")).toBe(1);
+    expect(versionLookupCount("old-bus")).toBe(2);
     vi.setSystemTime("2026-07-30T00:01:01.000Z");
     explicitVersion.resolve(db.oldVersion);
 
@@ -421,7 +460,7 @@ describe("getBusTimetableData 班车时刻表数据", () => {
     expect(firstData?.fetchedAt).toBe("2026-02-01T00:00:00.000Z");
     expect(secondData?.fetchedAt).toBe("2026-02-01T01:00:00.000Z");
     expect(third?.fetchedAt).toBe("2026-02-01T02:00:00.000Z");
-    expect(versionLookupCount("old-bus")).toBe(1);
+    expect(versionLookupCount("old-bus")).toBe(3);
   });
 
   it("不缓存最终 null", async () => {
@@ -502,7 +541,7 @@ describe("getBusTimetableData 班车时刻表数据", () => {
     });
     await flushAsyncWork();
 
-    expect(raceLookups).toBe(1);
+    expect(raceLookups).toBe(2);
     raceVersion.resolve({ ...db.oldVersion, key: "race-bus" });
     await expect(Promise.all([first, second])).resolves.toEqual([
       expect.objectContaining({
@@ -559,7 +598,7 @@ describe("getBusTimetableData 班车时刻表数据", () => {
       versionKey: "valid-0",
     });
 
-    expect(versionLookupCount("valid-0")).toBe(1);
+    expect(versionLookupCount("valid-0")).toBe(2);
   });
 
   it("每次访问都会清理所有过期成功项", async () => {


### PR DESCRIPTION
## Summary
- include the selected bus version id and `importedAt` in the runtime cache key
- resolve lightweight version metadata before reading the cached topology and trips
- reload cached timetable data when an import updates an existing version key

## Production evidence
The admin import succeeded with 7 campuses, 10 routes, and 195 trips, but the public timetable continued serving the prior 2026 spring payload from its 24-hour runtime cache because the version key did not change.

## Verification
- three TypeScript project checks
- 392 Vitest files / 2469 tests
- production build
- regression test for re-importing the same version key with a new `importedAt`
- `git diff --check`