### PR TITLE
fix(weather): use Shushan adcode for gaoxin, reject empty AMap payloads

### DIFF
--- a/docs/contracts/weather.json
+++ b/docs/contracts/weather.json
@@ -8,7 +8,7 @@
   },
   "rules": {
     "public-no-signin": "Weather is public campus life information; sign-in should not be a prerequisite.",
-    "two-locations-only": "Only two locations are tracked: ustc-main (本部, Amap adcode 340100) covers the closely clustered east/west/south/north/central campuses, and ustc-gaoxin (高新校区, adcode 340171) covers the distant Gaoxin campus.",
+    "two-locations-only": "Only two locations are tracked: ustc-main (本部, Amap adcode 340100) covers the closely clustered east/west/south/north/central campuses, and ustc-gaoxin (高新校区, adcode 340104 Shushan — the Gaoxin campus's district; the economic-zone adcode 340171 has no AMap weather coverage) covers the distant Gaoxin campus.",
     "amap-primary": "Amap (高德) is the primary provider; Open-Meteo supplements hourly forecast, precipitation probability, and other fields Amap does not return. The merged snapshot lists which providers contributed.",
     "raw-extensions-preserved": "Provider payloads are merged into a canonical snapshot and the raw Amap/Open-Meteo responses stay available under extensions for REST and MCP consumers.",
     "cache-and-history": "Snapshots are cached in the WEATHER KV namespace for 15 minutes per location and persisted to WeatherObservation history; a scheduled cron refreshes both locations to stay within the Amap monthly quota.",

--- a/src/features/weather/server/amap-adapter.ts
+++ b/src/features/weather/server/amap-adapter.ts
@@ -121,8 +121,23 @@ export async function fetchAmapWeather(
       }>;
     } | null;
 
-    const live = typedBase?.lives?.[0];
-    const casts = typedAll?.forecasts?.[0]?.casts ?? [];
+    const rawLive = typedBase?.lives?.[0];
+    // AMap can answer 200/OK with empty payloads (e.g. `lives: [[]]`) for
+    // adcodes it does not cover — treat that as provider failure so the
+    // merge can fall back to Open-Meteo.
+    const live =
+      rawLive && !Array.isArray(rawLive) && rawLive.temperature !== undefined
+        ? rawLive
+        : undefined;
+    const casts = (typedAll?.forecasts?.[0]?.casts ?? []).filter(
+      (cast) => cast && cast.date !== undefined,
+    );
+    if (!live && casts.length === 0) {
+      return {
+        ok: false,
+        error: new Error("Amap returned no weather data for this adcode"),
+      };
+    }
 
     const data: AmapWeatherData = {
       current: live

--- a/src/features/weather/server/weather-types.ts
+++ b/src/features/weather/server/weather-types.ts
@@ -19,7 +19,9 @@ export const WEATHER_LOCATIONS: WeatherLocation[] = [
   {
     key: "ustc-gaoxin",
     name: "高新校区",
-    amapAdcode: "340171",
+    // 340171 (高新区, an economic-zone adcode) has no AMap weather coverage;
+    // the Gaoxin campus sits in Shushan district, so use 340104 instead.
+    amapAdcode: "340104",
     openMeteoLat: 31.839,
     openMeteoLon: 117.094,
   },

--- a/tests/unit/weather-service.test.ts
+++ b/tests/unit/weather-service.test.ts
@@ -98,6 +98,52 @@ describe("weather service", () => {
     expect(result?.current.temperature).toBe(28);
   });
 
+  it("falls back to open-meteo when amap answers OK with empty data", async () => {
+    vi.stubEnv("AMAP_API_KEY", "test-amap-key");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string | Request) => {
+        const urlString = typeof url === "string" ? url : url.toString();
+        const parsedUrl = new URL(urlString);
+        if (parsedUrl.hostname === "restapi.amap.com") {
+          // Uncovered adcodes return 200/OK with empty payloads.
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve(
+                parsedUrl.searchParams.get("extensions") === "all"
+                  ? { forecasts: [{ casts: [] }] }
+                  : { lives: [[]] },
+              ),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              current: { temperature_2m: 25, weather_code: 0 },
+              hourly: { time: [], temperature_2m: [], weather_code: [] },
+              daily: {
+                time: ["2026-08-28"],
+                temperature_2m_max: [30],
+                temperature_2m_min: [20],
+                weather_code: [1],
+              },
+            }),
+        });
+      }),
+    );
+
+    const { getWeatherSnapshot } = await import(
+      "@/features/weather/server/weather-service"
+    );
+    const result = await getWeatherSnapshot("ustc-main");
+    expect(result).not.toBeNull();
+    expect(result?.providers).toEqual(["open-meteo"]);
+    expect(result?.current.temperature).toBe(25);
+    expect(result?.daily).toHaveLength(1);
+  });
+
   it("returns null when both providers fail", async () => {
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
## Problem

Two production issues found while babysitting the weather deployment:

1. **高新校区 AMap data silently empty**: adcode `340171` is an economic development zone with no AMap weather coverage — the API answers `200/OK` with `lives: [[]]` and empty `casts`, so the snapshot had a zeroed current and empty daily. Verified against the live API.
2. **OK-but-empty responses counted as success**, preventing the Open-Meteo fallback from engaging.

## Fix

- `ustc-gaoxin` now queries AMap with adcode `340104` (蜀山区 — the district the Gaoxin campus is actually in); verified live: 28°C 阴 + full 4-day forecast
- Adapter treats empty lives+casts as provider failure (`ok: false`), so the merge falls back to Open-Meteo
- New unit test covers the OK-but-empty fallback path

## Verification

- Real AMap calls: 340104 → full data; 340171 → correctly rejected
- Unit: 4/4 weather tests pass, biome clean