### PR TITLE
fix(weather): grant life_ustc_runtime access to WeatherObservation

### DIFF
--- a/prisma/migrations/20260901093000_grant_weather_observation/migration.sql
+++ b/prisma/migrations/20260901093000_grant_weather_observation/migration.sql
@@ -1,0 +1,16 @@
+-- The cron weather-history writer runs through the unprivileged app role.
+-- writeWeatherHistory upserts hourly snapshots into WeatherObservation,
+-- which needs SELECT (conflict check), INSERT, and UPDATE (ON CONFLICT DO UPDATE).
+DO $grant_weather_observation$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_roles WHERE rolname = 'life_ustc_runtime'
+  ) THEN
+    RAISE NOTICE 'Skipping weather observation grants; role life_ustc_runtime does not exist.';
+    RETURN;
+  END IF;
+
+  GRANT SELECT, INSERT, UPDATE ON TABLE "WeatherObservation"
+  TO life_ustc_runtime;
+END
+$grant_weather_observation$;


### PR DESCRIPTION
## Problem

Production cron events fire on schedule and the KV cache refresh succeeds, but every `writeWeatherHistory` call fails:

```
PrismaClientKnownRequestError: Database error. Code: 42501
permission denied for table WeatherObservation
```

Root cause: `20260901000000_add_weather_observation` created the table and indexes but granted no privileges. The broad `GRANT SELECT ON ALL TABLES` in `20260730192000_apply_app_runtime_table_grants` only covered tables that existed at that time, so the cron writer (running as `life_ustc_runtime`) cannot touch `WeatherObservation`. As a result the production history table has zero rows.

## Fix

New migration `20260901093000_grant_weather_observation` granting `SELECT, INSERT, UPDATE` on `WeatherObservation` to `life_ustc_runtime` (upsert needs SELECT for the conflict check and UPDATE for `ON CONFLICT DO UPDATE`). Follows the guarded `pg_roles` pattern of `20260831130000_grant_bus_catalog_import`, so it is a no-op where the role does not exist (local CI Postgres).

Verified locally against the isolated `life_ustc_weather_it` database: `prisma migrate deploy` applies cleanly, full unit suite passes (397 files / 2481 tests).