### PR TITLE
fix: remove user limiter from crawler ingestion

### DIFF
--- a/src/lib/auth/publication-ingestion-auth.ts
+++ b/src/lib/auth/publication-ingestion-auth.ts
@@ -1,11 +1,6 @@
 import { getOptionalTrimmedEnv } from "@/app-env";
-import { rateLimitResponse, unauthorized } from "@/lib/api/helpers";
+import { unauthorized } from "@/lib/api/helpers";
 import {
-  checkUserMutationRateLimit,
-  USER_MUTATION_RATE_LIMIT_PERIOD_SECONDS,
-} from "@/lib/security/user-mutation-rate-limit";
-import {
-  PUBLICATION_INGESTION_PRINCIPAL_KEY,
   PUBLICATION_INGESTION_SERVICE_PRINCIPAL,
   type PublicationIngestionServicePrincipal,
 } from "./service-principal";
@@ -63,19 +58,6 @@ export async function requirePublicationIngestionPrincipal(
     return unauthorized();
   }
   if (!matches) return unauthorized();
-
-  const outcome = await checkUserMutationRateLimit({
-    action: "publication:ingest:write",
-    host: new URL(request.url).host,
-    tier: "batch",
-    userId: PUBLICATION_INGESTION_PRINCIPAL_KEY,
-  });
-  if (!outcome.allowed) {
-    return rateLimitResponse(
-      outcome.reason,
-      USER_MUTATION_RATE_LIMIT_PERIOD_SECONDS,
-    );
-  }
 
   return PUBLICATION_INGESTION_SERVICE_PRINCIPAL;
 }

--- a/tests/unit/publication-ingestion-auth.test.ts
+++ b/tests/unit/publication-ingestion-auth.test.ts
@@ -1,5 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { setCloudflareRuntimeEnv } from "@/lib/adapters/cloudflare-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   PUBLICATION_INGESTION_SECRET_HEADER,
   requirePublicationIngestionPrincipal,
@@ -16,9 +15,7 @@ const request = (secret?: string) =>
   });
 
 describe("publication ingestion service authentication", () => {
-  beforeEach(() => setCloudflareRuntimeEnv(undefined));
   afterEach(() => {
-    setCloudflareRuntimeEnv(undefined);
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
@@ -88,40 +85,5 @@ describe("publication ingestion service authentication", () => {
       serviceId: "publication-crawler",
       principalKey: PUBLICATION_INGESTION_PRINCIPAL_KEY,
     });
-  });
-
-  it("rate-limits the stable service key after authentication", async () => {
-    const limit = vi.fn().mockResolvedValue({ success: true });
-    setCloudflareRuntimeEnv({ USER_BATCH_WRITE_RATE_LIMITER: { limit } });
-    vi.stubEnv("PUBLICATION_INGESTION_SECRET", "expected-secret");
-
-    await expect(
-      requirePublicationIngestionPrincipal(request("expected-secret")),
-    ).resolves.toMatchObject({ kind: "service" });
-    expect(limit).toHaveBeenCalledWith({
-      key: JSON.stringify([
-        "user-mutation:v1",
-        "life.example",
-        "publication:ingest:write",
-        PUBLICATION_INGESTION_PRINCIPAL_KEY,
-      ]),
-    });
-  });
-
-  it("fails closed when the service rate limiter is unavailable", async () => {
-    vi.stubEnv("PUBLICATION_INGESTION_SECRET", "expected-secret");
-    setCloudflareRuntimeEnv({});
-
-    const error = vi.spyOn(console, "error").mockImplementation(() => {});
-    const response = await requirePublicationIngestionPrincipal(
-      request("expected-secret"),
-    );
-
-    expect(response).toBeInstanceOf(Response);
-    expect((response as Response).status).toBe(503);
-    expect(error).toHaveBeenCalledOnce();
-    expect(error.mock.calls.flat().map(String).join(" ")).not.toContain(
-      "expected-secret",
-    );
   });
 });


### PR DESCRIPTION
## Summary
- keep dedicated machine-secret authentication for publication ingestion
- remove the user mutation limiter from R2 object plan/completion requests
- prevent large crawler syncs from exhausting retries after a handful of object confirmations

The ingestion secret is high-entropy and rotatable; batch idempotency, signed R2 uploads, and object integrity verification remain enforced.

## Validation
- Biome check on changed files
- 16 focused unit/contract tests
- TypeScript test typecheck
- Svelte check
