### PR TITLE
fix(weather): avoid AMap QPS limit and fall back to Open-Meteo daily

### DIFF
--- a/src/features/weather/server/amap-adapter.ts
+++ b/src/features/weather/server/amap-adapter.ts
@@ -77,11 +77,21 @@ export async function fetchAmapWeather(
 
   try {
     // extensions=base returns lives (current weather) only, extensions=all
-    // returns forecasts only, so both calls are needed.
-    const [baseResult, allResult] = await Promise.allSettled([
-      fetchJson("base"),
-      fetchJson("all"),
-    ]);
+    // returns forecasts only, so both calls are needed. AMap's free-tier QPS
+    // limit rejects concurrent requests (infocode 10021), and both campus
+    // crons can fire in the same second, so fetch sequentially.
+    const settle = async (extensions: "base" | "all") => {
+      try {
+        return {
+          status: "fulfilled" as const,
+          value: await fetchJson(extensions),
+        };
+      } catch (reason) {
+        return { status: "rejected" as const, reason };
+      }
+    };
+    const baseResult = await settle("base");
+    const allResult = await settle("all");
     if (baseResult.status === "rejected" && allResult.status === "rejected") {
       return {
         ok: false,

--- a/src/features/weather/server/weather-merge.ts
+++ b/src/features/weather/server/weather-merge.ts
@@ -59,26 +59,28 @@ export function mergeWeatherSnapshots(
       precipitationAmount: hourlySource?.precipitation?.[i],
     }));
 
-  const daily: WeatherDaily[] = amap.ok
-    ? (amap.data.daily ?? []).map((d) => ({
-        date: d.date,
-        temperatureHigh: d.temperatureHigh,
-        temperatureLow: d.temperatureLow,
-        condition: normalizeAmapCondition(d.weather, d.weatherCode),
-      }))
-    : openMeteo.ok
-      ? (() => {
-          const dailySource = openMeteo.data.daily;
-          return (dailySource?.time ?? []).map((time, i) => ({
-            date: time,
-            temperatureHigh: dailySource?.temperature_2m_max[i] ?? 0,
-            temperatureLow: dailySource?.temperature_2m_min[i] ?? 0,
-            condition: normalizeOpenMeteoCondition(
-              dailySource?.weather_code[i] ?? -1,
-            ),
-          }));
-        })()
-      : [];
+  const amapDaily = amap.ok ? (amap.data.daily ?? []) : [];
+  const daily: WeatherDaily[] =
+    amapDaily.length > 0
+      ? amapDaily.map((d) => ({
+          date: d.date,
+          temperatureHigh: d.temperatureHigh,
+          temperatureLow: d.temperatureLow,
+          condition: normalizeAmapCondition(d.weather, d.weatherCode),
+        }))
+      : openMeteo.ok
+        ? (() => {
+            const dailySource = openMeteo.data.daily;
+            return (dailySource?.time ?? []).map((time, i) => ({
+              date: time,
+              temperatureHigh: dailySource?.temperature_2m_max[i] ?? 0,
+              temperatureLow: dailySource?.temperature_2m_min[i] ?? 0,
+              condition: normalizeOpenMeteoCondition(
+                dailySource?.weather_code[i] ?? -1,
+              ),
+            }));
+          })()
+        : [];
 
   return {
     location: {

--- a/tests/unit/weather-adapters.test.ts
+++ b/tests/unit/weather-adapters.test.ts
@@ -23,6 +23,46 @@ describe("weather adapters", () => {
     expect(normalizeOpenMeteoCondition(999).text).toBe("未知");
   });
 
+  it("fetches AMap base and all sequentially to stay under the QPS limit", async () => {
+    vi.stubEnv("AMAP_API_KEY", "test-key");
+    const order: string[] = [];
+    let resolveBase!: (response: Response) => void;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("extensions=base")) {
+          order.push("base:start");
+          return new Promise<Response>((resolve) => {
+            resolveBase = resolve;
+          });
+        }
+        order.push("all:start");
+        return Promise.resolve(
+          new Response(JSON.stringify({ status: "1", forecasts: [] })),
+        );
+      }),
+    );
+
+    const pending = fetchAmapWeather(getWeatherLocation("ustc-main"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(order).toEqual(["base:start"]);
+
+    resolveBase(
+      new Response(
+        JSON.stringify({
+          status: "1",
+          lives: [{ weather: "阴", temperature: "27" }],
+        }),
+      ),
+    );
+    const result = await pending;
+    expect(order).toEqual(["base:start", "all:start"]);
+    expect(result.ok).toBe(true);
+
+    vi.unstubAllGlobals();
+  });
+
   it("fetches Open-Meteo weather for ustc-gaoxin", async () => {
     const location = getWeatherLocation("ustc-gaoxin");
     const result = await fetchOpenMeteoWeather(location);

--- a/tests/unit/weather-merge.test.ts
+++ b/tests/unit/weather-merge.test.ts
@@ -44,6 +44,50 @@ describe("weather merge", () => {
     expect(snapshot.providers).toContain("open-meteo");
   });
 
+  it("falls back to Open-Meteo daily when Amap returns no casts", () => {
+    const location = getWeatherLocation("ustc-main");
+    const amap = {
+      ok: true as const,
+      data: {
+        current: {
+          temperature: 27,
+          weather: "阴",
+        },
+        daily: [],
+        hourly: [],
+        alerts: [],
+      },
+      raw: {},
+    };
+    const openMeteo = {
+      ok: true as const,
+      data: {
+        current: { temperature_2m: 26, weather_code: 3 },
+        hourly: {
+          time: [],
+          temperature_2m: [],
+          weather_code: [],
+        },
+        daily: {
+          time: ["2026-09-01"],
+          temperature_2m_max: [29],
+          temperature_2m_min: [23],
+          weather_code: [61],
+        },
+      },
+      raw: {},
+    };
+
+    const snapshot = mergeWeatherSnapshots(location, amap, openMeteo);
+    expect(snapshot.current.temperature).toBe(27);
+    expect(snapshot.daily).toHaveLength(1);
+    expect(snapshot.daily[0]).toMatchObject({
+      date: "2026-09-01",
+      temperatureHigh: 29,
+      temperatureLow: 23,
+    });
+  });
+
   it("falls back to Open-Meteo when Amap fails", () => {
     const location = getWeatherLocation("ustc-gaoxin");
     const amap = {


### PR DESCRIPTION
## Problem

Found while verifying production data freshness: `ustc-main` had `daily: []` while `ustc-gaoxin` had 4 daily entries. The stored raw AMap response shows the forecast call failed with:

```json
{"status": "0", "info": "CUQPS_HAS_EXCEEDED_THE_LIMIT", "infocode": "10021"}
```

Two compounding causes:

1. `fetchAmapWeather` fired `extensions=base` and `extensions=all` concurrently via `Promise.allSettled`, and both campus crons fire in the same second at :00/:30 — up to 4 simultaneous AMap requests against the free-tier QPS limit, so the forecast call intermittently loses.
2. When that happened, `live` still succeeded so the provider was treated as ok, and the merge preferred AMap's (empty) daily list over Open-Meteo's daily data.

## Fix

- `amap-adapter.ts`: fetch `base` then `all` sequentially (max 2 concurrent AMap calls across both locations, under the QPS limit).
- `weather-merge.ts`: when AMap is ok but returns no casts, fall back to Open-Meteo daily instead of emitting `daily: []`.

## Tests

- New merge test: AMap ok with empty casts + Open-Meteo daily → snapshot uses Open-Meteo daily.
- New adapter test with mocked fetch: the `all` request only starts after `base` resolves.
- Full unit suite: 2518 tests pass.