### PR TITLE
perf(publications): bulk object planning

### DIFF
--- a/src/features/publications/server/publication-object-service.ts
+++ b/src/features/publications/server/publication-object-service.ts
@@ -13,6 +13,7 @@ import {
 } from "./publication-ingestion-service";
 
 const PRESIGN_TTL_SECONDS = 15 * 60;
+const OBJECT_OPERATION_CONCURRENCY = 8;
 
 export class PublicationObjectBadRequestError extends Error {
   readonly code = "publication_object_bad_request";
@@ -164,11 +165,30 @@ async function verifyR2Object(input: {
   return { ok: true as const };
 }
 
-async function findOwnedBatchObject(
+async function mapWithConcurrency<T, R>(
+  values: readonly T[],
+  concurrency: number,
+  mapper: (value: T, index: number) => Promise<R>,
+) {
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= values.length) return;
+      results[index] = await mapper(values[index], index);
+    }
+  }
+
+  const workerCount = Math.min(concurrency, values.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
+async function findOwnedBatchClaims(
   principal: PublicationIngestionServicePrincipal,
   batchId: string,
-  kind: ObjectKind,
-  sha256: string,
 ) {
   const principalKey = publicationPrincipalKey(principal);
   const batch = await prisma.ingestionBatch.findUnique({
@@ -179,17 +199,44 @@ async function findOwnedBatchObject(
   });
   if (!batch)
     throw new PublicationObjectNotFoundError("Ingestion batch not found");
-  const claim = batch.objects.find(
-    ({ object }) => object.kind === kind && object.sha256 === sha256,
-  );
-  if (!claim)
+
+  const claims = new Map<string, (typeof batch.objects)[number]>();
+  for (const claim of batch.objects) {
+    claims.set(`${claim.object.kind}:${claim.object.sha256}`, claim);
+  }
+  return claims;
+}
+
+async function findOwnedBatchObject(
+  principal: PublicationIngestionServicePrincipal,
+  batchId: string,
+  kind: ObjectKind,
+  sha256: string,
+) {
+  const principalKey = publicationPrincipalKey(principal);
+  const claim = await prisma.ingestionBatchObject.findFirst({
+    where: {
+      batch: { is: { principalKey, batchId } },
+      object: { is: { kind, sha256 } },
+    },
+    include: { object: true },
+  });
+
+  if (!claim) {
+    const batch = await prisma.ingestionBatch.findUnique({
+      where: { principalKey_batchId: { principalKey, batchId } },
+      select: { id: true },
+    });
+    if (!batch)
+      throw new PublicationObjectNotFoundError("Ingestion batch not found");
     throw new PublicationObjectNotFoundError("Object is not in this batch");
+  }
   if (claim.object.r2Key !== publicationObjectKey(kind, sha256)) {
     throw new PublicationObjectBadRequestError(
       "Stored object key does not match its content address",
     );
   }
-  return { batch, claim };
+  return claim;
 }
 
 export async function planPublicationObjects(input: {
@@ -198,7 +245,6 @@ export async function planPublicationObjects(input: {
 }) {
   const { payload } = input;
   const seen = new Set<string>();
-  const objects = [];
   for (const requested of payload.objects) {
     const lookupKey = `${requested.kind}:${requested.sha256}`;
     if (seen.has(lookupKey)) {
@@ -207,66 +253,115 @@ export async function planPublicationObjects(input: {
       );
     }
     seen.add(lookupKey);
-    const { claim } = await findOwnedBatchObject(
-      input.principal,
-      payload.batchId,
-      requested.kind,
-      requested.sha256,
-    );
-    const object = claim.object;
-    const headers = requiredHeaders({
-      contentType: claim.expectedContentType,
-      kind: object.kind,
-      sha256: claim.expectedSha256,
-    });
-    const verified = await verifyR2Object({
-      contentType: claim.expectedContentType,
-      kind: object.kind,
-      r2Key: object.r2Key,
-      sha256: claim.expectedSha256,
-      size: claim.expectedSize,
-    });
-    if (verified.ok) {
-      await prisma.publicationObject.update({
-        where: { id: object.id },
-        data: {
-          ...(object.status === "linked" ? {} : { status: "verified" }),
-          verifiedAt: new Date(),
-          lastError: null,
-        },
-      });
-      objects.push({
-        kind: object.kind,
-        sha256: object.sha256,
-        r2Key: object.r2Key,
-        status: "already_present" as const,
-        uploadUrl: null,
-        expiresAt: null,
-        requiredHeaders: headers,
-      });
-      continue;
+  }
+
+  const claims = await findOwnedBatchClaims(input.principal, payload.batchId);
+  const requestedObjects = payload.objects.map((requested) => {
+    const lookupKey = `${requested.kind}:${requested.sha256}`;
+    const claim = claims.get(lookupKey);
+    if (!claim)
+      throw new PublicationObjectNotFoundError("Object is not in this batch");
+    if (
+      claim.object.r2Key !==
+      publicationObjectKey(requested.kind, requested.sha256)
+    ) {
+      throw new PublicationObjectBadRequestError(
+        "Stored object key does not match its content address",
+      );
     }
-    const signed = await presignedPut({
-      contentType: claim.expectedContentType,
-      kind: object.kind,
-      r2Key: object.r2Key,
-      sha256: object.sha256,
-    });
-    await prisma.publicationObject.update({
-      where: { id: object.id },
-      data: { status: "pending", lastError: null },
-    });
-    objects.push({
-      kind: object.kind,
-      sha256: object.sha256,
-      r2Key: object.r2Key,
-      status: "upload_required" as const,
-      uploadUrl: signed.url,
-      expiresAt: signed.expiresAt,
-      requiredHeaders: signed.headers,
+    return { requested, claim };
+  });
+
+  const planned = await mapWithConcurrency(
+    requestedObjects,
+    OBJECT_OPERATION_CONCURRENCY,
+    async ({ claim }) => {
+      const object = claim.object;
+      const headers = requiredHeaders({
+        contentType: claim.expectedContentType,
+        kind: object.kind,
+        sha256: claim.expectedSha256,
+      });
+      const verified = await verifyR2Object({
+        contentType: claim.expectedContentType,
+        kind: object.kind,
+        r2Key: object.r2Key,
+        sha256: claim.expectedSha256,
+        size: claim.expectedSize,
+      });
+      if (verified.ok) {
+        return {
+          objectId: object.id,
+          linked: object.status === "linked",
+          storageStatus: "verified" as const,
+          response: {
+            kind: object.kind,
+            sha256: object.sha256,
+            r2Key: object.r2Key,
+            status: "already_present" as const,
+            uploadUrl: null,
+            expiresAt: null,
+            requiredHeaders: headers,
+          },
+        };
+      }
+      const signed = await presignedPut({
+        contentType: claim.expectedContentType,
+        kind: object.kind,
+        r2Key: object.r2Key,
+        sha256: object.sha256,
+      });
+      return {
+        objectId: object.id,
+        linked: false,
+        storageStatus: "pending" as const,
+        response: {
+          kind: object.kind,
+          sha256: object.sha256,
+          r2Key: object.r2Key,
+          status: "upload_required" as const,
+          uploadUrl: signed.url,
+          expiresAt: signed.expiresAt,
+          requiredHeaders: signed.headers,
+        },
+      };
+    },
+  );
+
+  const verifiedLinkedIds = planned
+    .filter((item) => item.storageStatus === "verified" && item.linked)
+    .map((item) => item.objectId);
+  const verifiedIds = planned
+    .filter((item) => item.storageStatus === "verified" && !item.linked)
+    .map((item) => item.objectId);
+  const pendingIds = planned
+    .filter((item) => item.storageStatus === "pending")
+    .map((item) => item.objectId);
+  const verifiedAt = new Date();
+
+  if (verifiedLinkedIds.length > 0) {
+    await prisma.publicationObject.updateMany({
+      where: { id: { in: verifiedLinkedIds } },
+      data: { verifiedAt, lastError: null },
     });
   }
-  return { batchId: payload.batchId, objects };
+  if (verifiedIds.length > 0) {
+    await prisma.publicationObject.updateMany({
+      where: { id: { in: verifiedIds }, status: { not: "linked" } },
+      data: { status: "verified", verifiedAt, lastError: null },
+    });
+  }
+  if (pendingIds.length > 0) {
+    await prisma.publicationObject.updateMany({
+      where: { id: { in: pendingIds } },
+      data: { status: "pending", lastError: null },
+    });
+  }
+
+  return {
+    batchId: payload.batchId,
+    objects: planned.map((item) => item.response),
+  };
 }
 
 export async function completePublicationObject(input: {
@@ -274,19 +369,13 @@ export async function completePublicationObject(input: {
   principal: PublicationIngestionServicePrincipal;
 }) {
   const { payload } = input;
-  const { claim } = await findOwnedBatchObject(
+  const claim = await findOwnedBatchObject(
     input.principal,
     payload.batchId,
     payload.kind,
     payload.sha256,
   );
   const object = claim.object;
-  if (object.status !== "linked") {
-    await prisma.publicationObject.update({
-      where: { id: object.id },
-      data: { status: "uploaded", lastError: null },
-    });
-  }
   const verified = await verifyR2Object({
     contentType: claim.expectedContentType,
     kind: object.kind,
@@ -304,17 +393,11 @@ export async function completePublicationObject(input: {
   await prisma.publicationObject.update({
     where: { id: object.id },
     data: {
-      ...(object.status === "linked" ? {} : { status: "verified" }),
+      ...(object.status === "linked" ? {} : { status: "linked" }),
       verifiedAt: new Date(),
       lastError: null,
     },
   });
-  if (object.status !== "linked") {
-    await prisma.publicationObject.update({
-      where: { id: object.id },
-      data: { status: "linked", verifiedAt: new Date(), lastError: null },
-    });
-  }
   return {
     batchId: payload.batchId,
     kind: object.kind,

--- a/tests/unit/publication-object-service.test.ts
+++ b/tests/unit/publication-object-service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PublicationObjectPlanRequest } from "@/lib/api/schemas/request-publication-ingestion-schemas";
 import { PUBLICATION_INGESTION_SERVICE_PRINCIPAL } from "@/lib/auth/service-principal";
 
 const mocks = vi.hoisted(() => {
@@ -10,7 +11,9 @@ const mocks = vi.hoisted(() => {
     bucket,
     getBucket: vi.fn(() => bucket),
     batchFindUnique: vi.fn(),
+    batchObjectFindFirst: vi.fn(),
     objectUpdate: vi.fn(),
+    objectUpdateMany: vi.fn(),
   };
 });
 
@@ -20,11 +23,18 @@ vi.mock("@/lib/adapters/cloudflare-runtime", () => ({
 vi.mock("@/lib/db/prisma", () => ({
   prisma: {
     ingestionBatch: { findUnique: mocks.batchFindUnique },
-    publicationObject: { update: mocks.objectUpdate },
+    ingestionBatchObject: { findFirst: mocks.batchObjectFindFirst },
+    publicationObject: {
+      update: mocks.objectUpdate,
+      updateMany: mocks.objectUpdateMany,
+    },
   },
 }));
 
-import { completePublicationObject } from "@/features/publications/server/publication-object-service";
+import {
+  completePublicationObject,
+  planPublicationObjects,
+} from "@/features/publications/server/publication-object-service";
 
 const sha256OfAbc =
   "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
@@ -40,27 +50,33 @@ function body(value: string) {
 }
 
 function configureObject() {
-  mocks.batchFindUnique.mockResolvedValue({
-    objects: [
-      {
-        expectedContentType: "text/plain",
-        expectedSha256: sha256OfAbc,
-        expectedSize: 3,
-        object: {
-          id: "object-1",
-          kind: "body_html",
-          r2Key: `publications/body_html/sha256/ba/${sha256OfAbc}`,
-          sha256: sha256OfAbc,
-        },
-      },
-    ],
-  });
+  const claim = {
+    expectedContentType: "text/plain",
+    expectedSha256: sha256OfAbc,
+    expectedSize: 3,
+    object: {
+      id: "object-1",
+      kind: "body_html",
+      r2Key: `publications/body_html/sha256/ba/${sha256OfAbc}`,
+      sha256: sha256OfAbc,
+      status: "pending",
+    },
+  };
+  mocks.batchFindUnique.mockResolvedValue({ objects: [claim] });
+  mocks.batchObjectFindFirst.mockResolvedValue(claim);
   mocks.objectUpdate.mockResolvedValue({});
+  mocks.objectUpdateMany.mockResolvedValue({ count: 1 });
   mocks.bucket.head.mockResolvedValue({
     customMetadata: { kind: "body_html", sha256: sha256OfAbc },
     httpMetadata: { contentType: "text/plain" },
     size: 3,
   });
+}
+
+function checksumBytes(value: string) {
+  return Uint8Array.from(value.match(/../g) ?? [], (pair) =>
+    Number.parseInt(pair, 16),
+  ).buffer;
 }
 
 describe("publication object completion", () => {
@@ -86,6 +102,8 @@ describe("publication object completion", () => {
     expect(mocks.bucket.get).toHaveBeenCalledWith(
       `publications/body_html/sha256/ba/${sha256OfAbc}`,
     );
+    expect(mocks.batchObjectFindFirst).toHaveBeenCalledTimes(1);
+    expect(mocks.batchFindUnique).not.toHaveBeenCalled();
     expect(mocks.objectUpdate).toHaveBeenLastCalledWith({
       where: { id: "object-1" },
       data: {
@@ -109,9 +127,70 @@ describe("publication object completion", () => {
       }),
     ).resolves.toMatchObject({ status: "linked" });
 
-    expect(mocks.objectUpdate).toHaveBeenCalledTimes(3);
+    expect(mocks.objectUpdate).toHaveBeenCalledTimes(1);
+    expect(mocks.objectUpdate).toHaveBeenCalledWith({
+      where: { id: "object-1" },
+      data: {
+        status: "linked",
+        verifiedAt: expect.any(Date),
+        lastError: null,
+      },
+    });
+  });
+
+  it("plans a large request with one batch lookup and bounded R2 concurrency", async () => {
+    const objectCount = 500;
+    const claims = Array.from({ length: objectCount }, (_, index) => {
+      const sha256 = index.toString(16).padStart(64, "0");
+      return {
+        expectedContentType: "text/plain",
+        expectedSha256: sha256,
+        expectedSize: 3,
+        object: {
+          id: `object-${index}`,
+          kind: "body_html" as const,
+          r2Key: `publications/body_html/sha256/${sha256.slice(0, 2)}/${sha256}`,
+          sha256,
+          status: "pending" as const,
+        },
+      };
+    });
+    mocks.batchFindUnique.mockResolvedValue({ objects: claims });
+
+    let activeHeads = 0;
+    let maxActiveHeads = 0;
+    mocks.bucket.head.mockImplementation(async (r2Key: string) => {
+      activeHeads += 1;
+      maxActiveHeads = Math.max(maxActiveHeads, activeHeads);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      activeHeads -= 1;
+      const sha256 = r2Key.split("/").at(-1) ?? "";
+      return {
+        checksums: { sha256: checksumBytes(sha256) },
+        customMetadata: { kind: "body_html", sha256 },
+        httpMetadata: { contentType: "text/plain" },
+        size: 3,
+      };
+    });
+
+    const payload: PublicationObjectPlanRequest = {
+      batchId: "batch-large",
+      objects: claims.map(({ object }) => ({
+        kind: object.kind,
+        sha256: object.sha256,
+      })),
+    };
+    const result = await planPublicationObjects({ principal, payload });
+
+    expect(result.objects).toHaveLength(objectCount);
     expect(
-      mocks.objectUpdate.mock.calls.map(([call]) => call.data.status),
-    ).toEqual(["uploaded", "verified", "linked"]);
+      result.objects.every(({ status }) => status === "already_present"),
+    ).toBe(true);
+    expect(mocks.batchFindUnique).toHaveBeenCalledTimes(1);
+    expect(mocks.batchObjectFindFirst).not.toHaveBeenCalled();
+    expect(mocks.objectUpdate).not.toHaveBeenCalled();
+    expect(mocks.objectUpdateMany).toHaveBeenCalledTimes(1);
+    expect(maxActiveHeads).toBeGreaterThan(1);
+    expect(maxActiveHeads).toBeLessThanOrEqual(8);
   });
 });


### PR DESCRIPTION
## Summary
- load an owned batch's object claims once for each plan request
- verify and presign R2 objects with bounded concurrency, preserving response order
- group publication object status writes and collapse completion's redundant transitions
- use a targeted owned-claim lookup for object completion

## Validation
- `bunx vitest run tests/unit/publication-object-service.test.ts`
- `bunx vitest run tests/unit/publication-object-service.test.ts tests/unit/publication-ingestion-service.test.ts tests/unit/publication-public-read-service.test.ts`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx biome check src/features/publications/server/publication-object-service.ts tests/unit/publication-object-service.test.ts`
