### PR TITLE
fix: extend publication ingestion transaction budget

### DIFF
--- a/src/features/publications/server/publication-ingestion-service.ts
+++ b/src/features/publications/server/publication-ingestion-service.ts
@@ -12,6 +12,14 @@ import { prisma } from "@/lib/db/prisma";
 
 type TransactionClient = Prisma.TransactionClient;
 
+/**
+ * A full publication batch is allowed to contain 500 items. Keep enough time
+ * for the associated writes to finish while leaving headroom in the Worker
+ * and crawler's 30-second request budgets for authentication, parsing, and
+ * response serialization.
+ */
+export const PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS = 20_000;
+
 export class PublicationIngestionBadRequestError extends Error {
   readonly code = "publication_ingestion_bad_request";
 }
@@ -738,145 +746,150 @@ async function ingestWithRetry(
   payloadDigest: string,
   principalKey: string,
 ) {
-  const response = await prisma.$transaction(async (tx) => {
-    const existing = await tx.ingestionBatch.findUnique({
-      where: {
-        principalKey_batchId: { principalKey, batchId: payload.batchId },
-      },
-    });
-    if (existing) {
-      if (existing.payloadDigest !== payloadDigest) {
-        throw new PublicationIngestionConflictError(
-          "The batch ID was already used with a different payload",
-        );
-      }
-      return storedResult(existing.result);
-    }
-
-    validateSourceDescriptors(payload);
-    const run = await tx.ingestionRun.upsert({
-      where: {
-        principalKey_clientRunId: {
-          principalKey,
-          clientRunId: payload.clientRunId,
+  const response = await prisma.$transaction(
+    async (tx) => {
+      const existing = await tx.ingestionBatch.findUnique({
+        where: {
+          principalKey_batchId: { principalKey, batchId: payload.batchId },
         },
-      },
-      create: {
-        clientRunId: payload.clientRunId,
-        principalKey,
-        observedAt: parsePublicationDate(payload.observedAt),
-      },
-      update: {
-        observedAt: parsePublicationDate(payload.observedAt),
-        status: "running",
-      },
-    });
+      });
+      if (existing) {
+        if (existing.payloadDigest !== payloadDigest) {
+          throw new PublicationIngestionConflictError(
+            "The batch ID was already used with a different payload",
+          );
+        }
+        return storedResult(existing.result);
+      }
 
-    const registeredSources = new Map<string, RegisteredSource>();
-    for (const source of payload.sources) {
-      const registered = await tx.publicationSource.upsert({
-        where: { id: source.id },
+      validateSourceDescriptors(payload);
+      const run = await tx.ingestionRun.upsert({
+        where: {
+          principalKey_clientRunId: {
+            principalKey,
+            clientRunId: payload.clientRunId,
+          },
+        },
         create: {
-          id: source.id,
-          name: source.name,
-          organizationLevel: source.organizationLevel ?? "unknown",
-          allowedHosts: source.allowedHosts ?? [],
-          blockedHosts: source.blockedHosts ?? [],
-          seedUrls: source.seedUrls ?? [],
-          aliases: source.aliases ?? [],
-          discoveryOnly: source.discoveryOnly ?? false,
-          maxImagesPerPage: source.maxImagesPerPage ?? null,
+          clientRunId: payload.clientRunId,
+          principalKey,
+          observedAt: parsePublicationDate(payload.observedAt),
         },
         update: {
-          name: source.name,
-          ...(source.organizationLevel === undefined
-            ? {}
-            : { organizationLevel: source.organizationLevel }),
-          ...(source.allowedHosts === undefined
-            ? {}
-            : { allowedHosts: source.allowedHosts }),
-          ...(source.blockedHosts === undefined
-            ? {}
-            : { blockedHosts: source.blockedHosts }),
-          ...(source.seedUrls === undefined
-            ? {}
-            : { seedUrls: source.seedUrls }),
-          ...(source.aliases === undefined ? {} : { aliases: source.aliases }),
-          ...(source.discoveryOnly === undefined
-            ? {}
-            : { discoveryOnly: source.discoveryOnly }),
-          ...(source.maxImagesPerPage === undefined
-            ? {}
-            : { maxImagesPerPage: source.maxImagesPerPage }),
+          observedAt: parsePublicationDate(payload.observedAt),
+          status: "running",
         },
       });
-      registeredSources.set(source.id, {
-        id: registered.id,
-        name: registered.name,
-        organizationLevel: registered.organizationLevel,
-        allowedHosts: source.allowedHosts ?? registered.allowedHosts,
-        blockedHosts: source.blockedHosts ?? registered.blockedHosts,
-        seedUrls: source.seedUrls ?? registered.seedUrls,
-        aliases: source.aliases ?? registered.aliases,
-        discoveryOnly: source.discoveryOnly ?? registered.discoveryOnly,
-        maxImagesPerPage:
-          source.maxImagesPerPage === undefined
-            ? registered.maxImagesPerPage
-            : source.maxImagesPerPage,
-        enabled: registered.enabled,
-        allowAnyHost:
-          (source.allowedHosts ?? registered.allowedHosts).length === 0,
-      });
-    }
 
-    const batch = await tx.ingestionBatch.create({
-      data: {
-        batchId: payload.batchId,
-        runId: run.id,
-        principalKey,
-        payloadDigest,
-        itemCount: payload.items.length,
-      },
-    });
-
-    const results: PublicationIngestionItemResult[] = [];
-    for (const item of payload.items) {
-      const source = registeredSources.get(item.sourceId);
-      if (!source?.enabled || source.discoveryOnly) {
-        results.push(
-          result(
-            item,
-            "rejected",
-            null,
-            null,
-            source && !source.enabled
-              ? "source is disabled"
-              : source
-                ? "discovery-only source cannot ingest publications"
-                : "source is not registered in this batch",
-          ),
-        );
-        continue;
+      const registeredSources = new Map<string, RegisteredSource>();
+      for (const source of payload.sources) {
+        const registered = await tx.publicationSource.upsert({
+          where: { id: source.id },
+          create: {
+            id: source.id,
+            name: source.name,
+            organizationLevel: source.organizationLevel ?? "unknown",
+            allowedHosts: source.allowedHosts ?? [],
+            blockedHosts: source.blockedHosts ?? [],
+            seedUrls: source.seedUrls ?? [],
+            aliases: source.aliases ?? [],
+            discoveryOnly: source.discoveryOnly ?? false,
+            maxImagesPerPage: source.maxImagesPerPage ?? null,
+          },
+          update: {
+            name: source.name,
+            ...(source.organizationLevel === undefined
+              ? {}
+              : { organizationLevel: source.organizationLevel }),
+            ...(source.allowedHosts === undefined
+              ? {}
+              : { allowedHosts: source.allowedHosts }),
+            ...(source.blockedHosts === undefined
+              ? {}
+              : { blockedHosts: source.blockedHosts }),
+            ...(source.seedUrls === undefined
+              ? {}
+              : { seedUrls: source.seedUrls }),
+            ...(source.aliases === undefined
+              ? {}
+              : { aliases: source.aliases }),
+            ...(source.discoveryOnly === undefined
+              ? {}
+              : { discoveryOnly: source.discoveryOnly }),
+            ...(source.maxImagesPerPage === undefined
+              ? {}
+              : { maxImagesPerPage: source.maxImagesPerPage }),
+          },
+        });
+        registeredSources.set(source.id, {
+          id: registered.id,
+          name: registered.name,
+          organizationLevel: registered.organizationLevel,
+          allowedHosts: source.allowedHosts ?? registered.allowedHosts,
+          blockedHosts: source.blockedHosts ?? registered.blockedHosts,
+          seedUrls: source.seedUrls ?? registered.seedUrls,
+          aliases: source.aliases ?? registered.aliases,
+          discoveryOnly: source.discoveryOnly ?? registered.discoveryOnly,
+          maxImagesPerPage:
+            source.maxImagesPerPage === undefined
+              ? registered.maxImagesPerPage
+              : source.maxImagesPerPage,
+          enabled: registered.enabled,
+          allowAnyHost:
+            (source.allowedHosts ?? registered.allowedHosts).length === 0,
+        });
       }
-      results.push(await ingestItem(tx, batch.id, item, source));
-    }
 
-    const response: PublicationIngestionBatchResult = {
-      batchId: payload.batchId,
-      clientRunId: payload.clientRunId,
-      payloadDigest,
-      results,
-    };
-    await tx.ingestionBatch.update({
-      where: { id: batch.id },
-      data: { result: response as unknown as Prisma.InputJsonObject },
-    });
-    await tx.ingestionRun.update({
-      where: { id: run.id },
-      data: { status: "completed" },
-    });
-    return response;
-  });
+      const batch = await tx.ingestionBatch.create({
+        data: {
+          batchId: payload.batchId,
+          runId: run.id,
+          principalKey,
+          payloadDigest,
+          itemCount: payload.items.length,
+        },
+      });
+
+      const results: PublicationIngestionItemResult[] = [];
+      for (const item of payload.items) {
+        const source = registeredSources.get(item.sourceId);
+        if (!source?.enabled || source.discoveryOnly) {
+          results.push(
+            result(
+              item,
+              "rejected",
+              null,
+              null,
+              source && !source.enabled
+                ? "source is disabled"
+                : source
+                  ? "discovery-only source cannot ingest publications"
+                  : "source is not registered in this batch",
+            ),
+          );
+          continue;
+        }
+        results.push(await ingestItem(tx, batch.id, item, source));
+      }
+
+      const response: PublicationIngestionBatchResult = {
+        batchId: payload.batchId,
+        clientRunId: payload.clientRunId,
+        payloadDigest,
+        results,
+      };
+      await tx.ingestionBatch.update({
+        where: { id: batch.id },
+        data: { result: response as unknown as Prisma.InputJsonObject },
+      });
+      await tx.ingestionRun.update({
+        where: { id: run.id },
+        data: { status: "completed" },
+      });
+      return response;
+    },
+    { timeout: PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS },
+  );
 
   return response;
 }

--- a/tests/unit/publication-ingestion-service.test.ts
+++ b/tests/unit/publication-ingestion-service.test.ts
@@ -347,6 +347,7 @@ vi.mock("@/lib/db/prisma", () => ({ prisma: fake.prisma }));
 
 import {
   ingestPublicationBatch,
+  PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS,
   PublicationIngestionBadRequestError,
 } from "@/features/publications/server/publication-ingestion-service";
 
@@ -576,5 +577,32 @@ describe("publication ingestion transaction", () => {
     expect(fake.state.publications.size).toBe(1);
     expect(fake.state.revisions.size).toBe(1);
     expect(fake.state.events.size).toBe(1);
+  });
+
+  it("configures a transaction budget for the maximum valid batch size", async () => {
+    const payload = publicationIngestionBatchRequestSchema.parse({
+      ...parsedFixture,
+      batchId: "batch-maximum-size",
+      clientRunId: "run-maximum-size",
+      items: Array.from({ length: 500 }, (_, index) => ({
+        ...parsedFixture.items[0],
+        canonicalUrl: `https://news.ustc.edu.cn/example/${index}.html`,
+        revisionHash: index.toString(16).padStart(64, "0"),
+        objects: [],
+      })),
+    });
+
+    const response = await ingestPublicationBatch({ payload, principal });
+
+    expect(response.results).toHaveLength(500);
+    expect(response.results.every(({ status }) => status === "created")).toBe(
+      true,
+    );
+    expect(PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS).toBeGreaterThan(5_000);
+    expect(PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS).toBeLessThan(30_000);
+    expect(fake.prisma.$transaction).toHaveBeenCalledWith(
+      expect.any(Function),
+      { timeout: PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS },
+    );
   });
 });


### PR DESCRIPTION
## Summary
- configure an explicit 20-second Prisma interactive transaction timeout for publication ingestion
- keep the budget below the 30-second Worker/crawler request limits while supporting the protocol's 500-item batch limit
- add a 500-item regression test that verifies the timeout option is passed and remains outside Prisma's 5-second default

The ingestion work remains atomic and preserves idempotency, per-item rejection, source validation, object linking, and outbox writes.

## Validation
- `bunx vitest run tests/unit/publication-ingestion-service.test.ts tests/unit/publication-ingestion-contract.test.ts tests/unit/publication-ingestion-auth.test.ts`
- `bunx biome check src/features/publications/server/publication-ingestion-service.ts tests/unit/publication-ingestion-service.test.ts`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
