### PR TITLE
fix: raise publication ingestion transaction budget

### DIFF
--- a/src/features/publications/server/publication-ingestion-service.ts
+++ b/src/features/publications/server/publication-ingestion-service.ts
@@ -13,12 +13,12 @@ import { prisma } from "@/lib/db/prisma";
 type TransactionClient = Prisma.TransactionClient;
 
 /**
- * A full publication batch is allowed to contain 500 items. Keep enough time
- * for the associated writes to finish while leaving headroom in the Worker
- * and crawler's 30-second request budgets for authentication, parsing, and
- * response serialization.
+ * A full publication batch is allowed to contain 500 items. The associated
+ * writes can take about 20 seconds in production, so allow enough time for
+ * database contention while staying below the crawler's 60-second request
+ * timeout.
  */
-export const PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS = 20_000;
+export const PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS = 45_000;
 
 export class PublicationIngestionBadRequestError extends Error {
   readonly code = "publication_ingestion_bad_request";

--- a/tests/unit/publication-ingestion-service.test.ts
+++ b/tests/unit/publication-ingestion-service.test.ts
@@ -598,8 +598,8 @@ describe("publication ingestion transaction", () => {
     expect(response.results.every(({ status }) => status === "created")).toBe(
       true,
     );
-    expect(PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS).toBeGreaterThan(5_000);
-    expect(PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS).toBeLessThan(30_000);
+    expect(PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS).toBe(45_000);
+    expect(PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS).toBeLessThan(60_000);
     expect(fake.prisma.$transaction).toHaveBeenCalledWith(
       expect.any(Function),
       { timeout: PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS },


### PR DESCRIPTION
## Summary
- raise the explicit Prisma publication-ingestion transaction timeout to 45 seconds
- keep the budget below the crawler's separately raised 60-second HTTP timeout
- assert the exact 45-second budget in the maximum 500-item regression test

The production all-eligible 500-item batch with 924 objects exceeded the previous 20-second budget and rolled back with P2028. This change only extends the interactive transaction budget; atomicity, idempotency, per-item rejection, source validation, object links, and outbox writes remain unchanged.

## Validation
- `bunx biome check src/features/publications/server/publication-ingestion-service.ts tests/unit/publication-ingestion-service.test.ts`
- `bunx vitest run tests/unit/publication-ingestion-service.test.ts tests/unit/publication-ingestion-contract.test.ts tests/unit/publication-ingestion-auth.test.ts`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
