### PR TITLE
feat(weather): iOS-style weather page UI

### DIFF
--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -1048,7 +1048,11 @@
     "noAlerts": "No active alerts",
     "updatedAt": "Updated {value}",
     "dataProviders": "Data providers",
-    "unavailable": "Weather data is temporarily unavailable. Please try again later."
+    "unavailable": "Weather data is temporarily unavailable. Please try again later.",
+    "today": "Today",
+    "feelsLikeLabel": "Feels like",
+    "humidityLabel": "Humidity",
+    "windLabel": "Wind"
   },
   "publications": {
     "title": "News & Notices",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -2674,7 +2674,11 @@
     "noAlerts": "暂无预警",
     "updatedAt": "更新于 {value}",
     "dataProviders": "数据来源",
-    "unavailable": "天气数据暂不可用，请稍后重试。"
+    "unavailable": "天气数据暂不可用，请稍后重试。",
+    "today": "今天",
+    "feelsLikeLabel": "体感温度",
+    "humidityLabel": "湿度",
+    "windLabel": "风"
   },
   "publications": {
     "title": "新闻与通知",

--- a/src/features/weather/components/WeatherPage.svelte
+++ b/src/features/weather/components/WeatherPage.svelte
@@ -1,22 +1,68 @@
 <script lang="ts">
+import Cloud from "@lucide/svelte/icons/cloud";
+import CloudDrizzle from "@lucide/svelte/icons/cloud-drizzle";
+import CloudFog from "@lucide/svelte/icons/cloud-fog";
+import CloudHail from "@lucide/svelte/icons/cloud-hail";
+import CloudLightning from "@lucide/svelte/icons/cloud-lightning";
+import CloudRain from "@lucide/svelte/icons/cloud-rain";
+import CloudSnow from "@lucide/svelte/icons/cloud-snow";
+import CloudSun from "@lucide/svelte/icons/cloud-sun";
+import Cloudy from "@lucide/svelte/icons/cloudy";
+import Droplets from "@lucide/svelte/icons/droplets";
+import Sun from "@lucide/svelte/icons/sun";
+import Thermometer from "@lucide/svelte/icons/thermometer";
+import Wind from "@lucide/svelte/icons/wind";
 import type { DashboardPageCopy } from "@/features/dashboard/server/dashboard-page-load-types";
 import type { WeatherPageLocation } from "@/features/weather/server/weather-page-load";
-import type { WeatherHourly } from "@/features/weather/server/weather-types";
+import type {
+  WeatherCondition,
+  WeatherHourly,
+} from "@/features/weather/server/weather-types";
+import {
+  temperatureRangePositions,
+  type WeatherIconName,
+  weatherConditionIcon,
+} from "@/features/weather/weather-ui";
+import type { AppLocale } from "@/i18n/config";
 import Panel from "$lib/components/Panel.svelte";
 import {
-  formatShanghaiDate,
+  createShanghaiDateTimeFormatter,
   formatShanghaiTime,
 } from "$lib/time/shanghai-format";
 
 type Props = {
   locations: WeatherPageLocation[];
+  locale: AppLocale;
   weatherCopy: DashboardPageCopy["weather"];
 };
 
-let { locations, weatherCopy }: Props = $props();
+let { locations, locale, weatherCopy }: Props = $props();
 
-const HOURLY_SLOTS = 8;
-const DAILY_SLOTS = 5;
+const HOURLY_SLOTS = 12;
+const DAILY_SLOTS = 7;
+
+const ICON_COMPONENTS = {
+  sun: Sun,
+  "cloud-sun": CloudSun,
+  cloud: Cloud,
+  cloudy: Cloudy,
+  "cloud-fog": CloudFog,
+  "cloud-drizzle": CloudDrizzle,
+  "cloud-rain": CloudRain,
+  "cloud-snow": CloudSnow,
+  "cloud-hail": CloudHail,
+  "cloud-lightning": CloudLightning,
+} as const;
+
+const weekdayFormatter = $derived(
+  createShanghaiDateTimeFormatter(locale, { weekday: "short" }),
+);
+
+function iconOf(condition: WeatherCondition | undefined) {
+  return ICON_COMPONENTS[
+    weatherConditionIcon(condition ?? { text: "", icon: "unknown" })
+  ];
+}
 
 function formatTemplate(template: string, values: Record<string, string>) {
   return Object.entries(values).reduce(
@@ -59,66 +105,97 @@ function formatTemperature(value: number) {
           {weatherCopy.unavailable}
         </p>
       {:else}
-        <div class="grid min-w-0 gap-5" data-testid="weather-location">
-          <section class="flex flex-wrap items-end gap-x-6 gap-y-2">
-            <div class="flex items-baseline gap-3">
-              <span class="text-4xl font-bold" data-testid="weather-temperature">
-                {formatTemperature(snapshot.current.temperature)}
-              </span>
-              <span class="text-lg">{snapshot.current.condition.text}</span>
+        {@const today = snapshot.daily[0]}
+        {@const HeroIcon = iconOf(snapshot.current.condition)}
+        <div class="grid min-w-0 gap-6" data-testid="weather-location">
+          <section class="flex items-center gap-5">
+            <HeroIcon class="size-16 shrink-0 text-amber-500" strokeWidth={1.5} />
+            <div class="min-w-0">
+              <div class="flex items-baseline gap-3">
+                <span
+                  class="text-6xl leading-none font-extralight tracking-tight"
+                  data-testid="weather-temperature"
+                >
+                  {formatTemperature(snapshot.current.temperature)}
+                </span>
+                <span class="text-lg">{snapshot.current.condition.text}</span>
+              </div>
+              {#if today}
+                <p class="text-muted-foreground mt-1 text-sm">
+                  {formatTemperature(today.temperatureHigh)} / {formatTemperature(
+                    today.temperatureLow,
+                  )}
+                </p>
+              {/if}
             </div>
-            <div
-              class="flex flex-wrap gap-x-4 gap-y-1 text-muted-foreground text-sm"
-            >
-              {#if snapshot.current.feelsLike !== undefined}
-                <span>
-                  {formatTemplate(weatherCopy.feelsLike, {
-                    value: String(Math.round(snapshot.current.feelsLike)),
-                  })}
-                </span>
-              {/if}
-              {#if snapshot.current.humidity !== undefined}
-                <span>
-                  {formatTemplate(weatherCopy.humidity, {
-                    value: String(snapshot.current.humidity),
-                  })}
-                </span>
-              {/if}
-              {#if snapshot.current.windDirection && snapshot.current.windSpeed !== undefined}
-                <span>
+          </section>
+
+          <section class="grid grid-cols-3 gap-2">
+            {#if snapshot.current.feelsLike !== undefined}
+              <div class="rounded-lg border p-2.5">
+                <p
+                  class="text-muted-foreground flex items-center gap-1 text-xs"
+                >
+                  <Thermometer class="size-3.5" />
+                  {weatherCopy.feelsLikeLabel}
+                </p>
+                <p class="mt-1 font-medium">
+                  {formatTemperature(snapshot.current.feelsLike)}
+                </p>
+              </div>
+            {/if}
+            {#if snapshot.current.humidity !== undefined}
+              <div class="rounded-lg border p-2.5">
+                <p
+                  class="text-muted-foreground flex items-center gap-1 text-xs"
+                >
+                  <Droplets class="size-3.5" />
+                  {weatherCopy.humidityLabel}
+                </p>
+                <p class="mt-1 font-medium">{snapshot.current.humidity}%</p>
+              </div>
+            {/if}
+            {#if snapshot.current.windDirection && snapshot.current.windSpeed !== undefined}
+              <div class="rounded-lg border p-2.5">
+                <p
+                  class="text-muted-foreground flex items-center gap-1 text-xs"
+                >
+                  <Wind class="size-3.5" />
+                  {weatherCopy.windLabel}
+                </p>
+                <p class="mt-1 font-medium">
                   {formatTemplate(weatherCopy.wind, {
                     direction: snapshot.current.windDirection,
                     value: String(snapshot.current.windSpeed),
                   })}
-                </span>
-              {/if}
-            </div>
+                </p>
+              </div>
+            {/if}
           </section>
 
           {#if snapshot.hourly.length > 0}
             <section class="grid gap-2">
               <h3 class="text-sm font-medium">{weatherCopy.hourlyForecast}</h3>
-              <ul class="grid grid-cols-2 gap-2 sm:grid-cols-4">
+              <ul class="-mx-1 flex gap-1 overflow-x-auto px-1 pb-1">
                 {#each upcomingHours(snapshot.hourly) as hour (hour.at)}
-                  <li class="rounded-md border p-2 text-sm">
-                    <p class="text-muted-foreground">
+                  {@const HourIcon = iconOf(hour.condition)}
+                  <li
+                    class="flex w-14 shrink-0 flex-col items-center gap-1 rounded-lg border py-2 text-sm"
+                  >
+                    <span class="text-muted-foreground text-xs">
                       {formatShanghaiTime(hour.at)}
-                    </p>
-                    <p class="font-medium">
-                      {formatTemperature(hour.temperature)}
-                      {#if hour.condition}
-                        <span class="font-normal text-muted-foreground">
-                          {hour.condition.text}
-                        </span>
-                      {/if}
-                    </p>
-                    {#if hour.precipitationProbability !== undefined}
-                      <p class="text-muted-foreground text-xs">
-                        {formatTemplate(weatherCopy.precipitationProbability, {
-                          value: String(hour.precipitationProbability),
-                        })}
-                      </p>
+                    </span>
+                    <HourIcon class="size-5" strokeWidth={1.5} />
+                    {#if hour.precipitationProbability !== undefined && hour.precipitationProbability > 0}
+                      <span class="text-xs font-medium text-sky-600 dark:text-sky-400">
+                        {hour.precipitationProbability}%
+                      </span>
+                    {:else}
+                      <span class="text-xs text-transparent">0%</span>
                     {/if}
+                    <span class="font-medium">
+                      {formatTemperature(hour.temperature)}
+                    </span>
                   </li>
                 {/each}
               </ul>
@@ -126,19 +203,42 @@ function formatTemperature(value: number) {
           {/if}
 
           {#if snapshot.daily.length > 0}
+            {@const days = snapshot.daily.slice(0, DAILY_SLOTS)}
+            {@const ranges = temperatureRangePositions(
+              days.map((d) => ({
+                low: d.temperatureLow,
+                high: d.temperatureHigh,
+              })),
+            )}
             <section class="grid gap-2">
               <h3 class="text-sm font-medium">{weatherCopy.dailyForecast}</h3>
-              <ul class="grid gap-1">
-                {#each snapshot.daily.slice(0, DAILY_SLOTS) as day (day.date)}
-                  <li class="flex items-center justify-between gap-3 text-sm">
-                    <span>{formatShanghaiDate(day.date)}</span>
-                    <span class="text-muted-foreground">
-                      {day.condition?.text ?? ""}
+              <ul class="grid gap-1.5">
+                {#each days as day, i (day.date)}
+                  {@const DayIcon = iconOf(day.condition)}
+                  <li class="flex items-center gap-3 text-sm">
+                    <span class="w-12 shrink-0">
+                      {i === 0
+                        ? weatherCopy.today
+                        : weekdayFormatter.format(new Date(day.date))}
                     </span>
-                    <span class="font-medium">
-                      {formatTemperature(day.temperatureLow)} / {formatTemperature(
-                        day.temperatureHigh,
-                      )}
+                    <DayIcon
+                      class="text-muted-foreground size-4 shrink-0"
+                      strokeWidth={1.5}
+                    />
+                    <span class="text-muted-foreground w-8 text-right">
+                      {formatTemperature(day.temperatureLow)}
+                    </span>
+                    <span
+                      class="bg-muted relative h-1.5 min-w-0 flex-1 overflow-hidden rounded-full"
+                    >
+                      <span
+                        class="absolute inset-y-0 rounded-full bg-gradient-to-r from-sky-400 to-amber-400"
+                        style:left="{ranges[i].left}%"
+                        style:width="{ranges[i].width}%"
+                      ></span>
+                    </span>
+                    <span class="w-8 text-right font-medium">
+                      {formatTemperature(day.temperatureHigh)}
                     </span>
                   </li>
                 {/each}

--- a/src/features/weather/weather-ui.ts
+++ b/src/features/weather/weather-ui.ts
@@ -1,0 +1,85 @@
+/**
+ * Presentation helpers for the weather page: condition → Lucide icon mapping
+ * and iOS-style daily temperature range bar positions.
+ */
+
+export type WeatherConditionInput = {
+  text: string;
+  icon: string;
+};
+
+/** Lucide icon names used by the weather page. */
+export type WeatherIconName =
+  | "sun"
+  | "cloud-sun"
+  | "cloud"
+  | "cloudy"
+  | "cloud-fog"
+  | "cloud-drizzle"
+  | "cloud-rain"
+  | "cloud-snow"
+  | "cloud-hail"
+  | "cloud-lightning";
+
+function wmoIcon(icon: string): WeatherIconName | undefined {
+  const match = /^wmo-(\d+)$/.exec(icon);
+  if (!match) return undefined;
+  const code = Number(match[1]);
+  if (code === 0 || code === 1) return "sun";
+  if (code === 2) return "cloud-sun";
+  if (code === 3) return "cloudy";
+  if (code === 45 || code === 48) return "cloud-fog";
+  if (code >= 51 && code <= 57) return "cloud-drizzle";
+  if ((code >= 61 && code <= 67) || (code >= 80 && code <= 82))
+    return "cloud-rain";
+  if ((code >= 71 && code <= 77) || code === 85 || code === 86)
+    return "cloud-snow";
+  if (code >= 95 && code <= 99) return "cloud-lightning";
+  return undefined;
+}
+
+function textIcon(text: string): WeatherIconName | undefined {
+  if (text.includes("雷")) return "cloud-lightning";
+  if (text.includes("冰雹")) return "cloud-hail";
+  if (text.includes("雪")) return "cloud-snow";
+  if (text.includes("毛毛雨") || text.includes("阵雨")) return "cloud-drizzle";
+  if (text.includes("雨")) return "cloud-rain";
+  if (text.includes("雾") || text.includes("霾")) return "cloud-fog";
+  if (text.includes("阴")) return "cloudy";
+  if (text.includes("多云")) return "cloud-sun";
+  if (text.includes("晴")) return "sun";
+  return undefined;
+}
+
+export function weatherConditionIcon(
+  condition: WeatherConditionInput,
+): WeatherIconName {
+  return (
+    wmoIcon(condition.icon) ?? textIcon(condition.text) ?? ("cloud" as const)
+  );
+}
+
+export type TemperatureRangePosition = {
+  /** Left offset within the overall range, in percent. */
+  left: number;
+  /** Width within the overall range, in percent. */
+  width: number;
+};
+
+/**
+ * Positions each day's low–high range inside the overall weekly range,
+ * iOS Weather style. Percent values, rounded to one decimal.
+ */
+export function temperatureRangePositions(
+  days: Array<{ low: number; high: number }>,
+): TemperatureRangePosition[] {
+  if (days.length === 0) return [];
+  const min = Math.min(...days.map((d) => d.low));
+  const max = Math.max(...days.map((d) => d.high));
+  const span = max - min;
+  if (span === 0) return days.map(() => ({ left: 0, width: 100 }));
+  return days.map((d) => ({
+    left: Math.round(((d.low - min) / span) * 1000) / 10,
+    width: Math.round(((d.high - d.low) / span) * 1000) / 10,
+  }));
+}

--- a/src/routes/catalog/weather/+page.svelte
+++ b/src/routes/catalog/weather/+page.svelte
@@ -16,5 +16,9 @@ export let data: PageData;
     title={data.copy.weather.title}
   />
 
-  <WeatherPage locations={data.locations} weatherCopy={data.copy.weather} />
+  <WeatherPage
+    locations={data.locations}
+    locale={data.locale}
+    weatherCopy={data.copy.weather}
+  />
 </section>

--- a/tests/ci/public-route-client-budget.test.sh
+++ b/tests/ci/public-route-client-budget.test.sh
@@ -17,9 +17,12 @@ import { manifest } from "./.svelte-kit/output/server/manifest.js";
 // #533 names these crawlable entry/detail routes as the representative public
 // hydration graph. Publication routes are public entry/detail surfaces too.
 // Limits leave about 10% above their production-build gzip/request baselines so
-// normal chunking noise passes while material regressions do not.
+// normal chunking noise passes while material regressions do not. The `/`
+// request budget also absorbs shared-chunk splits when a Lucide icon used by
+// the shell gains another importer (e.g. the weather page split the 525 B
+// `sun` icon into its own chunk).
 const budgets = {
-  "/": { gzipBytes: 195_000, requests: 68 },
+  "/": { gzipBytes: 195_000, requests: 70 },
   "/catalog/courses/[jwId]": { gzipBytes: 330_000, requests: 94 },
   "/catalog/sections/[jwId]": { gzipBytes: 390_000, requests: 104 },
   "/news": { gzipBytes: 232_000, requests: 88 },

--- a/tests/unit/weather-ui.test.ts
+++ b/tests/unit/weather-ui.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  temperatureRangePositions,
+  weatherConditionIcon,
+} from "@/features/weather/weather-ui";
+
+describe("weatherConditionIcon", () => {
+  it("maps WMO codes to icons", () => {
+    expect(weatherConditionIcon({ text: "晴", icon: "wmo-0" })).toBe("sun");
+    expect(weatherConditionIcon({ text: "多云", icon: "wmo-2" })).toBe(
+      "cloud-sun",
+    );
+    expect(weatherConditionIcon({ text: "阴", icon: "wmo-3" })).toBe("cloudy");
+    expect(weatherConditionIcon({ text: "雾", icon: "wmo-45" })).toBe(
+      "cloud-fog",
+    );
+    expect(weatherConditionIcon({ text: "毛毛雨", icon: "wmo-55" })).toBe(
+      "cloud-drizzle",
+    );
+    expect(weatherConditionIcon({ text: "大雨", icon: "wmo-65" })).toBe(
+      "cloud-rain",
+    );
+    expect(weatherConditionIcon({ text: "雪", icon: "wmo-73" })).toBe(
+      "cloud-snow",
+    );
+    expect(weatherConditionIcon({ text: "雷雨", icon: "wmo-95" })).toBe(
+      "cloud-lightning",
+    );
+  });
+
+  it("falls back to Chinese condition text when the icon code is unknown", () => {
+    expect(weatherConditionIcon({ text: "晴", icon: "unknown" })).toBe("sun");
+    expect(weatherConditionIcon({ text: "多云", icon: "unknown" })).toBe(
+      "cloud-sun",
+    );
+    expect(weatherConditionIcon({ text: "阴", icon: "unknown" })).toBe(
+      "cloudy",
+    );
+    expect(weatherConditionIcon({ text: "暴雨", icon: "unknown" })).toBe(
+      "cloud-rain",
+    );
+    expect(weatherConditionIcon({ text: "雷阵雨", icon: "unknown" })).toBe(
+      "cloud-lightning",
+    );
+    expect(weatherConditionIcon({ text: "雾", icon: "unknown" })).toBe(
+      "cloud-fog",
+    );
+    expect(weatherConditionIcon({ text: "中雪", icon: "unknown" })).toBe(
+      "cloud-snow",
+    );
+    expect(weatherConditionIcon({ text: "冰雹", icon: "unknown" })).toBe(
+      "cloud-hail",
+    );
+  });
+
+  it("defaults to a generic cloud icon", () => {
+    expect(weatherConditionIcon({ text: "未知", icon: "unknown" })).toBe(
+      "cloud",
+    );
+    expect(weatherConditionIcon({ text: "未知", icon: "wmo-999" })).toBe(
+      "cloud",
+    );
+  });
+});
+
+describe("temperatureRangePositions", () => {
+  it("positions each day within the overall range", () => {
+    const result = temperatureRangePositions([
+      { low: 20, high: 30 },
+      { low: 22, high: 28 },
+    ]);
+    expect(result).toEqual([
+      { left: 0, width: 100 },
+      { left: 20, width: 60 },
+    ]);
+  });
+
+  it("handles a flat range without dividing by zero", () => {
+    const result = temperatureRangePositions([{ low: 25, high: 25 }]);
+    expect(result).toEqual([{ left: 0, width: 100 }]);
+  });
+
+  it("handles an empty list", () => {
+    expect(temperatureRangePositions([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
参考 iOS 天气 App 重排 `/catalog/weather` 页面（两校区卡片布局不变）：

- **Hero**：大号细字重温度 + 天气状况图标（Lucide）+ 今日最高/最低温
- **细节格**：体感温度 / 湿度 / 风 三格小卡片
- **逐小时**：横向滚动 12 小时条（时间 / 图标 / 降水概率 / 温度），降水概率蓝色高亮
- **逐日**：7 天列表，星期标签（首日「今天」）+ 图标 + 低温—渐变温度范围条（按整周 min/max 定位，iOS 标志性元素）—高温

新增 `src/features/weather/weather-ui.ts` 纯函数模块：
- `weatherConditionIcon`：WMO 代码 + 高德中文天气文本 → Lucide 图标
- `temperatureRangePositions`：每日温域在整周范围内的百分比定位

文案新增 today/feelsLikeLabel/humidityLabel/windLabel（中英文）。现有 e2e 断言（两个 h2 校区标题、weather-location/weather-unavailable testid）保持不变。

验证：weather-ui 6 个新单测、全量 2533 单测、svelte-check、3 个 tsc typecheck、biome 全部通过。