### PR TITLE
fix(publications): reject NUL ingestion strings

### DIFF
--- a/src/lib/api/schemas/request-publication-ingestion-schemas.ts
+++ b/src/lib/api/schemas/request-publication-ingestion-schemas.ts
@@ -160,24 +160,32 @@ export const publicationIngestionBatchRequestSchema = z
     addNulCharacterIssues(payload, [], context);
   });
 
-export const publicationObjectPlanRequestSchema = z.strictObject({
-  batchId: z.string().trim().min(1).max(200),
-  objects: z
-    .array(
-      z.strictObject({
-        kind: publicationObjectManifestSchema.shape.kind,
-        sha256: sha256Schema,
-      }),
-    )
-    .min(1)
-    .max(500),
-});
+export const publicationObjectPlanRequestSchema = z
+  .strictObject({
+    batchId: z.string().trim().min(1).max(200),
+    objects: z
+      .array(
+        z.strictObject({
+          kind: publicationObjectManifestSchema.shape.kind,
+          sha256: sha256Schema,
+        }),
+      )
+      .min(1)
+      .max(500),
+  })
+  .superRefine((payload, context) => {
+    addNulCharacterIssues(payload, [], context);
+  });
 
-export const publicationObjectCompleteRequestSchema = z.strictObject({
-  batchId: z.string().trim().min(1).max(200),
-  kind: publicationObjectManifestSchema.shape.kind,
-  sha256: sha256Schema,
-});
+export const publicationObjectCompleteRequestSchema = z
+  .strictObject({
+    batchId: z.string().trim().min(1).max(200),
+    kind: publicationObjectManifestSchema.shape.kind,
+    sha256: sha256Schema,
+  })
+  .superRefine((payload, context) => {
+    addNulCharacterIssues(payload, [], context);
+  });
 
 export type PublicationIngestionBatchRequest = z.output<
   typeof publicationIngestionBatchRequestSchema

--- a/src/lib/api/schemas/request-publication-ingestion-schemas.ts
+++ b/src/lib/api/schemas/request-publication-ingestion-schemas.ts
@@ -50,6 +50,50 @@ export const publicationObjectManifestSchema = z.strictObject({
   altText: z.string().trim().max(1_000).optional(),
 });
 
+const NUL_CHARACTER = "\u0000";
+const NUL_CHARACTER_MESSAGE = "NUL characters are not allowed";
+
+function addNulCharacterIssues(
+  value: unknown,
+  path: Array<string | number>,
+  context: z.RefinementCtx,
+) {
+  if (typeof value === "string") {
+    if (value.includes(NUL_CHARACTER)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: NUL_CHARACTER_MESSAGE,
+        path,
+      });
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((nested, index) => {
+      addNulCharacterIssues(nested, [...path, index], context);
+    });
+    return;
+  }
+
+  if (!value || typeof value !== "object") return;
+
+  for (const [key, nested] of Object.entries(value)) {
+    const nestedPath = [
+      ...path,
+      key.includes(NUL_CHARACTER) ? "[invalid-string]" : key,
+    ];
+    if (key.includes(NUL_CHARACTER)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: NUL_CHARACTER_MESSAGE,
+        path: nestedPath,
+      });
+    }
+    addNulCharacterIssues(nested, nestedPath, context);
+  }
+}
+
 export const publicationSourceDescriptorSchema = z.strictObject({
   id: sourceIdSchema,
   name: z.string().trim().min(1).max(200),
@@ -99,18 +143,22 @@ const publicationItemSchema = z.union([
   }),
 ]);
 
-export const publicationIngestionBatchRequestSchema = z.strictObject({
-  protocolVersion: z.literal("1"),
-  producerVersion: z.string().trim().min(1).max(200),
-  clientRunId: z.string().trim().min(1).max(200),
-  batchId: z.string().trim().min(1).max(200),
-  observedAt: publicationDateTimeSchema,
-  sources: z.array(publicationSourceDescriptorSchema).min(1).max(500),
-  items: z
-    .array(publicationItemSchema)
-    .min(1)
-    .max(PUBLICATION_INGESTION_BATCH_MAX_ITEMS),
-});
+export const publicationIngestionBatchRequestSchema = z
+  .strictObject({
+    protocolVersion: z.literal("1"),
+    producerVersion: z.string().trim().min(1).max(200),
+    clientRunId: z.string().trim().min(1).max(200),
+    batchId: z.string().trim().min(1).max(200),
+    observedAt: publicationDateTimeSchema,
+    sources: z.array(publicationSourceDescriptorSchema).min(1).max(500),
+    items: z
+      .array(publicationItemSchema)
+      .min(1)
+      .max(PUBLICATION_INGESTION_BATCH_MAX_ITEMS),
+  })
+  .superRefine((payload, context) => {
+    addNulCharacterIssues(payload, [], context);
+  });
 
 export const publicationObjectPlanRequestSchema = z.strictObject({
   batchId: z.string().trim().min(1).max(200),

--- a/tests/unit/publication-ingestion-contract.test.ts
+++ b/tests/unit/publication-ingestion-contract.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { parsePublicationDateInput } from "@/features/publications/lib/publication-date";
 import { PUBLICATION_INGESTION_BATCH_MAX_ITEMS } from "@/features/publications/lib/publication-ingestion-limits";
 import { publicationIngestionPayloadDigest } from "@/features/publications/server/publication-ingestion-service";
-import { publicationIngestionBatchRequestSchema } from "@/lib/api/schemas/request-publication-ingestion-schemas";
+import {
+  publicationIngestionBatchRequestSchema,
+  publicationObjectCompleteRequestSchema,
+  publicationObjectPlanRequestSchema,
+} from "@/lib/api/schemas/request-publication-ingestion-schemas";
 import { publicationIngestionBatchResponseSchema } from "@/lib/api/schemas/response-publication-ingestion-schemas";
 import { PUBLICATION_INGESTION_SECRET_HEADER } from "@/lib/auth/publication-ingestion-auth";
 import { PUBLICATION_INGESTION_PRINCIPAL_KEY } from "@/lib/auth/service-principal";
@@ -236,6 +240,38 @@ describe("publication ingestion contract", () => {
     if (item && !item.tombstone) {
       expect(item.title).toBe("校园通知");
       expect(item.bodyText).toBe("第一段\n第二段  ");
+    }
+  });
+
+  it.each([
+    {
+      label: "object plan",
+      schema: publicationObjectPlanRequestSchema,
+      payload: {
+        batchId: "fixture\u0000batch",
+        objects: [{ kind: "body_html", sha256: "a".repeat(64) }],
+      },
+    },
+    {
+      label: "object completion",
+      schema: publicationObjectCompleteRequestSchema,
+      payload: {
+        batchId: "fixture\u0000batch",
+        kind: "body_html",
+        sha256: "a".repeat(64),
+      },
+    },
+  ])("rejects NUL characters in $label requests", ({ schema, payload }) => {
+    const parsed = schema.safeParse(payload);
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toContainEqual(
+        expect.objectContaining({
+          message: "NUL characters are not allowed",
+          path: ["batchId"],
+        }),
+      );
     }
   });
 

--- a/tests/unit/publication-ingestion-contract.test.ts
+++ b/tests/unit/publication-ingestion-contract.test.ts
@@ -117,6 +117,128 @@ describe("publication ingestion contract", () => {
     ).toBe(false);
   });
 
+  it.each([
+    {
+      label: "batch metadata",
+      path: ["producerVersion"],
+      payload: { producerVersion: "crawler\u0000/1" },
+    },
+    {
+      label: "source descriptor",
+      path: ["sources", 0, "name"],
+      payload: {
+        sources: [{ ...fixture.sources[0], name: "USTC\u0000 News" }],
+      },
+    },
+    {
+      label: "publication title",
+      path: ["items", 0, "title"],
+      payload: {
+        items: [{ ...fixture.items[0], title: "Fixture\u0000 publication" }],
+      },
+    },
+    {
+      label: "publication author",
+      path: ["items", 0, "author"],
+      payload: {
+        items: [{ ...fixture.items[0], author: "Author\u0000" }],
+      },
+    },
+    {
+      label: "publication body",
+      path: ["items", 0, "bodyText"],
+      payload: {
+        items: [{ ...fixture.items[0], bodyText: "Fixture body\u0000" }],
+      },
+    },
+    {
+      label: "object metadata",
+      path: ["items", 0, "objects", 0, "altText"],
+      payload: {
+        items: [
+          {
+            ...fixture.items[0],
+            objects: [
+              {
+                kind: "media",
+                sha256: "b".repeat(64),
+                size: 4,
+                contentType: "image/png",
+                altText: "Campus\u0000 image",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      label: "nested raw metadata",
+      path: ["items", 0, "rawMetadata", "authors", 1, "name"],
+      payload: {
+        items: [
+          {
+            ...fixture.items[0],
+            rawMetadata: {
+              authors: [{ name: "张三" }, { name: "李四\u0000" }],
+            },
+          },
+        ],
+      },
+    },
+    {
+      label: "raw metadata key",
+      path: ["items", 0, "rawMetadata", "[invalid-string]"],
+      payload: {
+        items: [
+          {
+            ...fixture.items[0],
+            rawMetadata: { "author\u0000": "李四" },
+          },
+        ],
+      },
+    },
+  ])("rejects NUL characters in $label", ({ path, payload }) => {
+    const parsed = publicationIngestionBatchRequestSchema.safeParse({
+      ...fixture,
+      ...payload,
+    });
+
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues).toContainEqual(
+        expect.objectContaining({
+          message: "NUL characters are not allowed",
+          path,
+        }),
+      );
+    }
+  });
+
+  it("accepts ordinary Unicode and trims whitespace without rejecting it", () => {
+    const parsed = publicationIngestionBatchRequestSchema.parse({
+      ...fixture,
+      producerVersion: "  爬虫 / 1  ",
+      sources: [{ ...fixture.sources[0], name: "  中国科大新闻  " }],
+      items: [
+        {
+          ...fixture.items[0],
+          title: "  校园通知  ",
+          bodyText: "第一段\n第二段  ",
+          rawMetadata: { authors: ["张三", { note: "含有中文" }] },
+        },
+      ],
+    });
+
+    expect(parsed.producerVersion).toBe("爬虫 / 1");
+    expect(parsed.sources[0]?.name).toBe("中国科大新闻");
+    const item = parsed.items[0];
+    expect(item?.tombstone).toBe(false);
+    if (item && !item.tombstone) {
+      expect(item.title).toBe("校园通知");
+      expect(item.bodyText).toBe("第一段\n第二段  ");
+    }
+  });
+
   it("caps one object manifest at the first-slice 32 MiB limit", () => {
     const manifest = {
       kind: "body_html",

--- a/tests/unit/publication-ingestion-routes.test.ts
+++ b/tests/unit/publication-ingestion-routes.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { PUBLICATION_INGESTION_PRINCIPAL_KEY } from "@/lib/auth/service-principal";
+import fixture from "../../docs/contracts/fixtures/publication-batch.json";
+
+const { requirePrincipalMock, prismaMock } = vi.hoisted(() => ({
+  requirePrincipalMock: vi.fn(),
+  prismaMock: {
+    $transaction: vi.fn(),
+    ingestionBatch: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/auth/publication-ingestion-auth", () => ({
+  requirePublicationIngestionPrincipal: requirePrincipalMock,
+}));
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: prismaMock }));
+
+function postRequest(body: unknown) {
+  return new Request(
+    "https://life.example/api/ingestion/publications/batches",
+    {
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+      method: "POST",
+    },
+  );
+}
+
+describe("publication ingestion routes", () => {
+  let postPublicationIngestionBatchRoute: typeof import("@/lib/api/routes/publication-ingestion-routes").postPublicationIngestionBatchRoute;
+
+  beforeAll(async () => {
+    ({ postPublicationIngestionBatchRoute } = await import(
+      "@/lib/api/routes/publication-ingestion-routes"
+    ));
+  });
+
+  afterEach(() => {
+    requirePrincipalMock.mockReset();
+    prismaMock.$transaction.mockReset();
+    prismaMock.ingestionBatch.findUnique.mockReset();
+  });
+
+  it("rejects nested NUL characters before opening a database transaction", async () => {
+    requirePrincipalMock.mockResolvedValue({
+      kind: "service",
+      serviceId: "publication-crawler",
+      principalKey: PUBLICATION_INGESTION_PRINCIPAL_KEY,
+    });
+
+    const response = await postPublicationIngestionBatchRoute(
+      postRequest({
+        ...fixture,
+        items: [
+          {
+            ...fixture.items[0],
+            rawMetadata: {
+              authors: [{ name: "张三" }, { name: "李四\u0000" }],
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid publication ingestion batch",
+    });
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    expect(prismaMock.ingestionBatch.findUnique).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- reject literal U+0000 in every string in publication ingestion payloads, including nested raw metadata and object keys
- return the existing 400 validation response before any database transaction
- add schema coverage for batch/source/publication/object/nested metadata fields and Unicode/whitespace acceptance

## Verification
- `bunx vitest run` (405 files, 2548 tests)
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx biome check`
- `bun run openapi:check`
- `bunx wrangler types --include-runtime=false --check`