### PR TITLE
feat(weather): hourly temperature curve and precipitation chart

### DIFF
--- a/src/features/weather/components/WeatherHourlyChart.svelte
+++ b/src/features/weather/components/WeatherHourlyChart.svelte
@@ -1,0 +1,129 @@
+<script lang="ts" module>
+function formatTemperature(value: number) {
+  return `${Math.round(value)}°`;
+}
+</script>
+
+<script lang="ts">
+import type { WeatherHourly } from "@/features/weather/server/weather-types";
+import { buildHourlyChartGeometry } from "@/features/weather/weather-ui";
+import { formatShanghaiTime } from "$lib/time/shanghai-format";
+
+type Props = {
+  hours: WeatherHourly[];
+  chartAriaLabel: string;
+};
+
+let { hours, chartAriaLabel }: Props = $props();
+
+const WIDTH = 640;
+
+const geometry = $derived(buildHourlyChartGeometry(hours, { width: WIDTH }));
+
+let hoverIndex = $state<number | null>(null);
+
+function handleMove(event: MouseEvent) {
+  const svg = event.currentTarget as SVGSVGElement;
+  const rect = svg.getBoundingClientRect();
+  if (rect.width === 0 || geometry.points.length === 0) return;
+  const x = ((event.clientX - rect.left) / rect.width) * WIDTH;
+  let best = 0;
+  let bestDistance = Infinity;
+  geometry.points.forEach((point, i) => {
+    const distance = Math.abs(point.x - x);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = i;
+    }
+  });
+  hoverIndex = best;
+}
+
+const hoverHour = $derived(hoverIndex === null ? null : hours[hoverIndex]);
+const hoverPoint = $derived(
+  hoverIndex === null ? null : geometry.points[hoverIndex],
+);
+</script>
+
+<div class="relative" data-testid="weather-hourly-chart">
+  <svg
+    viewBox="0 0 {WIDTH} {geometry.height}"
+    class="h-auto w-full touch-none select-none"
+    role="img"
+    aria-label={chartAriaLabel}
+    onmousemove={handleMove}
+    onmouseleave={() => (hoverIndex = null)}
+  >
+    <line
+      x1="0"
+      x2={WIDTH}
+      y1={geometry.tempBaselineY}
+      y2={geometry.tempBaselineY}
+      class="stroke-border"
+      stroke-dasharray="3 4"
+    />
+    {#if geometry.areaPath}
+      <path d={geometry.areaPath} class="fill-amber-500/10" />
+      <path
+        d={geometry.tempPath}
+        fill="none"
+        class="stroke-amber-500"
+        stroke-width="2"
+        stroke-linecap="round"
+      />
+    {/if}
+    {#each geometry.bars as bar, i (hours[i].at)}
+      <rect
+        x={bar.x}
+        y={bar.y}
+        width={bar.width}
+        height={bar.height}
+        rx="2"
+        class={bar.probability > 0 ? "fill-sky-500/70" : "fill-transparent"}
+      />
+    {/each}
+    {#each geometry.xLabels as label (label.label + label.x)}
+      <text
+        x={label.x}
+        y={geometry.height - 6}
+        text-anchor="middle"
+        class="fill-muted-foreground text-[11px]"
+      >
+        {label.label}
+      </text>
+    {/each}
+    {#if hoverPoint && hoverIndex !== null}
+      <line
+        x1={hoverPoint.x}
+        x2={hoverPoint.x}
+        y1="4"
+        y2={geometry.height - 22}
+        class="stroke-foreground/30"
+      />
+      <circle cx={hoverPoint.x} cy={hoverPoint.y} r="4" class="fill-amber-500" />
+    {/if}
+  </svg>
+
+  {#if hoverHour && hoverPoint}
+    <div
+      class="bg-popover text-popover-foreground pointer-events-none absolute top-0 z-10 -translate-x-1/2 rounded-md border px-2 py-1 text-xs shadow-md"
+      style:left="{(hoverPoint.x / WIDTH) * 100}%"
+    >
+      <p class="font-medium whitespace-nowrap">
+        {formatShanghaiTime(hoverHour.at)}
+        {formatTemperature(hoverHour.temperature)}
+        {#if hoverHour.condition}
+          <span class="text-muted-foreground">{hoverHour.condition.text}</span>
+        {/if}
+      </p>
+      {#if hoverHour.precipitationProbability !== undefined}
+        <p class="text-sky-600 whitespace-nowrap dark:text-sky-400">
+          {hoverHour.precipitationProbability}%
+          {#if hoverHour.precipitationAmount !== undefined && hoverHour.precipitationAmount > 0}
+            · {hoverHour.precipitationAmount}mm
+          {/if}
+        </p>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/src/features/weather/components/WeatherPage.svelte
+++ b/src/features/weather/components/WeatherPage.svelte
@@ -13,6 +13,7 @@ import Sun from "@lucide/svelte/icons/sun";
 import Thermometer from "@lucide/svelte/icons/thermometer";
 import Wind from "@lucide/svelte/icons/wind";
 import type { DashboardPageCopy } from "@/features/dashboard/server/dashboard-page-load-types";
+import WeatherHourlyChart from "@/features/weather/components/WeatherHourlyChart.svelte";
 import type { WeatherPageLocation } from "@/features/weather/server/weather-page-load";
 import type {
   WeatherCondition,
@@ -75,6 +76,14 @@ function upcomingHours(hourly: WeatherHourly[]): WeatherHourly[] {
   const now = Date.now();
   const upcoming = hourly.filter((hour) => Date.parse(hour.at) >= now);
   return (upcoming.length > 0 ? upcoming : hourly).slice(0, HOURLY_SLOTS);
+}
+
+const CHART_HOURLY_SLOTS = 24;
+
+function upcomingHoursAll(hourly: WeatherHourly[]): WeatherHourly[] {
+  const now = Date.now();
+  const upcoming = hourly.filter((hour) => Date.parse(hour.at) >= now);
+  return (upcoming.length > 0 ? upcoming : hourly).slice(0, CHART_HOURLY_SLOTS);
 }
 
 function formatTemperature(value: number) {
@@ -176,7 +185,16 @@ function formatTemperature(value: number) {
           {#if snapshot.hourly.length > 0}
             <section class="grid gap-2">
               <h3 class="text-sm font-medium">{weatherCopy.hourlyForecast}</h3>
-              <ul class="-mx-1 flex gap-1 overflow-x-auto px-1 pb-1">
+              <WeatherHourlyChart
+                hours={upcomingHoursAll(snapshot.hourly)}
+                chartAriaLabel={weatherCopy.hourlyForecast}
+              />
+              <!-- svelte-ignore a11y_no_noninteractive_tabindex (focus enables keyboard scrolling for the overflowing hourly strip) -->
+              <ul
+                class="-mx-1 flex gap-1 overflow-x-auto px-1 pb-1"
+                tabindex={0}
+                aria-label={weatherCopy.hourlyForecast}
+              >
                 {#each upcomingHours(snapshot.hourly) as hour (hour.at)}
                   {@const HourIcon = iconOf(hour.condition)}
                   <li

--- a/src/features/weather/weather-ui.ts
+++ b/src/features/weather/weather-ui.ts
@@ -83,3 +83,161 @@ export function temperatureRangePositions(
     width: Math.round(((d.high - d.low) / span) * 1000) / 10,
   }));
 }
+
+export type HourlyChartDatum = {
+  at: string;
+  temperature: number;
+  precipitationProbability?: number;
+};
+
+export type HourlyChartPoint = {
+  x: number;
+  y: number;
+  temperature: number;
+};
+
+export type HourlyChartBar = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  probability: number;
+};
+
+export type HourlyChartLabel = {
+  x: number;
+  label: string;
+};
+
+export type HourlyChartGeometry = {
+  width: number;
+  height: number;
+  /** Y of the baseline separating the temperature band from the precip band. */
+  tempBaselineY: number;
+  points: HourlyChartPoint[];
+  tempPath: string;
+  areaPath: string;
+  bars: HourlyChartBar[];
+  xLabels: HourlyChartLabel[];
+};
+
+const CHART_PAD_X = 24;
+const CHART_PAD_TOP = 16;
+const CHART_TEMP_BAND = 96;
+const CHART_BAND_GAP = 12;
+const CHART_PRECIP_BAND = 44;
+const CHART_LABEL_H = 20;
+const CHART_PAD_BOTTOM = 4;
+const CHART_HEIGHT =
+  CHART_PAD_TOP +
+  CHART_TEMP_BAND +
+  CHART_BAND_GAP +
+  CHART_PRECIP_BAND +
+  CHART_LABEL_H +
+  CHART_PAD_BOTTOM;
+
+function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/** Catmull-Rom spline converted to cubic Bézier segments. */
+function smoothPath(points: HourlyChartPoint[]): string {
+  if (points.length === 0) return "";
+  const [first, ...rest] = points;
+  let path = `M${round1(first.x)},${round1(first.y)}`;
+  if (points.length === 1) return path;
+  for (let i = 0; i < rest.length; i++) {
+    const p0 = points[i - 1] ?? first;
+    const p1 = points[i];
+    const p2 = rest[i];
+    const p3 = points[i + 2] ?? p2;
+    const c1x = p1.x + (p2.x - p0.x) / 6;
+    const c1y = p1.y + (p2.y - p0.y) / 6;
+    const c2x = p2.x - (p3.x - p1.x) / 6;
+    const c2y = p2.y - (p3.y - p1.y) / 6;
+    path +=
+      `C${round1(c1x)},${round1(c1y)} ` +
+      `${round1(c2x)},${round1(c2y)} ` +
+      `${round1(p2.x)},${round1(p2.y)}`;
+  }
+  return path;
+}
+
+/**
+ * Geometry for the hourly temperature curve + precipitation bar chart.
+ * Pure SVG-space math so the component stays declarative.
+ */
+export function buildHourlyChartGeometry(
+  data: HourlyChartDatum[],
+  { width }: { width: number },
+): HourlyChartGeometry {
+  const tempBaselineY = CHART_PAD_TOP + CHART_TEMP_BAND;
+  const precipBaseY = tempBaselineY + CHART_BAND_GAP + CHART_PRECIP_BAND;
+  const empty: HourlyChartGeometry = {
+    width,
+    height: CHART_HEIGHT,
+    tempBaselineY,
+    points: [],
+    tempPath: "",
+    areaPath: "",
+    bars: [],
+    xLabels: [],
+  };
+  if (data.length === 0) return empty;
+
+  const temps = data.map((d) => d.temperature);
+  const lo = Math.min(...temps) - 1;
+  const hi = Math.max(...temps) + 1;
+  const span = hi - lo || 1;
+  const innerWidth = width - CHART_PAD_X * 2;
+  const stepX = data.length > 1 ? innerWidth / (data.length - 1) : 0;
+  const xAt = (i: number) =>
+    data.length > 1 ? CHART_PAD_X + i * stepX : width / 2;
+
+  const points = data.map((d, i) => ({
+    x: round1(xAt(i)),
+    y: round1(
+      CHART_PAD_TOP + (1 - (d.temperature - lo) / span) * CHART_TEMP_BAND,
+    ),
+    temperature: d.temperature,
+  }));
+
+  const tempPath = smoothPath(points);
+  const areaPath = tempPath
+    ? `${tempPath}L${round1(points[points.length - 1].x)},${tempBaselineY}` +
+      `L${round1(points[0].x)},${tempBaselineY}Z`
+    : "";
+
+  const barWidth = Math.min(24, (innerWidth / data.length) * 0.5);
+  const bars = data.map((d, i) => {
+    const probability = Math.max(
+      0,
+      Math.min(100, d.precipitationProbability ?? 0),
+    );
+    const height = round1((probability / 100) * CHART_PRECIP_BAND);
+    return {
+      x: round1(xAt(i) - barWidth / 2),
+      y: round1(precipBaseY - height),
+      width: round1(barWidth),
+      height,
+      probability,
+    };
+  });
+
+  const labelStep = Math.max(1, Math.ceil(data.length / 8));
+  const xLabels = data
+    .map((d, i) => ({ x: round1(xAt(i)), label: d.at.slice(11, 16), i }))
+    .filter(({ i }) => i % labelStep === 0)
+    .map(({ x, label }) => ({ x, label }));
+
+  return {
+    width,
+    height: CHART_HEIGHT,
+    tempBaselineY,
+    points,
+    tempPath,
+    areaPath,
+    bars,
+    xLabels,
+  };
+}

--- a/tests/unit/weather-adapters.test.ts
+++ b/tests/unit/weather-adapters.test.ts
@@ -63,7 +63,9 @@ describe("weather adapters", () => {
     vi.unstubAllGlobals();
   });
 
-  it("fetches Open-Meteo weather for ustc-gaoxin", async () => {
+  it("fetches Open-Meteo weather for ustc-gaoxin", {
+    timeout: 20000,
+  }, async () => {
     const location = getWeatherLocation("ustc-gaoxin");
     const result = await fetchOpenMeteoWeather(location);
     // Allow network failures in CI/test environments; verify shape on success.

--- a/tests/unit/weather-hourly-chart.test.ts
+++ b/tests/unit/weather-hourly-chart.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { buildHourlyChartGeometry } from "@/features/weather/weather-ui";
+
+const hours = [
+  {
+    at: "2026-09-02T00:00:00+08:00",
+    temperature: 24,
+    precipitationProbability: 80,
+  },
+  {
+    at: "2026-09-02T01:00:00+08:00",
+    temperature: 23,
+    precipitationProbability: 60,
+  },
+  {
+    at: "2026-09-02T02:00:00+08:00",
+    temperature: 26,
+    precipitationProbability: 0,
+  },
+  { at: "2026-09-02T03:00:00+08:00", temperature: 28 },
+];
+
+describe("buildHourlyChartGeometry", () => {
+  it("maps temperatures into the chart area with padding", () => {
+    const g = buildHourlyChartGeometry(hours, { width: 600 });
+    expect(g.points).toHaveLength(4);
+    // coldest hour (23) sits lowest on screen = largest y within the temp band
+    const yByTemp = g.points.map((p) => [p.temperature, p.y] as const);
+    const y23 = yByTemp.find(([t]) => t === 23)?.[1] ?? -1;
+    const y28 = yByTemp.find(([t]) => t === 28)?.[1] ?? -1;
+    expect(y23).toBeGreaterThanOrEqual(0);
+    expect(y28).toBeGreaterThanOrEqual(0);
+    expect(y23).toBeGreaterThan(y28);
+    // x positions spread across the width and stay in bounds
+    expect(g.points[0].x).toBeGreaterThan(0);
+    expect(g.points[3].x).toBeLessThan(600);
+    expect(g.points[1].x).toBeGreaterThan(g.points[0].x);
+  });
+
+  it("emits smooth temp and area paths", () => {
+    const g = buildHourlyChartGeometry(hours, { width: 600 });
+    expect(g.tempPath.startsWith("M")).toBe(true);
+    expect(g.tempPath).toContain("C");
+    expect(g.areaPath.startsWith("M")).toBe(true);
+    expect(g.areaPath.endsWith("Z")).toBe(true);
+  });
+
+  it("scales precipitation bars by probability", () => {
+    const g = buildHourlyChartGeometry(hours, { width: 600 });
+    expect(g.bars).toHaveLength(4);
+    const b80 = g.bars[0];
+    const b60 = g.bars[1];
+    const b0 = g.bars[2];
+    const bNone = g.bars[3];
+    expect(b80.height).toBeGreaterThan(b60.height);
+    expect(b0.height).toBe(0);
+    expect(bNone.height).toBe(0);
+    for (const bar of g.bars) {
+      expect(bar.y + bar.height).toBeLessThanOrEqual(g.height);
+    }
+  });
+
+  it("handles flat temperatures without dividing by zero", () => {
+    const flat = [
+      { at: "2026-09-02T00:00:00+08:00", temperature: 25 },
+      { at: "2026-09-02T01:00:00+08:00", temperature: 25 },
+    ];
+    const g = buildHourlyChartGeometry(flat, { width: 300 });
+    expect(g.points.every((p) => Number.isFinite(p.y))).toBe(true);
+  });
+
+  it("handles empty and single-point input", () => {
+    const empty = buildHourlyChartGeometry([], { width: 300 });
+    expect(empty.points).toEqual([]);
+    expect(empty.tempPath).toBe("");
+    const single = buildHourlyChartGeometry([hours[0]], { width: 300 });
+    expect(single.points).toHaveLength(1);
+    expect(single.tempPath.startsWith("M")).toBe(true);
+  });
+
+  it("places sparse x-axis hour labels", () => {
+    const many = Array.from({ length: 24 }, (_, i) => ({
+      at: `2026-09-02T${String(i).padStart(2, "0")}:00:00+08:00`,
+      temperature: 20 + (i % 5),
+    }));
+    const g = buildHourlyChartGeometry(many, { width: 600 });
+    expect(g.xLabels.length).toBeGreaterThanOrEqual(3);
+    expect(g.xLabels.length).toBeLessThanOrEqual(9);
+    expect(g.xLabels[0].label).toBe("00:00");
+  });
+});


### PR DESCRIPTION
在逐小时卡片条上方新增一张 SVG 图表：

- **温度曲线**：Catmull-Rom 平滑折线 + 浅色面积填充（琥珀色）
- **降水概率柱状图**：每小时一根柱，高度=概率（天蓝色），0% 不渲染
- **悬停**：最近点吸附，竖向参考线 + tooltip（时间/状况/温度/降水概率/降水量）
- X 轴稀疏小时标签（自适应步长，≤8 个）

实现：几何计算全部在 `weather-ui.ts` 的 `buildHourlyChartGeometry` 纯函数里（含 6 个单测：边界、平坦温度、空/单点输入、标签稀疏化），组件只做声明式渲染。纯 SVG，无新依赖，响应式 viewBox。

验证：2544 单测、svelte-check、tsc×2、biome 全过。