### PR TITLE
fix(weather): make hourly forecast keyboard scrollable

### DIFF
--- a/src/features/weather/components/WeatherPage.svelte
+++ b/src/features/weather/components/WeatherPage.svelte
@@ -176,29 +176,38 @@ function formatTemperature(value: number) {
           {#if snapshot.hourly.length > 0}
             <section class="grid gap-2">
               <h3 class="text-sm font-medium">{weatherCopy.hourlyForecast}</h3>
-              <ul class="-mx-1 flex gap-1 overflow-x-auto px-1 pb-1">
-                {#each upcomingHours(snapshot.hourly) as hour (hour.at)}
-                  {@const HourIcon = iconOf(hour.condition)}
-                  <li
-                    class="flex w-14 shrink-0 flex-col items-center gap-1 rounded-lg border py-2 text-sm"
-                  >
-                    <span class="text-muted-foreground text-xs">
-                      {formatShanghaiTime(hour.at)}
-                    </span>
-                    <HourIcon class="size-5" strokeWidth={1.5} />
-                    {#if hour.precipitationProbability !== undefined && hour.precipitationProbability > 0}
-                      <span class="text-xs font-medium text-sky-600 dark:text-sky-400">
-                        {hour.precipitationProbability}%
+              <!-- svelte-ignore a11y_no_noninteractive_tabindex (focus enables keyboard scrolling for this overflowing forecast) -->
+              <div
+                aria-label={weatherCopy.hourlyForecast}
+                class="-mx-1 overflow-x-auto px-1 pb-1 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                data-testid="weather-hourly-scroll-region"
+                role="region"
+                tabindex="0"
+              >
+                <ul class="flex gap-1">
+                  {#each upcomingHours(snapshot.hourly) as hour (hour.at)}
+                    {@const HourIcon = iconOf(hour.condition)}
+                    <li
+                      class="flex w-14 shrink-0 flex-col items-center gap-1 rounded-lg border py-2 text-sm"
+                    >
+                      <span class="text-muted-foreground text-xs">
+                        {formatShanghaiTime(hour.at)}
                       </span>
-                    {:else}
-                      <span class="text-xs text-transparent">0%</span>
-                    {/if}
-                    <span class="font-medium">
-                      {formatTemperature(hour.temperature)}
-                    </span>
-                  </li>
-                {/each}
-              </ul>
+                      <HourIcon class="size-5" strokeWidth={1.5} />
+                      {#if hour.precipitationProbability !== undefined && hour.precipitationProbability > 0}
+                        <span class="text-xs font-medium text-sky-600 dark:text-sky-400">
+                          {hour.precipitationProbability}%
+                        </span>
+                      {:else}
+                        <span class="text-xs text-transparent">0%</span>
+                      {/if}
+                      <span class="font-medium">
+                        {formatTemperature(hour.temperature)}
+                      </span>
+                    </li>
+                  {/each}
+                </ul>
+              </div>
             </section>
           {/if}
 

--- a/tests/e2e/src/app/weather/test.ts
+++ b/tests/e2e/src/app/weather/test.ts
@@ -45,5 +45,20 @@ test.describe("/catalog/weather", () => {
     );
     await expect(panels.first()).toBeVisible();
     expect(await panels.count()).toBe(2);
+
+    // Live snapshots include a horizontally scrollable hourly forecast. Keep
+    // that region in the keyboard tab order whenever providers return it.
+    for (const region of await page
+      .getByTestId("weather-hourly-scroll-region")
+      .all()) {
+      await expect(region).toHaveRole("region");
+      await expect(region).toHaveAttribute("tabindex", "0");
+      await expect(region).toHaveAttribute(
+        "aria-label",
+        /逐小时预报|Hourly forecast/,
+      );
+      await region.focus();
+      await expect(region).toBeFocused();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- preserve the hourly forecast list semantics inside a labeled keyboard-focusable scroll region
- add a focused E2E assertion for the region semantics and focus behavior

## Validation
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.tests.json`
- `bunx tsc --noEmit -p tsconfig.typecheck.operational.json`
- weather unit tests (20 passing)
- focused weather E2E (2 passing)
- `bun run build`