### PR TITLE
fix(publications): prevent object response transforms

### DIFF
--- a/src/features/publications/server/publication-public-read-service.ts
+++ b/src/features/publications/server/publication-public-read-service.ts
@@ -154,8 +154,9 @@ export const PUBLICATION_READ_CACHE_HEADERS = {
 } as const;
 
 const PUBLICATION_OBJECT_CACHE_HEADERS = {
-  "Cache-Control": "public, max-age=31536000, immutable",
-  "Cloudflare-CDN-Cache-Control": "public, max-age=31536000, immutable",
+  "Cache-Control": "public, max-age=31536000, immutable, no-transform",
+  "Cloudflare-CDN-Cache-Control":
+    "public, max-age=31536000, immutable, no-transform",
 } as const;
 
 function normalizePublicationPagination(input: PaginationInput = {}) {

--- a/tests/unit/publication-public-read-service.test.ts
+++ b/tests/unit/publication-public-read-service.test.ts
@@ -232,6 +232,10 @@ describe("public publication reads", () => {
     expect(response?.status).toBe(200);
     expect(response?.headers.get("ETag")).toBe('"r2-etag"');
     expect(response?.headers.get("Cache-Control")).toContain("immutable");
+    expect(response?.headers.get("Cache-Control")).toContain("no-transform");
+    expect(response?.headers.get("Cloudflare-CDN-Cache-Control")).toContain(
+      "no-transform",
+    );
     expect(response?.headers.get("Content-Disposition")).toBe("inline");
     await expect(response?.text()).resolves.toBe("bytes");
   });


### PR DESCRIPTION
## Summary
- mark immutable publication object responses as no-transform for browsers and Cloudflare CDN
- preserve content-addressed SHA-256 bytes for body_html objects instead of allowing analytics beacon injection

## Verification
- DATABASE_URL=postgresql://life_ustc:life_ustc@127.0.0.1:5432/life_ustc bun run app:prepare
- bunx vitest run tests/unit/publication-public-read-service.test.ts (6 passed)
- bunx biome check ... (passed)