### PR TITLE
feat(weather): move updated-at and data providers to page bottom-right

### DIFF
--- a/src/features/weather/components/WeatherPage.svelte
+++ b/src/features/weather/components/WeatherPage.svelte
@@ -59,6 +59,21 @@ const weekdayFormatter = $derived(
   createShanghaiDateTimeFormatter(locale, { weekday: "short" }),
 );
 
+const latestFetchedAt = $derived(
+  locations.reduce<string | undefined>(
+    (latest, { snapshot }) =>
+      snapshot &&
+      (!latest || Date.parse(snapshot.fetchedAt) > Date.parse(latest))
+        ? snapshot.fetchedAt
+        : latest,
+    undefined,
+  ),
+);
+
+const allProviders = $derived([
+  ...new Set(locations.flatMap(({ snapshot }) => snapshot?.providers ?? [])),
+]);
+
 function iconOf(condition: WeatherCondition | undefined) {
   return ICON_COMPONENTS[
     weatherConditionIcon(condition ?? { text: "", icon: "unknown" })
@@ -95,18 +110,9 @@ function formatTemperature(value: number) {
   {#each locations as { locationKey, snapshot } (locationKey)}
     <Panel>
       {#snippet header()}
-        <div class="flex items-baseline justify-between gap-3">
-          <h2 class="text-lg font-semibold">
-            {weatherCopy.locationNames[locationKey]}
-          </h2>
-          {#if snapshot}
-            <span class="text-muted-foreground text-sm">
-              {formatTemplate(weatherCopy.updatedAt, {
-                value: formatShanghaiTime(snapshot.fetchedAt),
-              })}
-            </span>
-          {/if}
-        </div>
+        <h2 class="text-lg font-semibold">
+          {weatherCopy.locationNames[locationKey]}
+        </h2>
       {/snippet}
 
       {#if !snapshot}
@@ -287,14 +293,22 @@ function formatTemperature(value: number) {
           </section>
         </div>
       {/if}
-
-      {#snippet footer()}
-        {#if snapshot}
-          <span class="text-muted-foreground text-xs">
-            {weatherCopy.dataProviders}: {snapshot.providers.join(", ")}
-          </span>
-        {/if}
-      {/snippet}
     </Panel>
   {/each}
 </div>
+
+{#if latestFetchedAt}
+  <div
+    class="text-muted-foreground mt-3 flex flex-wrap items-center justify-end gap-x-3 gap-y-1 text-xs"
+    data-testid="weather-page-meta"
+  >
+    <span>
+      {formatTemplate(weatherCopy.updatedAt, {
+        value: formatShanghaiTime(latestFetchedAt),
+      })}
+    </span>
+    {#if allProviders.length > 0}
+      <span>{weatherCopy.dataProviders}: {allProviders.join(", ")}</span>
+    {/if}
+  </div>
+{/if}


### PR DESCRIPTION
## What

Move the per-card "更新于 XX:XX" (header) and "数据来源: …" (card footer) out of the two location panels into a single page-level line at the bottom-right of /catalog/weather.

- 更新于 shows the latest `fetchedAt` across location snapshots
- 数据来源 shows the deduped union of providers across snapshots
- Hidden entirely when no snapshot is available

## Verification

- biome / svelte-check / tsc clean
- weather unit tests pass
- E2E page contract covers axe on this page