### PR TITLE
fix(news): use table layout and link pagination

### DIFF
--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -1061,6 +1061,8 @@
     "news": "News",
     "notice": "Notice",
     "all": "All",
+    "publicationType": "Type",
+    "headline": "Title and summary",
     "source": "Source",
     "sourceId": "Source ID",
     "search": "Search",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -2687,6 +2687,8 @@
     "news": "新闻",
     "notice": "通知",
     "all": "全部",
+    "publicationType": "类型",
+    "headline": "标题与摘要",
     "source": "来源",
     "sourceId": "来源 ID",
     "search": "搜索",

--- a/src/features/publications/components/PublicationListPage.svelte
+++ b/src/features/publications/components/PublicationListPage.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
-import ArrowRightIcon from "@lucide/svelte/icons/arrow-right";
 import SearchIcon from "@lucide/svelte/icons/search";
 import PageHeader from "$lib/components/PageHeader.svelte";
 import { Button } from "$lib/components/ui/button/index.js";
-import * as Card from "$lib/components/ui/card/index.js";
 import * as Empty from "$lib/components/ui/empty/index.js";
 import * as Field from "$lib/components/ui/field/index.js";
 import { Input } from "$lib/components/ui/input/index.js";
 import * as NativeSelect from "$lib/components/ui/native-select/index.js";
-import { Separator } from "$lib/components/ui/separator/index.js";
+import * as Table from "$lib/components/ui/table/index.js";
 import { formatShanghaiDate } from "$lib/time/shanghai-format";
 import PublicationPagination from "./PublicationPagination.svelte";
 import PublicationTypeBadge from "./PublicationTypeBadge.svelte";
@@ -78,12 +76,12 @@ function resultCount() {
     </Field.Field>
 
     <Field.Field class="gap-1">
-      <Field.Label for="publication-type">{copy.title}</Field.Label>
+      <Field.Label for="publication-type">{copy.publicationType}</Field.Label>
       <NativeSelect.Root
         id="publication-type"
         name="type"
         value={data.filters.type ?? ""}
-        aria-label={copy.title}
+        aria-label={copy.publicationType}
       >
         <NativeSelect.Option value="">{copy.all}</NativeSelect.Option>
         <NativeSelect.Option value="news">{copy.news}</NativeSelect.Option>
@@ -111,43 +109,50 @@ function resultCount() {
     </Empty.Root>
   {:else}
     <p class="text-sm text-muted-foreground">{resultCount()}</p>
-    <div class="grid gap-4" aria-label={copy.pageTitle}>
-      {#each data.publications.data as item (item.id)}
-        <Card.Root class="overflow-hidden">
-          <Card.Header class="gap-3">
-            <div class="flex flex-wrap items-center gap-2 text-sm">
-              <PublicationTypeBadge type={item.publicationType} {copy} />
-              <span class="text-muted-foreground">{item.source.name}</span>
-            </div>
-            <h2 class="text-xl leading-tight font-medium">
-              <a class="hover:underline" href={`/news/${item.id}`}>
-                {item.revision.title}
-              </a>
-            </h2>
-            {#if item.revision.summary}
-              <Card.Description class="line-clamp-3">
-                {item.revision.summary}
-              </Card.Description>
-            {/if}
-          </Card.Header>
-          <Card.Content class="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-            <span>{copy.publishedAt}: {formatDate(item.revision.publishedAt)}</span>
-            {#if item.revision.updatedAtSource}
-              <Separator orientation="vertical" class="h-4" />
-              <span>{copy.updatedAt}: {formatDate(item.revision.updatedAtSource)}</span>
-            {/if}
-          </Card.Content>
-          <Card.Footer>
-            <a
-              class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-              href={`/news/${item.id}`}
-            >
-              {copy.readMore}
-              <ArrowRightIcon data-icon="inline-end" aria-hidden="true" />
-            </a>
-          </Card.Footer>
-        </Card.Root>
-      {/each}
+    <div class="min-w-0 rounded-xl border bg-card">
+      <Table.Root containerLabel={copy.pageTitle} class="min-w-[60rem] table-fixed">
+        <Table.Caption class="sr-only">{resultCount()}</Table.Caption>
+        <Table.Header class="bg-muted/30">
+          <Table.Row>
+            <Table.Head class="w-24">{copy.publicationType}</Table.Head>
+            <Table.Head>{copy.headline}</Table.Head>
+            <Table.Head class="w-56">{copy.source}</Table.Head>
+            <Table.Head class="w-36">{copy.publishedAt}</Table.Head>
+            <Table.Head class="w-36">{copy.updatedAt}</Table.Head>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {#each data.publications.data as item (item.id)}
+            <Table.Row class="has-[a:hover]:bg-muted/50">
+              <Table.Cell class="align-top">
+                <PublicationTypeBadge type={item.publicationType} {copy} />
+              </Table.Cell>
+              <Table.Cell class="align-top">
+                <a
+                  class="font-medium text-foreground hover:underline"
+                  href={`/news/${item.id}`}
+                >
+                  {item.revision.title}
+                </a>
+                {#if item.revision.summary}
+                  <p class="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+                    {item.revision.summary}
+                  </p>
+                {/if}
+              </Table.Cell>
+              <Table.Cell class="align-top text-muted-foreground">
+                {item.source.name}
+              </Table.Cell>
+              <Table.Cell class="align-top whitespace-nowrap tabular-nums text-muted-foreground">
+                {formatDate(item.revision.publishedAt)}
+              </Table.Cell>
+              <Table.Cell class="align-top whitespace-nowrap tabular-nums text-muted-foreground">
+                {formatDate(item.revision.updatedAtSource)}
+              </Table.Cell>
+            </Table.Row>
+          {/each}
+        </Table.Body>
+      </Table.Root>
     </div>
 
     {#if data.publications.pagination.totalPages > 1}

--- a/src/features/publications/components/PublicationPagination.svelte
+++ b/src/features/publications/components/PublicationPagination.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import ChevronLeftIcon from "@lucide/svelte/icons/chevron-left";
 import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
-import { goto } from "$app/navigation";
+import { Button } from "$lib/components/ui/button/index.js";
 import * as Pagination from "$lib/components/ui/pagination/index.js";
 
 export let page: number;
@@ -12,56 +12,75 @@ export let previousLabel: string;
 export let nextLabel: string;
 export let ariaLabel: string;
 
-function handlePageChange(nextPage: number) {
-  if (nextPage !== page) void goto(buildHref(nextPage));
-}
+$: totalPages = Math.ceil(total / pageSize);
 </script>
 
 <Pagination.Root
   count={total}
   perPage={pageSize}
-  bind:page
+  {page}
   siblingCount={1}
-  onPageChange={handlePageChange}
   aria-label={ariaLabel}
 >
   {#snippet children({ pages, currentPage })}
     <Pagination.Content>
       <Pagination.Item>
-        <Pagination.Previous
-          aria-label={previousLabel}
-          disabled={page <= 1}
-        >
-          {#snippet children()}
+        {#if page <= 1}
+          <Button variant="ghost" aria-label={previousLabel} disabled>
             <ChevronLeftIcon data-icon="inline-start" aria-hidden="true" />
             <span class="hidden sm:block">{previousLabel}</span>
-          {/snippet}
-        </Pagination.Previous>
+          </Button>
+        {:else}
+          <Button
+            href={buildHref(page - 1)}
+            variant="ghost"
+            aria-label={previousLabel}
+          >
+            <ChevronLeftIcon data-icon="inline-start" aria-hidden="true" />
+            <span class="hidden sm:block">{previousLabel}</span>
+          </Button>
+        {/if}
       </Pagination.Item>
-      {#each pages as item (item.key)}
-        {#if item.type === "ellipsis"}
+      {#each pages as pageItem (pageItem.key)}
+        {#if pageItem.type === "ellipsis"}
           <Pagination.Item>
             <Pagination.Ellipsis />
           </Pagination.Item>
         {:else}
           <Pagination.Item>
             <Pagination.Link
-              page={item}
-              isActive={currentPage === item.value}
-            />
+              page={pageItem}
+              isActive={currentPage === pageItem.value}
+            >
+              {#snippet child({ props })}
+                <a
+                  {...props}
+                  href={buildHref(pageItem.value)}
+                  aria-label={`${ariaLabel} ${pageItem.value}`}
+                >
+                  {pageItem.value}
+                </a>
+              {/snippet}
+            </Pagination.Link>
           </Pagination.Item>
         {/if}
       {/each}
       <Pagination.Item>
-        <Pagination.Next
-          aria-label={nextLabel}
-          disabled={page >= Math.ceil(total / pageSize)}
-        >
-          {#snippet children()}
+        {#if page >= totalPages}
+          <Button variant="ghost" aria-label={nextLabel} disabled>
             <span class="hidden sm:block">{nextLabel}</span>
             <ChevronRightIcon data-icon="inline-end" aria-hidden="true" />
-          {/snippet}
-        </Pagination.Next>
+          </Button>
+        {:else}
+          <Button
+            href={buildHref(page + 1)}
+            variant="ghost"
+            aria-label={nextLabel}
+          >
+            <span class="hidden sm:block">{nextLabel}</span>
+            <ChevronRightIcon data-icon="inline-end" aria-hidden="true" />
+          </Button>
+        {/if}
       </Pagination.Item>
     </Pagination.Content>
   {/snippet}

--- a/src/features/publications/components/publication-component-types.ts
+++ b/src/features/publications/components/publication-component-types.ts
@@ -28,6 +28,8 @@ export type PublicationPageCopy = {
   news: string;
   notice: string;
   all: string;
+  publicationType: string;
+  headline: string;
   source: string;
   sourceId: string;
   search: string;

--- a/tests/e2e/src/app/news/test.ts
+++ b/tests/e2e/src/app/news/test.ts
@@ -44,15 +44,54 @@ test.describe("/news 新闻与通知预览", () => {
       page.getByRole("searchbox", { name: /搜索|Search/i }),
     ).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: fixture.title }),
+      page.getByRole("link", { name: fixture.title, exact: true }),
     ).toBeVisible();
     await expect(page.getByText(/新闻|News/i).first()).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: /类型|Type/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: /标题与摘要|Title and summary/i }),
+    ).toBeVisible();
 
     await page.getByRole("combobox").selectOption("notice");
     await page.getByRole("button", { name: /筛选|Filter/i }).click();
     await expect(
       page.getByText(/暂无公开内容|No public publications/i),
     ).toBeVisible();
+  });
+
+  test("分页使用链接导航并保留筛选条件", async ({ page }, testInfo) => {
+    const sourceQuery = `source=${encodeURIComponent(fixture.sourceId)}`;
+    await gotoAndWaitForReady(page, `/news?${sourceQuery}`, {
+      testInfo,
+      screenshotLabel: "news-pagination-first-page",
+    });
+
+    await expect(
+      page.locator("[data-slot='table-body'] [data-slot='table-row']"),
+    ).toHaveCount(20);
+    const nextPage = page.getByRole("link", { name: /下一页|Next page/i });
+    await expect(nextPage).toHaveAttribute(
+      "href",
+      `/news?${sourceQuery}&page=2`,
+    );
+    await nextPage.click();
+
+    await expect(page).toHaveURL(new RegExp(`/news\\?${sourceQuery}&page=2$`));
+    await expect(
+      page.locator("[data-slot='table-body'] [data-slot='table-row']"),
+    ).toHaveCount(fixture.total - 20);
+    const previousPage = page.getByRole("link", {
+      name: /上一页|Previous page/i,
+    });
+    await expect(previousPage).toHaveAttribute("href", `/news?${sourceQuery}`);
+    await expect(
+      page.getByRole("button", { name: /下一页|Next page/i }),
+    ).toBeDisabled();
+
+    await previousPage.click();
+    await expect(page).toHaveURL(new RegExp(`/news\\?${sourceQuery}$`));
   });
 
   test("详情页显示正文和来源链接", async ({ page }, testInfo) => {

--- a/tests/e2e/utils/e2e-db/publications.ts
+++ b/tests/e2e/utils/e2e-db/publications.ts
@@ -5,6 +5,7 @@ export type PublicationFixture = {
   id: string;
   sourceId: string;
   title: string;
+  total: number;
 };
 
 export async function createPublicationFixture(prefix: string) {
@@ -12,6 +13,8 @@ export async function createPublicationFixture(prefix: string) {
   const canonicalUrl = `https://news.example.test/${prefix}`;
   const title = `E2E publication ${prefix}`;
   const revisionHash = "e".repeat(64);
+  const total = 21;
+  const publishedAt = new Date("2026-09-01T00:00:00+08:00");
 
   return withE2ePrisma(async (prisma) => {
     await prisma.publicationSource.create({
@@ -23,48 +26,58 @@ export async function createPublicationFixture(prefix: string) {
       },
     });
 
-    const publication = await prisma.publication.create({
-      data: {
-        sourceId,
-        canonicalUrl,
-        title,
-        summary: "A deterministic publication used by the news page E2E test.",
-        bodyText: "This is the body text rendered by the public detail page.",
-        sourcePageUrl: canonicalUrl,
-        publicationType: "news",
-        publishedAt: new Date("2026-09-01T00:00:00+08:00"),
-      },
-    });
-    const revision = await prisma.publicationRevision.create({
-      data: {
-        publicationId: publication.id,
-        revisionHash,
-        observedAt: new Date("2026-09-01T00:00:00+08:00"),
-        title,
-        summary: "A deterministic publication used by the news page E2E test.",
-        bodyText: "This is the body text rendered by the public detail page.",
-        sourcePageUrl: canonicalUrl,
-        publishedAt: new Date("2026-09-01T00:00:00+08:00"),
-        publicationType: "news",
-      },
-    });
-    await prisma.publication.update({
-      where: { id: publication.id },
-      data: { currentRevisionId: revision.id },
-    });
+    let firstPublicationId = "";
+    for (let index = 0; index < total; index += 1) {
+      const itemTitle = index === 0 ? title : `${title} ${index + 1}`;
+      const itemUrl =
+        index === 0 ? canonicalUrl : `${canonicalUrl}/${index + 1}`;
+      const itemPublishedAt = new Date(publishedAt.getTime() - index * 60_000);
+      const publication = await prisma.publication.create({
+        data: {
+          sourceId,
+          canonicalUrl: itemUrl,
+          title: itemTitle,
+          summary:
+            "A deterministic publication used by the news page E2E test.",
+          bodyText: "This is the body text rendered by the public detail page.",
+          sourcePageUrl: itemUrl,
+          publicationType: "news",
+          publishedAt: itemPublishedAt,
+        },
+      });
+      const revision = await prisma.publicationRevision.create({
+        data: {
+          publicationId: publication.id,
+          revisionHash,
+          observedAt: itemPublishedAt,
+          title: itemTitle,
+          summary:
+            "A deterministic publication used by the news page E2E test.",
+          bodyText: "This is the body text rendered by the public detail page.",
+          sourcePageUrl: itemUrl,
+          publishedAt: itemPublishedAt,
+          publicationType: "news",
+        },
+      });
+      await prisma.publication.update({
+        where: { id: publication.id },
+        data: { currentRevisionId: revision.id },
+      });
+      if (index === 0) firstPublicationId = publication.id;
+    }
 
     return {
       canonicalUrl,
-      id: publication.id,
+      id: firstPublicationId,
       sourceId,
       title,
+      total,
     } satisfies PublicationFixture;
   });
 }
 
 export async function deletePublicationFixture(fixture: PublicationFixture) {
   await withE2ePrisma(async (prisma) => {
-    await prisma.publication.delete({ where: { id: fixture.id } });
     await prisma.publicationSource.delete({ where: { id: fixture.sourceId } });
   });
 }


### PR DESCRIPTION
## Summary
- replace news and notice cards with the shared shadcn-svelte table
- render page controls as real links that preserve active filters
- add browser coverage for table semantics and forward/back pagination

## Verification
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx vitest run tests/unit --passWithNoTests` (2556 tests)
- `bun run build`
- `CAPTURE_STEP_SCREENSHOTS=1 bunx playwright test tests/e2e/src/app/news/test.ts --project=chromium` (6 tests)