### PR TITLE
fix(graphql): update MCP operation manifest count after young events ops

### DIFF
--- a/tests/integration/graphql-mcp-resources.test.ts
+++ b/tests/integration/graphql-mcp-resources.test.ts
@@ -80,7 +80,7 @@ describe("GraphQL MCP operations", () => {
         }),
       ]),
     });
-    expect((manifest.operations as unknown[]).length).toBe(47);
+    expect((manifest.operations as unknown[]).length).toBe(49);
     expect(JSON.stringify(manifest)).not.toContain('"document"');
   });
 


### PR DESCRIPTION
## Summary

PR #997 added `catalog.young_event.list.v1` / `catalog.young_event.get.v1`, raising the registered GraphQL operation count from 47 to 49. The MCP integration test that asserts the manifest length only runs on main, so the stale `toBe(47)` slipped through PR CI and failed post-merge.

One-line fix: `toBe(47)` → `toBe(49)`.

## Verification

- `tests/integration/graphql-mcp-resources.test.ts`: 13/13 pass locally against a seeded Postgres.