### PR TITLE
fix(young): grant life_ustc_runtime SELECT on YoungEvent

### DIFF
--- a/prisma/migrations/20260902150000_grant_young_event/migration.sql
+++ b/prisma/migrations/20260902150000_grant_young_event/migration.sql
@@ -1,0 +1,16 @@
+-- The app runtime role reads YoungEvent for the public catalog pages and
+-- APIs; writes happen through the migrator role during static imports.
+-- No-op when life_ustc_runtime is not provisioned (local CI Postgres).
+DO $grant_young_event$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_roles WHERE rolname = 'life_ustc_runtime'
+  ) THEN
+    RAISE NOTICE 'Skipping young event grants; role life_ustc_runtime does not exist.';
+    RETURN;
+  END IF;
+
+  GRANT SELECT ON TABLE "YoungEvent"
+  TO life_ustc_runtime;
+END
+$grant_young_event$;


### PR DESCRIPTION
## Summary

`/catalog/young-events` and `/api/catalog/young-events` 500 in production: the `20260901210000_add_young_events` migration created the table but granted nothing, so the unprivileged `life_ustc_runtime` role gets Postgres 42501 (surfaced as Prisma P2039 via the driver adapter) on every query.

Same class of issue as #976 (WeatherObservation); same fix shape — a conditional grant migration that no-ops where the role isn't provisioned.

## Verification

- Applied locally via `db:migrate:deploy` (NOTICE path without the role).
- Production log evidence: `PrismaClientKnownRequestError P2039` on `/catalog/young-events` (wrangler tail); migration itself deployed fine per the DB Migrate Deploy run on the merge commit.