### PR TITLE
feat(shell): add campus weather link to sidebar catalog

### DIFF
--- a/src/lib/components/shell/AppShell.svelte
+++ b/src/lib/components/shell/AppShell.svelte
@@ -6,6 +6,7 @@ import CableIcon from "@lucide/svelte/icons/cable";
 import CalendarDaysIcon from "@lucide/svelte/icons/calendar-days";
 import ChartBarIcon from "@lucide/svelte/icons/chart-bar";
 import ClipboardCheckIcon from "@lucide/svelte/icons/clipboard-check";
+import CloudSunIcon from "@lucide/svelte/icons/cloud-sun";
 import CompassIcon from "@lucide/svelte/icons/compass";
 import GavelIcon from "@lucide/svelte/icons/gavel";
 import GraduationCapIcon from "@lucide/svelte/icons/graduation-cap";
@@ -216,6 +217,11 @@ function buildShellNavGroups(
       icon: SparklesIcon,
       label: copy.nav.youngEvents,
     },
+    {
+      href: "/catalog/weather",
+      icon: CloudSunIcon,
+      label: copy.nav.weather,
+    },
     { href: "/news", icon: ScrollTextIcon, label: copy.nav.news },
   ];
   const usageLinks: ShellLink[] = [
@@ -401,6 +407,11 @@ function buildMobileSecondaryNavGroups(
       href: "/catalog/young-events",
       icon: SparklesIcon,
       label: copy.nav.youngEvents,
+    },
+    {
+      href: "/catalog/weather",
+      icon: CloudSunIcon,
+      label: copy.nav.weather,
     },
     {
       href: "/news",

--- a/src/lib/shell/layout-server-data.ts
+++ b/src/lib/shell/layout-server-data.ts
@@ -15,6 +15,7 @@ const layoutMessages = {
     publications: enUsMessages.publications,
     profile: enUsMessages.profile,
     theme: enUsMessages.theme,
+    weather: enUsMessages.weather,
     youngEvents: enUsMessages.youngEvents,
   },
   "zh-cn": {
@@ -30,6 +31,7 @@ const layoutMessages = {
     publications: zhCnMessages.publications,
     profile: zhCnMessages.profile,
     theme: zhCnMessages.theme,
+    weather: zhCnMessages.weather,
     youngEvents: zhCnMessages.youngEvents,
   },
 };
@@ -70,6 +72,7 @@ export function buildLayoutCopy(locale: LayoutLocale) {
       news: messages.publications.title,
       todos: messages.meDashboard.nav.todos.title,
       transitMap: messages.metadata.pages.busMap,
+      weather: messages.weather.title,
       youngEvents: messages.youngEvents.title,
       mobileApp: messages.metadata.pages.mobileApp,
       prestoBot: messages.metadata.pages.prestoBot,


### PR DESCRIPTION
## What

在侧边栏课程目录分组中、links 和第二课堂（young-events）下方加入「校园天气」入口（/catalog/weather，cloud-sun 图标），桌面端和移动端次级导航同步。

## Test

- `svelte-check`：改动文件无错误（68 个存量错误均在与本改动无关的文件）
- shell 相关单测（layout-shell / app-shell-actions / shell-bootstrap-client / navigation-preload-policy / dashboard-nav）全部通过
- `biome check` 干净