### PR TITLE
fix(news): redirect overflowing publication pages

### DIFF
--- a/src/routes/news/+page.server.ts
+++ b/src/routes/news/+page.server.ts
@@ -1,3 +1,4 @@
+import { redirect } from "@sveltejs/kit";
 import { getPublicationPageCopy } from "@/features/publications/server/publication-page-copy";
 import { listPublications } from "@/features/publications/server/publication-public-read-service";
 import { publicationsQuerySchema } from "@/lib/api/schemas/request-schemas";
@@ -19,13 +20,22 @@ export const load: PageServerLoad = async (event) => {
   );
   const parsedQuery = publicationsQuerySchema.safeParse(rawQuery);
   const filters = parsedQuery.success ? parsedQuery.data : {};
+  const requestedPage = parsePage(event.url.searchParams.get("page"));
   const publications = await listPublications({
     filters,
     pagination: {
-      page: parsePage(event.url.searchParams.get("page")),
+      page: requestedPage,
       pageSize: 20,
     },
   });
+  if (
+    publications.pagination.totalPages > 0 &&
+    requestedPage > publications.pagination.totalPages
+  ) {
+    const target = new URL(event.url);
+    target.searchParams.set("page", String(publications.pagination.totalPages));
+    redirect(307, `${target.pathname}${target.search}`);
+  }
   const copy = getPublicationPageCopy(event.locals.locale);
 
   return {

--- a/tests/e2e/src/app/news/test.ts
+++ b/tests/e2e/src/app/news/test.ts
@@ -94,6 +94,22 @@ test.describe("/news 新闻与通知预览", () => {
     await expect(page).toHaveURL(new RegExp(`/news\\?${sourceQuery}$`));
   });
 
+  test("越界页重定向到保留筛选条件的最后一页", async ({ page }, testInfo) => {
+    const sourceQuery = `source=${encodeURIComponent(fixture.sourceId)}`;
+    await gotoAndWaitForReady(page, `/news?${sourceQuery}&page=9999`, {
+      testInfo,
+      screenshotLabel: "news-pagination-overflow",
+    });
+
+    await expect(page).toHaveURL(new RegExp(`/news\\?${sourceQuery}&page=2$`));
+    await expect(
+      page.locator("[data-slot='table-body'] [data-slot='table-row']"),
+    ).toHaveCount(fixture.total - 20);
+    await expect(
+      page.getByRole("link", { name: /上一页|Previous page/i }),
+    ).toHaveAttribute("href", `/news?${sourceQuery}`);
+  });
+
   test("详情页显示正文和来源链接", async ({ page }, testInfo) => {
     await gotoAndWaitForReady(page, `/news/${fixture.id}`, {
       testInfo,


### PR DESCRIPTION
## Summary
- redirect out-of-range publication list pages to the current last page
- preserve active type, source, and search query parameters
- keep the table and pagination controls available when historical page links exceed the current result count

## Validation
- `bun run check` (409 files, 2588 tests; 9 existing Biome warnings)
- added Playwright coverage for an overflowing page with a source filter