### PR TITLE
fix(subscriptions): explain how to import course selections

### DIFF
--- a/docs/contracts/subscription.json
+++ b/docs/contracts/subscription.json
@@ -207,7 +207,7 @@
       "display": {
         "fields": [
           "A standalone quick-add dialog searches section codes, course codes, localized course names, and localized teacher names within one semester, shows matching sections as checkbox options, and subscribes the selected sections without entering the batch-import confirmation flow",
-          "A separate batch-import dialog accepts pasted course and section codes for one selected semester",
+          "A separate batch-import dialog links to the undergraduate and graduate academic systems, explains how to copy section codes such as MATH1001.01 from course selection results, and accepts the pasted text for the matching semester",
           "Batch subscribe, unsubscribe, and replace/update actions",
           "Subscribed sections are grouped by semester into separate responsive tables ordered from the latest semester to the earliest; the layout stays single-column until an extra-wide viewport, where supporting browsers use native CSS Grid Lanes to pack tables into two columns and other browsers fall back to a row-ordered two-column grid",
           "Long course names and teacher lists are visually truncated inside table rows; when truncated, their complete text remains available from the shared tooltip and the section details dialog",

--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -172,7 +172,11 @@
     },
     "bulkImport": {
       "title": "Bulk Add Subscriptions",
-      "description": "Paste text containing section or course codes. The system will match sections from the selected semester and let you choose which ones to subscribe to.",
+      "descriptionPrefix": "Visit the",
+      "undergraduateSystem": "Undergraduate Academic Affairs System",
+      "descriptionConjunction": "or the",
+      "graduateSystem": "Graduate Information System",
+      "description": " to get your course selection results containing section codes, such as MATH1001.01. Select the matching semester and paste that text below to import your subscriptions in bulk.",
       "semesterLabel": "Semester",
       "semesterPlaceholder": "Select a semester",
       "sectionCodesLabel": "Section or course codes",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -172,7 +172,11 @@
     },
     "bulkImport": {
       "title": "批量添加订阅",
-      "description": "粘贴包含教学班代码或课程代码的文本，系统会匹配所选学期的教学班，并允许你选择要订阅的教学班。",
+      "descriptionPrefix": "请访问",
+      "undergraduateSystem": "本科生教务系统",
+      "descriptionConjunction": "或",
+      "graduateSystem": "研究生信息系统",
+      "description": "，获取包含教学班代码（如 MATH1001.01）的选课结果。选择对应学期，将包含这些代码的文本复制粘贴到下方，即可批量导入你的选课结果。",
       "semesterLabel": "学期",
       "semesterPlaceholder": "选择学期",
       "sectionCodesLabel": "班级或课程代码",

--- a/src/features/subscriptions/components/BulkImportDialog.svelte
+++ b/src/features/subscriptions/components/BulkImportDialog.svelte
@@ -29,12 +29,22 @@ const titleId = "bulk-import-title";
 </script>
 
 <Dialog.Root open={isOpen} onOpenChange={onOpenChange}>
-  <Dialog.Content class="max-w-lg sm:max-w-lg" aria-labelledby={titleId}>
-    <Dialog.Header>
+  <Dialog.Content class="flex max-w-lg flex-col overflow-hidden sm:max-w-lg" aria-labelledby={titleId}>
+    <Dialog.Header class="shrink-0">
       <Dialog.Title id={titleId}>{copy.title}</Dialog.Title>
-      <Dialog.Description>{copy.description}</Dialog.Description>
+      <Dialog.Description>
+        {copy.descriptionPrefix}{" "}<a
+          href="https://jw.ustc.edu.cn"
+          target="_blank"
+          rel="noopener noreferrer"
+        >{copy.undergraduateSystem}</a>{" "}{copy.descriptionConjunction}{" "}<a
+          href="https://yjs1.ustc.edu.cn"
+          target="_blank"
+          rel="noopener noreferrer"
+        >{copy.graduateSystem}</a>{copy.description}
+      </Dialog.Description>
     </Dialog.Header>
-    <Field.Group class="gap-4 px-5 py-4">
+    <Field.Group class="min-h-0 gap-4 overflow-y-auto px-5 py-4">
       {#if error}
         <Alert.Root variant="destructive">
           <Alert.Description>{error}</Alert.Description>
@@ -68,7 +78,7 @@ const titleId = "bulk-import-title";
         />
       </Field.Field>
     </Field.Group>
-    <Dialog.Footer>
+    <Dialog.Footer class="shrink-0">
       <Button type="button" variant="outline" onclick={onCancel}>{copy.cancel}</Button>
       <Button disabled={!canMatch} type="button" onclick={match}>
         {#if isMatching}

--- a/src/features/subscriptions/components/bulk-import-types.ts
+++ b/src/features/subscriptions/components/bulk-import-types.ts
@@ -1,6 +1,10 @@
 export type BulkImportCopy = {
   cancel: string;
   confirmTitle: string;
+  descriptionPrefix: string;
+  undergraduateSystem: string;
+  descriptionConjunction: string;
+  graduateSystem: string;
   description: string;
   importing: string;
   matchButton: string;

--- a/src/features/welcome/components/welcome-component-types.ts
+++ b/src/features/welcome/components/welcome-component-types.ts
@@ -39,6 +39,10 @@ export type WelcomeRootCopy = {
 
 export type WelcomeBulkImportCopy = Record<string, string> & {
   cancel: string;
+  descriptionPrefix: string;
+  undergraduateSystem: string;
+  descriptionConjunction: string;
+  graduateSystem: string;
   description: string;
   matchButton: string;
   matching: string;

--- a/src/features/workspace/components/subscription-tab-types.ts
+++ b/src/features/workspace/components/subscription-tab-types.ts
@@ -29,6 +29,10 @@ export type WorkspaceSubscriptionsTabCopy = WorkspaceSubscriptionsCopy & {
   bulkImport: {
     cancel: string;
     confirmTitle: string;
+    descriptionPrefix: string;
+    undergraduateSystem: string;
+    descriptionConjunction: string;
+    graduateSystem: string;
     description: string;
     importing: string;
     matchButton: string;

--- a/src/features/workspace/lib/workspace-controller-types.ts
+++ b/src/features/workspace/lib/workspace-controller-types.ts
@@ -231,6 +231,10 @@ export type WorkspaceSubscriptionsCopy = WorkspaceRecord & {
     cancel: string;
     checkFormat: string;
     confirmTitle: string;
+    descriptionPrefix: string;
+    undergraduateSystem: string;
+    descriptionConjunction: string;
+    graduateSystem: string;
     description: string;
     fetchFailed: string;
     importFailed: string;

--- a/tests/e2e/src/app/workspace/subscriptions/sections/test.ts
+++ b/tests/e2e/src/app/workspace/subscriptions/sections/test.ts
@@ -480,6 +480,14 @@ test.describe("仪表盘教学班订阅", () => {
     await signInAsDebugUser(page, "/workspace/subscriptions");
 
     const textarea = await openBulkImportDialog(page);
+    const importDialog = page.getByRole("dialog");
+    await expect(
+      importDialog.getByRole("link", { name: "本科生教务系统" }),
+    ).toHaveAttribute("href", "https://jw.ustc.edu.cn");
+    await expect(
+      importDialog.getByRole("link", { name: "研究生信息系统" }),
+    ).toHaveAttribute("href", "https://yjs1.ustc.edu.cn");
+    await expect(importDialog).toContainText("MATH1001.01");
     await textarea.fill(DEV_SEED.section.code);
 
     const matchResponse = page.waitForResponse(


### PR DESCRIPTION
Explain how to bulk import course selections: link to the undergraduate and graduate academic systems, show `MATH1001.01` as a section-code example, and ask users to select the matching semester before pasting their results. The shared dialog updates both workspace subscriptions and first-time setup, in Chinese and English.

Keep the dialog actions visible on short mobile screens while allowing the form to scroll.

Validation: full `bun run check` (2,594 unit tests), production build, 26 subscription/welcome browser tests, and Chinese/English screenshots at desktop, mobile, and 320×568 viewport sizes.
