### PR TITLE
fix(homeworks): simplify creation dialog and align date controls

### DIFF
--- a/docs/contracts/homework.json
+++ b/docs/contracts/homework.json
@@ -82,7 +82,7 @@
           "mobile compact toolbar with direct completion filters and overflow display-mode control",
           "cards/list view mode persisted in browser storage",
           "detail popup order: description, due summary, vertical metadata excluding platform createdAt, action controls, discussion; desktop places discussion to the right of the details",
-          "create form exposes the collapsible advisory homework title and description style guide",
+          "create form keeps major/team flags outside optional timestamps, omits subtitle and advisory style guide, and uses aligned date inputs with adjacent shortcut menus",
           "create dialog uses a wider desktop layout with section, title, and timestamps on the left and description editing with simultaneous live Markdown preview on the right; mobile stacks the fields",
           "create section options identify course, teachers, and semester; common deadlines include the selected section's next classes and future this/next-week weekend cutoffs in Asia/Shanghai"
         ]

--- a/messages/en-us.json
+++ b/messages/en-us.json
@@ -1990,6 +1990,7 @@
     "submissionStart": "Submission opens",
     "submissionDue": "Submission due",
     "calendarButtonLabel": "Open calendar picker",
+    "timeShortcuts": "Common times",
     "dueDateShortcuts": "Common deadlines",
     "helperPublishNow": "Publish now",
     "helperStartNow": "Start now",

--- a/messages/zh-cn.json
+++ b/messages/zh-cn.json
@@ -1860,6 +1860,7 @@
     "submissionStart": "提交开始",
     "submissionDue": "提交截止",
     "calendarButtonLabel": "打开日历选择器",
+    "timeShortcuts": "常用时间",
     "dueDateShortcuts": "常用截止时间",
     "helperPublishNow": "立即发布",
     "helperStartNow": "立即开始",

--- a/src/features/homeworks/components/HomeworkDescriptionFields.svelte
+++ b/src/features/homeworks/components/HomeworkDescriptionFields.svelte
@@ -3,7 +3,6 @@ import { HOMEWORK_DESCRIPTION_MAX_LENGTH } from "@/features/homeworks/lib/homewo
 import { campusReferenceMarkdownPlugins } from "@/features/markdown/lib/campus-reference-markdown";
 import MarkdownEditor from "$lib/components/MarkdownEditor.svelte";
 import * as Field from "$lib/components/ui/field/index.js";
-import HomeworkStyleGuide from "./HomeworkStyleGuide.svelte";
 import type {
   HomeworkFormCommentsCopy,
   HomeworkFormCopy,
@@ -15,7 +14,6 @@ export let description = "";
 export let disabled = false;
 export let idPrefix = "homework";
 export let markdownModeLabel = "";
-export let styleGuidePrefix = idPrefix;
 export let previewLayout: "tabs" | "split" = "tabs";
 </script>
 
@@ -39,4 +37,3 @@ export let previewLayout: "tabs" | "split" = "tabs";
     value={description}
   />
 </Field.Field>
-<HomeworkStyleGuide {copy} testIdPrefix={styleGuidePrefix} />

--- a/src/features/homeworks/components/HomeworkEditorFields.svelte
+++ b/src/features/homeworks/components/HomeworkEditorFields.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import * as Field from "$lib/components/ui/field/index.js";
 import HomeworkDescriptionFields from "./HomeworkDescriptionFields.svelte";
+import HomeworkStyleGuide from "./HomeworkStyleGuide.svelte";
 import HomeworkTagFields from "./HomeworkTagFields.svelte";
 import HomeworkTimestampFields from "./HomeworkTimestampFields.svelte";
 import HomeworkTitleField from "./HomeworkTitleField.svelte";
@@ -54,8 +55,8 @@ export let title = "";
         {disabled}
         {idPrefix}
         {markdownModeLabel}
-        {styleGuidePrefix}
       />
+      <HomeworkStyleGuide {copy} testIdPrefix={styleGuidePrefix} />
     {/snippet}
     {#snippet optionalSettings()}
       <HomeworkTagFields

--- a/src/features/homeworks/components/HomeworkTimestampFields.svelte
+++ b/src/features/homeworks/components/HomeworkTimestampFields.svelte
@@ -4,7 +4,6 @@ import type { Snippet } from "svelte";
 import DateTimePicker from "$lib/components/DateTimePicker.svelte";
 import * as Accordion from "$lib/components/ui/accordion/index.js";
 import { Button } from "$lib/components/ui/button/index.js";
-import * as ButtonGroup from "$lib/components/ui/button-group/index.js";
 import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
 import * as Field from "$lib/components/ui/field/index.js";
 import type {
@@ -33,9 +32,6 @@ $: hasDueShortcuts = Boolean(
     actions.dueInWeek ||
     dueShortcuts.length > 0,
 );
-$: hasAdvancedShortcuts = Boolean(
-  actions.publishNow || actions.startAtSemesterStart || actions.startNow,
-);
 </script>
 
 <Field.Group class="gap-4">
@@ -60,7 +56,6 @@ $: hasAdvancedShortcuts = Boolean(
               {...props}
               class="shrink-0"
               disabled={disabled}
-              size="sm"
               type="button"
               variant="outline"
             >
@@ -125,88 +120,83 @@ $: hasAdvancedShortcuts = Boolean(
         {advancedOpen ? copy.advancedHide : copy.advancedShow}
       </Accordion.Trigger>
       <Accordion.Content class="grid gap-4 pb-4">
-        <Field.Group class="grid gap-3 sm:grid-cols-2">
+        <Field.Group class="gap-4">
           <Field.Field data-disabled={disabled ? "true" : undefined}>
-            <Field.Title id={`${idPrefix}-published-at-label`}>
-              {copy.publishedAt}
-            </Field.Title>
-            <DateTimePicker
-              aria-labelledby={`${idPrefix}-published-at-label`}
-              bind:value={publishedAt}
-              calendarButtonLabel={copy.calendarButtonLabel}
-              defaultTime="00:00"
-              disabled={disabled}
-              name="publishedAt"
-            />
-            {#if hasAdvancedShortcuts}
-              <ButtonGroup.Root class="ml-auto max-w-full flex-wrap justify-end">
-                {#if actions.publishNow}
-                  <Button
-                    disabled={disabled}
-                    type="button"
-                    variant="outline"
-                    onclick={actions.publishNow}
-                  >
-                    {copy.helperPublishNow}
-                  </Button>
-                {/if}
-                <Button
-                  disabled={disabled}
-                  type="button"
-                  variant="outline"
-                  onclick={() => {
-                    publishedAt = "";
-                  }}
-                >
-                  {copy.helperClear}
-                </Button>
-              </ButtonGroup.Root>
-            {/if}
+            <Field.Title id={`${idPrefix}-published-at-label`}>{copy.publishedAt}</Field.Title>
+            <div class="flex flex-wrap items-end gap-2">
+              <DateTimePicker
+                aria-labelledby={`${idPrefix}-published-at-label`}
+                bind:value={publishedAt}
+                calendarButtonLabel={copy.calendarButtonLabel}
+                class="min-w-48 flex-1"
+                defaultTime="00:00"
+                {disabled}
+                name={advancedOpen ? "publishedAt" : undefined}
+              />
+              <DropdownMenu.Root>
+                <DropdownMenu.Trigger>
+                  {#snippet child({ props })}
+                    <Button {...props} aria-label={`${copy.publishedAt} · ${copy.timeShortcuts}`} {disabled} type="button" variant="outline">
+                      <CalendarClock data-icon="inline-start" />
+                      {copy.timeShortcuts}
+                    </Button>
+                  {/snippet}
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Content align="end" class="w-max max-w-[calc(100vw-2rem)]">
+                  <DropdownMenu.Group>
+                  {#if actions.publishNow}
+                    <DropdownMenu.Item disabled={disabled} onSelect={actions.publishNow}>
+                      {copy.helperPublishNow}
+                    </DropdownMenu.Item>
+                  {/if}
+                    <DropdownMenu.Item {disabled} onSelect={() => { publishedAt = ""; }}>
+                      {copy.helperClear}
+                    </DropdownMenu.Item>
+                  </DropdownMenu.Group>
+                </DropdownMenu.Content>
+              </DropdownMenu.Root>
+            </div>
           </Field.Field>
           <Field.Field data-disabled={disabled ? "true" : undefined}>
-            <Field.Title id={`${idPrefix}-submission-start-label`}>
-              {copy.submissionStart}
-            </Field.Title>
-            <DateTimePicker
-              aria-labelledby={`${idPrefix}-submission-start-label`}
-              bind:value={submissionStartAt}
-              calendarButtonLabel={copy.calendarButtonLabel}
-              defaultTime="00:00"
-              disabled={disabled}
-              name="submissionStartAt"
-            />
-            <ButtonGroup.Root class="ml-auto max-w-full flex-wrap justify-end">
-              {#if actions.startNow}
-                <Button
-                  disabled={disabled}
-                  type="button"
-                  variant="outline"
-                  onclick={actions.startNow}
-                >
-                  {copy.helperStartNow}
-                </Button>
-              {/if}
-              {#if actions.startAtSemesterStart}
-                <Button
-                  disabled={disabled || capabilities.hasSemesterStart === false}
-                  type="button"
-                  variant="outline"
-                  onclick={actions.startAtSemesterStart}
-                >
-                  {copy.helperSemesterStart}
-                </Button>
-              {/if}
-              <Button
-                disabled={disabled}
-                type="button"
-                variant="outline"
-                onclick={() => {
-                  submissionStartAt = "";
-                }}
-              >
-                {copy.helperClear}
-              </Button>
-            </ButtonGroup.Root>
+            <Field.Title id={`${idPrefix}-submission-start-label`}>{copy.submissionStart}</Field.Title>
+            <div class="flex flex-wrap items-end gap-2">
+              <DateTimePicker
+                aria-labelledby={`${idPrefix}-submission-start-label`}
+                bind:value={submissionStartAt}
+                calendarButtonLabel={copy.calendarButtonLabel}
+                class="min-w-48 flex-1"
+                defaultTime="00:00"
+                {disabled}
+                name={advancedOpen ? "submissionStartAt" : undefined}
+              />
+              <DropdownMenu.Root>
+                <DropdownMenu.Trigger>
+                  {#snippet child({ props })}
+                    <Button {...props} aria-label={`${copy.submissionStart} · ${copy.timeShortcuts}`} {disabled} type="button" variant="outline">
+                      <CalendarClock data-icon="inline-start" />
+                      {copy.timeShortcuts}
+                    </Button>
+                  {/snippet}
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Content align="end" class="w-max max-w-[calc(100vw-2rem)]">
+                  <DropdownMenu.Group>
+                  {#if actions.startNow}
+                    <DropdownMenu.Item disabled={disabled} onSelect={actions.startNow}>
+                      {copy.helperStartNow}
+                    </DropdownMenu.Item>
+                  {/if}
+                  {#if actions.startAtSemesterStart}
+                    <DropdownMenu.Item disabled={disabled || capabilities.hasSemesterStart === false} onSelect={actions.startAtSemesterStart}>
+                      {copy.helperSemesterStart}
+                    </DropdownMenu.Item>
+                  {/if}
+                    <DropdownMenu.Item {disabled} onSelect={() => { submissionStartAt = ""; }}>
+                      {copy.helperClear}
+                    </DropdownMenu.Item>
+                  </DropdownMenu.Group>
+                </DropdownMenu.Content>
+              </DropdownMenu.Root>
+            </div>
           </Field.Field>
         </Field.Group>
         {#if optionalSettings}

--- a/src/features/homeworks/components/homework-form-types.ts
+++ b/src/features/homeworks/components/homework-form-types.ts
@@ -25,6 +25,7 @@ export type HomeworkTimestampCopy = HomeworkDueShortcutCopy & {
   advancedShow: string;
   calendarButtonLabel: string;
   dueDateShortcuts: string;
+  timeShortcuts: string;
   helperClear: string;
   helperMonth: string;
   helperPublishNow: string;

--- a/src/features/section-detail/lib/section-detail-controller-types.ts
+++ b/src/features/section-detail/lib/section-detail-controller-types.ts
@@ -177,6 +177,7 @@ export type SectionDetailCopy = {
     descriptionLabel: string;
     descriptionPlaceholder: string;
     dueDateShortcuts: string;
+    timeShortcuts: string;
     editAction: string;
     helperClear: string;
     helperBeforeMonday: string;

--- a/src/features/workspace/components/HomeworkCreateDialog.svelte
+++ b/src/features/workspace/components/HomeworkCreateDialog.svelte
@@ -43,6 +43,7 @@ export let toShanghaiDateTimeLocalValue: (value: Date) => string;
     }}
   >
     <Dialog.Content
+      aria-describedby={undefined}
       class="flex h-[calc(100dvh-2rem)] max-h-[calc(100dvh-2rem)] min-h-0 max-w-lg flex-col gap-0 overflow-clip p-0 sm:h-[min(84dvh,52rem)] sm:max-h-[min(84dvh,52rem)] sm:max-w-6xl"
     >
       <form
@@ -53,7 +54,6 @@ export let toShanghaiDateTimeLocalValue: (value: Date) => string;
       >
         <Dialog.Header class="shrink-0 px-5 pb-2 pt-4">
           <Dialog.Title class="break-words">{homeworksCopy.createTitle}</Dialog.Title>
-          <Dialog.Description>{homeworksCopy.subtitle}</Dialog.Description>
         </Dialog.Header>
         <ScrollArea class="h-0 min-h-0 flex-1">
           <HomeworkCreateFormFields

--- a/src/features/workspace/components/HomeworkCreateFormFields.svelte
+++ b/src/features/workspace/components/HomeworkCreateFormFields.svelte
@@ -72,7 +72,6 @@ $: homeworkTimestampCapabilities = {
   {/if}
   <Field.Group class="min-w-0 gap-4">
   <Field.Field
-    class="rounded-lg bg-muted/40 p-3"
     data-disabled={isCreatingHomework ? "true" : undefined}
   >
     <Field.Label for="workspace-homework-section">
@@ -105,11 +104,8 @@ $: homeworkTimestampCapabilities = {
       bind:publishedAt={createHomeworkPublishedAt}
       bind:submissionDueAt={createHomeworkSubmissionDueAt}
       bind:submissionStartAt={createHomeworkSubmissionStartAt}
-    >
-      {#snippet optionalSettings()}
-        <HomeworkTagFields copy={homeworksCopy} disabled={isCreatingHomework} idPrefix="workspace-homework" />
-      {/snippet}
-    </HomeworkTimestampFields>
+    />
+    <HomeworkTagFields copy={homeworksCopy} disabled={isCreatingHomework} idPrefix="workspace-homework" />
   </Field.Group>
   <Field.Group class="min-w-0 gap-4">
     <HomeworkDescriptionFields
@@ -119,7 +115,6 @@ $: homeworkTimestampCapabilities = {
       idPrefix="workspace-homework"
       markdownModeLabel={commentsCopy.markdownModeLabel}
       previewLayout="split"
-      styleGuidePrefix="workspace-homework"
     />
   </Field.Group>
 </Field.Group>

--- a/src/features/workspace/lib/workspace-controller-types.ts
+++ b/src/features/workspace/lib/workspace-controller-types.ts
@@ -319,6 +319,7 @@ export interface WorkspaceHomeworksCopy extends HomeworkStyleGuideCopy {
   descriptionLabel: string;
   descriptionPlaceholder: string;
   dueDateShortcuts: string;
+  timeShortcuts: string;
   errorDescriptionTooLong: string;
   errorInvalidSubmissionDue: string;
   errorSectionNotFound: string;

--- a/tests/e2e/src/app/workspace/homeworks/create-experience.test.ts
+++ b/tests/e2e/src/app/workspace/homeworks/create-experience.test.ts
@@ -23,6 +23,49 @@ for (const width of [1280, 390]) {
       await expect(option).toContainText(DEV_SEED.teacher.nameCn);
       await expect(option).not.toContainText(fixture.sections[0].code);
 
+      // Flags remain available when optional timestamps are collapsed.
+      await dialog
+        .getByRole("checkbox", { name: "大作业", exact: true })
+        .check();
+      await dialog
+        .getByRole("checkbox", { name: "需要组队", exact: true })
+        .check();
+      await dialog
+        .getByRole("button", { name: "其他可选设置", exact: true })
+        .click();
+      await dialog
+        .getByRole("button", { name: "发布日期 · 常用时间", exact: true })
+        .click();
+      await page.getByRole("menuitem", { name: "清空", exact: true }).click();
+      await expect(dialog.locator('input[name="publishedAt"]')).toHaveValue("");
+      await dialog
+        .getByRole("button", { name: "发布日期 · 常用时间", exact: true })
+        .click();
+      await page
+        .getByRole("menuitem", { name: "立即发布", exact: true })
+        .click();
+      const publishedAt = await dialog
+        .locator('input[name="publishedAt"]')
+        .inputValue();
+      expect(publishedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+      await dialog
+        .getByRole("button", { name: "提交开始 · 常用时间", exact: true })
+        .click();
+      await page.getByRole("menuitem", { name: "清空", exact: true }).click();
+      await expect(
+        dialog.locator('input[name="submissionStartAt"]'),
+      ).toHaveValue("");
+      await dialog
+        .getByRole("button", { name: "收起其他可选设置", exact: true })
+        .click();
+      await expect(dialog.locator('input[name="publishedAt"]')).toHaveCount(1);
+      await expect(dialog.locator('input[name="publishedAt"]')).toHaveValue(
+        publishedAt,
+      );
+      await expect(
+        dialog.locator('input[name="submissionStartAt"]'),
+      ).toHaveValue("");
+
       const title = dialog.getByTestId("workspace-homework-title");
       const editor = dialog.getByRole("textbox", { name: "说明", exact: true });
       const markdown = "## 第一次作业\n\n- 完成 **第一题**\n- 提交到课堂";
@@ -69,6 +112,8 @@ for (const width of [1280, 390]) {
         (item: { title: string }) => item.title === `第一次作业 ${width}`,
       );
       expect(saved).toBeDefined();
+      expect(saved.isMajor).toBe(true);
+      expect(saved.requiresTeam).toBe(true);
       expect(saved.description.content).toBe(
         markdown.replace("第一题", "第二题"),
       );

--- a/tests/e2e/src/app/workspace/homeworks/test.ts
+++ b/tests/e2e/src/app/workspace/homeworks/test.ts
@@ -740,7 +740,7 @@ test.describe("仪表盘作业", () => {
     await captureStepScreenshot(page, testInfo, "homeworks/created");
   });
 
-  test("新建作业默认展开英文填写规范", async ({ page }, testInfo) => {
+  test("新建作业保留英文输入提示并隐藏填写规范", async ({ page }, testInfo) => {
     await signInAsDebugUser(page, "/workspace/homeworks");
     await ensureSeedSectionSubscription(page);
     const localeResponse = await page.request.post("/api/account/preferences", {
@@ -763,32 +763,16 @@ test.describe("仪表盘作业", () => {
       createDialog.getByRole("textbox", { name: "Details" }),
     ).toHaveAttribute("placeholder", /题目：/);
 
-    const trigger = createDialog.getByTestId(
-      "workspace-homework-style-guide-trigger",
-    );
-    await expect(trigger).toHaveAttribute("aria-expanded", "true");
-    const guide = createDialog.getByTestId(
-      "workspace-homework-style-guide-content",
-    );
-    await expect(guide).toBeVisible();
-    await expect(guide).toContainText("第{N}次作业");
-    await expect(guide).toContainText("{主题}作业");
-    await expect(guide).toContainText(
-      "Avoid chapter-only titles such as 第一章作业",
-    );
-    await expect(guide).toContainText("Do not include the course name or code");
-    await expect(guide.locator("pre")).toContainText(
-      "- 题目：...\n- 提交方式：...\n- 提交地址：...\n- 备注：...",
-    );
-    await expect(guide).toContainText("never blocks saving");
+    await expect(
+      createDialog.getByTestId("workspace-homework-style-guide-trigger"),
+    ).toHaveCount(0);
+    await expect(
+      createDialog.locator('[data-slot="dialog-description"]'),
+    ).toHaveCount(0);
     await expect(
       createDialog.getByTestId("workspace-homework-create"),
     ).toBeVisible();
-    await captureStepScreenshot(
-      page,
-      testInfo,
-      "homeworks/style-guide-desktop",
-    );
+    await captureStepScreenshot(page, testInfo, "homeworks/create-desktop");
   });
 
   test("创建作业时可设置重要、组队、截止日期和说明", async ({


### PR DESCRIPTION
Simplify the workspace homework creation dialog by removing its subtitle, the section field’s decorative wrapper, and the homework writing guide. Major-assignment and team flags remain visible outside optional timestamp settings.

Date inputs and their shortcut buttons now share the same height. Published/start timestamps use the same input-plus-menu layout as the due timestamp; their existing immediate, semester-start, and clear actions remain available. Collapsed date controls no longer duplicate the hidden fields submitted with the form. The section-detail editor composes its existing writing guide explicitly.

Validation:
- Full local check: Svelte/TypeScript and 2,602 unit tests passed; production build passed.
- All 21 workspace homework browser tests passed, including desktop/mobile creation, flags, timestamp menus, and values preserved after collapsing optional settings.
- Inspected Chinese desktop/mobile screenshots and checked matching input/button heights.
