### PR TITLE
fix(server): harden ingestion retries, cut R2 probe noise, restore legacy URL shims

### DIFF
--- a/docs/contracts/ical.json
+++ b/docs/contracts/ical.json
@@ -63,7 +63,7 @@
               "The opaque credential authorizes feed retrieval.",
               "The credential is carried only in the canonical path segment.",
               "An existing user with a valid feed token receives a valid empty VCALENDAR when no items are currently available, so calendar clients can keep the subscription active.",
-              "When the user exists but the feed token is wrong or revoked, the route returns 410 Gone with a short Cache-Control so calendar clients stop aggressive re-polling; unknown users return 404."
+              "When the user exists but the feed token is wrong or revoked, the route returns 410 Gone with a short Cache-Control so calendar clients stop aggressive re-polling; unknown users return 404. Legacy /api/users/[id]:[token]/calendar.ics URLs permanently redirect (308) here with the credential preserved; the retired JWT-based /api/calendar-subscriptions/[id]/calendar.ics URL has no modern equivalent and returns 410 Gone."
             ]
           },
           {

--- a/docs/contracts/publications.json
+++ b/docs/contracts/publications.json
@@ -95,7 +95,7 @@
             "returns": "{ batchId, objects[] }",
             "notes": [
               "Only manifests registered by the caller's accepted batch may be planned.",
-              "Each object is already_present or upload_required. An already_present object has been verified and linked; upload_required includes the authenticated Worker uploadUrl, r2Key, and requiredHeaders."
+              "Each object is already_present or upload_required. An already_present object is trusted from a prior verification (status verified or linked) without re-heading R2; upload_required includes the authenticated Worker uploadUrl, r2Key, and requiredHeaders."
             ]
           },
           {

--- a/docs/contracts/user.json
+++ b/docs/contracts/user.json
@@ -16,6 +16,7 @@
     "welcome-completion-resume": "If the welcome flow was reached from an app-relative callbackUrl, successful completion returns to that page; otherwise completion returns home.",
     "auth-callback-not-intercepted": "Authorization callback continuation requests carrying OAuth code/error and state must be allowed to complete the protocol redirect; the welcome page interceptor must not break the authorization result redirect.",
     "post-login-redirect": "After successful login, the user should be redirected back to the originally requested app-relative page whenever possible; unsafe external callbacks fall back to the home page.",
+    "legacy-sign-in-redirect": "The retired /signin page permanently redirects (308) to /account/sign-in, preserving the query string such as callbackUrl.",
     "oauth-login-resume": "If an OAuth authorization request lands on /account/sign-in with raw authorization query parameters instead of callbackUrl, the sign-in flow should resume that exact authorization request after login rather than falling back to /.",
     "oauth-consent-loopback-continuation": "The OAuth consent step must continue working for loopback public clients even when the client uses 127.0.0.1 and the app itself is being browsed via localhost; consent submission should preserve the original authorization query and complete the redirect back to the registered loopback callback.",
     "public-identity-display": "Public identity defaults to displaying name or username, not internal identifiers.",

--- a/docs/contracts/young-event.json
+++ b/docs/contracts/young-event.json
@@ -11,7 +11,7 @@
     "static-snapshot-sourced": "Events are scraped by the static repo (authenticated young.ustc.edu.cn enrolmentList/endList APIs) into the published SQLite snapshot and imported into Postgres by the static loader; the only request-time call to young.ustc.edu.cn is the poster-image proxy, which fetches the public /login/<pic> URL once and caches it in R2.",
     "snapshot-authoritative": "The static snapshot is authoritative; the loader upserts by upstream youngId and deletes events absent from the snapshot. An empty snapshot never wipes existing rows (treated as upstream breakage).",
     "raw-payload-preserved": "Curated columns cover the common fields; the complete upstream record stays available under rawJson for REST and MCP consumers.",
-    "image-proxy-cached": "The database stores the raw upstream `pic` path; the public imageUrl field is a local proxy path (/api/catalog/young-events/[youngId]/image). The proxy route lazily fetches https://young.ustc.edu.cn/login/<pic> on first miss, stores the bytes in the R2 publications bucket under young-events/images/<pic>, and serves them with immutable year-long cache headers. Origin failures return 502 and are never cached.",
+    "image-proxy-cached": "The public imageUrl is a local proxy path (/api/catalog/young-events/[youngId]/image). On first miss the route fetches https://young.ustc.edu.cn/login/<pic>, stores bytes in R2 under young-events/images/<pic>, and serves immutable year-long cache headers. Final responses are also held in the per-colo Cache API keyed by youngId for their Cache-Control TTL (200 long-term, 404 for 300s, 502 for 60s); the 503 storage-unavailable response is never cached.",
     "shanghai-local-times": "Upstream datetimes are Asia/Shanghai local times; startAt/endAt/applyStartAt/applyEndAt are stored and returned as instants.",
     "read-only": "Events are imported facts; no transport exposes writes."
   },
@@ -42,8 +42,8 @@
             "path": "/api/catalog/young-events/[youngId]/image",
             "returns": "poster image bytes (Content-Type from the origin or the file extension)",
             "notes": [
-              "Cache-aside proxy: serves the R2-cached copy under young-events/images/<pic> with immutable year-long cache headers and ETag/304 support; on a miss it fetches https://young.ustc.edu.cn/login/<pic> and stores the result.",
-              "404 when the youngId is unknown or the event has no image; 502 when the origin fetch fails (failures are not cached)."
+              "Cache-aside proxy: serves the R2-cached copy under young-events/images/<pic> with immutable year-long cache headers and ETag/304 support; on a miss it fetches https://young.ustc.edu.cn/login/<pic> and stores the result. Repeat requests are served from the per-colo Cache API keyed by youngId.",
+              "404 when the youngId is unknown or the event has no image (cached for 300s); 502 when the origin fetch fails (cached for 60s)."
             ]
           }
         ]

--- a/src/features/publications/server/publication-ingestion-errors.ts
+++ b/src/features/publications/server/publication-ingestion-errors.ts
@@ -6,6 +6,16 @@
  */
 export const PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS = 45_000;
 
+/**
+ * Transient transaction failures (P2028 interactive-transaction timeouts,
+ * serialization conflicts) abort the whole batch write with no rows
+ * retained, so the transaction can be retried a bounded number of times.
+ * A retry after a partially visible commit still resolves through the
+ * batchId/payload-digest re-read instead of double-ingesting.
+ */
+export const PUBLICATION_INGESTION_TRANSACTION_MAX_ATTEMPTS = 3;
+export const PUBLICATION_INGESTION_TRANSACTION_RETRY_DELAY_MS = 200;
+
 export class PublicationIngestionBadRequestError extends Error {
   readonly code = "publication_ingestion_bad_request";
 }

--- a/src/features/publications/server/publication-ingestion-keys.ts
+++ b/src/features/publications/server/publication-ingestion-keys.ts
@@ -32,7 +32,21 @@ async function sha256Text(value: string) {
 export async function publicationIngestionPayloadDigest(
   payload: PublicationIngestionBatchRequest,
 ) {
-  return sha256Text(JSON.stringify(canonicalize(payload)));
+  // Stringify with sorted keys via the replacer instead of materializing a
+  // fully canonicalized deep copy first: batches carry up to 100 full-text
+  // items, and the extra copy meaningfully raises the Worker memory peak.
+  return sha256Text(
+    JSON.stringify(payload, (_key, value: unknown) => {
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        return value;
+      }
+      return Object.fromEntries(
+        Object.entries(value).sort(([left], [right]) =>
+          left.localeCompare(right),
+        ),
+      );
+    }),
+  );
 }
 
 export function publicationPrincipalKey(

--- a/src/features/publications/server/publication-ingestion-service.ts
+++ b/src/features/publications/server/publication-ingestion-service.ts
@@ -2,7 +2,10 @@ import { Prisma } from "@/generated/prisma/client";
 import type { PublicationIngestionBatchRequest } from "@/lib/api/schemas/request-publication-ingestion-schemas";
 import type { PublicationIngestionServicePrincipal } from "@/lib/auth/service-principal";
 import { prisma } from "@/lib/db/prisma";
+import { isSerializationError } from "@/lib/db/serializable-transaction";
 import {
+  PUBLICATION_INGESTION_TRANSACTION_MAX_ATTEMPTS,
+  PUBLICATION_INGESTION_TRANSACTION_RETRY_DELAY_MS,
   PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS,
   type PublicationIngestionBatchResult,
   PublicationIngestionConflictError,
@@ -23,6 +26,8 @@ import { parsePublicationDate } from "./publication-ingestion-revision-semantics
 export { PUBLICATION_INGESTION_BATCH_MAX_ITEMS } from "@/features/publications/lib/publication-ingestion-limits";
 
 export {
+  PUBLICATION_INGESTION_TRANSACTION_MAX_ATTEMPTS,
+  PUBLICATION_INGESTION_TRANSACTION_RETRY_DELAY_MS,
   PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS,
   PublicationIngestionBadRequestError,
   type PublicationIngestionBatchResult,
@@ -40,6 +45,23 @@ function isUniqueViolation(error: unknown) {
   return (
     error instanceof Prisma.PrismaClientKnownRequestError &&
     error.code === "P2002"
+  );
+}
+
+function isTransientTransactionError(error: unknown) {
+  return (
+    isSerializationError(error) ||
+    (error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2028")
+  );
+}
+
+function retryDelay(attempt: number) {
+  return new Promise((resolve) =>
+    setTimeout(
+      resolve,
+      PUBLICATION_INGESTION_TRANSACTION_RETRY_DELAY_MS * attempt,
+    ),
   );
 }
 
@@ -67,152 +89,162 @@ async function ingestWithRetry(
   payloadDigest: string,
   principalKey: string,
 ) {
-  const response = await prisma.$transaction(
-    async (tx) => {
-      const existing = await tx.ingestionBatch.findUnique({
-        where: {
-          principalKey_batchId: { principalKey, batchId: payload.batchId },
-        },
-      });
-      if (existing) {
-        if (existing.payloadDigest !== payloadDigest) {
-          throw new PublicationIngestionConflictError(
-            "The batch ID was already used with a different payload",
-          );
-        }
-        return storedResult(existing.result);
-      }
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await prisma.$transaction(
+        async (tx) => {
+          const existing = await tx.ingestionBatch.findUnique({
+            where: {
+              principalKey_batchId: { principalKey, batchId: payload.batchId },
+            },
+          });
+          if (existing) {
+            if (existing.payloadDigest !== payloadDigest) {
+              throw new PublicationIngestionConflictError(
+                "The batch ID was already used with a different payload",
+              );
+            }
+            return storedResult(existing.result);
+          }
 
-      validateSourceDescriptors(payload);
-      const run = await tx.ingestionRun.upsert({
-        where: {
-          principalKey_clientRunId: {
-            principalKey,
+          validateSourceDescriptors(payload);
+          const run = await tx.ingestionRun.upsert({
+            where: {
+              principalKey_clientRunId: {
+                principalKey,
+                clientRunId: payload.clientRunId,
+              },
+            },
+            create: {
+              clientRunId: payload.clientRunId,
+              principalKey,
+              observedAt: parsePublicationDate(payload.observedAt),
+            },
+            update: {
+              observedAt: parsePublicationDate(payload.observedAt),
+              status: "running",
+            },
+          });
+
+          const registeredSources = new Map<string, RegisteredSource>();
+          for (const source of payload.sources) {
+            const registered = await tx.publicationSource.upsert({
+              where: { id: source.id },
+              create: {
+                id: source.id,
+                name: source.name,
+                organizationLevel: source.organizationLevel ?? "unknown",
+                allowedHosts: source.allowedHosts ?? [],
+                blockedHosts: source.blockedHosts ?? [],
+                seedUrls: source.seedUrls ?? [],
+                aliases: source.aliases ?? [],
+                discoveryOnly: source.discoveryOnly ?? false,
+                maxImagesPerPage: source.maxImagesPerPage ?? null,
+              },
+              update: {
+                name: source.name,
+                ...(source.organizationLevel === undefined
+                  ? {}
+                  : { organizationLevel: source.organizationLevel }),
+                ...(source.allowedHosts === undefined
+                  ? {}
+                  : { allowedHosts: source.allowedHosts }),
+                ...(source.blockedHosts === undefined
+                  ? {}
+                  : { blockedHosts: source.blockedHosts }),
+                ...(source.seedUrls === undefined
+                  ? {}
+                  : { seedUrls: source.seedUrls }),
+                ...(source.aliases === undefined
+                  ? {}
+                  : { aliases: source.aliases }),
+                ...(source.discoveryOnly === undefined
+                  ? {}
+                  : { discoveryOnly: source.discoveryOnly }),
+                ...(source.maxImagesPerPage === undefined
+                  ? {}
+                  : { maxImagesPerPage: source.maxImagesPerPage }),
+              },
+            });
+            registeredSources.set(source.id, {
+              id: registered.id,
+              name: registered.name,
+              organizationLevel: registered.organizationLevel,
+              allowedHosts: source.allowedHosts ?? registered.allowedHosts,
+              blockedHosts: source.blockedHosts ?? registered.blockedHosts,
+              seedUrls: source.seedUrls ?? registered.seedUrls,
+              aliases: source.aliases ?? registered.aliases,
+              discoveryOnly: source.discoveryOnly ?? registered.discoveryOnly,
+              maxImagesPerPage:
+                source.maxImagesPerPage === undefined
+                  ? registered.maxImagesPerPage
+                  : source.maxImagesPerPage,
+              enabled: registered.enabled,
+              allowAnyHost:
+                (source.allowedHosts ?? registered.allowedHosts).length === 0,
+            });
+          }
+
+          const batch = await tx.ingestionBatch.create({
+            data: {
+              batchId: payload.batchId,
+              runId: run.id,
+              principalKey,
+              payloadDigest,
+              itemCount: payload.items.length,
+            },
+          });
+
+          const results: PublicationIngestionItemResult[] = [];
+          for (const item of payload.items) {
+            const source = registeredSources.get(item.sourceId);
+            if (!source?.enabled || source.discoveryOnly) {
+              results.push(
+                result(
+                  item,
+                  "rejected",
+                  null,
+                  null,
+                  source && !source.enabled
+                    ? "source is disabled"
+                    : source
+                      ? "discovery-only source cannot ingest publications"
+                      : "source is not registered in this batch",
+                ),
+              );
+              continue;
+            }
+            results.push(await ingestItem(tx, batch.id, item, source));
+          }
+
+          const response: PublicationIngestionBatchResult = {
+            batchId: payload.batchId,
             clientRunId: payload.clientRunId,
-          },
+            payloadDigest,
+            results,
+          };
+          await tx.ingestionBatch.update({
+            where: { id: batch.id },
+            data: { result: response as unknown as Prisma.InputJsonObject },
+          });
+          await tx.ingestionRun.update({
+            where: { id: run.id },
+            data: { status: "completed" },
+          });
+          return response;
         },
-        create: {
-          clientRunId: payload.clientRunId,
-          principalKey,
-          observedAt: parsePublicationDate(payload.observedAt),
-        },
-        update: {
-          observedAt: parsePublicationDate(payload.observedAt),
-          status: "running",
-        },
-      });
-
-      const registeredSources = new Map<string, RegisteredSource>();
-      for (const source of payload.sources) {
-        const registered = await tx.publicationSource.upsert({
-          where: { id: source.id },
-          create: {
-            id: source.id,
-            name: source.name,
-            organizationLevel: source.organizationLevel ?? "unknown",
-            allowedHosts: source.allowedHosts ?? [],
-            blockedHosts: source.blockedHosts ?? [],
-            seedUrls: source.seedUrls ?? [],
-            aliases: source.aliases ?? [],
-            discoveryOnly: source.discoveryOnly ?? false,
-            maxImagesPerPage: source.maxImagesPerPage ?? null,
-          },
-          update: {
-            name: source.name,
-            ...(source.organizationLevel === undefined
-              ? {}
-              : { organizationLevel: source.organizationLevel }),
-            ...(source.allowedHosts === undefined
-              ? {}
-              : { allowedHosts: source.allowedHosts }),
-            ...(source.blockedHosts === undefined
-              ? {}
-              : { blockedHosts: source.blockedHosts }),
-            ...(source.seedUrls === undefined
-              ? {}
-              : { seedUrls: source.seedUrls }),
-            ...(source.aliases === undefined
-              ? {}
-              : { aliases: source.aliases }),
-            ...(source.discoveryOnly === undefined
-              ? {}
-              : { discoveryOnly: source.discoveryOnly }),
-            ...(source.maxImagesPerPage === undefined
-              ? {}
-              : { maxImagesPerPage: source.maxImagesPerPage }),
-          },
-        });
-        registeredSources.set(source.id, {
-          id: registered.id,
-          name: registered.name,
-          organizationLevel: registered.organizationLevel,
-          allowedHosts: source.allowedHosts ?? registered.allowedHosts,
-          blockedHosts: source.blockedHosts ?? registered.blockedHosts,
-          seedUrls: source.seedUrls ?? registered.seedUrls,
-          aliases: source.aliases ?? registered.aliases,
-          discoveryOnly: source.discoveryOnly ?? registered.discoveryOnly,
-          maxImagesPerPage:
-            source.maxImagesPerPage === undefined
-              ? registered.maxImagesPerPage
-              : source.maxImagesPerPage,
-          enabled: registered.enabled,
-          allowAnyHost:
-            (source.allowedHosts ?? registered.allowedHosts).length === 0,
-        });
+        { timeout: PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS },
+      );
+    } catch (error) {
+      if (
+        !isTransientTransactionError(error) ||
+        attempt >= PUBLICATION_INGESTION_TRANSACTION_MAX_ATTEMPTS
+      ) {
+        throw error;
       }
-
-      const batch = await tx.ingestionBatch.create({
-        data: {
-          batchId: payload.batchId,
-          runId: run.id,
-          principalKey,
-          payloadDigest,
-          itemCount: payload.items.length,
-        },
-      });
-
-      const results: PublicationIngestionItemResult[] = [];
-      for (const item of payload.items) {
-        const source = registeredSources.get(item.sourceId);
-        if (!source?.enabled || source.discoveryOnly) {
-          results.push(
-            result(
-              item,
-              "rejected",
-              null,
-              null,
-              source && !source.enabled
-                ? "source is disabled"
-                : source
-                  ? "discovery-only source cannot ingest publications"
-                  : "source is not registered in this batch",
-            ),
-          );
-          continue;
-        }
-        results.push(await ingestItem(tx, batch.id, item, source));
-      }
-
-      const response: PublicationIngestionBatchResult = {
-        batchId: payload.batchId,
-        clientRunId: payload.clientRunId,
-        payloadDigest,
-        results,
-      };
-      await tx.ingestionBatch.update({
-        where: { id: batch.id },
-        data: { result: response as unknown as Prisma.InputJsonObject },
-      });
-      await tx.ingestionRun.update({
-        where: { id: run.id },
-        data: { status: "completed" },
-      });
-      return response;
-    },
-    { timeout: PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS },
-  );
-
-  return response;
+      await retryDelay(attempt);
+    }
+  }
 }
 
 export async function ingestPublicationBatch(input: {

--- a/src/features/publications/server/publication-object-service.ts
+++ b/src/features/publications/server/publication-object-service.ts
@@ -224,7 +224,13 @@ export async function planPublicationObjects(input: {
       const headers = requiredHeaders({
         contentType: claim.expectedContentType,
       });
-      if (object.status === "linked") {
+      // "verified" and "linked" are the public object statuses (see
+      // publication-public-read-service.ts). A row only reaches them after
+      // strict byte verification, and the manifest is content-addressed with
+      // its size pinned at registration, so the plan trusts the DB row and
+      // skips the R2 head. If the object is deleted or replaced out-of-band,
+      // the plan reports already_present until a public read surfaces it.
+      if (object.status === "linked" || object.status === "verified") {
         return {
           objectId: object.id,
           storageStatus: "linked" as const,

--- a/src/features/young/server/young-event-image-service.ts
+++ b/src/features/young/server/young-event-image-service.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db/prisma";
+import { logAppEvent } from "@/lib/log/app-logger";
 import { getCloudflareR2PublicationsBucket } from "@/lib/ports/runtime";
 
 const YOUNG_EVENT_IMAGE_ORIGIN = "https://young.ustc.edu.cn/login/";
@@ -61,7 +62,7 @@ function normalizeEtag(etag: string) {
   return `"${trimmed.replaceAll('"', "")}"`;
 }
 
-function requestMatchesEtag(request: Request, etag: string) {
+export function requestMatchesEtag(request: Request, etag: string) {
   const value = request.headers.get("If-None-Match");
   if (!value) return false;
   return value.split(",").some((candidate) => {
@@ -186,7 +187,18 @@ export async function getYoungEventImageResponse(input: {
 
   const store = bucket.put(key, body, { httpMetadata: { contentType } });
   if (input.defer) {
-    input.defer(store);
+    // The deferred write outlives the response; log failures instead of
+    // dropping the rejection silently.
+    input.defer(
+      store.catch((error: unknown) => {
+        logAppEvent(
+          "error",
+          "Failed to cache young event image in R2",
+          { source: "young-event-image", youngId: input.youngId },
+          error,
+        );
+      }),
+    );
   } else {
     await store;
   }

--- a/src/lib/api/routes/young-event-routes.ts
+++ b/src/lib/api/routes/young-event-routes.ts
@@ -1,5 +1,6 @@
 import {
   getYoungEventImageResponse,
+  requestMatchesEtag,
   YoungEventImageOriginError,
   YoungEventImageStorageUnavailableError,
 } from "@/features/young/server/young-event-image-service";
@@ -20,6 +21,11 @@ import {
   youngEventDetailSchema,
   youngEventsQuerySchema,
 } from "@/lib/api/schemas/young-event-schemas";
+import { logAppEvent } from "@/lib/log/app-logger";
+import {
+  type CloudflareCache,
+  getCloudflareNamedCache,
+} from "@/lib/ports/runtime";
 import { PUBLIC_CATALOG_HEADERS } from "@/lib/public-cache-control";
 
 export async function getYoungEventsRoute(request: Request) {
@@ -65,6 +71,67 @@ export async function getYoungEventDetailRoute(
   }
 }
 
+const YOUNG_EVENT_IMAGE_COLO_CACHE_NAME = "life-ustc-young-event-image-v1";
+const YOUNG_EVENT_IMAGE_COLO_CACHE_PATH =
+  "/_life-ustc-internal-cache/young-event-image/v1";
+
+type YoungEventImageColoCache = {
+  cache: CloudflareCache;
+  request: Request;
+};
+
+async function openYoungEventImageColoCache(
+  request: Request,
+  youngId: string,
+): Promise<YoungEventImageColoCache | undefined> {
+  const cache = await getCloudflareNamedCache(
+    YOUNG_EVENT_IMAGE_COLO_CACHE_NAME,
+  )?.catch(() => undefined);
+  if (!cache) return undefined;
+  const key = new URL(
+    `${YOUNG_EVENT_IMAGE_COLO_CACHE_PATH}/${encodeURIComponent(youngId)}`,
+    request.url,
+  );
+  return { cache, request: new Request(key, { method: "GET" }) };
+}
+
+/** The Cache API expires entries with the response's own Cache-Control TTL;
+ * only responses carrying an explicit max-age are stored (304s and the 503
+ * storage-unavailable response are not). */
+function isYoungEventImageColoCacheable(response: Response) {
+  if (response.status === 304) return false;
+  const cacheControl = response.headers.get("Cache-Control") ?? "";
+  return (
+    /\bmax-age=\d+/.test(cacheControl) && !/\bno-store\b/.test(cacheControl)
+  );
+}
+
+async function writeYoungEventImageColoCache(
+  target: YoungEventImageColoCache,
+  response: Response,
+  defer?: (promise: Promise<unknown>) => void,
+) {
+  let write: Promise<void>;
+  try {
+    write = target.cache.put(target.request, response);
+  } catch {
+    return;
+  }
+  const logged = write.catch((error: unknown) => {
+    logAppEvent(
+      "error",
+      "Failed to cache young event image response",
+      { source: "young-event-image" },
+      error,
+    );
+  });
+  if (defer) {
+    defer(logged);
+  } else {
+    await logged;
+  }
+}
+
 export async function getYoungEventImageRoute(
   request: Request,
   params: { youngId: string },
@@ -77,6 +144,25 @@ export async function getYoungEventImageRoute(
   );
   if (parsed instanceof Response) return parsed;
 
+  // Repeat image requests are served from the per-colo Cache API so they skip
+  // the DB + R2 + origin chain entirely.
+  const coloCache = await openYoungEventImageColoCache(request, parsed.youngId);
+  if (coloCache) {
+    const cached = await coloCache.cache
+      .match(coloCache.request)
+      .catch(() => undefined);
+    if (cached) {
+      const etag = cached.headers.get("ETag");
+      if (etag && requestMatchesEtag(request, etag)) {
+        const headers = new Headers(cached.headers);
+        headers.delete("Content-Length");
+        return new Response(null, { status: 304, headers });
+      }
+      return cached;
+    }
+  }
+
+  let response: Response;
   try {
     const result = await getYoungEventImageResponse({
       request,
@@ -86,30 +172,37 @@ export async function getYoungEventImageRoute(
     if (!result) {
       // Short CDN caching on errors absorbs repeat misses without pinning a
       // stale 404 if the event gains a poster later.
-      const response = notFound("Young event image not found");
+      response = notFound("Young event image not found");
       response.headers.set("Cache-Control", "public, max-age=300");
-      return response;
+    } else {
+      response = result;
     }
-    return result;
   } catch (error) {
     if (error instanceof YoungEventImageStorageUnavailableError) {
-      const response = handleRouteError(
+      response = handleRouteError(
         "Young event image storage unavailable",
         error,
         503,
       );
       response.headers.set("Retry-After", "60");
-      return response;
-    }
-    if (error instanceof YoungEventImageOriginError) {
-      const response = handleRouteError(
+    } else if (error instanceof YoungEventImageOriginError) {
+      response = handleRouteError(
         "Failed to fetch young event image from origin",
         error,
         502,
       );
       response.headers.set("Cache-Control", "public, max-age=60");
-      return response;
+    } else {
+      return handleRouteError("Failed to fetch young event image", error);
     }
-    return handleRouteError("Failed to fetch young event image", error);
   }
+
+  if (coloCache && isYoungEventImageColoCacheable(response)) {
+    await writeYoungEventImageColoCache(
+      coloCache,
+      response.clone(),
+      options.defer,
+    );
+  }
+  return response;
 }

--- a/src/lib/cloudflare/public-ssr-gateway.ts
+++ b/src/lib/cloudflare/public-ssr-gateway.ts
@@ -74,6 +74,10 @@ const DYNAMIC_OR_PRIVATE_ROOTS = [
 ];
 
 const LEGACY_CATALOG_PATH = /^\/(sections|courses|teachers)\/(.+)$/;
+const LEGACY_SIGN_IN_PATH = "/signin";
+const LEGACY_USER_CALENDAR_FEED_PATH = /^\/api\/users\/([^/]+)\/calendar\.ics$/;
+const LEGACY_CALENDAR_SUBSCRIPTION_FEED_PATH =
+  /^\/api\/calendar-subscriptions\/[^/]+\/calendar\.ics$/;
 
 export function resolveLegacyCatalogRedirect(request: Request) {
   if (request.method !== "GET" && request.method !== "HEAD") return null;
@@ -81,6 +85,28 @@ export function resolveLegacyCatalogRedirect(request: Request) {
   const match = LEGACY_CATALOG_PATH.exec(url.pathname);
   if (!match) return null;
   return `/catalog/${match[1]}/${match[2]}${url.search}`;
+}
+
+export function resolveLegacySignInRedirect(request: Request) {
+  if (request.method !== "GET" && request.method !== "HEAD") return null;
+  const url = new URL(request.url);
+  if (url.pathname !== LEGACY_SIGN_IN_PATH) return null;
+  return `/account/sign-in${url.search}`;
+}
+
+export function resolveLegacyCalendarFeedRedirect(request: Request) {
+  if (request.method !== "GET" && request.method !== "HEAD") return null;
+  const url = new URL(request.url);
+  const match = LEGACY_USER_CALENDAR_FEED_PATH.exec(url.pathname);
+  if (!match) return null;
+  return `/api/calendar-feeds/${match[1]}.ics${url.search}`;
+}
+
+export function isLegacyCalendarSubscriptionFeedRequest(request: Request) {
+  if (request.method !== "GET" && request.method !== "HEAD") return false;
+  return LEGACY_CALENDAR_SUBSCRIPTION_FEED_PATH.test(
+    new URL(request.url).pathname,
+  );
 }
 
 export function resolveCourseDetailTabRedirect(request: Request) {

--- a/src/lib/log/worker-entrypoint-observability.ts
+++ b/src/lib/log/worker-entrypoint-observability.ts
@@ -12,6 +12,7 @@ const REQUEST_ID_PATTERN =
 export type EdgeRequestClass =
   | "catalog-redirect"
   | "dynamic"
+  | "legacy-redirect"
   | "public-not-found"
   | "public-ssr-cache";
 
@@ -48,7 +49,12 @@ const SAFE_CACHE_OUTCOMES = new Set<EdgeCacheOutcome>([
   "updating",
 ]);
 
-export type WorkerQueue = "audit" | "calendar" | "unknown";
+export type WorkerQueue =
+  | "audit"
+  | "audit-dead-letter"
+  | "calendar"
+  | "calendar-dead-letter"
+  | "unknown";
 export type WorkerQueueCompletionOutcome =
   | "error"
   | "partial"
@@ -58,6 +64,10 @@ export type WorkerQueueCompletionOutcome =
 export function resolveWorkerQueue(queue: string): WorkerQueue {
   if (queue === "life-ustc-audit-log-write") return "audit";
   if (queue === "life-ustc-calendar-export-rebuild") return "calendar";
+  if (queue === "life-ustc-audit-log-write-dlq") return "audit-dead-letter";
+  if (queue === "life-ustc-calendar-export-rebuild-dlq") {
+    return "calendar-dead-letter";
+  }
   return "unknown";
 }
 
@@ -325,6 +335,41 @@ export function logWorkerQueueError(input: {
     },
     input.error,
   );
+}
+
+export type WorkerDeadLetterMessage = {
+  attempts?: number;
+  body: unknown;
+  id?: string;
+};
+
+function deadLetterMessageType(body: unknown) {
+  if (typeof body !== "object" || body === null) return undefined;
+  const type = (body as { type?: unknown }).type;
+  return typeof type === "string" && type.length <= 128 ? type : undefined;
+}
+
+export function logWorkerDeadLetterMessage(input: {
+  message: WorkerDeadLetterMessage;
+  queue: WorkerQueue;
+}) {
+  // Like the source queue consumers, never log the message body: it may carry
+  // credentials or PII. The platform message id and envelope type identify the
+  // dead letter without retaining its payload.
+  const messageType = deadLetterMessageType(input.message.body);
+  logAppEvent("error", "worker.queue.dead-letter", {
+    ...(typeof input.message.attempts === "number"
+      ? { attempts: input.message.attempts }
+      : {}),
+    event: "worker.queue.dead-letter",
+    ...(typeof input.message.id === "string"
+      ? { messageId: input.message.id }
+      : {}),
+    ...(messageType === undefined ? {} : { messageType }),
+    outcome: "dead-letter",
+    queue: input.queue,
+    source: "worker-entrypoint",
+  });
 }
 
 type ScheduledTask =

--- a/src/lib/metrics/analytics-engine.ts
+++ b/src/lib/metrics/analytics-engine.ts
@@ -324,6 +324,7 @@ const HTTP_METHODS = new Set([
 const WORKER_REQUEST_CLASSES = new Set([
   "catalog-redirect",
   "dynamic",
+  "legacy-redirect",
   "public-not-found",
   "public-ssr-cache",
 ]);

--- a/src/worker.js
+++ b/src/worker.js
@@ -21,6 +21,7 @@ import { handleAuditLogWriteBatch } from "./lib/audit/audit-log-queue";
 import { CATALOG_EDGE_CACHE_TAG } from "./lib/catalog-edge-cache-tag";
 import {
   buildPublicNotFoundHtml,
+  isLegacyCalendarSubscriptionFeedRequest,
   PUBLIC_SSR_BROWSER_CACHE_CONTROL,
   PUBLIC_SSR_HEADER,
   PUBLIC_SSR_LOCALE_CACHE_PARAM,
@@ -32,7 +33,9 @@ import {
   removePublicSsrHeaders,
   resolveCourseDetailTabQueryRedirect,
   resolveCourseDetailTabRedirect,
+  resolveLegacyCalendarFeedRedirect,
   resolveLegacyCatalogRedirect,
+  resolveLegacySignInRedirect,
   resolvePublicSsrLocale,
   resolvePublicSsrMode,
   resolveSectionDetailTabQueryRedirect,
@@ -49,6 +52,7 @@ import {
   logScheduledTaskError,
   logScheduledTaskFinish,
   logUnknownScheduledTask,
+  logWorkerDeadLetterMessage,
   logWorkerFetchError,
   logWorkerQueueError,
   logWorkerQueueFinish,
@@ -320,6 +324,53 @@ async function handleFetch(request, env, context, requestId, edgeObservation) {
       "/:legacy-catalog-route",
     );
   }
+  const legacySignInRedirect = resolveLegacySignInRedirect(request);
+  if (legacySignInRedirect) {
+    return finish(
+      new Response(null, {
+        status: 308,
+        headers: {
+          "Cache-Control": "public, max-age=86400",
+          Location: legacySignInRedirect,
+        },
+      }),
+      "legacy-redirect",
+      "/signin",
+    );
+  }
+  const legacyCalendarFeedRedirect = resolveLegacyCalendarFeedRedirect(request);
+  if (legacyCalendarFeedRedirect) {
+    return finish(
+      new Response(null, {
+        status: 308,
+        headers: {
+          "Cache-Control": "public, max-age=86400",
+          Location: legacyCalendarFeedRedirect,
+        },
+      }),
+      "legacy-redirect",
+      "/api/users/:credential/calendar.ics",
+    );
+  }
+  if (isLegacyCalendarSubscriptionFeedRequest(request)) {
+    return finish(
+      new Response(
+        JSON.stringify({
+          error:
+            "This calendar feed URL was retired. Copy a new feed URL from workspace subscriptions.",
+        }),
+        {
+          status: 410,
+          headers: {
+            "Cache-Control": "public, max-age=86400",
+            "Content-Type": "application/json; charset=utf-8",
+          },
+        },
+      ),
+      "legacy-redirect",
+      "/api/calendar-subscriptions/:id/calendar.ics",
+    );
+  }
   const sectionTabRedirect = resolveSectionDetailTabRedirect(request);
   if (sectionTabRedirect) {
     return finish(
@@ -510,6 +561,18 @@ export default {
           }
           if (queue === "calendar") {
             return handleCalendarExportRebuildBatch(batch);
+          }
+          if (
+            queue === "audit-dead-letter" ||
+            queue === "calendar-dead-letter"
+          ) {
+            // Dead letters are terminal: log each message once and ack so the
+            // DLQ consumer can never retry-loop.
+            for (const message of batch.messages) {
+              logWorkerDeadLetterMessage({ message, queue });
+              message.ack();
+            }
+            return { outcome: "success" };
           }
           throw new Error("Unsupported queue");
         },

--- a/tests/unit/features/catalog/public-ssr-gateway.test.ts
+++ b/tests/unit/features/catalog/public-ssr-gateway.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, test } from "vitest";
 import { resolveCatalogListPublicSsrMode } from "@/features/catalog/lib/catalog-list-query";
 import {
   buildPublicNotFoundHtml,
+  isLegacyCalendarSubscriptionFeedRequest,
   PUBLIC_SSR_BROWSER_CACHE_CONTROL,
   PUBLIC_SSR_PAGE_EDGE_CACHE_CONTROL,
   resolvePublicSsrMode as resolveBasePublicSsrMode,
   resolveCourseDetailTabRedirect,
+  resolveLegacyCalendarFeedRedirect,
   resolveLegacyCatalogRedirect,
+  resolveLegacySignInRedirect,
   resolvePublicSsrLocale,
   resolveSectionDetailTabRedirect,
   resolveTeacherDetailTabRedirect,
@@ -73,6 +76,84 @@ describe("public SSR gateway", () => {
         }),
       ),
     ).toBeNull();
+  });
+
+  test.each([
+    ["/signin", "/account/sign-in"],
+    [
+      "/signin?callbackUrl=%2Fworkspace%2Foverview",
+      "/account/sign-in?callbackUrl=%2Fworkspace%2Foverview",
+    ],
+  ])(
+    "redirects legacy sign-in path %s preserving the query",
+    (path, target) => {
+      expect(resolveLegacySignInRedirect(request(path))).toBe(target);
+    },
+  );
+
+  test("does not redirect a non-read legacy sign-in request", () => {
+    expect(
+      resolveLegacySignInRedirect(
+        new Request("https://life-ustc.test/signin", { method: "POST" }),
+      ),
+    ).toBeNull();
+    expect(resolveLegacySignInRedirect(request("/signin/"))).toBeNull();
+    expect(resolveLegacySignInRedirect(request("/account/sign-in"))).toBeNull();
+  });
+
+  test.each([
+    [
+      "/api/users/user-1:feed-token/calendar.ics",
+      "/api/calendar-feeds/user-1:feed-token.ics",
+    ],
+    [
+      "/api/users/user-1/calendar.ics?token=feed-token",
+      "/api/calendar-feeds/user-1.ics?token=feed-token",
+    ],
+  ])(
+    "redirects legacy user calendar feed %s preserving the credential",
+    (path, target) => {
+      expect(resolveLegacyCalendarFeedRedirect(request(path))).toBe(target);
+    },
+  );
+
+  test("does not redirect other user API paths", () => {
+    expect(
+      resolveLegacyCalendarFeedRedirect(request("/api/users/user-1")),
+    ).toBeNull();
+    expect(
+      resolveLegacyCalendarFeedRedirect(
+        request("/api/users/user-1/calendar.ics/extra"),
+      ),
+    ).toBeNull();
+    expect(
+      resolveLegacyCalendarFeedRedirect(
+        new Request("https://life-ustc.test/api/users/u:t/calendar.ics", {
+          method: "POST",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  test("marks retired calendar-subscription feed URLs as gone", () => {
+    expect(
+      isLegacyCalendarSubscriptionFeedRequest(
+        request("/api/calendar-subscriptions/sub-1/calendar.ics"),
+      ),
+    ).toBe(true);
+    expect(
+      isLegacyCalendarSubscriptionFeedRequest(
+        new Request(
+          "https://life-ustc.test/api/calendar-subscriptions/sub-1/calendar.ics",
+          { method: "POST" },
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      isLegacyCalendarSubscriptionFeedRequest(
+        request("/api/calendar-feeds/user-1:feed-token.ics"),
+      ),
+    ).toBe(false);
   });
 
   test.each([

--- a/tests/unit/features/publications/publication-ingestion-contract.test.ts
+++ b/tests/unit/features/publications/publication-ingestion-contract.test.ts
@@ -329,6 +329,30 @@ describe("publication ingestion contract", () => {
     );
   });
 
+  it("digests nested payload objects independent of key order", async () => {
+    const parsed = publicationIngestionBatchRequestSchema.parse({
+      ...fixture,
+      items: [
+        {
+          ...fixture.items[0],
+          rawMetadata: { b: 1, a: { d: 2, c: [4, 5] } },
+        },
+      ],
+    });
+    const reordered = {
+      ...parsed,
+      items: [
+        {
+          ...parsed.items[0],
+          rawMetadata: { a: { c: [4, 5], d: 2 }, b: 1 },
+        },
+      ],
+    };
+    await expect(publicationIngestionPayloadDigest(parsed)).resolves.toBe(
+      await publicationIngestionPayloadDigest(reordered),
+    );
+  });
+
   it("requires a canonical SHA-256 payload digest in batch responses", () => {
     const response = {
       batchId: fixture.batchId,

--- a/tests/unit/features/publications/publication-ingestion-service.test.ts
+++ b/tests/unit/features/publications/publication-ingestion-service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PUBLICATION_INGESTION_BATCH_MAX_ITEMS } from "@/features/publications/lib/publication-ingestion-limits";
+import { Prisma } from "@/generated/prisma/client";
 import { publicationIngestionBatchRequestSchema } from "@/lib/api/schemas/request-publication-ingestion-schemas";
 import { PUBLICATION_INGESTION_SERVICE_PRINCIPAL } from "@/lib/auth/service-principal";
 import fixture from "../../../../docs/contracts/fixtures/publication-batch.json";
@@ -351,12 +352,27 @@ vi.mock("@/lib/db/prisma", () => ({ prisma: fake.prisma }));
 
 import {
   ingestPublicationBatch,
+  PUBLICATION_INGESTION_TRANSACTION_MAX_ATTEMPTS,
   PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS,
   PublicationIngestionBadRequestError,
 } from "@/features/publications/server/publication-ingestion-service";
 
 const parsedFixture = publicationIngestionBatchRequestSchema.parse(fixture);
 const principal = PUBLICATION_INGESTION_SERVICE_PRINCIPAL;
+
+function transactionTimeoutError() {
+  return new Prisma.PrismaClientKnownRequestError(
+    "Transaction API error: Transaction not found",
+    { code: "P2028", clientVersion: "test" },
+  );
+}
+
+function uniqueViolationError() {
+  return new Prisma.PrismaClientKnownRequestError(
+    "Unique constraint failed on the fields: (`principalKey`,`batchId`)",
+    { code: "P2002", clientVersion: "test" },
+  );
+}
 
 function payloadFor(item: Record<string, unknown>, batchId: string) {
   return publicationIngestionBatchRequestSchema.parse({
@@ -790,5 +806,72 @@ describe("publication ingestion transaction", () => {
       expect.any(Function),
       { timeout: PUBLICATION_INGESTION_TRANSACTION_TIMEOUT_MS },
     );
+  });
+
+  it("retries an interactive transaction timeout and commits on a later attempt", async () => {
+    fake.prisma.$transaction.mockImplementationOnce(() =>
+      Promise.reject(transactionTimeoutError()),
+    );
+
+    const payload = payloadFor({}, "batch-transaction-timeout-retry");
+    const response = await ingestPublicationBatch({ payload, principal });
+
+    expect(response.batchId).toBe("batch-transaction-timeout-retry");
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0].status).toBe("created");
+    expect(fake.prisma.$transaction).toHaveBeenCalledTimes(2);
+    expect(fake.state.batches.size).toBe(1);
+    expect(fake.state.publications.size).toBe(1);
+  });
+
+  it("rethrows the transaction timeout after exhausting all attempts", async () => {
+    const error = transactionTimeoutError();
+    for (
+      let attempt = 0;
+      attempt < PUBLICATION_INGESTION_TRANSACTION_MAX_ATTEMPTS;
+      attempt += 1
+    ) {
+      fake.prisma.$transaction.mockImplementationOnce(() =>
+        Promise.reject(error),
+      );
+    }
+
+    const payload = payloadFor({}, "batch-transaction-timeout-exhausted");
+    await expect(ingestPublicationBatch({ payload, principal })).rejects.toBe(
+      error,
+    );
+
+    expect(fake.prisma.$transaction).toHaveBeenCalledTimes(
+      PUBLICATION_INGESTION_TRANSACTION_MAX_ATTEMPTS,
+    );
+    expect(fake.state.batches.size).toBe(0);
+    expect(fake.state.publications.size).toBe(0);
+  });
+
+  it("does not retry non-transient transaction failures", async () => {
+    fake.prisma.$transaction.mockImplementationOnce(() =>
+      Promise.reject(uniqueViolationError()),
+    );
+
+    const payload = payloadFor({}, "batch-non-transient-failure");
+    await expect(
+      ingestPublicationBatch({ payload, principal }),
+    ).rejects.toBeInstanceOf(Prisma.PrismaClientKnownRequestError);
+
+    expect(fake.prisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves a committed batch through the unique-violation re-read without retrying", async () => {
+    const payload = payloadFor({}, "batch-committed-race");
+    const committed = await ingestPublicationBatch({ payload, principal });
+
+    fake.prisma.$transaction.mockImplementationOnce(() =>
+      Promise.reject(uniqueViolationError()),
+    );
+    const replayed = await ingestPublicationBatch({ payload, principal });
+
+    expect(replayed).toEqual(committed);
+    expect(fake.prisma.$transaction).toHaveBeenCalledTimes(2);
+    expect(fake.state.batches.size).toBe(1);
   });
 });

--- a/tests/unit/features/publications/publication-object-service.test.ts
+++ b/tests/unit/features/publications/publication-object-service.test.ts
@@ -278,6 +278,72 @@ describe("publication object upload", () => {
     expect(mocks.objectUpdateMany).not.toHaveBeenCalled();
   });
 
+  it("trusts a verified object's prior verification without reading R2", async () => {
+    const claim = {
+      expectedContentType: "text/plain",
+      expectedSha256: sha256OfAbc,
+      expectedSize: 3,
+      object: {
+        id: "object-1",
+        kind: "body_html" as const,
+        r2Key: `publications/body_html/sha256/ba/${sha256OfAbc}`,
+        sha256: sha256OfAbc,
+        status: "verified" as const,
+      },
+    };
+    mocks.batchFindUnique.mockResolvedValue({ objects: [claim] });
+
+    const planned = await planPublicationObjects({
+      origin: "https://life.example",
+      principal,
+      payload: {
+        batchId: "batch-verified",
+        objects: [{ kind: "body_html", sha256: sha256OfAbc }],
+      },
+    });
+
+    expect(planned.objects).toEqual([
+      expect.objectContaining({
+        kind: "body_html",
+        sha256: sha256OfAbc,
+        status: "already_present",
+        uploadUrl: null,
+      }),
+    ]);
+    expect(mocks.getBucket).not.toHaveBeenCalled();
+    expect(mocks.bucket.head).not.toHaveBeenCalled();
+    expect(mocks.bucket.get).not.toHaveBeenCalled();
+    expect(mocks.objectUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("heads R2 and requires upload for a pending object missing from storage", async () => {
+    mocks.bucket.head.mockResolvedValue(null);
+
+    const planned = await planPublicationObjects({
+      origin: "https://life.example",
+      principal,
+      payload: {
+        batchId: "batch-pending",
+        objects: [{ kind: "body_html", sha256: sha256OfAbc }],
+      },
+    });
+
+    expect(planned.objects).toEqual([
+      expect.objectContaining({
+        kind: "body_html",
+        sha256: sha256OfAbc,
+        status: "upload_required",
+        uploadUrl: `https://life.example/api/ingestion/publications/objects/batch-pending/body_html/${sha256OfAbc}`,
+      }),
+    ]);
+    expect(mocks.bucket.head).toHaveBeenCalledTimes(1);
+    expect(mocks.bucket.get).not.toHaveBeenCalled();
+    expect(mocks.objectUpdateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["object-1"] } },
+      data: { status: "pending", lastError: null },
+    });
+  });
+
   it("plans a large request with one batch lookup and bounded R2 concurrency", async () => {
     const objectCount = 500;
     const claims = Array.from({ length: objectCount }, (_, index) => {

--- a/tests/unit/features/young/young-event-image-route.test.ts
+++ b/tests/unit/features/young/young-event-image-route.test.ts
@@ -7,7 +7,16 @@ const mocks = vi.hoisted(() => ({
     get: vi.fn(),
     put: vi.fn(),
   },
+  cache: {
+    match: vi.fn<(request: Request) => Promise<Response | undefined>>(),
+    put: vi.fn<(request: Request, response: Response) => Promise<void>>(),
+  },
+  state: {
+    bucketAvailable: true,
+    cacheAvailable: true,
+  },
   fetchMock: vi.fn(),
+  logAppEvent: vi.fn(),
 }));
 
 vi.mock("@/lib/db/prisma", () => ({
@@ -18,7 +27,15 @@ vi.mock("@/lib/adapters/cloudflare-runtime", async (importOriginal) => ({
   ...(await importOriginal<
     typeof import("@/lib/adapters/cloudflare-runtime")
   >()),
-  getCloudflareR2PublicationsBucket: () => mocks.bucket,
+  getCloudflareNamedCache: () =>
+    mocks.state.cacheAvailable ? Promise.resolve(mocks.cache) : undefined,
+  getCloudflareR2PublicationsBucket: () =>
+    mocks.state.bucketAvailable ? mocks.bucket : undefined,
+}));
+
+vi.mock("@/lib/log/app-logger", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/log/app-logger")>()),
+  logAppEvent: mocks.logAppEvent,
 }));
 
 import { YOUNG_EVENT_IMAGE_MAX_BYTES } from "@/features/young/server/young-event-image-service";
@@ -28,6 +45,8 @@ const PIC_PATH = "group1/M00/31/B5/wKgUEWpR3ciAJX_MAABnEoFLBaI860.jpg";
 const R2_KEY = `young-events/images/${PIC_PATH}`;
 const ORIGIN_URL = `https://young.ustc.edu.cn/login/${PIC_PATH}`;
 const ROUTE_URL = "https://life.test/api/catalog/young-events/42/image";
+const CACHE_KEY_URL =
+  "https://life.test/_life-ustc-internal-cache/young-event-image/v1/42";
 
 function stream(value: string) {
   return new ReadableStream<Uint8Array>({
@@ -46,6 +65,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.stubGlobal("fetch", mocks.fetchMock);
   mocks.youngEventFindUnique.mockResolvedValue(eventWithImage());
+  mocks.state.bucketAvailable = true;
+  mocks.state.cacheAvailable = true;
+  mocks.cache.match.mockResolvedValue(undefined);
+  mocks.cache.put.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -127,8 +150,13 @@ describe("young event image route", () => {
       expect.any(ArrayBuffer),
       { httpMetadata: { contentType: "image/jpeg" } },
     );
-    expect(deferred).toHaveLength(1);
-    await expect(deferred[0]).resolves.toBeUndefined();
+    // Deferred: the R2 cache write and the Cache API response write.
+    expect(deferred).toHaveLength(2);
+    await expect(Promise.all(deferred)).resolves.toHaveLength(2);
+    expect(mocks.cache.put).toHaveBeenCalledTimes(1);
+    const [cacheRequest, cacheResponse] = mocks.cache.put.mock.calls[0];
+    expect(cacheRequest.url).toBe(CACHE_KEY_URL);
+    expect(cacheResponse.status).toBe(200);
   });
 
   it("falls back to an extension-based content type when the origin omits it", async () => {
@@ -153,7 +181,7 @@ describe("young event image route", () => {
     );
   });
 
-  it("responds 502 and caches nothing when the origin fails", async () => {
+  it("responds 502 and stores nothing in R2 when the origin fails", async () => {
     mocks.bucket.head.mockResolvedValue(null);
     mocks.fetchMock.mockResolvedValue(new Response("nope", { status: 404 }));
 
@@ -273,5 +301,167 @@ describe("young event image route", () => {
     expect(response.status).toBe(404);
     expect(mocks.bucket.head).not.toHaveBeenCalled();
     expect(mocks.fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("serves a repeat request from the Cache API without touching the DB, R2, or the origin", async () => {
+    mocks.cache.match.mockResolvedValue(
+      new Response(stream("cached-bytes"), {
+        status: 200,
+        headers: {
+          "Cache-Control": "public, max-age=31536000, immutable, no-transform",
+          "Content-Type": "image/jpeg",
+          ETag: '"cached-etag"',
+        },
+      }),
+    );
+
+    const response = await getYoungEventImageRoute(new Request(ROUTE_URL), {
+      youngId: "42",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("ETag")).toBe('"cached-etag"');
+    await expect(response.text()).resolves.toBe("cached-bytes");
+    expect(mocks.cache.match.mock.calls[0][0].url).toBe(CACHE_KEY_URL);
+    expect(mocks.youngEventFindUnique).not.toHaveBeenCalled();
+    expect(mocks.bucket.head).not.toHaveBeenCalled();
+    expect(mocks.fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("answers 304 from the Cache API when If-None-Match matches the cached ETag", async () => {
+    mocks.cache.match.mockResolvedValue(
+      new Response(stream("cached-bytes"), {
+        status: 200,
+        headers: { ETag: '"cached-etag"', "Content-Length": "12" },
+      }),
+    );
+
+    const response = await getYoungEventImageRoute(
+      new Request(ROUTE_URL, {
+        headers: { "If-None-Match": 'W/"cached-etag"' },
+      }),
+      { youngId: "42" },
+    );
+
+    expect(response.status).toBe(304);
+    expect(response.headers.get("Content-Length")).toBeNull();
+    expect(mocks.youngEventFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("caches 404 and 502 responses in the Cache API with their header TTLs", async () => {
+    mocks.youngEventFindUnique.mockResolvedValue(null);
+    const missing = await getYoungEventImageRoute(new Request(ROUTE_URL), {
+      youngId: "missing",
+    });
+    expect(missing.status).toBe(404);
+    expect(mocks.cache.put).toHaveBeenCalledTimes(1);
+    const [notFoundRequest, notFoundResponse] = mocks.cache.put.mock.calls[0];
+    expect(notFoundRequest.url).toBe(
+      "https://life.test/_life-ustc-internal-cache/young-event-image/v1/missing",
+    );
+    expect(notFoundResponse.status).toBe(404);
+    expect(notFoundResponse.headers.get("Cache-Control")).toBe(
+      "public, max-age=300",
+    );
+
+    mocks.youngEventFindUnique.mockResolvedValue(eventWithImage());
+    mocks.bucket.head.mockResolvedValue(null);
+    mocks.fetchMock.mockResolvedValue(new Response("nope", { status: 404 }));
+    const failure = await getYoungEventImageRoute(new Request(ROUTE_URL), {
+      youngId: "42",
+    });
+    expect(failure.status).toBe(502);
+    expect(mocks.cache.put).toHaveBeenCalledTimes(2);
+    const [, failureResponse] = mocks.cache.put.mock.calls[1];
+    expect(failureResponse.status).toBe(502);
+    expect(failureResponse.headers.get("Cache-Control")).toBe(
+      "public, max-age=60",
+    );
+  });
+
+  it("does not cache the 503 storage-unavailable response", async () => {
+    mocks.state.bucketAvailable = false;
+
+    const response = await getYoungEventImageRoute(new Request(ROUTE_URL), {
+      youngId: "42",
+    });
+
+    expect(response.status).toBe(503);
+    expect(mocks.cache.put).not.toHaveBeenCalled();
+  });
+
+  it("still serves the image when the Cache API is unavailable", async () => {
+    mocks.state.cacheAvailable = false;
+    mocks.bucket.head.mockResolvedValue({
+      size: 5,
+      etag: "r2-etag",
+      httpMetadata: { contentType: "image/jpeg" },
+    });
+    mocks.bucket.get.mockResolvedValue({
+      size: 5,
+      body: stream("bytes"),
+      httpMetadata: { contentType: "image/jpeg" },
+    });
+
+    const response = await getYoungEventImageRoute(new Request(ROUTE_URL), {
+      youngId: "42",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("bytes");
+  });
+
+  it("logs an error when the deferred R2 cache write fails", async () => {
+    mocks.bucket.head.mockResolvedValue(null);
+    mocks.fetchMock.mockResolvedValue(
+      new Response(stream("origin-bytes"), {
+        status: 200,
+        headers: { "Content-Type": "image/jpeg" },
+      }),
+    );
+    const failure = new Error("r2 write failed");
+    mocks.bucket.put.mockRejectedValue(failure);
+    const deferred: Promise<unknown>[] = [];
+
+    const response = await getYoungEventImageRoute(
+      new Request(ROUTE_URL),
+      { youngId: "42" },
+      { defer: (promise) => deferred.push(promise) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(Promise.all(deferred)).resolves.toBeDefined();
+    expect(mocks.logAppEvent).toHaveBeenCalledWith(
+      "error",
+      "Failed to cache young event image in R2",
+      expect.objectContaining({ source: "young-event-image", youngId: "42" }),
+      failure,
+    );
+  });
+
+  it("logs an error when the Cache API write fails and still serves the image", async () => {
+    mocks.bucket.head.mockResolvedValue(null);
+    mocks.fetchMock.mockResolvedValue(
+      new Response(stream("origin-bytes"), {
+        status: 200,
+        headers: { "Content-Type": "image/jpeg" },
+      }),
+    );
+    mocks.bucket.put.mockResolvedValue(undefined);
+    const failure = new Error("cache put failed");
+    mocks.cache.put.mockRejectedValue(failure);
+
+    const response = await getYoungEventImageRoute(new Request(ROUTE_URL), {
+      youngId: "42",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("origin-bytes");
+    expect(mocks.logAppEvent).toHaveBeenCalledWith(
+      "error",
+      "Failed to cache young event image response",
+      expect.objectContaining({ source: "young-event-image" }),
+      failure,
+    );
   });
 });

--- a/tests/unit/lib/cloudflare/wrangler-rate-limit-config.test.ts
+++ b/tests/unit/lib/cloudflare/wrangler-rate-limit-config.test.ts
@@ -79,6 +79,38 @@ describe("Wrangler mutation rate-limit bindings", () => {
     expect(config.upload_source_maps).toBe(true);
   });
 
+  it("consumes both dead-letter queues without retries", async () => {
+    const source = await readFile(
+      new URL("../../../../wrangler.jsonc", import.meta.url),
+      "utf8",
+    );
+    const config = JSON.parse(source) as {
+      queues?: {
+        consumers?: {
+          dead_letter_queue?: string;
+          max_retries?: number;
+          queue: string;
+        }[];
+      };
+    };
+    const consumers = config.queues?.consumers ?? [];
+
+    for (const deadLetterQueue of [
+      "life-ustc-calendar-export-rebuild-dlq",
+      "life-ustc-audit-log-write-dlq",
+    ]) {
+      const consumer = consumers.find(
+        (entry) => entry.queue === deadLetterQueue,
+      );
+      expect(consumer, deadLetterQueue).toBeDefined();
+      expect(consumer?.max_retries).toBe(0);
+      expect(consumer?.dead_letter_queue).toBeUndefined();
+    }
+    expect(
+      consumers.filter((entry) => entry.queue.endsWith("-dlq")),
+    ).toHaveLength(2);
+  });
+
   it("routes production CIMD fetches through the public Internet boundary", async () => {
     const source = await readFile(
       new URL("../../../../wrangler.jsonc", import.meta.url),

--- a/tests/unit/lib/misc/worker-entrypoint-observability.test.ts
+++ b/tests/unit/lib/misc/worker-entrypoint-observability.test.ts
@@ -19,6 +19,7 @@ import {
   logScheduledTaskError,
   logScheduledTaskFinish,
   logUnknownScheduledTask,
+  logWorkerDeadLetterMessage,
   logWorkerFetchError,
   logWorkerQueueError,
   logWorkerQueueFinish,
@@ -354,12 +355,67 @@ describe("worker entrypoint observability", () => {
     expect(trusted.headers.get("x-request-id")).toBeNull();
   });
 
-  it("classifies only the two configured queues", () => {
+  it("classifies only the configured queues and dead-letter queues", () => {
     expect(resolveWorkerQueue("life-ustc-audit-log-write")).toBe("audit");
     expect(resolveWorkerQueue("life-ustc-calendar-export-rebuild")).toBe(
       "calendar",
     );
+    expect(resolveWorkerQueue("life-ustc-audit-log-write-dlq")).toBe(
+      "audit-dead-letter",
+    );
+    expect(resolveWorkerQueue("life-ustc-calendar-export-rebuild-dlq")).toBe(
+      "calendar-dead-letter",
+    );
     expect(resolveWorkerQueue("unexpected-queue")).toBe("unknown");
+  });
+
+  it("logs dead-letter envelope metadata without the message body", () => {
+    logWorkerDeadLetterMessage({
+      message: {
+        attempts: 4,
+        body: {
+          params: { sessionId: "session-secret" },
+          type: "audit-log.write.v1",
+        },
+        id: "message-1",
+      },
+      queue: "audit-dead-letter",
+    });
+
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "error",
+      "worker.queue.dead-letter",
+      {
+        attempts: 4,
+        event: "worker.queue.dead-letter",
+        messageId: "message-1",
+        messageType: "audit-log.write.v1",
+        outcome: "dead-letter",
+        queue: "audit-dead-letter",
+        source: "worker-entrypoint",
+      },
+    );
+    expect(JSON.stringify(logAppEventMock.mock.calls)).not.toContain(
+      "session-secret",
+    );
+  });
+
+  it("omits unavailable dead-letter envelope fields", () => {
+    logWorkerDeadLetterMessage({
+      message: { body: "not-an-envelope" },
+      queue: "calendar-dead-letter",
+    });
+
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "error",
+      "worker.queue.dead-letter",
+      {
+        event: "worker.queue.dead-letter",
+        outcome: "dead-letter",
+        queue: "calendar-dead-letter",
+        source: "worker-entrypoint",
+      },
+    );
   });
 
   it("records queue and scheduled outcomes", () => {

--- a/tests/unit/lib/misc/worker-routing-entrypoint.test.ts
+++ b/tests/unit/lib/misc/worker-routing-entrypoint.test.ts
@@ -433,6 +433,173 @@ describe("Worker routing entrypoint", () => {
     );
   });
 
+  it("redirects the legacy sign-in path preserving the query string", async () => {
+    const response = await worker.fetch(
+      new Request(
+        "https://life-ustc.test/signin?callbackUrl=%2Fworkspace%2Foverview",
+      ),
+      {},
+      { waitUntil: vi.fn() },
+    );
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe(
+      "/account/sign-in?callbackUrl=%2Fworkspace%2Foverview",
+    );
+    expect(response.headers.get("cache-control")).toBe("public, max-age=86400");
+    expect(appFetchMock).not.toHaveBeenCalled();
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "info",
+      "edge.request.finish",
+      expect.objectContaining({
+        requestClass: "legacy-redirect",
+        route: "/signin",
+        status: 308,
+      }),
+    );
+  });
+
+  it("redirects legacy user calendar feeds preserving the credential", async () => {
+    const response = await worker.fetch(
+      new Request(
+        "https://life-ustc.test/api/users/user-1:feed-token/calendar.ics",
+      ),
+      {},
+      { waitUntil: vi.fn() },
+    );
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe(
+      "/api/calendar-feeds/user-1:feed-token.ics",
+    );
+    expect(appFetchMock).not.toHaveBeenCalled();
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "info",
+      "edge.request.finish",
+      expect.objectContaining({
+        requestClass: "legacy-redirect",
+        route: "/api/users/:credential/calendar.ics",
+        status: 308,
+      }),
+    );
+  });
+
+  it("retires legacy calendar-subscription feeds with a gone response", async () => {
+    const response = await worker.fetch(
+      new Request(
+        "https://life-ustc.test/api/calendar-subscriptions/sub-1/calendar.ics",
+      ),
+      {},
+      { waitUntil: vi.fn() },
+    );
+
+    expect(response.status).toBe(410);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    await expect(response.json()).resolves.toEqual({
+      error: expect.stringContaining("retired"),
+    });
+    expect(appFetchMock).not.toHaveBeenCalled();
+    expect(logAppEventMock).toHaveBeenCalledWith(
+      "info",
+      "edge.request.finish",
+      expect.objectContaining({
+        requestClass: "legacy-redirect",
+        route: "/api/calendar-subscriptions/:id/calendar.ics",
+        status: 410,
+      }),
+    );
+  });
+
+  it("logs and acks each calendar dead-letter message without retrying", async () => {
+    const messages = [
+      {
+        ack: vi.fn(),
+        attempts: 4,
+        body: { type: "user", userId: "user-secret" },
+        id: "message-1",
+        retry: vi.fn(),
+      },
+      {
+        ack: vi.fn(),
+        attempts: 4,
+        body: { type: "section", sectionId: 159446 },
+        id: "message-2",
+        retry: vi.fn(),
+      },
+    ];
+
+    await worker.queue(
+      {
+        messages,
+        queue: "life-ustc-calendar-export-rebuild-dlq",
+      },
+      {},
+      { waitUntil: vi.fn() },
+    );
+
+    expect(handleCalendarExportRebuildBatchMock).not.toHaveBeenCalled();
+    for (const message of messages) {
+      expect(message.ack).toHaveBeenCalledTimes(1);
+      expect(message.retry).not.toHaveBeenCalled();
+    }
+    const deadLetters = logAppEventMock.mock.calls.filter(
+      ([, event]) => event === "worker.queue.dead-letter",
+    );
+    expect(deadLetters).toHaveLength(2);
+    expect(deadLetters[0]).toEqual([
+      "error",
+      "worker.queue.dead-letter",
+      expect.objectContaining({
+        messageId: "message-1",
+        messageType: "user",
+        outcome: "dead-letter",
+        queue: "calendar-dead-letter",
+      }),
+    ]);
+    expect(JSON.stringify(deadLetters)).not.toContain("user-secret");
+  });
+
+  it("logs and acks each audit dead-letter message without retrying", async () => {
+    const message = {
+      ack: vi.fn(),
+      attempts: 6,
+      body: {
+        auditId: "audit-1",
+        params: { action: "sign-in", sessionId: "session-secret" },
+        type: "audit-log.write.v1",
+      },
+      id: "message-9",
+      retry: vi.fn(),
+    };
+
+    await worker.queue(
+      {
+        messages: [message],
+        queue: "life-ustc-audit-log-write-dlq",
+      },
+      {},
+      { waitUntil: vi.fn() },
+    );
+
+    expect(handleAuditLogWriteBatchMock).not.toHaveBeenCalled();
+    expect(message.ack).toHaveBeenCalledTimes(1);
+    expect(message.retry).not.toHaveBeenCalled();
+    const deadLetters = logAppEventMock.mock.calls.filter(
+      ([, event]) => event === "worker.queue.dead-letter",
+    );
+    expect(deadLetters).toHaveLength(1);
+    expect(deadLetters[0]?.[2]).toEqual(
+      expect.objectContaining({
+        messageId: "message-9",
+        messageType: "audit-log.write.v1",
+        queue: "audit-dead-letter",
+      }),
+    );
+    expect(JSON.stringify(logAppEventMock.mock.calls)).not.toContain(
+      "session-secret",
+    );
+  });
+
   it("records one queue completion with the audit handler outcome", async () => {
     handleAuditLogWriteBatchMock.mockResolvedValue({ outcome: "retry" });
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -36,7 +36,6 @@
   "observability": {
     "enabled": true,
     "head_sampling_rate": 1,
-    "redact_query_string": false,
     "logs": {
       "enabled": true,
       "head_sampling_rate": 1,
@@ -157,6 +156,16 @@
         "max_batch_size": 20,
         "max_retries": 5,
         "dead_letter_queue": "life-ustc-audit-log-write-dlq"
+      },
+      {
+        "queue": "life-ustc-calendar-export-rebuild-dlq",
+        "max_batch_size": 100,
+        "max_retries": 0
+      },
+      {
+        "queue": "life-ustc-audit-log-write-dlq",
+        "max_batch_size": 100,
+        "max_retries": 0
       }
     ]
   }


### PR DESCRIPTION
## Why

Production observability audit (Workers Logs/Traces, 7d) found:

- **~140 × 500/wk** on `POST /api/ingestion/publications/batches`, all Prisma **P2028** transaction timeouts — `ingestWithRetry` had no retry despite the name. Same endpoint caused **all 20 `exceededMemory`** outcomes (128MB cap).
- **~19.1K/wk ERROR-level `r2_head` spans (97.5% of all error logs)** were R2 `HeadObject` NoSuchKey probes from the ingestion plan path — a normal cache miss, drowning every real error.
- **~9.6K/wk 404s on `/signin`** and **~700/wk on legacy calendar feed URLs** (`/api/users/<id>:<token>/calendar.ics`, `/api/calendar-subscriptions/<id>/calendar.ics`) — routes removed in 1a00f897 with no shims; the calendar ones are old clients (likely iOS) whose feeds silently broke.
- **2 messages stuck in `life-ustc-calendar-export-rebuild-dlq`** with zero error logs; nothing watching the DLQs.
- `GET /api/catalog/young-events/<id>/image` traces at **4–12s**: sequential DB → R2 → origin chain on every request, deferred R2 cache write failing silently.
- `wrangler.jsonc` set `observability.redact_query_string`, which wrangler rejects as unknown — silently ignored.

## What changed

- **Ingestion**: bounded retry (3 attempts, 200ms×attempt backoff) for transient transaction errors (P2028, serialization/write-conflict); P2002/conflict still resolve via the existing batchId+digest idempotency re-read. Payload digest now stringifies with a sorted-key replacer instead of materializing a full canonicalized deep copy (byte-identical digests verified; ~2× lower peak on 100-item batches).
- **Plan path**: DB rows in `verified`/`linked` state are trusted (`already_present`, no R2 head, no write). Upload path stays byte-strict. Tradeoff documented in code comment.
- **Edge shims** (`worker.js`, same pattern as existing legacy redirects): 308 `/signin` → `/account/sign-in` (query preserved); 308 `/api/users/<credential>/calendar.ics` → `/api/calendar-feeds/<credential>.ics` (credential verbatim); 410 Gone (24h cacheable) for the retired JWT-based calendar-subscription feed.
- **DLQ consumers** for both dead-letter queues (`max_retries: 0`): each dead letter logged at error level (queue, message id, envelope type, attempts — no bodies, they can carry PII) and acked. Deploying drains + logs the 2 stuck messages.
- **Young-events image**: per-colo Cache API layer keyed by youngId honoring response TTLs (200 → 1yr, 404 → 300s, 502 → 60s, 503 never); `If-None-Match`/304 preserved; deferred R2 `put` failures now logged at error level.
- **Config**: removed unsupported `redact_query_string` key (validated against wrangler config schema).

Contracts updated: `ical.json`, `user.json`, `publications.json`, `young-event.json`.

## Verification

- `tsc` typecheck (main + tests): clean
- `biome check`: only pre-existing warnings in untouched files
- Full unit suite: 2630/2632 — the 2 failures (`graphql-server` maxDepth, `graphql-observability`) reproduce identically at clean HEAD
- ~15 new tests across ingestion retry/digest, plan head-skip, edge redirects, DLQ handling, image caching